### PR TITLE
Upgrade 1.0.5 and 1.1.2 SDK images to include CLI 1.1.0

### DIFF
--- a/1.0/sdk/jessie/Dockerfile
+++ b/1.0/sdk/jessie/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.4
+ENV DOTNET_SDK_VERSION 1.1.0
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/sdk/nanoserver/Dockerfile
+++ b/1.0/sdk/nanoserver/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.1593
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.4
+ENV DOTNET_SDK_VERSION 1.1.0
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/1.1/sdk/jessie/Dockerfile
+++ b/1.1/sdk/jessie/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.4
+ENV DOTNET_SDK_VERSION 1.1.0
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.1/sdk/nanoserver/Dockerfile
+++ b/1.1/sdk/nanoserver/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.1593
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.4
+ENV DOTNET_SDK_VERSION 1.1.0
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/manifest.json
+++ b/manifest.json
@@ -79,7 +79,7 @@
         {
           "readmeOrder": 2,
           "sharedTags": {
-            "1.0.5-sdk-1.0.4": {
+            "1.0.5-sdk-1.1.0": {
               "isUndocumented": true
             },
             "1.0.5-sdk": {},
@@ -97,10 +97,10 @@
               "dockerfile": "1.0/sdk/nanoserver",
               "os": "windows",
               "tags": {
-                "1.0.5-sdk-1.0.4-nanoserver": {
+                "1.0.5-sdk-1.1.0-nanoserver": {
                   "isUndocumented": true
                 },
-                "1.0.5-sdk-1.0.4-nanoserver-$(nanoServerVersion)": {
+                "1.0.5-sdk-1.1.0-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.0.5-sdk-nanoserver": {},
@@ -194,7 +194,7 @@
         {
           "readmeOrder": 5,
           "sharedTags": {
-            "1.1.2-sdk-1.0.4": {
+            "1.1.2-sdk-1.1.0": {
               "isUndocumented": true
             },
             "1.1.2-sdk": {},
@@ -213,10 +213,10 @@
               "dockerfile": "1.1/sdk/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.2-sdk-1.0.4-nanoserver": {
+                "1.1.2-sdk-1.1.0-nanoserver": {
                   "isUndocumented": true
                 },
-                "1.1.2-sdk-1.0.4-nanoserver-$(nanoServerVersion)": {
+                "1.1.2-sdk-1.1.0-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.1.2-sdk-nanoserver": {},


### PR DESCRIPTION
This is needed to align the SDK images with VS 15.3 which included CLI 1.1.0.