### PR TITLE
Fix example tag name in README

### DIFF
--- a/0.0.1-alpha/README.md
+++ b/0.0.1-alpha/README.md
@@ -27,8 +27,8 @@ This image also includes the `ENTRYPOINT dotnet run` instruction which will run 
 You can then build and run the Docker image:
 
 ```console
-$ docker build -t myDotNetApp .
-$ docker run -it --rm --name myRunningApp myDotNetApp
+$ docker build -t my-dotnet-app .
+$ docker run -it --rm --name my-running-app my-dotnet-app
 ```
 
 ## Compile your app inside the Docker container


### PR DESCRIPTION
Tag names are case-insensitive in Docker, and Docker 1.10 introduced
validation logic that causes `docker build` to fail if the specified tag
contains uppercase characters, as stated in https://github.com/docker/distribution/issues/1433.

It appears that Docker container names are case-sensitive (in contrast
with tag names), but the default container names are all-lowercase with
underscores, and I think it looks better to use the same naming
convention for tag names and container names in the `docker run` example
command.

I chose hyphens over underscores because our tags in this repo use
hyphens (e.g. 0.0.1-alpha-onbuild), but underscores would be fine too.

cc: @dleeapho @MichaelSimons