### PR TITLE
Modified the base Dockerfile to install dotnet Debian repo

### DIFF
--- a/0.0.1-alpha/Dockerfile
+++ b/0.0.1-alpha/Dockerfile
@@ -1,13 +1,7 @@
 FROM buildpack-deps:trusty-scm
 
 # install dotnet
-RUN echo "deb [arch=amd64] http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" > /etc/apt/sources.list.d/llvm.list \
-    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|apt-key add - \
+RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
+    && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
     && apt-get update \
-    && apt-get install -y liblldb-3.6 liblttng-ust0 libunwind8 libssl-dev libicu52 \
-    && wget https://dotnetcli.blob.core.windows.net/dotnet/dev/Installers/Latest/dotnet-linux-x64.latest.deb \
-    && dpkg -i dotnet-linux-x64.latest.deb \
-    && rm dotnet-linux-x64.latest.deb
-
-# https://github.com/dotnet/cli/issues/234 - DOTNET package does not set DOTNET_HOME which is required.
-ENV DOTNET_HOME /usr/share/dotnet
+    && apt-get install -y dotnet

--- a/0.0.1-alpha/Dockerfile
+++ b/0.0.1-alpha/Dockerfile
@@ -1,6 +1,5 @@
 FROM buildpack-deps:trusty-scm
 
-# install dotnet
 RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
     && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
     && apt-get update \


### PR DESCRIPTION
Modified the base Dockerfile to install dotnet via the public Debian package repo.  Also removed the logic that set the DOTNET_HOME environment variable since .NET CLI addressed the issue that required this.

fixes #12 