### PR TITLE
Added Dockerfile labels from label-schema.org

### DIFF
--- a/1.0/debian/runtime-deps/Dockerfile
+++ b/1.0/debian/runtime-deps/Dockerfile
@@ -1,5 +1,19 @@
 FROM debian:jessie
 
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - Runtime Dependencies" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the operating system with all of the native dependencies needed by .NET Core. This image DOES NOT include .NET Core and is designed for self-contained applications." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/1.0/debian/runtime/Dockerfile
+++ b/1.0/debian/runtime/Dockerfile
@@ -9,6 +9,21 @@ RUN apt-get update \
 ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - Runtime" \
+      org.label-schema.version=$DOTNET_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core (runtime and libraries) and is optimized for running .NET Core apps in production." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/1.0/debian/sdk/msbuild/Dockerfile
+++ b/1.0/debian/sdk/msbuild/Dockerfile
@@ -17,8 +17,24 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_SDK_VERSION 1.0.0-rc4-004771
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - MSBuild based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your MSBuild based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/1.0/debian/sdk/projectjson/Dockerfile
+++ b/1.0/debian/sdk/projectjson/Dockerfile
@@ -17,8 +17,24 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-003156
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - project.json based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your project.json based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/1.0/nanoserver/runtime/Dockerfile
+++ b/1.0/nanoserver/runtime/Dockerfile
@@ -6,6 +6,21 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - Runtime" \
+      org.label-schema.version=$DOTNET_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core (runtime and libraries) and is optimized for running .NET Core apps in production." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
     Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
     Remove-Item -Force dotnet.zip

--- a/1.0/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.0/nanoserver/sdk/msbuild/Dockerfile
@@ -3,8 +3,24 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_SDK_VERSION 1.0.0-rc4-004771
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - MSBuild based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your MSBuild based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \
     Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \

--- a/1.0/nanoserver/sdk/projectjson/Dockerfile
+++ b/1.0/nanoserver/sdk/projectjson/Dockerfile
@@ -3,8 +3,24 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.0.3
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-003156
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - project.json based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your project.json based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \
     Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \

--- a/1.1/debian/runtime-deps/Dockerfile
+++ b/1.1/debian/runtime-deps/Dockerfile
@@ -1,5 +1,19 @@
 FROM debian:jessie
 
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - Runtime Dependencies" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the operating system with all of the native dependencies needed by .NET Core. This image DOES NOT include .NET Core and is designed for self-contained applications." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/1.1/debian/runtime/Dockerfile
+++ b/1.1/debian/runtime/Dockerfile
@@ -9,6 +9,21 @@ RUN apt-get update \
 ENV DOTNET_VERSION 1.1.0
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - Runtime" \
+      org.label-schema.version=$DOTNET_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core (runtime and libraries) and is optimized for running .NET Core apps in production." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/1.1/debian/sdk/msbuild/Dockerfile
+++ b/1.1/debian/sdk/msbuild/Dockerfile
@@ -17,8 +17,24 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.1.0
 ENV DOTNET_SDK_VERSION 1.0.0-rc4-004771
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - MSBuild based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your MSBuild based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/1.1/debian/sdk/projectjson/Dockerfile
+++ b/1.1/debian/sdk/projectjson/Dockerfile
@@ -17,8 +17,24 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.1.0
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-1-003177
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - project.json based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your project.json based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/1.1/nanoserver/runtime/Dockerfile
+++ b/1.1/nanoserver/runtime/Dockerfile
@@ -6,6 +6,21 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV DOTNET_VERSION 1.1.0
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - Runtime" \
+      org.label-schema.version=$DOTNET_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core (runtime and libraries) and is optimized for running .NET Core apps in production." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
+
 RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
     Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
     Remove-Item -Force dotnet.zip

--- a/1.1/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.1/nanoserver/sdk/msbuild/Dockerfile
@@ -3,8 +3,24 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.1.0
 ENV DOTNET_SDK_VERSION 1.0.0-rc4-004771
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - MSBuild based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your MSBuild based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \
     Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \

--- a/1.1/nanoserver/sdk/projectjson/Dockerfile
+++ b/1.1/nanoserver/sdk/projectjson/Dockerfile
@@ -3,8 +3,24 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
+ENV DOTNET_VERSION 1.1.0
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-1-003177
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
+
+# Metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name=".NET Core - project.json based SDK" \
+      org.label-schema.version="{ \"dotnet-core\":\"$DOTNET_VERSION\", \"dotnet-tools\": \"$DOTNET_SDK_VERSION\" }" \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your project.json based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/dotnet/articles/core/" \
+      org.label-schema.usage="https://github.com/dotnet/dotnet-docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/dotnet/dotnet-docker.git" \
+      org.label-schema.vcs-ref=$VCS_REF
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \
     Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -15,6 +15,8 @@ if ($UseImageCache) {
 else {
     $optionalDockerBuildArgs = "--no-cache"
 }
+$optionalDockerBuildArgs += " --build-arg BUILD_DATE=`"" + $(Get-Date((Get-Date).ToUniversalTime()) -UFormat "%Y-%m-%dT%H:%M:%SZ") + "`""
+$optionalDockerBuildArgs += " --build-arg VCS_REF=`"" + $(git rev-parse HEAD) + "`""
 
 $platform = docker version -f "{{ .Server.Os }}"
 

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -19,6 +19,8 @@ if ($UseImageCache) {
 else {
     $optionalDockerBuildArgs = "--no-cache"
 }
+$optionalDockerBuildArgs += " --build-arg BUILD_DATE=`"" + $(Get-Date((Get-Date).ToUniversalTime()) -UFormat "%Y-%m-%dT%H:%M:%SZ") + "`""
+$optionalDockerBuildArgs += " --build-arg VCS_REF=`"" + $(git rev-parse HEAD) + "`""
 
 $dockerRepo="microsoft/dotnet"
 $dirSeparator = [IO.Path]::DirectorySeparatorChar


### PR DESCRIPTION
There is a drive from some within the container community towards a standard label schema for container images.

> Label Schema Convention DRAFT (1.0.0-rc.1)
> http://label-schema.org/rc1/
> 
> Docker Inc. express a preference that container labels should be namespaced. Label Schema is a community project to provide a shared namespace for use by multiple tools, specifically org.label-schema.
>
> By providing a shared and community owned namespace we aim to:
> - Avoid duplication in cases where the same information is needed in multiple labels
> - Encourage the use of labels, both by image creators and by tool builders which might consume them
> - Codify good community practice in a way that is easy to consume and keep up-to-date with

There are some blog posts that discuss this:
- [Building agreement around Docker labels](https://puppet.com/blog/building-agreement-around-docker-labels)
- [MicroBadger - helping you manage your containers](http://blog.microscaling.com/2016/06/microbadger-manage-your-containers.html)
- [New for the Image-Conscious Container: Label-Schema.org](https://medium.com/microscaling-systems/new-for-the-image-conscious-container-label-schema-org-78654a270f07#.5nlpzvz0i)

[MicroBadger](http://microbadger.com) provides tooling around these labels to provide badges and docker image details. See the following examples:
- [MicroBadger - Metadata from image puppet/puppetserver](https://microbadger.com/images/puppet/puppetserver)
- [GitHub - puppetlabs/puppet-in-docker](https://github.com/puppetlabs/puppet-in-docker)

In this PR, I've updated all the `Dockerfile` files to contain the org.label-schema labels. The `docker build` command will now expect two arguments: `BUILD_DATE` and `VCS_REF`.

Running the following command:
```
$ docker build --no-cache --build-arg BUILD_DATE="$(Get-Date((Get-Date).ToUniversalTime()) -UFormat "%Y-%m-%dT%H:%M:%SZ")" --build-arg VCS_REF="$(git rev-parse HEAD)" "microsoft/dotnet:1.1-sdk-msbuild" 1.1\debian\sdk\msbuild
```
Will result in:
```
$ docker inspect microsoft/dotnet:1.1-sdk-msbuild -f "{{json .Config.Labels}}" | jq .
{
  "org.label-schema.build-date": "2017-02-12T07:21:23Z",
  "org.label-schema.description": "This image contains the .NET Core SDK which is comprised of two parts: .NET Core and the .NET Core command line tools. Use this image for your MSBuild based development process (developing, building and testing applications). Once the tooling stabilizes, the project.json variant will be deprecated and there will only be the MSBuild variant.",
  "org.label-schema.license": "MIT",
  "org.label-schema.name": ".NET Core - MSBuild based SDK",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://docs.microsoft.com/en-us/dotnet/articles/core/",
  "org.label-schema.usage": "https://github.com/dotnet/dotnet-docker",
  "org.label-schema.vcs-ref": "2839d1b45c98fefa657d5d5fc1f5d2c9ca3636d2",
  "org.label-schema.vcs-url": "https://github.com/dotnet/dotnet-docker.git",
  "org.label-schema.vendor": "Microsoft",
  "org.label-schema.version": "{ \"dotnet-core\":\"1.0.3\", \"dotnet-tools\": \"1.0.0-rc4-004771\" }\""
}
```

I added multiple versions to the `org.label-schema.version` label for all the `sdk` based images to avoid confusion around why the label version and the container tag version were different. Hope my assumptions were correct.

I also updated the `build-and-test.ps1` and `test\run-test.ps1` scripts to add the two additional build arguments when using `docker build`. If you are leveraging the automated build integration with GitHub for publishing the images to Docker Hub (from the hook scripts it appears so), you will probably need to add a `build` hook script to ensure the new build arguments are passed to the `docker build` command. An example of this is explained in this [post](https://medium.com/microscaling-systems/labelling-automated-builds-on-docker-hub-f3d073fb8e1#.csv4tsl2s) and [GitHub repo](https://github.com/rossf7/label-schema-automated-build).