### PR TITLE
Removed mandatory attribute from the Platform param of build-and-test.ps1

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -1,6 +1,5 @@
 [cmdletbinding()]
 param(
-    [Parameter(Mandatory=$true)]
     [ValidateSet("win", "linux")]
     [string]$Platform,
     [switch]$UseImageCache
@@ -13,7 +12,7 @@ $dockerRepo="microsoft/dotnet"
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
 
 if ($UseImageCache) {
-    $optionalDockerBuildArgs=""
+    $optionalDockerBuildArgs = ""
 }
 else {
     $optionalDockerBuildArgs = "--no-cache"


### PR DESCRIPTION
The usage of this parameter was removed in https://github.com/dotnet/dotnet-docker/commit/6ce7bf25a74f8097e18757b484b4cd2c9399302c but in order to update CI to not specify it, it can't be a required parameter.