### PR TITLE
Updates for 1.0.7/1.1.4 release

### DIFF
--- a/1.0/runtime/jessie/Dockerfile
+++ b/1.0/runtime/jessie/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.0.5
+ENV DOTNET_VERSION 1.0.7
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/runtime/nanoserver/Dockerfile
+++ b/1.0/runtime/nanoserver/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.1593
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.0.5
+ENV DOTNET_VERSION 1.0.7
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/1.0/sdk/jessie/Dockerfile
+++ b/1.0/sdk/jessie/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.1.0
+ENV DOTNET_SDK_VERSION 1.1.4
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/sdk/nanoserver/Dockerfile
+++ b/1.0/sdk/nanoserver/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.1593
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.1.0
+ENV DOTNET_SDK_VERSION 1.1.4
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/1.1/runtime/jessie/Dockerfile
+++ b/1.1/runtime/jessie/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.1.2
+ENV DOTNET_VERSION 1.1.4
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.1/runtime/nanoserver/Dockerfile
+++ b/1.1/runtime/nanoserver/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.1593
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.1.2
+ENV DOTNET_VERSION 1.1.4
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/1.1/sdk/jessie/Dockerfile
+++ b/1.1/sdk/jessie/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.1.0
+ENV DOTNET_SDK_VERSION 1.1.4
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.1/sdk/nanoserver/Dockerfile
+++ b/1.1/sdk/nanoserver/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.1593
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.1.0
+ENV DOTNET_SDK_VERSION 1.1.4
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Supported Linux amd64 tags
 
-- [`1.0.5-runtime-jessie`, `1.0.5-runtime`, `1.0-runtime` (*1.0/runtime/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/jessie/Dockerfile)
-- [`1.0.5-runtime-deps-jessie`, `1.0.5-runtime-deps`, `1.0-runtime-deps` (*1.0/runtime-deps/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime-deps/jessie/Dockerfile)
-- [`1.0.5-sdk-jessie`, `1.0.5-sdk`, `1.0-sdk` (*1.0/sdk/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/sdk/jessie/Dockerfile)
-- [`1.1.2-runtime-jessie`, `1.1.2-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/jessie/Dockerfile)
-- [`1.1.2-runtime-deps-jessie`, `1.1.2-runtime-deps`, `1.1-runtime-deps`, `1-runtime-deps` (*1.1/runtime-deps/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime-deps/jessie/Dockerfile)
-- [`1.1.2-sdk-jessie`, `1.1.2-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/Dockerfile)
+- [`1.0.7-runtime-jessie`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/jessie/Dockerfile)
+- [`1.0.7-runtime-deps-jessie`, `1.0.7-runtime-deps`, `1.0-runtime-deps` (*1.0/runtime-deps/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime-deps/jessie/Dockerfile)
+- [`1.0.7-sdk-jessie`, `1.0.7-sdk`, `1.0-sdk` (*1.0/sdk/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/sdk/jessie/Dockerfile)
+- [`1.1.4-runtime-jessie`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/jessie/Dockerfile)
+- [`1.1.4-runtime-deps-jessie`, `1.1.4-runtime-deps`, `1.1-runtime-deps`, `1-runtime-deps` (*1.1/runtime-deps/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime-deps/jessie/Dockerfile)
+- [`1.1.4-sdk-jessie`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/Dockerfile)
 - [`2.0.0-runtime-stretch`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/stretch/amd64/Dockerfile)
 - [`2.0.0-runtime-jessie`, `2.0-runtime-jessie`, `2-runtime-jessie` (*2.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/jessie/amd64/Dockerfile)
 - [`2.0.0-runtime-deps-stretch`, `2.0.0-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/stretch/amd64/Dockerfile)
@@ -15,10 +15,10 @@
 
 # Supported Windows amd64 tags
 
-- [`1.0.5-runtime-nanoserver`, `1.0.5-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver/Dockerfile)
-- [`1.0.5-sdk-nanoserver`, `1.0.5-sdk`, `1.0-sdk` (*1.0/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/sdk/nanoserver/Dockerfile)
-- [`1.1.2-runtime-nanoserver`, `1.1.2-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver/Dockerfile)
-- [`1.1.2-sdk-nanoserver`, `1.1.2-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver/Dockerfile)
+- [`1.0.7-runtime-nanoserver`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver/Dockerfile)
+- [`1.0.7-sdk-nanoserver`, `1.0.7-sdk`, `1.0-sdk` (*1.0/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/sdk/nanoserver/Dockerfile)
+- [`1.1.4-runtime-nanoserver`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver/Dockerfile)
+- [`1.1.4-sdk-nanoserver`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver/Dockerfile)
 - [`2.0.0-runtime-nanoserver`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
 - [`2.0.0-sdk-nanoserver`, `2.0.0-sdk`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
 

--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170807153845"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316"
     },
     "image-builder.args": {
       "value": "build --manifest manifest.json --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) --test-var Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -176,7 +176,7 @@
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170807153845"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316"
     },
     "image-builder.args": {
       "value": "build --manifest manifest.json --path $(PB.image-builder.path) --architecture arm --test-var Filter=$(PB.image-builder.path) --test-var Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170807153845"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-windows-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-amd64-images.json
@@ -73,7 +73,7 @@
       },
       "inputs": {
         "filename": "docker ",
-        "arguments": "cp $(image-builder.containerName):/out $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
+        "arguments": "cp $(image-builder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170807153845"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170818060355"
     },
     "image-builder.args": {
       "value": "build --manifest manifest.json --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) --test-var Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
         {
           "readmeOrder": 1,
           "sharedTags": {
-            "1.0.5-runtime-deps": {},
+            "1.0.7-runtime-deps": {},
             "1.0-runtime-deps": {}
           },
           "platforms": [
@@ -27,10 +27,7 @@
               "dockerfile": "1.0/runtime-deps/jessie",
               "os": "linux",
               "tags": {
-                "1.0.5-runtime-deps-jessie": {},
-                "1.0.5-core-deps": {
-                  "isUndocumented": true
-                },
+                "1.0.7-runtime-deps-jessie": {},
                 "1.0-core-deps": {
                   "isUndocumented": true
                 }
@@ -41,7 +38,7 @@
         {
           "readmeOrder": 0,
           "sharedTags": {
-            "1.0.5-runtime": {},
+            "1.0.7-runtime": {},
             "1.0-runtime": {}
           },
           "platforms": [
@@ -49,10 +46,7 @@
               "dockerfile": "1.0/runtime/jessie",
               "os": "linux",
               "tags": {
-                "1.0.5-runtime-jessie": {},
-                "1.0.5-core": {
-                  "isUndocumented": true
-                },
+                "1.0.7-runtime-jessie": {},
                 "1.0-core": {
                   "isUndocumented": true
                 }
@@ -62,8 +56,8 @@
               "dockerfile": "1.0/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.0.5-runtime-nanoserver": {},
-                "1.0.5-runtime-nanoserver-$(nanoServerVersion)": {
+                "1.0.7-runtime-nanoserver": {},
+                "1.0.7-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.0-runtime-nanoserver": {
@@ -79,10 +73,7 @@
         {
           "readmeOrder": 2,
           "sharedTags": {
-            "1.0.5-sdk-1.1.0": {
-              "isUndocumented": true
-            },
-            "1.0.5-sdk": {},
+            "1.0.7-sdk": {},
             "1.0-sdk": {}
           },
           "platforms": [
@@ -90,21 +81,15 @@
               "dockerfile": "1.0/sdk/jessie",
               "os": "linux",
               "tags": {
-                "1.0.5-sdk-jessie": {}
+                "1.0.7-sdk-jessie": {}
               }
             },
             {
               "dockerfile": "1.0/sdk/nanoserver",
               "os": "windows",
               "tags": {
-                "1.0.5-sdk-1.1.0-nanoserver": {
-                  "isUndocumented": true
-                },
-                "1.0.5-sdk-1.1.0-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                },
-                "1.0.5-sdk-nanoserver": {},
-                "1.0.5-sdk-nanoserver-$(nanoServerVersion)": {
+                "1.0.7-sdk-nanoserver": {},
+                "1.0.7-sdk-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.0-sdk-nanoserver": {
@@ -120,7 +105,7 @@
         {
           "readmeOrder": 4,
           "sharedTags": {
-            "1.1.2-runtime-deps": {},
+            "1.1.4-runtime-deps": {},
             "1.1-runtime-deps": {},
             "1-runtime-deps": {}
           },
@@ -129,7 +114,7 @@
               "dockerfile": "1.1/runtime-deps/jessie",
               "os": "linux",
               "tags": {
-                "1.1.2-runtime-deps-jessie": {},
+                "1.1.4-runtime-deps-jessie": {},
                 "1-core-deps": {
                   "isUndocumented": true
                 },
@@ -143,7 +128,7 @@
         {
           "readmeOrder": 3,
           "sharedTags": {
-            "1.1.2-runtime": {},
+            "1.1.4-runtime": {},
             "1.1-runtime": {},
             "1-runtime": {}
           },
@@ -152,7 +137,7 @@
               "dockerfile": "1.1/runtime/jessie",
               "os": "linux",
               "tags": {
-                "1.1.2-runtime-jessie": {},
+                "1.1.4-runtime-jessie": {},
                 "1-core": {
                   "isUndocumented": true
                 },
@@ -165,8 +150,8 @@
               "dockerfile": "1.1/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.2-runtime-nanoserver": {},
-                "1.1.2-runtime-nanoserver-$(nanoServerVersion)": {
+                "1.1.4-runtime-nanoserver": {},
+                "1.1.4-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.1-runtime-nanoserver": {
@@ -194,10 +179,7 @@
         {
           "readmeOrder": 5,
           "sharedTags": {
-            "1.1.2-sdk-1.1.0": {
-              "isUndocumented": true
-            },
-            "1.1.2-sdk": {},
+            "1.1.4-sdk": {},
             "1.1-sdk": {},
             "1-sdk": {}
           },
@@ -206,21 +188,15 @@
               "dockerfile": "1.1/sdk/jessie",
               "os": "linux",
               "tags": {
-                "1.1.2-sdk-jessie": {}
+                "1.1.4-sdk-jessie": {}
               }
             },
             {
               "dockerfile": "1.1/sdk/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.2-sdk-1.1.0-nanoserver": {
-                  "isUndocumented": true
-                },
-                "1.1.2-sdk-1.1.0-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                },
-                "1.1.2-sdk-nanoserver": {},
-                "1.1.2-sdk-nanoserver-$(nanoServerVersion)": {
+                "1.1.4-sdk-nanoserver": {},
+                "1.1.4-sdk-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.1-sdk-nanoserver": {


### PR DESCRIPTION
This is a pseudo migration of the changes from dotnet-docker-nightly.  This release will not include the image consolidation changes that were recently made in nightly.  This is an update for https://github.com/dotnet/dotnet-docker/pull/292.
