### PR TITLE
Remove the Platform param from nano CI

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -13,7 +13,7 @@ platformList.each { platform ->
     def newJob = job(newJobName) {
         steps {
             if (hostOS == 'Windows_2016') {
-                batchFile("powershell -NoProfile -Command .\\build-and-test.ps1 -Platform win")
+                batchFile("powershell -NoProfile -Command .\\build-and-test.ps1")
             }
             else {
                 shell("./build-and-test.sh")


### PR DESCRIPTION
Logic was added to the CI script to self detect the Platform therefore it is no longer being used and can be removed.  Once this PR is merged I will make a follow-up PR to remove the parameter from the build-and-test script.