### PR TITLE
Fix tag in README

### DIFF
--- a/1.0/README.md
+++ b/1.0/README.md
@@ -39,7 +39,7 @@ The most straightforward way to use .NET Core with Docker is to use a .NET Core 
 In your Dockerfile, include the following line to reference the .NET Core SDK:
 
 ```dockerfile
-FROM microsoft/dotnet:1.0.0-preview2
+FROM microsoft/dotnet
 ```
 
 For [Windows Containers](http://aka.ms/windowscontainers), you should instead include the Nanoserver version of the .NET Core SDK image:


### PR DESCRIPTION
The tag `1.0.0-preview2` does not exist.  This should either be `1.0.0-preview2-sdk` or should just refer to the `latest` tag.  I think the latter makes more sense, because that is what is used in other examples in the README, e.g. `FROM microsoft/dotnet:nanoserver` and `docker run -it --rm microsoft/dotnet`

/cc @richlander @MichaelSimons 