### PR TITLE
dotnet-sdk image installs `make`

### DIFF
--- a/1.0.0-preview2/debian/Dockerfile
+++ b/1.0.0-preview2/debian/Dockerfile
@@ -9,6 +9,7 @@ ENV LTTNG_UST_REGISTER_TIMEOUT 0
 # Install .NET CLI dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        make \
         libc6 \
         libcurl3 \
         libgcc1 \


### PR DESCRIPTION
I have a "development environment" container that only exists for the purpose of installing `make`. It would be helpful (and in my mind, consistent with an "SDK container")  if it contained `make`. 