### PR TITLE
Split official builds into smaller legs to decrease overall build time

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -1,6 +1,7 @@
 [cmdletbinding()]
 param(
-    [switch]$UseImageCache
+    [switch]$UseImageCache,
+    [string]$Filter
 )
 
 Set-StrictMode -Version Latest
@@ -22,7 +23,8 @@ $manifestRepo.Images |
     ForEach-Object {
         $images = $_
         $_.Platforms |
-            Where-Object {[bool]($_.PSobject.Properties.name -match $platform)} |
+            Where-Object { [bool]($_.PSobject.Properties.name -match $platform) } |
+            Where-Object { [string]::IsNullOrEmpty($Filter) -or $_.$platform.dockerfile -like "$Filter*" } |
             ForEach-Object {
                 $dockerfilePath = $_.$platform.dockerfile
                 $tags = $_.$platform.Tags
@@ -44,6 +46,6 @@ $manifestRepo.Images |
             }
     }
 
-./test/run-test.ps1 -UseImageCache:$UseImageCache
+./test/run-test.ps1 -UseImageCache:$UseImageCache -Filter $Filter
 
 Write-Host "Tags built and tested:`n$($builtTags | Out-String)"

--- a/build-pipeline/dotnet-docker-linux-images.json
+++ b/build-pipeline/dotnet-docker-linux-images.json
@@ -122,10 +122,10 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170627165706"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170710090943"
     },
     "image-builder.args": {
-      "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",
+      "value": "--command build --manifest manifest.json --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) --push --username $(PB.docker.username) --password $(PB.docker.password)",
       "allowOverride": true
     },
     "image-builder.containerName": {
@@ -134,6 +134,9 @@
     "PB.docker.password": {
       "value": null,
       "isSecret": true
+    },
+    "PB.image-builder.path": {
+      "value": ""
     }
   },
   "demands": [

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170627165706"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170710090943"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/dotnet-docker-windows-images.json
+++ b/build-pipeline/dotnet-docker-windows-images.json
@@ -183,10 +183,10 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170627165707"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170710090943"
     },
     "image-builder.args": {
-      "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",
+      "value": "--command build --manifest manifest.json --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) --push --username $(PB.docker.username) --password $(PB.docker.password)",
       "allowOverride": true
     },
     "image-builder.containerName": {
@@ -195,6 +195,9 @@
     "PB.docker.password": {
       "value": null,
       "isSecret": true
+    },
+    "PB.image-builder.path": {
+      "value": ""
     }
   },
   "demands": [

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -14,7 +14,22 @@
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-linux-images"
+          "Name": "dotnet-docker-linux-images",
+          "Parameters": {
+            "PB.image-builder.path": "1.0"
+          }
+        },
+        {
+          "Name": "dotnet-docker-linux-images",
+          "Parameters": {
+            "PB.image-builder.path": "1.1"
+          }
+        },
+        {
+          "Name": "dotnet-docker-linux-images",
+          "Parameters": {
+            "PB.image-builder.path": "2.0"
+          }
         }
       ]
     },
@@ -25,7 +40,22 @@
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-windows-images"
+          "Name": "dotnet-docker-windows-images",
+          "Parameters": {
+            "PB.image-builder.path": "1.0"
+          }
+        },
+        {
+          "Name": "dotnet-docker-windows-images",
+          "Parameters": {
+            "PB.image-builder.path": "1.1"
+          }
+        },
+        {
+          "Name": "dotnet-docker-windows-images",
+          "Parameters": {
+            "PB.image-builder.path": "2.0"
+          }
         }
       ]
     },

--- a/manifest.json
+++ b/manifest.json
@@ -5,10 +5,10 @@
   "testCommands": {
     "linux": [
       "docker build --rm -t testrunner -f ./test/Dockerfile.linux.testrunner .",
-      "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/run-test.ps1"
+      "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/run-test.ps1 -Filter $(Filter)"
     ],
     "windows": [
-      "powershell -NoProfile -Command .\\test\\run-test.ps1"
+      "powershell -NoProfile -Command .\\test\\run-test.ps1 -Filter $(Filter)"
     ]
   },
   "repos": [


### PR DESCRIPTION
Migration of https://github.com/dotnet/dotnet-docker-nightly/pull/352 from dotnet-docker-nightly to dotnet-docker.