### PR TITLE
Updating Nano Server Dockerfiles to be based on 10.0.14393.1770

### DIFF
--- a/1.0/runtime/nanoserver/Dockerfile
+++ b/1.0/runtime/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14393.1715
+FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/1.0/sdk/nanoserver/Dockerfile
+++ b/1.0/sdk/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14393.1715
+FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/1.1/runtime/nanoserver/Dockerfile
+++ b/1.1/runtime/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14393.1715
+FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/1.1/sdk/nanoserver/Dockerfile
+++ b/1.1/sdk/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14393.1715
+FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.0/runtime/nanoserver/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14393.1715
+FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.0/sdk/nanoserver/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14393.1715
+FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "tagVariables": {
-    "nanoServerVersion": "10.0.14393.1715"
+    "nanoServerVersion": "10.0.14393.1770"
   },
   "testCommands": {
     "linux": [


### PR DESCRIPTION
Updating Nano Server Dockerfiles to be based on 10.0.14393.1770