### PR TITLE
Upgrading 1.0 Dockerfiles to be based on 1.0.3 of the runtime

### DIFF
--- a/1.0/README.md
+++ b/1.0/README.md
@@ -1,17 +1,17 @@
 # Supported tags and respective `Dockerfile` links
 
--       [`1.0.1-runtime`, `1.0-runtime` (*1.0/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/runtime/Dockerfile)
--       [`1.0.1-runtime-nanoserver`, `1.0-runtime-nanoserver` (*1.0/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/nanoserver/runtime/Dockerfile)
--       [`1.0.1-runtime-deps`, `1.0-runtime-deps` (*1.0/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/runtime-deps/Dockerfile)
--       [`1.0.1-sdk-projectjson`, `1.0-sdk-projectjson` (*1.0/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/sdk/projectjson/Dockerfile)
--       [`1.0.1-sdk-projectjson-nanoserver`, `1.0-sdk-projectjson-nanoserver` (*1.0/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/nanoserver/sdk/projectjson/Dockerfile)
--       [`1.0.1-sdk-msbuild`, `1.0-sdk-msbuild` (*1.0/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/sdk/msbuild/Dockerfile)
+-       [`1.0.3-runtime`, `1.0-runtime` (*1.0/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/runtime/Dockerfile)
+-       [`1.0.3-runtime-nanoserver`, `1.0-runtime-nanoserver` (*1.0/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/nanoserver/runtime/Dockerfile)
+-       [`1.0.3-runtime-deps`, `1.0-runtime-deps` (*1.0/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/runtime-deps/Dockerfile)
+-       [`1.0.3-sdk-projectjson`, `1.0-sdk-projectjson` (*1.0/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/sdk/projectjson/Dockerfile)
+-       [`1.0.3-sdk-projectjson-nanoserver`, `1.0-sdk-projectjson-nanoserver` (*1.0/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/nanoserver/sdk/projectjson/Dockerfile)
+-       [`1.0.3-sdk-msbuild`, `1.0-sdk-msbuild` (*1.0/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/debian/sdk/msbuild/Dockerfile)
 -       [`1.1.0-runtime`, `1.1-runtime`, `1-runtime`, `runtime` (*1.1/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/runtime/Dockerfile)
 -       [`1.1.0-runtime-nanoserver`, `1.1-runtime-nanoserver`, `1-runtime-nanoserver`, `runtime-nanoserver` (*1.1/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/nanoserver/runtime/Dockerfile)
 -       [`1.1.0-runtime-deps`, `1.1-runtime-deps`, `1-runtime-deps`, `runtime-deps` (*1.1/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/runtime-deps/Dockerfile)
--       [`1.1.0-sdk-projectjson`, `1.1-sdk-projectjson`, `sdk`, `latest` (*1.1/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/sdk/projectjson/Dockerfile)
--       [`1.1.0-sdk-projectjson-nanoserver`, `1.1-sdk-projectjson-nanoserver`, `sdk-nanoserver`, `nanoserver` (*1.1/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/nanoserver/sdk/projectjson/Dockerfile)
--       [`1.1.0-sdk-msbuild`, `1.1-sdk-msbuild` (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
+-       [`1.1.0-sdk-projectjson`, `1.1-sdk-projectjson`, `1-sdk-projectjson`, `sdk`, `latest` (*1.1/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/sdk/projectjson/Dockerfile)
+-       [`1.1.0-sdk-projectjson-nanoserver`, `1.1-sdk-projectjson-nanoserver`, `1-sdk-projectjson-nanoserver`, `sdk-nanoserver`, `nanoserver` (*1.1/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/nanoserver/sdk/projectjson/Dockerfile)
+-       [`1.1.0-sdk-msbuild`, `1.1-sdk-msbuild`, `1-sdk-msbuild` (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile (`dotnet/dotnet-docker`)](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls?utf8=%E2%9C%93&q=).
 

--- a/1.0/debian/runtime-deps/Dockerfile
+++ b/1.0/debian/runtime-deps/Dockerfile
@@ -1,8 +1,10 @@
 FROM debian:jessie
 
-# Install .NET Core dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
         libc6 \
         libcurl3 \
         libgcc1 \

--- a/1.0/debian/runtime-deps/hooks/post_push
+++ b/1.0/debian/runtime-deps/hooks/post_push
@@ -3,12 +3,12 @@
 set -e
 
 echo "Pushing additional runtime-deps tags"
-imageName=$DOCKER_REPO":1.0.1-runtime-deps"
+imageName=$DOCKER_REPO":1.0.3-runtime-deps"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
 # Existing core-deps tags are obsolete but being preserved for through the 1* release
-imageName=$DOCKER_REPO":1.0.1-core-deps"
+imageName=$DOCKER_REPO":1.0.3-core-deps"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
@@ -18,7 +18,7 @@ docker push $imageName
 
 
 echo "Pushing runtime tags"
-imageName=$DOCKER_REPO":1.0.1-runtime"
+imageName=$DOCKER_REPO":1.0.3-runtime"
 docker tag runtime $imageName
 docker push $imageName
 
@@ -27,7 +27,7 @@ docker tag runtime $imageName
 docker push $imageName
 
 # Existing core tags are obsolete but being preserved for through the 1* release
-imageName=$DOCKER_REPO":1.0.1-core"
+imageName=$DOCKER_REPO":1.0.3-core"
 docker tag runtime $imageName
 docker push $imageName
 

--- a/1.0/debian/runtime/Dockerfile
+++ b/1.0/debian/runtime/Dockerfile
@@ -2,12 +2,11 @@ FROM microsoft/dotnet:1.0-runtime-deps
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.0.1
+ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/debian/sdk/msbuild/Dockerfile
+++ b/1.0/debian/sdk/msbuild/Dockerfile
@@ -16,21 +16,33 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-preview3-004056
-ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+# Install .NET Core
+ENV DOTNET_VERSION 1.0.3
+ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
-RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 1.0.0-preview3-004056
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+
+RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE true
 RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
+    # Projects created with .NET Core SDK preview3 target 1.0.1, replace with 1.0.3 to populate cache
+    && sed -i "s/1.0.1/1.0.3/" ./warmup.csproj \
+    && dotnet restore \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch

--- a/1.0/debian/sdk/msbuild/hooks/post_push
+++ b/1.0/debian/sdk/msbuild/hooks/post_push
@@ -3,6 +3,6 @@
 set -e
 
 echo "Pushing additional sdk-msbuild tags"
-imageName=$DOCKER_REPO":1.0.1-sdk-msbuild"
+imageName=$DOCKER_REPO":1.0.3-sdk-msbuild"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName

--- a/1.0/debian/sdk/projectjson/Dockerfile
+++ b/1.0/debian/sdk/projectjson/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-preview2-003131
+ENV DOTNET_SDK_VERSION 1.0.0-preview2-003156
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/debian/sdk/projectjson/hooks/post_push
+++ b/1.0/debian/sdk/projectjson/hooks/post_push
@@ -3,6 +3,6 @@
 set -e
 
 echo "Pushing additional sdk-projectjson tags"
-imageName=$DOCKER_REPO":1.0.1-sdk-projectjson"
+imageName=$DOCKER_REPO":1.0.3-sdk-projectjson"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName

--- a/1.0/nanoserver/runtime/Dockerfile
+++ b/1.0/nanoserver/runtime/Dockerfile
@@ -1,7 +1,7 @@
 FROM microsoft/nanoserver:10.0.14393.447
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.0.1
+ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
 RUN powershell -NoProfile -Command \

--- a/1.0/nanoserver/sdk/projectjson/Dockerfile
+++ b/1.0/nanoserver/sdk/projectjson/Dockerfile
@@ -1,7 +1,7 @@
 FROM microsoft/nanoserver:10.0.14393.447
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-preview2-003131
+ENV DOTNET_SDK_VERSION 1.0.0-preview2-003156
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN powershell -NoProfile -Command \

--- a/1.1/debian/runtime-deps/hooks/post_push
+++ b/1.1/debian/runtime-deps/hooks/post_push
@@ -20,9 +20,9 @@ imageName=$DOCKER_REPO":1-core-deps"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
-latestImageName=$DOCKER_REPO":core-deps"
-docker tag $IMAGE_NAME $latestImageName
-docker push $latestImageName
+imageName=$DOCKER_REPO":core-deps"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
 
 
 echo "Pushing runtime tags"

--- a/1.1/debian/sdk/msbuild/hooks/post_push
+++ b/1.1/debian/sdk/msbuild/hooks/post_push
@@ -6,3 +6,7 @@ echo "Pushing additional sdk-msbuild tags"
 imageName=$DOCKER_REPO":1.1.0-sdk-msbuild"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
+
+imageName=$DOCKER_REPO":1-sdk-msbuild"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName

--- a/1.1/debian/sdk/projectjson/hooks/post_push
+++ b/1.1/debian/sdk/projectjson/hooks/post_push
@@ -7,6 +7,10 @@ imageName=$DOCKER_REPO":1.1.0-sdk-projectjson"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
+imageName=$DOCKER_REPO":1-sdk-projectjson"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
+
 imageName=$DOCKER_REPO":sdk"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName

--- a/test/create-run-publish-app.ps1
+++ b/test/create-run-publish-app.ps1
@@ -13,7 +13,10 @@ if (-NOT $?) {
     throw  "Failed to create project"
 }
 
-if ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
+if ($SdkTag -eq "1.0-sdk-msbuild-nanoserver") {
+    (Get-Content project.json).replace("1.0.1", "1.0.3") | Set-Content project.json
+}
+elseif ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
     (Get-Content project.json).replace("1.0.1", "1.1.0").replace("netcoreapp1.0", "netcoreapp1.1") | Set-Content project.json
 }
 

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -9,7 +9,9 @@ cd $1
 echo "Testing framework-dependent deployment"
 dotnet new
 
-if [[ $2 == "1.1-sdk-msbuild" ]]; then
+if [[ $2 == "1.0-sdk-msbuild" ]]; then
+    sed -i "s/1.0.1/1.0.3/" ./${PWD##*/}.csproj
+elif [[ $2 == "1.1-sdk-msbuild" ]]; then
     sed -i "s/1.0.1/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./${PWD##*/}.csproj
 fi
 


### PR DESCRIPTION
This change won't be merged until the 1.0.3 runtime packages are published.  Until then Debian CI will fail.

Fixes #121

@naamunds 