### PR TITLE
Add Alpine SDK image

### DIFF
--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -1,12 +1,19 @@
 FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
 
+# Disable the invariant mode (set in base image)
+RUN apk add --no-cache icu-libs
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview1-008123
+ENV DOTNET_SDK_VERSION 2.1.300-preview1-008162
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-alpine.3.6-x64.tar.gz \
-    && dotnet_sha512='9a8a9bf060bbd8e6950e40e456f5a9556746b88407511bd60371b4c5a40e67abf675f42cd4ff69211e83fe59d9bad5b9efec92b5e49f7f17c608200c7fb05956' \
+    && dotnet_sha512='f1ceda789db6ede8398d1a87ad4e3ff90b2fefab5e2504a8522a445e7ef4c94b8d1fb5f52df344932360c52d03e7ac1a179c12fdabeb8c979329350b824929e3' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
@@ -14,17 +21,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && rm dotnet.tar.gz \
     && apk del .build-deps
 
-# Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
-RUN mkdir warmup \
-    && cd warmup \
-    && dotnet new \
-    && cd .. \
-    && rm -rf warmup \
-    && rm -rf /tmp/NuGetScratch
 
-RUN apk add --no-cache icu-libs
-
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
+# Trigger first run experience by running arbitrary cmd to populate local package cache
+RUN dotnet help

--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -1,0 +1,30 @@
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
+
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.1.300-preview1-008123
+
+RUN apk add --no-cache --virtual .build-deps \
+        openssl \
+    && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-alpine.3.6-x64.tar.gz \
+    && dotnet_sha512='9a8a9bf060bbd8e6950e40e456f5a9556746b88407511bd60371b4c5a40e67abf675f42cd4ff69211e83fe59d9bad5b9efec92b5e49f7f17c608200c7fb05956' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet.tar.gz \
+    && apk del .build-deps
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN mkdir warmup \
+    && cd warmup \
+    && dotnet new \
+    && cd .. \
+    && rm -rf warmup \
+    && rm -rf /tmp/NuGetScratch
+
+RUN apk add --no-cache icu-libs
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for image
 - [`2.1.0-preview1-runtime-jessie`, `2.1-runtime-jessie` (*2.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/jessie/amd64/Dockerfile)
 - [`2.1.0-preview1-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine/amd64/Dockerfile)
 - [`2.1.300-preview1-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-preview1-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.300-preview1-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine/amd64/Dockerfile)
 - [`2.1.300-preview1-sdk-jessie`, `2.1-sdk-jessie` (*2.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/jessie/amd64/Dockerfile)
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags

--- a/manifest.json
+++ b/manifest.json
@@ -416,7 +416,7 @@
           ]
         },
         {
-          "readmeOrder": 15,
+          "readmeOrder": 16,
           "platforms": [
             {
               "dockerfile": "2.1/sdk/jessie/amd64",
@@ -450,6 +450,19 @@
               "tags": {
                 "2.1.0-preview1-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
+              }
+            }
+          ]
+        },
+        {
+          "readmeOrder": 15,
+          "platforms": [
+            {
+              "dockerfile": "2.1/sdk/alpine/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.300-preview1-sdk-alpine": {},
+                "2.1-sdk-alpine": {}
               }
             }
           ]

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = OS.Stretch, SdkOsVariant = "", Architecture = "arm" },
                 new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0" },
                 new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0", OsVariant = OS.Jessie },
-                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Alpine, SdkOsVariant = "", },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Alpine },
                 new ImageDescriptor
                 {
                     DotNetCoreVersion = "2.1",


### PR DESCRIPTION
_Copied from https://github.com/dotnet/dotnet-docker-nightly/pull/508 by @richlander_

This PR isn't quite ready. Work items:

* [x] Update URL format (to match other images)
* [x] Add hash/checksum matching (to match other images)
~* [ ] Consider globalization invariant mode support for the SDK.~
* [x] Update tests appropriately to verify Alpine SDK image
* [x] Update manifest.json
* [x] Update readme

Sample I used for testing: https://github.com/dotnet/dotnet-docker-samples/tree/alpine/dotnetapp-prod

I got the image to work as expected but needed to remove invariant-mode support for the SDK. it seems like the SDK fails to run with invariant mode.

This is the error that I saw before removing globalization invariant mode / adding ICU:

```console
Step 7/11 : RUN dotnet publish -c Release -o out
 ---> Running in 0f3ff19e0e0f
Microsoft (R) Build Engine version 15.6.22.57775 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 46.27 ms for /app/dotnetapp.csproj.
/usr/share/dotnet/sdk/2.2.0-preview1-007846/Microsoft.Common.CurrentVersion.targets(2051,5): error MSB3095: Invalid argument. SafeHandle cannot be null. [/app/dotnetapp.csproj]
/usr/share/dotnet/sdk/2.2.0-preview1-007846/Microsoft.Common.CurrentVersion.targets(2051,5): error MSB3095: Parameter name: pHandle [/app/dotnetapp.csproj]
The command '/bin/sh -c dotnet publish -c Release -o out' returned a non-zero code: 1
```
