### PR TITLE
Add 1.1-sdk-msbuild and 1.0-sdk-msbuild tags

### DIFF
--- a/1.0/README.md
+++ b/1.0/README.md
@@ -8,10 +8,10 @@
 -       ['1.1.0-runtime-deps', '1.1-runtime-deps', '1-runtime-deps', 'runtime-deps' (*1.1/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/runtime-deps/Dockerfile)
 -       ['1.0.1-sdk-projectjson', '1.0-sdk-projectjson' (*1.0/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/sdk/projectjson/Dockerfile)
 -       ['1.0.1-sdk-projectjson-nanoserver', '1.0-sdk-projectjson-nanoserver' (*1.0/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/nanoserver/sdk/projectjson/Dockerfile)
--       ['1.0.1-sdk-msbuild' (*1.0/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/sdk/msbuild/Dockerfile)
+-       ['1.0.1-sdk-msbuild', '1.0-sdk-msbuild' (*1.0/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/sdk/msbuild/Dockerfile)
 -       ['1.1.0-sdk-projectjson', '1.1-sdk-projectjson', 'sdk', 'latest' (*1.1/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/sdk/projectjson/Dockerfile)
 -       ['1.1.0-sdk-projectjson-nanoserver', '1.1-sdk-projectjson-nanoserver', 'sdk-nanoserver', 'nanoserver' (*1.1/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/nanoserver/sdk/projectjson/Dockerfile)
--       ['1.1.0-sdk-msbuild' (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
+-       ['1.1.0-sdk-msbuild', '1.1-sdk-msbuild' (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile (`dotnet/dotnet-docker`)](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls?utf8=%E2%9C%93&q=).
 


### PR DESCRIPTION
In regards to https://github.com/dotnet/dotnet-docker/pull/156#discussion_r88139619, we should still have a 1.X versioned tags.  I think it is reasonable to add them with the *-sdk-msbuild suffix.  Having these tags allow us to run our CI tests against the DH artifacts which is valuable.

@naamunds, @richlander 