### PR TITLE
Upgrade to use latest image builder

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -7,7 +7,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
-$dockerRepo = (Get-Content "manifest.json" | ConvertFrom-Json).DockerRepo
+$dockerRepo = (Get-Content "manifest.json" | ConvertFrom-Json).Repos[0].Name
 
 if ($UseImageCache) {
     $optionalDockerBuildArgs = ""

--- a/build-pipeline/dotnet-docker-linux-images.json
+++ b/build-pipeline/dotnet-docker-linux-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170520053236"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170520053236"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",
@@ -156,7 +156,7 @@
       "allowOverride": true
     },
     "image-builder.containerName": {
-      "value": "dotnet-docker-linux-$(Build.BuildId)"
+      "value": "dotnet-docker-post-image-build-$(Build.BuildId)"
     },
     "PB.docker.password": {
       "value": null,
@@ -218,7 +218,7 @@
     }
   },
   "id": 6218,
-  "name": "dotnet-docker-manifest",
+  "name": "dotnet-docker-post-image-build",
   "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6218",
   "path": "\\",
   "type": "build",

--- a/build-pipeline/dotnet-docker-windows-images.json
+++ b/build-pipeline/dotnet-docker-windows-images.json
@@ -183,14 +183,14 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170520053238"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",
       "allowOverride": true
     },
     "image-builder.containerName": {
-      "value": "dotnet-docker-linux-$(Build.BuildId)"
+      "value": "dotnet-docker-windows-$(Build.BuildId)"
     },
     "PB.docker.password": {
       "value": null,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,8 @@
 {
-  "DockerRepo": "microsoft/dotnet",
-  "ReadmePath": "README.md",
-  "TestCommands": {
+  "tagVariables": {
+    "nanoServerVersion": "10.0.14393.1198"
+  },
+  "testCommands": {
     "linux": [
       "docker build --rm -t testrunner -f ./test/Dockerfile.linux.testrunner .",
       "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/run-test.ps1"
@@ -10,224 +11,230 @@
       "powershell -NoProfile -Command .\\test\\run-test.ps1"
     ]
   },
-  "Images": [
+  "repos": [
     {
-      "sharedTags": [
-        "1.0.5-runtime-deps",
-        "1.0-runtime-deps"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.0/runtime-deps/jessie",
-          "tags": [
-            "1.0.5-runtime-deps-jessie",
-            "1.0.5-core-deps",
-            "1.0-core-deps"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.0.5-runtime",
-        "1.0-runtime"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.0/runtime/jessie",
-          "tags": [
-            "1.0.5-runtime-jessie",
-            "1.0.5-core",
-            "1.0-core"
-          ]
+      "name": "microsoft/dotnet",
+      "readmePath": "README.md",
+      "images": [
+        {
+          "sharedTags": [
+            "1.0.5-runtime-deps",
+            "1.0-runtime-deps"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/runtime-deps/jessie",
+              "tags": [
+                "1.0.5-runtime-deps-jessie",
+                "1.0.5-core-deps",
+                "1.0-core-deps"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.0/runtime/nanoserver",
-          "tags": [
-            "1.0.5-runtime-nanoserver",
-            "1.0.5-runtime-nanoserver-10.0.14393.1198",
-            "1.0-runtime-nanoserver",
-            "1.0-runtime-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.0.5-sdk-1.0.4",
-        "1.0.5-sdk",
-        "1.0-sdk"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.0/sdk/jessie",
-          "tags": [
-            "1.0.5-sdk-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.0.5-runtime",
+            "1.0-runtime"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/runtime/jessie",
+              "tags": [
+                "1.0.5-runtime-jessie",
+                "1.0.5-core",
+                "1.0-core"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.0/runtime/nanoserver",
+              "tags": [
+                "1.0.5-runtime-nanoserver",
+                "1.0.5-runtime-nanoserver-$(nanoServerVersion)",
+                "1.0-runtime-nanoserver",
+                "1.0-runtime-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.0/sdk/nanoserver",
-          "tags": [
-            "1.0.5-sdk-1.0.4-nanoserver",
-            "1.0.5-sdk-1.0.4-nanoserver-10.0.14393.1198",
-            "1.0.5-sdk-nanoserver",
-            "1.0.5-sdk-nanoserver-10.0.14393.1198",
-            "1.0-sdk-nanoserver",
-            "1.0-sdk-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.1.2-runtime-deps",
-        "1.1-runtime-deps",
-        "1-runtime-deps",
-        "runtime-deps"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.1/runtime-deps/jessie",
-          "tags": [
-            "1.1.2-runtime-deps-jessie",
-            "1-core-deps",
-            "core-deps"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.1.2-runtime",
-        "1.1-runtime",
-        "1-runtime",
-        "runtime"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.1/runtime/jessie",
-          "tags": [
-            "1.1.2-runtime-jessie",
-            "1-core",
-            "core"
-          ]
+        {
+          "sharedTags": [
+            "1.0.5-sdk-1.0.4",
+            "1.0.5-sdk",
+            "1.0-sdk"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/sdk/jessie",
+              "tags": [
+                "1.0.5-sdk-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.0/sdk/nanoserver",
+              "tags": [
+                "1.0.5-sdk-1.0.4-nanoserver",
+                "1.0.5-sdk-1.0.4-nanoserver-$(nanoServerVersion)",
+                "1.0.5-sdk-nanoserver",
+                "1.0.5-sdk-nanoserver-$(nanoServerVersion)",
+                "1.0-sdk-nanoserver",
+                "1.0-sdk-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.1/runtime/nanoserver",
-          "tags": [
-            "1.1.2-runtime-nanoserver",
-            "1.1.2-runtime-nanoserver-10.0.14393.1198",
-            "1.1-runtime-nanoserver",
-            "1.1-runtime-nanoserver-10.0.14393.1198",
-            "1-runtime-nanoserver",
-            "1-runtime-nanoserver-10.0.14393.1198",
-            "runtime-nanoserver",
-            "runtime-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.1.2-sdk-1.0.4",
-        "1.1.2-sdk",
-        "1.1-sdk",
-        "1-sdk",
-        "sdk",
-        "latest"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.1/sdk/jessie",
-          "tags": [
-            "1.1.2-sdk-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.1.2-runtime-deps",
+            "1.1-runtime-deps",
+            "1-runtime-deps",
+            "runtime-deps"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/runtime-deps/jessie",
+              "tags": [
+                "1.1.2-runtime-deps-jessie",
+                "1-core-deps",
+                "core-deps"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.1/sdk/nanoserver",
-          "tags": [
-            "1.1.2-sdk-1.0.4-nanoserver",
-            "1.1.2-sdk-1.0.4-nanoserver-10.0.14393.1198",
-            "1.1.2-sdk-nanoserver",
-            "1.1.2-sdk-nanoserver-10.0.14393.1198",
-            "1.1-sdk-nanoserver",
-            "1.1-sdk-nanoserver-10.0.14393.1198",
-            "1-sdk-nanoserver",
-            "1-sdk-nanoserver-10.0.14393.1198",
-            "sdk-nanoserver",
-            "sdk-nanoserver-10.0.14393.1198",
-            "nanoserver",
-            "nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "2.0.0-preview1-runtime-deps",
-        "2.0-runtime-deps",
-        "2-runtime-deps"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "2.0/runtime-deps/jessie",
-          "tags": [
-            "2.0.0-preview1-runtime-deps-jessie"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "2.0.0-preview1-runtime",
-        "2.0-runtime",
-        "2-runtime"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "2.0/runtime/jessie",
-          "tags": [
-            "2.0.0-preview1-runtime-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.1.2-runtime",
+            "1.1-runtime",
+            "1-runtime",
+            "runtime"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/runtime/jessie",
+              "tags": [
+                "1.1.2-runtime-jessie",
+                "1-core",
+                "core"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.1/runtime/nanoserver",
+              "tags": [
+                "1.1.2-runtime-nanoserver",
+                "1.1.2-runtime-nanoserver-$(nanoServerVersion)",
+                "1.1-runtime-nanoserver",
+                "1.1-runtime-nanoserver-$(nanoServerVersion)",
+                "1-runtime-nanoserver",
+                "1-runtime-nanoserver-$(nanoServerVersion)",
+                "runtime-nanoserver",
+                "runtime-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "2.0/runtime/nanoserver",
-          "tags": [
-            "2.0.0-preview1-runtime-nanoserver",
-            "2.0.0-preview1-runtime-nanoserver-10.0.14393.1198",
-            "2.0-runtime-nanoserver",
-            "2.0-runtime-nanoserver-10.0.14393.1198",
-            "2-runtime-nanoserver",
-            "2-runtime-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "2.0.0-preview1-sdk",
-        "2.0-sdk",
-        "2-sdk"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "2.0/sdk/jessie",
-          "tags": [
-            "2.0.0-preview1-sdk-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.1.2-sdk-1.0.4",
+            "1.1.2-sdk",
+            "1.1-sdk",
+            "1-sdk",
+            "sdk",
+            "latest"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/sdk/jessie",
+              "tags": [
+                "1.1.2-sdk-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.1/sdk/nanoserver",
+              "tags": [
+                "1.1.2-sdk-1.0.4-nanoserver",
+                "1.1.2-sdk-1.0.4-nanoserver-$(nanoServerVersion)",
+                "1.1.2-sdk-nanoserver",
+                "1.1.2-sdk-nanoserver-$(nanoServerVersion)",
+                "1.1-sdk-nanoserver",
+                "1.1-sdk-nanoserver-$(nanoServerVersion)",
+                "1-sdk-nanoserver",
+                "1-sdk-nanoserver-$(nanoServerVersion)",
+                "sdk-nanoserver",
+                "sdk-nanoserver-$(nanoServerVersion)",
+                "nanoserver",
+                "nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "2.0/sdk/nanoserver",
-          "tags": [
-            "2.0.0-preview1-sdk-nanoserver",
-            "2.0.0-preview1-sdk-nanoserver-10.0.14393.1198",
-            "2.0-sdk-nanoserver",
-            "2.0-sdk-nanoserver-10.0.14393.1198",
-            "2-sdk-nanoserver",
-            "2-sdk-nanoserver-10.0.14393.1198"
-          ]
+        {
+          "sharedTags": [
+            "2.0.0-preview1-runtime-deps",
+            "2.0-runtime-deps",
+            "2-runtime-deps"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/runtime-deps/jessie",
+              "tags": [
+                "2.0.0-preview1-runtime-deps-jessie"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "2.0.0-preview1-runtime",
+            "2.0-runtime",
+            "2-runtime"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/runtime/jessie",
+              "tags": [
+                "2.0.0-preview1-runtime-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "2.0/runtime/nanoserver",
+              "tags": [
+                "2.0.0-preview1-runtime-nanoserver",
+                "2.0.0-preview1-runtime-nanoserver-$(nanoServerVersion)",
+                "2.0-runtime-nanoserver",
+                "2.0-runtime-nanoserver-$(nanoServerVersion)",
+                "2-runtime-nanoserver",
+                "2-runtime-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "2.0.0-preview1-sdk",
+            "2.0-sdk",
+            "2-sdk"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/sdk/jessie",
+              "tags": [
+                "2.0.0-preview1-sdk-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "2.0/sdk/nanoserver",
+              "tags": [
+                "2.0.0-preview1-sdk-nanoserver",
+                "2.0.0-preview1-sdk-nanoserver-$(nanoServerVersion)",
+                "2.0-sdk-nanoserver",
+                "2.0-sdk-nanoserver-$(nanoServerVersion)",
+                "2-sdk-nanoserver",
+                "2-sdk-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         }
-      }
+      ]
     }
   ]
 }

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -23,7 +23,7 @@ else {
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $manifestPath = [IO.Path]::combine(${repoRoot}, "manifest.json")
-$dockerRepo = (Get-Content $manifestPath | ConvertFrom-Json).DockerRepo
+$dockerRepo = (Get-Content $manifestPath | ConvertFrom-Json).Repos[0].Name
 $testFilesPath = "$PSScriptRoot$dirSeparator"
 $platform = docker version -f "{{ .Server.Os }}"
 


### PR DESCRIPTION
- Upgraded to use latest image builder tool.  This required a manifest schema change.  
- Refactored manifest to make use of tagVariables which will make patch Tuesday work easier/less error prone.
- Minor build-pipeline build definitions cleanup.