### PR TITLE
Renamed ltsc2016 to sac2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 
 # Supported Windows Server 2016 amd64 tags
 
-- [`1.0.7-runtime-nanoserver-ltsc2016`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver/Dockerfile)
-- [`1.1.4-runtime-nanoserver-ltsc2016`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver/Dockerfile)
-- [`1.1.4-sdk-nanoserver-ltsc2016`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver/Dockerfile)
-- [`2.0.0-runtime-nanoserver-ltsc2016`, `2.0-runtime-nanoserver-ltsc2016`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
-- [`2.0.0-sdk-2.0.2-nanoserver-ltsc2016`, `2.0-sdk-nanoserver-ltsc2016`, `2.0.0-sdk-2.0.2`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
+- [`1.0.7-runtime-nanoserver-sac2016`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver/Dockerfile)
+- [`1.1.4-runtime-nanoserver-sac2016`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver/Dockerfile)
+- [`1.1.4-sdk-nanoserver-sac2016`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver/Dockerfile)
+- [`2.0.0-runtime-nanoserver-sac2016`, `2.0-runtime-nanoserver-sac2016`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
+- [`2.0.0-sdk-2.0.2-nanoserver-sac2016`, `2.0-sdk-nanoserver-sac2016`, `2.0.0-sdk-2.0.2`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
 
 # Supported Linux arm32 tags
 

--- a/manifest.json
+++ b/manifest.json
@@ -72,7 +72,7 @@
               "dockerfile": "1.0/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.0.7-runtime-nanoserver-ltsc2016": {},
+                "1.0.7-runtime-nanoserver-sac2016": {},
                 "1.0.7-runtime-nanoserver": {
                   "isUndocumented": true
                 },
@@ -111,7 +111,7 @@
               "dockerfile": "1.1/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.4-runtime-nanoserver-ltsc2016": {},
+                "1.1.4-runtime-nanoserver-sac2016": {},
                 "1.1.4-runtime-nanoserver": {
                   "isUndocumented": true
                 },
@@ -159,7 +159,7 @@
               "dockerfile": "1.1/sdk/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.4-sdk-nanoserver-ltsc2016": {},
+                "1.1.4-sdk-nanoserver-sac2016": {},
                 "1.1.4-sdk-nanoserver": {
                   "isUndocumented": true
                 },
@@ -257,14 +257,14 @@
               "dockerfile": "2.0/runtime/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.0.0-runtime-nanoserver-ltsc2016": {},
+                "2.0.0-runtime-nanoserver-sac2016": {},
                 "2.0.0-runtime-nanoserver": {
                   "isUndocumented": true
                 },
                 "2.0.0-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
-                "2.0-runtime-nanoserver-ltsc2016": {},
+                "2.0-runtime-nanoserver-sac2016": {},
                 "2.0-runtime-nanoserver": {
                   "isUndocumented": true
                 },
@@ -306,7 +306,7 @@
               "dockerfile": "2.0/sdk/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.0.0-sdk-2.0.2-nanoserver-ltsc2016": {},
+                "2.0.0-sdk-2.0.2-nanoserver-sac2016": {},
                 "2.0.0-sdk-2.0.2-nanoserver": {
                   "isUndocumented": true
                 },
@@ -319,7 +319,7 @@
                 "2.0.0-sdk-nanoserver-2.0.2-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
-                "2.0-sdk-nanoserver-ltsc2016": {},
+                "2.0-sdk-nanoserver-sac2016": {},
                 "2.0-sdk-nanoserver": {
                   "isUndocumented": true
                 },


### PR DESCRIPTION
Per guidance from Windows team - nanoserver RS1 is not ltsc2016 it it sac2016