### PR TITLE
Changed Dockerfile to be based on Ubuntu

### DIFF
--- a/0.0.1-alpha/Dockerfile
+++ b/0.0.1-alpha/Dockerfile
@@ -1,10 +1,10 @@
-FROM buildpack-deps:jessie-scm
+FROM buildpack-deps:trusty-scm
 
 # install dotnet
 RUN echo "deb [arch=amd64] http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" > /etc/apt/sources.list.d/llvm.list \
     && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|apt-key add - \
     && apt-get update \
-    && apt-get install -y liblldb-3.6 liblttng-ust0 libunwind8 libssl-dev \
+    && apt-get install -y liblldb-3.6 liblttng-ust0 libunwind8 libssl-dev libicu52 \
     && wget https://dotnetcli.blob.core.windows.net/dotnet/dev/Installers/Latest/dotnet-linux-x64.latest.deb \
     && dpkg -i dotnet-linux-x64.latest.deb \
     && rm dotnet-linux-x64.latest.deb

--- a/0.0.1-alpha/onbuild/Dockerfile
+++ b/0.0.1-alpha/onbuild/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /dotnetapp
 ENTRYPOINT ["dotnet", "run"]
 
 ONBUILD COPY . /dotnetapp
-ONBUILD RUN dotnet restore --runtime ubuntu.14.04-x64
+ONBUILD RUN dotnet restore


### PR DESCRIPTION
Changed Dockerfile to be based on Ubuntu since CLI doesn't yet have full support for Debian.  This is a short term change until CLI has full support for Debian.

Fix #6 