### PR TITLE
Update to windows 10.0.14393.206

### DIFF
--- a/1.0.0-preview2/nanoserver/Dockerfile
+++ b/1.0.0-preview2/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14300.1030
+FROM microsoft/nanoserver:10.0.14393.206
 
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-003131
@@ -15,10 +15,6 @@ RUN powershell -NoProfile -Command \
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
-
-# Copy forwarders assemblies to workaround 
-# https://github.com/dotnet/cli/blob/rel/1.0.0-preview2/Documentation/known-issues.md#running-net-core-cli-on-nano-server
-RUN copy "%windir%\System32\forwarders\*" "%ProgramFiles%\dotnet\shared\Microsoft.NETCore.App\1.0.1\"
 
 # Trigger the population of the local package cache  
 ENV NUGET_XMLDOC_MODE skip  

--- a/1.0.0-preview2/windowsservercore/Dockerfile
+++ b/1.0.0-preview2/windowsservercore/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14300.1030
+FROM microsoft/windowsservercore:10.0.14393.206
 
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-003131

--- a/1.0/nanoserver/core/Dockerfile
+++ b/1.0/nanoserver/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14300.1030
+FROM microsoft/nanoserver:10.0.14393.206
 
 # Install .NET Core
 ENV DOTNET_VERSION 1.0.1
@@ -15,7 +15,3 @@ RUN powershell -NoProfile -Command \
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
-
-# Copy forwarders assemblies to workaround 
-# https://github.com/dotnet/cli/blob/rel/1.0.0-preview2/Documentation/known-issues.md#running-net-core-cli-on-nano-server
-RUN copy "%windir%\System32\forwarders\*" "%ProgramFiles%\dotnet\shared\Microsoft.NETCore.App\1.0.1\"

--- a/1.0/windowsservercore/core/Dockerfile
+++ b/1.0/windowsservercore/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14300.1030
+FROM microsoft/windowsservercore:10.0.14393.206
 
 # Install .NET Core
 ENV DOTNET_VERSION 1.0.1


### PR DESCRIPTION
With this new version the forwarders workaround is no longer needed therefore it was removed.

Fixes #120 
Fixes #75

cc @naamunds 