### PR TITLE
Update Get-TagsDocumentation.ps1 for RS3 images

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -261,6 +261,7 @@
             {
               "dockerfile": "2.0/runtime/nanoserver-1709/amd64",
               "os": "windows",
+              "osVersion": "1709",
               "tags": {
                 "2.0.0-runtime-nanoserver-1709": {},
                 "2.0-runtime-nanoserver-1709": {}
@@ -309,6 +310,7 @@
             {
               "dockerfile": "2.0/sdk/nanoserver-1709/amd64",
               "os": "windows",
+              "osVersion": "1709",
               "tags": {
                 "2.0.0-sdk-2.0.2-nanoserver-1709": {},
                 "2.0-sdk-nanoserver-1709": {}

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -1,6 +1,6 @@
 param(
     [string]$Branch='master',
-    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171005132855',
+    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171031123612',
     [string]$RepoName
 )
 


### PR DESCRIPTION
Rollout of https://github.com/dotnet/docker-tools/issues/56