### PR TITLE
Fix 2.0.2 Nano Server tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - [`1.1.4-runtime-nanoserver`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver/Dockerfile)
 - [`1.1.4-sdk-nanoserver`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver/Dockerfile)
 - [`2.0.0-runtime-nanoserver`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
-- [`2.0.0-sdk-nanoserver-2.0.2`, `2.0.0-sdk-2.0.2`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
+- [`2.0.0-sdk-2.0.2-nanoserver`, `2.0.0-sdk-2.0.2`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
 
 # Supported Linux arm32 tags
 

--- a/manifest.json
+++ b/manifest.json
@@ -303,7 +303,13 @@
               "dockerfile": "2.0/sdk/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.0.0-sdk-nanoserver-2.0.2": {},
+                "2.0.0-sdk-2.0.2-nanoserver": {},
+                "2.0.0-sdk-2.0.2-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "2.0.0-sdk-nanoserver-2.0.2": {
+                  "isUndocumented": true
+                },
                 "2.0.0-sdk-nanoserver-2.0.2-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },


### PR DESCRIPTION
Nano Server version tag is updated to be in the format -
`<version of the .Net Core app the sdk image is intended to build>-sdk-<version of the sdk the image includes>-nanoserver`

Updated `README.md` accordingly.