### PR TITLE
[update-dependencies] Use ProductVersion from build info

### DIFF
--- a/update-dependencies/Program.cs
+++ b/update-dependencies/Program.cs
@@ -81,8 +81,7 @@ namespace Dotnet.Docker.Nightly
 
                 return new[]
                 {
-                    // TODO use sdkBuild.ProductVersion once written to build-info
-                    CreateDependencyBuildInfo(SdkBuildInfoName, sdkBuild.BuildId),
+                    CreateDependencyBuildInfo(SdkBuildInfoName, sdkBuild.ProductVersion),
                     CreateDependencyBuildInfo(RuntimeBuildInfoName, coreSetupBuild.ProductVersion),
                 };
             };


### PR DESCRIPTION
Fixed #375 

@dotnet-bot skip ci please