### PR TITLE
update dotnet ver to 001793-1

### DIFF
--- a/0.0.1-alpha/Dockerfile
+++ b/0.0.1-alpha/Dockerfile
@@ -9,5 +9,5 @@ ENV LTTNG_UST_REGISTER_TIMEOUT 0
 RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
     && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
     && apt-get update \
-    && apt-get install -y dotnet=1.0.0.001598-1 \
+    && apt-get install -y dotnet=1.0.0.001793-1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Getting version(s) available from 
http://apt-mo.trafficmanager.net/repos/dotnet/dists/trusty/main/binary-amd64/Packages

maybe should publish 02339 to the apt-get feeds and update PR?