### PR TITLE
Removed the liblldb package from the image

### DIFF
--- a/1.0.0-preview1/Dockerfile
+++ b/1.0.0-preview1/Dockerfile
@@ -7,16 +7,13 @@ FROM buildpack-deps:jessie-scm
 ENV LTTNG_UST_REGISTER_TIMEOUT 0
 
 # Install .NET CLI dependencies
-RUN echo "deb [arch=amd64] http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.6 main" > /etc/apt/sources.list.d/llvm.list \
-    && wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key|apt-key add - \
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         clang-3.5 \
         libc6 \
         libcurl3 \
         libgcc1 \
         libicu52 \
-        liblldb-3.6 \
         liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \


### PR DESCRIPTION
The llvm repo was taken down unexpectedly and there is no immediate signs of it coming back soon. The microsoft/dotnet repo uses this to get the liblldb-3.6 package. This package is only used if you try to use the sos plugin for lldb. It is not a critical dependency and has been argued that it should be an optional dependency. As a result the Dockerfile is failing to build. Additionally if you pull the latest image, you will get errors when running apt-get update because this repo is registered in the image yet is unavailable.

Fixes #48 

@dleeapho, @naamunds