### PR TITLE
Add nanoserver Dockerfiles for 1709 release

### DIFF
--- a/2.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -1,0 +1,28 @@
+# escape=`
+
+# Installer image
+FROM microsoft/windowsservercore:1709 AS installer-env
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Retrieve .NET Core Runtime
+ENV DOTNET_VERSION 2.0.0
+ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-win-x64.zip
+ENV DOTNET_DOWNLOAD_SHA 7D7D0A9B03CB7BB16A2E7B97288B03EABFFB37073C2B025BB9D535CCD51E3F46DB9546A521D5719366DCB6E45529B1B8C54708CF47C619521B556F21F1FFAB59
+
+RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_DOWNLOAD_SHA) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM microsoft/nanoserver:1709
+
+COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+
+RUN setx PATH "%PATH%;C:\Program Files\dotnet"

--- a/2.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -1,0 +1,36 @@
+# escape=`
+
+# Installer image
+FROM microsoft/windowsservercore:1709 AS installer-env
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Retrieve .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.0.2
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-win-x64.zip
+ENV DOTNET_SDK_DOWNLOAD_SHA 4864A36D3BE9D460A17D0EBE9D03B17CE224EC18880BCDBC087889F32DDFC2CF3753A1AB7D0414B1E73E863E0D10F5A8381E80EFFC7F7C0A50600DD82A1F0048
+
+RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_SDK_DOWNLOAD_SHA) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    Remove-Item -Force dotnet.zip
+
+
+# SDK image
+FROM microsoft/nanoserver:1709
+
+COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+
+RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN mkdir warmup `
+    && cd warmup `
+    && dotnet new `
+    && cd .. `
+    && rmdir /s /q warmup

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@
 - [`2.0.0-sdk-2.0.2-stretch`, `2.0.0-sdk-2.0.2`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/stretch/amd64/Dockerfile)
 - [`2.0.0-sdk-2.0.2-jessie`, `2.0-sdk-jessie`, `2-sdk-jessie` (*2.0/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/jessie/amd64/Dockerfile)
 
-# Supported Windows amd64 tags
+# Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
+
+- [`2.0.0-runtime-nanoserver-1709` (*2.0/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.0.0-sdk-2.0.2-nanoserver-1709` (*2.0/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver-1709/amd64/Dockerfile)
+
+# Supported Windows Server 2016 amd64 tags
 
 - [`1.0.7-runtime-nanoserver`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver/Dockerfile)
 - [`1.0.7-sdk-nanoserver`, `1.0.7-sdk`, `1.0-sdk` (*1.0/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/sdk/nanoserver/Dockerfile)

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -47,7 +47,7 @@ $manifestRepo.Images |
                 }
                 $formattedTags = $qualifiedTags -join ', '
                 Write-Host "--- Building $formattedTags from $dockerfilePath ---"
-                #Invoke-Expression "docker build $optionalDockerBuildArgs -t $($qualifiedTags -join ' -t ') $dockerfilePath"
+                Invoke-Expression "docker build $optionalDockerBuildArgs -t $($qualifiedTags -join ' -t ') $dockerfilePath"
                 if ($LastExitCode -ne 0) {
                     throw "Failed building $formattedTags"
                 }
@@ -56,6 +56,6 @@ $manifestRepo.Images |
             }
     }
 
-#./test/run-test.ps1 -Filter $Filter -Architecture $Architecture -OS $OS
+./test/run-test.ps1 -Filter $Filter -Architecture $Architecture -OS $OS
 
 Write-Host "Tags built and tested:`n$($builtTags | Out-String)"

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -23,8 +23,9 @@ $manifestRepo = $manifest.Repos[0]
 $activeOS = docker version -f "{{ .Server.Os }}"
 $builtTags = @()
 
-if ($activeOS -eq "windows" -and $Filter -eq "2.0*") {
-    $Filter = "$Filter/nanoserver/*"
+$buildFilter = $Filter
+if ($activeOS -eq "windows" -and $buildFilter -eq "2.0*") {
+    $buildFilter = "$buildFilter/nanoserver/*"
 }
 
 $manifestRepo.Images |
@@ -32,7 +33,7 @@ $manifestRepo.Images |
         $images = $_
         $_.Platforms |
             Where-Object { $_.os -eq "$activeOS" } |
-            Where-Object { [string]::IsNullOrEmpty($Filter) -or $_.dockerfile -like "$Filter" } |
+            Where-Object { [string]::IsNullOrEmpty($buildFilter) -or $_.dockerfile -like "$buildFilter" } |
             Where-Object { ( [string]::IsNullOrEmpty($Architecture) -and -not [bool]($_.PSobject.Properties.name -match "architecture"))`
                 -or ( [bool]($_.PSobject.Properties.name -match "architecture") -and $_.architecture -eq "$Architecture" ) } |
             ForEach-Object {

--- a/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
@@ -1,7 +1,7 @@
 {
   "build": [
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Cleanup Docker",
@@ -117,7 +117,7 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Cleanup Docker",

--- a/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
@@ -1,7 +1,7 @@
 {
   "build": [
     {
-      "enabled": true,
+      "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Cleanup Docker",
@@ -17,7 +17,7 @@
         "scriptName": "",
         "arguments": "",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
         "failOnStandardError": "true"
       }
     },
@@ -117,7 +117,7 @@
       }
     },
     {
-      "enabled": true,
+      "enabled": false,
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Cleanup Docker",
@@ -133,7 +133,7 @@
         "scriptName": "",
         "arguments": "",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
         "failOnStandardError": "true"
       }
     }
@@ -204,7 +204,7 @@
     }
   },
   "demands": [
-    "Agent.OS -equals Windows_NT"
+    "VSTS_OS -equals Windows_Server_2016_Data_Center_RS3"
   ],
   "retentionRules": [
     {
@@ -250,16 +250,16 @@
   "processParameters": {},
   "quality": "definition",
   "queue": {
-    "id": 330,
-    "name": "DotNetCore-Build",
+    "id": 832,
+    "name": "DotNetCore-Infra",
     "pool": {
-      "id": 97,
-      "name": "DotNetCore-Build"
+      "id": 135,
+      "name": "DotNetCore-Infra"
     }
   },
-  "id": 6216,
-  "name": "dotnet-docker-windows-amd64-images",
-  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6216",
+  "id": 6222,
+  "name": "dotnet-docker-windows-1709-amd64-images",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6222",
   "path": "\\",
   "type": "build",
   "project": {

--- a/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
@@ -17,7 +17,7 @@
         "scriptName": "",
         "arguments": "",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
         "failOnStandardError": "true"
       }
     },
@@ -133,7 +133,7 @@
         "scriptName": "",
         "arguments": "",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
         "failOnStandardError": "true"
       }
     }

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -76,7 +76,7 @@
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
             "PB.image-builder.path": "2.0*/nanoserver-1709/*",
-            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver-1709 --repo-owner msimons --skip-pulling"
+            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver-1709 --repo-owner msimons"
           }
         }
       ]

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,13 +16,15 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1.*"
+            "PB.image-builder.path": "1.*",
+            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
           }
         },
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.*"
+            "PB.image-builder.path": "2.*",
+            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
           }
         }
       ]
@@ -36,7 +38,8 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB.image-builder.path": "2.*"
+            "PB.image-builder.path": "2.*",
+            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
           }
         }
       ]
@@ -50,13 +53,30 @@
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1.*"
+            "PB.image-builder.path": "1.*",
+            "PB.image-builder.customCommonArgs": "--test-var Filter=1.* --repo-owner msimons"
           }
         },
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.0*"
+            "PB.image-builder.path": "2.0*/nanoserver/*",
+            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver --repo-owner msimons"
+          }
+        }
+      ]
+    },
+    {
+      "Name": "Build Windows 1709 AMD64 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-windows-1709-amd64-images",
+          "Parameters": {
+            "PB.image-builder.path": "2.0*/nanoserver-1709/*",
+            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver-1709 --repo-owner msimons --skip-pulling"
           }
         }
       ]
@@ -68,10 +88,14 @@
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-post-image-build"
+          "Name": "dotnet-docker-post-image-build",
+          "Parameters": {
+            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
+          }
         }
       ],
       "DependsOn": [
+        "Build Windows 1709 AMD64 Images",
         "Build Windows AMD64 Images",
         "Build Linux AMD64 Images",
         "Build Linux ARM32v7 Images"

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,15 +16,13 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1.*",
-            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
+            "PB.image-builder.path": "1.*"
           }
         },
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.*",
-            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
+            "PB.image-builder.path": "2.*"
           }
         }
       ]
@@ -38,8 +36,7 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB.image-builder.path": "2.*",
-            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
+            "PB.image-builder.path": "2.*"
           }
         }
       ]
@@ -54,14 +51,14 @@
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
             "PB.image-builder.path": "1.*",
-            "PB.image-builder.customCommonArgs": "--test-var Filter=1.* --repo-owner msimons"
+            "PB.image-builder.customCommonArgs": "--test-var Filter=1.*"
           }
         },
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
             "PB.image-builder.path": "2.0*/nanoserver/*",
-            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver --repo-owner msimons"
+            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver"
           }
         }
       ]
@@ -76,7 +73,7 @@
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
             "PB.image-builder.path": "2.0*/nanoserver-1709/*",
-            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver-1709 --repo-owner msimons"
+            "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver-1709"
           }
         }
       ]
@@ -88,10 +85,7 @@
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-post-image-build",
-          "Parameters": {
-            "PB.image-builder.customCommonArgs": "--repo-owner msimons"
-          }
+          "Name": "dotnet-docker-post-image-build"
         }
       ],
       "DependsOn": [

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
       "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/run-test.ps1 -Filter $(Filter) -Architecture $(Architecture)"
     ],
     "windows": [
-      "powershell -NoProfile -Command .\\test\\run-test.ps1 -Filter $(Filter)"
+      "powershell -NoProfile -Command .\\test\\run-test.ps1 -Filter $(Filter) -OS $(OS)"
     ]
   },
   "repos": [
@@ -279,6 +279,13 @@
                   "isUndocumented": true
                 }
               }
+            },
+            {
+              "dockerfile": "2.0/runtime/nanoserver-1709/amd64",
+              "os": "windows",
+              "tags": {
+                "2.0.0-runtime-nanoserver-1709": {}
+              }
             }
           ]
         },
@@ -319,6 +326,13 @@
                 "2-sdk-nanoserver": {
                   "isUndocumented": true
                 }
+              }
+            },
+            {
+              "dockerfile": "2.0/sdk/nanoserver-1709/amd64",
+              "os": "windows",
+              "tags": {
+                "2.0.0-sdk-2.0.2-nanoserver-1709": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   },
   "repos": [
     {
-      "name": "msimons/dotnet",
+      "name": "microsoft/dotnet",
       "readmePath": "README.md",
       "images": [
         {

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   },
   "repos": [
     {
-      "name": "microsoft/dotnet",
+      "name": "msimons/dotnet",
       "readmePath": "README.md",
       "images": [
         {

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.testapp
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.testapp
@@ -1,10 +1,14 @@
 ARG base_image
 FROM $base_image
 
+# Switch to cmd shell to have consistency since this Dockerfile is used across multiple
+# sdk versions which have different shells (due to nanoserver base image).
+SHELL ["cmd", "/S", "/C"]
+
 ARG netcoreapp_version
-ARG optional_new_args
+ARG optional_new_args=" "
 
 WORKDIR testApp
-RUN dotnet new console --framework netcoreapp$env:netcoreapp_version $env:optional_new_args
+RUN dotnet new console --framework netcoreapp%netcoreapp_version% %optional_new_args%
 RUN dotnet restore -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json
 RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/ImageDescriptor.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageDescriptor.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public string DotNetCoreVersion { get; set; }
         public bool IsArm { get => String.Equals("arm", Architecture, StringComparison.OrdinalIgnoreCase); }
         public string OsVariant { get; set; }
+        public string PlatformOS { get; set; }
 
         public string RuntimeDepsVersion
         {

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string imageVersion, DotNetImageType imageType, string osVariant, bool isArm = false)
         {
             string variantName = Enum.GetName(typeof(DotNetImageType), imageType).ToLowerInvariant().Replace('_', '-');
-            string imageName = $"msimons/dotnet:{imageVersion}-{variantName}";
+            string imageName = $"microsoft/dotnet:{imageVersion}-{variantName}";
             if (!string.IsNullOrEmpty(osVariant))
             {
                 imageName += $"-{osVariant}";

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Docker.Tests
     public class ImageTests
     {
         private static string ArchFilter => Environment.GetEnvironmentVariable("IMAGE_ARCH_FILTER");
-        private static string OsFilter => Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
-        private static string VersionFilter { get; set; } = Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
+        private static string OsFilter { get; set; } = Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
+        private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
 
         private DockerHelper DockerHelper { get; set; }
 
@@ -32,10 +32,10 @@ namespace Microsoft.DotNet.Docker.Tests
             {
                 testData = new List<ImageDescriptor>
                 {
-                    new ImageDescriptor {DotNetCoreVersion = "1.0", SdkVersion = "1.1"},
-                    new ImageDescriptor {DotNetCoreVersion = "1.1", RuntimeDepsVersion = "1.0"},
-                    new ImageDescriptor {DotNetCoreVersion = "2.0"},
-                    new ImageDescriptor {DotNetCoreVersion = "2.0", OsVariant = "jessie"},
+                    new ImageDescriptor { DotNetCoreVersion = "1.0", SdkVersion = "1.1" },
+                    new ImageDescriptor { DotNetCoreVersion = "1.1", RuntimeDepsVersion = "1.0" },
+                    new ImageDescriptor { DotNetCoreVersion = "2.0" },
+                    new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = "jessie" },
                     new ImageDescriptor
                     {
                         DotNetCoreVersion = "2.0",
@@ -49,15 +49,15 @@ namespace Microsoft.DotNet.Docker.Tests
             {
                 testData = new List<ImageDescriptor>
                 {
-                        new ImageDescriptor {DotNetCoreVersion = "1.0", PlatformOS = "nanoserver", SdkVersion = "1.1"},
-                        new ImageDescriptor {DotNetCoreVersion = "1.1", PlatformOS = "nanoserver", RuntimeDepsVersion = "1.0"},
-                        new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver" },
-                        new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver-1709" },
+                    new ImageDescriptor { DotNetCoreVersion = "1.0", PlatformOS = "nanoserver", SdkVersion = "1.1" },
+                    new ImageDescriptor { DotNetCoreVersion = "1.1", PlatformOS = "nanoserver", RuntimeDepsVersion = "1.0" },
+                    new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver" },
+                    new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver-1709" },
                 };
 
-                if (VersionFilter == null)
+                if (OsFilter == null)
                 {
-                    VersionFilter = "nanoserver";
+                    OsFilter = "nanoserver";
                 }
             }
 

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -14,7 +14,8 @@ namespace Microsoft.DotNet.Docker.Tests
     public class ImageTests
     {
         private static string ArchFilter => Environment.GetEnvironmentVariable("IMAGE_ARCH_FILTER");
-        private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
+        private static string OsFilter => Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
+        private static string VersionFilter { get; set; } = Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
 
         private DockerHelper DockerHelper { get; set; }
 
@@ -25,26 +26,39 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public static IEnumerable<object[]> GetVerifyImagesData()
         {
-            List<ImageDescriptor> testData = new List<ImageDescriptor>
-            {
-                new ImageDescriptor {DotNetCoreVersion = "1.0", SdkVersion = "1.1"},
-                new ImageDescriptor {DotNetCoreVersion = "1.1", RuntimeDepsVersion = "1.0"},
-                new ImageDescriptor {DotNetCoreVersion = "2.0"},
-            };
+            List<ImageDescriptor> testData;
 
             if (DockerHelper.IsLinuxContainerModeEnabled)
             {
-                testData.AddRange(new List<ImageDescriptor>
+                testData = new List<ImageDescriptor>
+                {
+                    new ImageDescriptor {DotNetCoreVersion = "1.0", SdkVersion = "1.1"},
+                    new ImageDescriptor {DotNetCoreVersion = "1.1", RuntimeDepsVersion = "1.0"},
+                    new ImageDescriptor {DotNetCoreVersion = "2.0"},
+                    new ImageDescriptor {DotNetCoreVersion = "2.0", OsVariant = "jessie"},
+                    new ImageDescriptor
                     {
-                        new ImageDescriptor {DotNetCoreVersion = "2.0", OsVariant = "jessie"},
-                        new ImageDescriptor
-                        {
-                            DotNetCoreVersion = "2.0",
-                            OsVariant = "stretch",
-                            SdkOsVariant = "",
-                            Architecture = "arm"
-                        },
-                    });
+                        DotNetCoreVersion = "2.0",
+                        OsVariant = "stretch",
+                        SdkOsVariant = "",
+                        Architecture = "arm"
+                    },
+                };
+            }
+            else
+            {
+                testData = new List<ImageDescriptor>
+                {
+                        new ImageDescriptor {DotNetCoreVersion = "1.0", PlatformOS = "nanoserver", SdkVersion = "1.1"},
+                        new ImageDescriptor {DotNetCoreVersion = "1.1", PlatformOS = "nanoserver", RuntimeDepsVersion = "1.0"},
+                        new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver" },
+                        new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver-1709" },
+                };
+
+                if (VersionFilter == null)
+                {
+                    VersionFilter = "nanoserver";
+                }
             }
 
             string versionFilterPattern = null;
@@ -53,10 +67,19 @@ namespace Microsoft.DotNet.Docker.Tests
                 versionFilterPattern = "^" + Regex.Escape(VersionFilter).Replace(@"\*", ".*").Replace(@"\?", ".") + "$";
             }
 
+            string osFilterPattern = null;
+            if (OsFilter != null)
+            {
+                osFilterPattern = "^" + Regex.Escape(OsFilter).Replace(@"\*", ".*").Replace(@"\?", ".") + "$";
+            }
+
             // Filter out test data that does not match the active architecture and version filters.
             return testData
                 .Where(imageDescriptor => ArchFilter == null
                     || string.Equals(imageDescriptor.Architecture, ArchFilter, StringComparison.OrdinalIgnoreCase))
+                .Where(imageDescriptor => OsFilter == null
+                    || (imageDescriptor.PlatformOS != null
+                        && Regex.IsMatch(imageDescriptor.PlatformOS, osFilterPattern, RegexOptions.IgnoreCase)))
                 .Where(imageDescriptor => VersionFilter == null
                     || Regex.IsMatch(imageDescriptor.DotNetCoreVersion, versionFilterPattern, RegexOptions.IgnoreCase))
                 .Select(imageDescriptor => new object[] { imageDescriptor });
@@ -204,7 +227,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string imageVersion, DotNetImageType imageType, string osVariant, bool isArm = false)
         {
             string variantName = Enum.GetName(typeof(DotNetImageType), imageType).ToLowerInvariant().Replace('_', '-');
-            string imageName = $"microsoft/dotnet:{imageVersion}-{variantName}";
+            string imageName = $"msimons/dotnet:{imageVersion}-{variantName}";
             if (!string.IsNullOrEmpty(osVariant))
             {
                 imageName += $"-{osVariant}";

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -6,7 +6,8 @@
 [cmdletbinding()]
 param(
     [string]$Filter,
-    [string]$Architecture
+    [string]$Architecture,
+    [string]$OS
 )
 
 Set-StrictMode -Version Latest
@@ -51,6 +52,7 @@ Try {
     }
 
     $env:IMAGE_ARCH_FILTER = $Architecture
+    $env:IMAGE_OS_FILTER = $OS
     $env:IMAGE_VERSION_FILTER = $Filter
 
     & $DotnetInstallDir/dotnet test -v n


### PR DESCRIPTION
Fixes #298 

Remaining changes:

- [x] Enable cleanup steps on Windows-1709 build leg (can't enable until base images are GA)
- [x] Replace `msimons` Docker registry references with `microsoft`
