### PR TITLE
Rollback release of 1.1.6

### DIFF
--- a/1.1/sdk/jessie/amd64/Dockerfile
+++ b/1.1/sdk/jessie/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.1.6
+ENV DOTNET_SDK_VERSION 1.1.5
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -5,7 +5,7 @@ FROM microsoft/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.1.6
+ENV DOTNET_SDK_VERSION 1.1.5
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; `

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - [`1.0.8-runtime-jessie`, `1.0.8-runtime`, `1.0-runtime` (*1.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/jessie/amd64/Dockerfile)
 - [`1.0.8-runtime-deps-jessie`, `1.0.8-runtime-deps`, `1.0-runtime-deps`, `1-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime-deps/jessie/amd64/Dockerfile)
 - [`1.1.5-runtime-jessie`, `1.1.5-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/jessie/amd64/Dockerfile)
-- [`1.1.5-sdk-1.1.6-jessie`, `1.1.5-sdk-1.1.6`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/amd64/Dockerfile)
+- [`1.1.5-sdk-jessie`, `1.1.5-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/amd64/Dockerfile)
 - [`2.0.3-runtime-stretch`, `2.0-runtime-stretch`, `2.0.3-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/stretch/amd64/Dockerfile)
 - [`2.0.3-runtime-jessie`, `2.0-runtime-jessie`, `2-runtime-jessie` (*2.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/jessie/amd64/Dockerfile)
 - [`2.0.3-runtime-deps-stretch`, `2.0-runtime-deps-stretch`, `2.0.3-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/stretch/amd64/Dockerfile)
@@ -20,7 +20,7 @@
 
 - [`1.0.8-runtime-nanoserver-sac2016`, `1.0.8-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.1.5-runtime-nanoserver-sac2016`, `1.1.5-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.5-sdk-1.1.6-nanoserver-sac2016`, `1.1.5-sdk-1.1.6`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.5-sdk-nanoserver-sac2016`, `1.1.5-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.0.3-runtime-nanoserver-sac2016`, `2.0-runtime-nanoserver-sac2016`, `2.0.3-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.0.3-sdk-nanoserver-sac2016`, `2.0-sdk-nanoserver-sac2016`, `2.0.3-sdk`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
 

--- a/manifest.json
+++ b/manifest.json
@@ -113,7 +113,7 @@
         {
           "readmeOrder": 3,
           "sharedTags": {
-            "1.1.5-sdk-1.1.6": {},
+            "1.1.5-sdk": {},
             "1.1-sdk": {},
             "1-sdk": {},
             "1.0-sdk": {
@@ -125,14 +125,14 @@
               "dockerfile": "1.1/sdk/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.1.5-sdk-1.1.6-jessie": {}
+                "1.1.5-sdk-jessie": {}
               }
             },
             {
               "dockerfile": "1.1/sdk/nanoserver-sac2016/amd64",
               "os": "windows",
               "tags": {
-                "1.1.5-sdk-1.1.6-nanoserver-sac2016": {},
+                "1.1.5-sdk-nanoserver-sac2016": {},
                 "1.1-sdk-nanoserver": {
                   "isUndocumented": true
                 },


### PR DESCRIPTION
SDK 1.1.6 release was rolled backed - therefore the Docker images need to as well.