### PR TITLE
Remove the Platform parameter from build-an-test.ps1

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -1,7 +1,5 @@
 [cmdletbinding()]
 param(
-    [ValidateSet("win", "linux")]
-    [string]$Platform,
     [switch]$UseImageCache
 )
 
@@ -18,9 +16,9 @@ else {
     $optionalDockerBuildArgs = "--no-cache"
 }
 
-$actualPlatform = docker version -f "{{ .Server.Os }}"
+$platform = docker version -f "{{ .Server.Os }}"
 
-if ($actualPlatform -eq "windows") {
+if ($platform -eq "windows") {
     $imageOs = "nanoserver"
     $tagSuffix = "-nanoserver"
 }

--- a/test/Dockerfile.linux.testrunner
+++ b/test/Dockerfile.linux.testrunner
@@ -1,17 +1,17 @@
 # Use this Dockerfile to create a Linux test-runner image
-#     docker build -t testrunner -f .\test\Dockerfile.runner .\test\.
-#     docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/run --workdir /run testrunner powershell -File build-and-test.ps1 -Platform linux -UseImageCache
+#     docker build -t testrunner -f .\test\Dockerfile.linux.testrunner .\test\.
+#     docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/run --workdir /run testrunner powershell -File build-and-test.ps1 -UseImageCache
 
 FROM ubuntu
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		docker.io \
-		libicu55 \
-		libcurl3 \
-		libunwind8 \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        docker.io \
+        libicu55 \
+        libcurl3 \
+        libunwind8 \
+    && rm -rf /var/lib/apt/lists/*
 RUN curl -o powershell.deb -ssL https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-alpha.15/powershell_6.0.0-alpha.15-1ubuntu1.16.04.1_amd64.deb \
-	&& dpkg -i powershell.deb \
-	&& rm -f powershell.deb
+    && dpkg -i powershell.deb \
+    && rm -f powershell.deb

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -25,17 +25,15 @@ $dirSeparator = [IO.Path]::DirectorySeparatorChar
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $platform = docker version -f "{{ .Server.Os }}"
 
-if ($Platform -eq "windows") {
+if ($platform -eq "windows") {
     $imageOs = "nanoserver"
     $tagSuffix = "-nanoserver"
-    $testScriptSuffix = "ps1"
     $containerRoot = "C:\"
     $platformDirSeparator = '\'
 }
 else {
     $imageOs = "debian"
     $tagSuffix = ""
-    $testScriptSuffix = "sh"
     $containerRoot = "/"
     $platformDirSeparator = '/'
 }
@@ -100,7 +98,6 @@ Get-ChildItem -Recurse -Filter Dockerfile |
             }
             else {
                 $projectType = "msbuild"
-                $publishArg = ''
             }
 
             $selfContainedImage = "self-contained-build-${buildImage}"


### PR DESCRIPTION
With 6ce7bf25a74f8097e18757b484b4cd2c9399302c, logic was added to self-detect the platform.  With 5d594b45e08ed2c24d0555d221bc50ac980fcf54, CI was updated to not specify the parameter.  This PR completes the cleanup by removing the parameter from the script.