### PR TITLE
Temporarily work around LTTng failed assertion

### DIFF
--- a/0.0.1-alpha/Dockerfile
+++ b/0.0.1-alpha/Dockerfile
@@ -1,5 +1,11 @@
 FROM buildpack-deps:trusty-scm
 
+# Work around https://github.com/dotnet/cli/issues/1582 until Docker releases a
+# fix (https://github.com/docker/docker/issues/20818). This workaround allows
+# the container to be run with the default seccomp Docker settings by avoiding
+# the restart_syscall made by LTTng which causes a failed assertion.
+ENV LTTNG_UST_REGISTER_TIMEOUT 0
+
 RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
     && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
     && apt-get update \


### PR DESCRIPTION
Same change as in https://github.com/dotnet/dotnet-docker-preview/pull/2

cc: @MichaelSimons @dleeapho