### PR TITLE
Add support for specifying a custom repo-owner when building

### DIFF
--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -122,23 +122,26 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171006102106"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB.image-builder.path) --test-var VersionFilter=$(PB.image-builder.path) --test-var ArchitectureFilter=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --var VersionFilter=$(PB_image-builder_path) --var ArchitectureFilter=amd64 $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "image-builder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
-    "PB.docker.password": {
+    "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB.image-builder.customCommonArgs": {
+    "PB_image-builder_customVars": {
       "value": ""
     },
-    "PB.image-builder.path": {
+    "PB_image-builder_path": {
+      "value": ""
+    },
+    "PB_image-builder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -33,7 +33,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "pull $(image-builder.imageName)",
+        "arguments": "pull $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -52,7 +52,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.args)",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(imageBuilder.containerName) $(imageBuilder.imageName) $(imageBuilder.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -121,27 +121,27 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.imageName": {
+    "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
-    "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --var VersionFilter=$(PB_image-builder_path) --var ArchitectureFilter=amd64 $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
+    "imageBuilder.args": {
+      "value": "build --manifest manifest.json --path $(PB_imageBuilder_path) --var VersionFilter=$(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
-    "image-builder.containerName": {
+    "imageBuilder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB_image-builder_customVars": {
+    "PB_imageBuilder_customVars": {
       "value": ""
     },
-    "PB_image-builder_path": {
+    "PB_imageBuilder_path": {
       "value": ""
     },
-    "PB_image-builder_queueCustomArgs": {
+    "PB_imageBuilder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -198,28 +198,31 @@
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171006102106"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
     "image-builder.commonArgs": {
-      "value": "build --manifest manifest.json $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "image-builder.armBuildArgs": {
-      "value": "$(image-builder.commonArgs) --path $(PB.image-builder.path) --architecture arm --skip-test --test-var VersionFilter=$(PB.image-builder.path) --test-var ArchitectureFilter=arm --push --username $(PB.docker.username) --password $(PB.docker.password)",
+      "value": "$(image-builder.commonArgs) --path $(PB_image-builder_path) --architecture arm --skip-test --var VersionFilter=$(PB_image-builder_path) --var ArchitectureFilter=arm $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password)",
       "allowOverride": true
     },
     "image-builder.sdkBuildArgs": {
-      "value": "$(image-builder.commonArgs) --path $(PB.image-builder.path)/sdk/stretch/amd64 --architecture amd64 --skip-test",
+      "value": "$(image-builder.commonArgs) --path $(PB_image-builder_path)/sdk/stretch/amd64 --architecture amd64 --skip-test",
       "allowOverride": true
     },
-    "PB.docker.password": {
+    "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB.image-builder.customCommonArgs": {
+    "PB_image-builder_customVars": {
       "value": ""
     },
-    "PB.image-builder.path": {
+    "PB_image-builder_path": {
+      "value": ""
+    },
+    "PB_image-builder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -75,7 +75,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "pull $(image-builder.imageName)",
+        "arguments": "pull $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -94,7 +94,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "$(docker.runImageBuilder) $(image-builder.sdkBuildArgs)",
+        "arguments": "$(docker.runImageBuilder) $(imageBuilder.sdkBuildArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -113,7 +113,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "$(docker.runImageBuilder) $(image-builder.armBuildArgs)",
+        "arguments": "$(docker.runImageBuilder) $(imageBuilder.armBuildArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -186,7 +186,7 @@
       "value": "--rm -v $(docker.volumeName):/repo -w /repo --name $(docker.containerName)"
     },
     "docker.runImageBuilder": {
-      "value": "run  $(docker.commonRunArgs) -v /var/run/docker.sock:/var/run/docker.sock $(image-builder.imageName)"
+      "value": "run  $(docker.commonRunArgs) -v /var/run/docker.sock:/var/run/docker.sock $(imageBuilder.imageName)"
     },
     "docker.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
@@ -197,32 +197,32 @@
     "docker.volumeName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
-    "image-builder.imageName": {
+    "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
-    "image-builder.commonArgs": {
-      "value": "build --manifest manifest.json $(PB_image-builder_queueCustomArgs)",
+    "imageBuilder.commonArgs": {
+      "value": "build --manifest manifest.json $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
-    "image-builder.armBuildArgs": {
-      "value": "$(image-builder.commonArgs) --path $(PB_image-builder_path) --architecture arm --skip-test --var VersionFilter=$(PB_image-builder_path) --var ArchitectureFilter=arm $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password)",
+    "imageBuilder.armBuildArgs": {
+      "value": "$(imageBuilder.commonArgs) --path $(PB_imageBuilder_path) --architecture arm --skip-test --var VersionFilter=$(PB_imageBuilder_path) --var ArchitectureFilter=arm $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password)",
       "allowOverride": true
     },
-    "image-builder.sdkBuildArgs": {
-      "value": "$(image-builder.commonArgs) --path $(PB_image-builder_path)/sdk/stretch/amd64 --architecture amd64 --skip-test",
+    "imageBuilder.sdkBuildArgs": {
+      "value": "$(imageBuilder.commonArgs) --path $(PB_imageBuilder_path)/sdk/stretch/amd64 --architecture amd64 --skip-test",
       "allowOverride": true
     },
     "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB_image-builder_customVars": {
+    "PB_imageBuilder_customVars": {
       "value": ""
     },
-    "PB_image-builder_path": {
+    "PB_imageBuilder_path": {
       "value": ""
     },
-    "PB_image-builder_queueCustomArgs": {
+    "PB_imageBuilder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -33,7 +33,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "pull $(image-builder.imageName)",
+        "arguments": "pull $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -52,7 +52,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.publishManifest.args)",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(imageBuilder.containerName) $(imageBuilder.imageName) $(imageBuilder.publishManifest.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -71,7 +71,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.updateReadme.args)",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(imageBuilder.containerName) $(imageBuilder.imageName) $(imageBuilder.updateReadme.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -140,29 +140,29 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.imageName": {
+    "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
-    "image-builder.common.args": {
-      "value": "--manifest manifest.json --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
+    "imageBuilder.common.args": {
+      "value": "--manifest manifest.json --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
-    "image-builder.publishManifest.args": {
-      "value": "publishManifest $(image-builder.common.args)",
+    "imageBuilder.publishManifest.args": {
+      "value": "publishManifest $(imageBuilder.common.args)",
       "allowOverride": true
     },
-    "image-builder.updateReadme.args": {
-      "value": "updateReadme $(image-builder.common.args)",
+    "imageBuilder.updateReadme.args": {
+      "value": "updateReadme $(imageBuilder.common.args)",
       "allowOverride": true
     },
-    "image-builder.containerName": {
+    "imageBuilder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB_image-builder_queueCustomArgs": {
+    "PB_imageBuilder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -141,10 +141,10 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171006102106"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
     "image-builder.common.args": {
-      "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "--manifest manifest.json --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "image-builder.publishManifest.args": {
@@ -158,12 +158,12 @@
     "image-builder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
-    "PB.image-builder.customCommonArgs": {
-      "value": ""
-    },
-    "PB.docker.password": {
+    "PB_docker_password": {
       "value": null,
       "isSecret": true
+    },
+    "PB_image-builder_queueCustomArgs": {
+      "value": ""
     }
   },
   "demands": [

--- a/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
@@ -35,7 +35,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "pull $(image-builder.imageName)",
+        "arguments": "pull $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -54,7 +54,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
+        "arguments": "create --name $(imageBuilder.containerName) $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -73,7 +73,7 @@
       },
       "inputs": {
         "filename": "docker ",
-        "arguments": "cp $(image-builder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
+        "arguments": "cp $(imageBuilder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -92,7 +92,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "rmi -f $(image-builder.imageName)",
+        "arguments": "rmi -f $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -111,7 +111,7 @@
       },
       "inputs": {
         "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
-        "arguments": "$(image-builder.args)",
+        "arguments": "$(imageBuilder.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -182,27 +182,27 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.imageName": {
+    "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
     },
-    "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --var ArchitectureFilter=amd64 $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
+    "imageBuilder.args": {
+      "value": "build --manifest manifest.json --path $(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
-    "image-builder.containerName": {
+    "imageBuilder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB_image-builder_customVars": {
+    "PB_imageBuilder_customVars": {
       "value": ""
     },
-    "PB_image-builder_path": {
+    "PB_imageBuilder_path": {
       "value": ""
     },
-    "PB_image-builder_queueCustomArgs": {
+    "PB_imageBuilder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
@@ -183,23 +183,26 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20171006103436"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
     },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB.image-builder.path) --test-var ArchitectureFilter=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --var ArchitectureFilter=amd64 $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "image-builder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
-    "PB.docker.password": {
+    "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB.image-builder.customCommonArgs": {
+    "PB_image-builder_customVars": {
       "value": ""
     },
-    "PB.image-builder.path": {
+    "PB_image-builder_path": {
+      "value": ""
+    },
+    "PB_image-builder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
@@ -183,23 +183,26 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20171006103436"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
     },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB.image-builder.path) --test-var ArchitectureFilter=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --var ArchitectureFilter=amd64 $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "image-builder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
-    "PB.docker.password": {
+    "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB.image-builder.customCommonArgs": {
+    "PB_image-builder_customVars": {
       "value": ""
     },
-    "PB.image-builder.path": {
+    "PB_image-builder_path": {
+      "value": ""
+    },
+    "PB_image-builder_queueCustomArgs": {
       "value": ""
     }
   },
@@ -258,7 +261,7 @@
     }
   },
   "id": 6216,
-  "name": "dotnet-docker-windows-amd64-images",
+  "name": "dotnet-docker-windows-sac2016-amd64-images",
   "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6216",
   "path": "\\",
   "type": "build",

--- a/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
@@ -35,7 +35,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "pull $(image-builder.imageName)",
+        "arguments": "pull $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -54,7 +54,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
+        "arguments": "create --name $(imageBuilder.containerName) $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -73,7 +73,7 @@
       },
       "inputs": {
         "filename": "docker ",
-        "arguments": "cp $(image-builder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
+        "arguments": "cp $(imageBuilder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -92,7 +92,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "rmi -f $(image-builder.imageName)",
+        "arguments": "rmi -f $(imageBuilder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -111,7 +111,7 @@
       },
       "inputs": {
         "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
-        "arguments": "$(image-builder.args)",
+        "arguments": "$(imageBuilder.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -182,27 +182,27 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.imageName": {
+    "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
     },
-    "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --var ArchitectureFilter=amd64 $(PB_image-builder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
+    "imageBuilder.args": {
+      "value": "build --manifest manifest.json --path $(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
-    "image-builder.containerName": {
+    "imageBuilder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB_image-builder_customVars": {
+    "PB_imageBuilder_customVars": {
       "value": ""
     },
-    "PB_image-builder_path": {
+    "PB_imageBuilder_path": {
       "value": ""
     },
-    "PB_image-builder_queueCustomArgs": {
+    "PB_imageBuilder_queueCustomArgs": {
       "value": ""
     }
   },

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,13 +16,13 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "1.*"
+            "PB_imageBuilder_path": "1.*"
           }
         },
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "2.*"
+            "PB_imageBuilder_path": "2.*"
           }
         }
       ]
@@ -36,7 +36,7 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB_image-builder_path": "2.*"
+            "PB_imageBuilder_path": "2.*"
           }
         }
       ]
@@ -50,22 +50,22 @@
         {
           "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "1.*",
-            "PB_image-builder_customVars": "--var VersionFilter=1.* --var OSFilter=nanoserver-sac2016"
+            "PB_imageBuilder_path": "1.*",
+            "PB_imageBuilder_customVars": "--var VersionFilter=1.* --var OSFilter=nanoserver-sac2016"
           }
         },
         {
           "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "2.0*/nanoserver-sac2016/*",
-            "PB_image-builder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-sac2016"
+            "PB_imageBuilder_path": "2.0*/nanoserver-sac2016/*",
+            "PB_imageBuilder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-sac2016"
           }
         },
         {
           "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "2.1*/nanoserver-sac2016/*",
-            "PB_image-builder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-sac2016"
+            "PB_imageBuilder_path": "2.1*/nanoserver-sac2016/*",
+            "PB_imageBuilder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-sac2016"
           }
         }
       ]
@@ -79,15 +79,15 @@
         {
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "2.0*/nanoserver-1709/*",
-            "PB_image-builder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-1709"
+            "PB_imageBuilder_path": "2.0*/nanoserver-1709/*",
+            "PB_imageBuilder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-1709"
           }
         },
         {
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "2.1*/nanoserver-1709/*",
-            "PB_image-builder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-1709"
+            "PB_imageBuilder_path": "2.1*/nanoserver-1709/*",
+            "PB_imageBuilder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-1709"
           }
         }
       ]

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,13 +16,13 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1.*"
+            "PB_image-builder_path": "1.*"
           }
         },
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.*"
+            "PB_image-builder_path": "2.*"
           }
         }
       ]
@@ -36,36 +36,36 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB.image-builder.path": "2.*"
+            "PB_image-builder_path": "2.*"
           }
         }
       ]
     },
     {
-      "Name": "Build Windows AMD64 Images",
+      "Name": "Build Windows sac2016 AMD64 Images",
       "Parameters": {
         "TreatWarningsAsErrors": "false"
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-windows-amd64-images",
+          "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1.*",
-            "PB.image-builder.customCommonArgs": "--test-var VersionFilter=1.*"
+            "PB_image-builder_path": "1.*",
+            "PB_image-builder_customVars": "--var VersionFilter=1.* --var OSFilter=nanoserver-sac2016"
           }
         },
         {
-          "Name": "dotnet-docker-windows-amd64-images",
+          "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.0*/nanoserver-sac2016/*",
-            "PB.image-builder.customCommonArgs": "--test-var VersionFilter=2.0* --test-var OSFilter=nanoserver-sac2016"
+            "PB_image-builder_path": "2.0*/nanoserver-sac2016/*",
+            "PB_image-builder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-sac2016"
           }
         },
         {
-          "Name": "dotnet-docker-windows-amd64-images",
+          "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.1*/nanoserver-sac2016/*",
-            "PB.image-builder.customCommonArgs": "--test-var VersionFilter=2.1* --test-var OSFilter=nanoserver-sac2016"
+            "PB_image-builder_path": "2.1*/nanoserver-sac2016/*",
+            "PB_image-builder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-sac2016"
           }
         }
       ]
@@ -79,15 +79,15 @@
         {
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.0*/nanoserver-1709/*",
-            "PB.image-builder.customCommonArgs": "--test-var VersionFilter=2.0* --test-var OSFilter=nanoserver-1709"
+            "PB_image-builder_path": "2.0*/nanoserver-1709/*",
+            "PB_image-builder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-1709"
           }
         },
         {
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.1*/nanoserver-1709/*",
-            "PB.image-builder.customCommonArgs": "--test-var VersionFilter=2.1* --test-var OSFilter=nanoserver-1709"
+            "PB_image-builder_path": "2.1*/nanoserver-1709/*",
+            "PB_image-builder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-1709"
           }
         }
       ]
@@ -104,7 +104,7 @@
       ],
       "DependsOn": [
         "Build Windows 1709 AMD64 Images",
-        "Build Windows AMD64 Images",
+        "Build Windows sac2016 AMD64 Images",
         "Build Linux AMD64 Images",
         "Build Linux ARM32v7 Images"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "testCommands": {
     "linux": [
       "docker build --rm -t testrunner -f ./test/Dockerfile.linux.testrunner .",
-      "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File ./test/run-test.ps1 -VersionFilter $(VersionFilter) -ArchitectureFilter $(ArchitectureFilter)"
+      "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File ./test/run-test.ps1 -VersionFilter $(VersionFilter) -ArchitectureFilter $(ArchitectureFilter) -RepoOwner $(System:RepoOwner)"
     ],
     "windows": [
-      "powershell -NoProfile -Command .\\test\\run-test.ps1 -VersionFilter $(VersionFilter) -OSFilter $(OSFilter)"
+      "powershell -NoProfile -Command .\\test\\run-test.ps1 -VersionFilter $(VersionFilter) -OSFilter $(OSFilter) -RepoOwner $(System:RepoOwner)"
     ]
   },
   "repos": [

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Docker.Tests
     {
         private static string ArchFilter => Environment.GetEnvironmentVariable("IMAGE_ARCH_FILTER");
         private static string OsFilter => Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
+        private static string RepoOwner => Environment.GetEnvironmentVariable("REPO_OWNER") ?? "microsoft";
         private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
 
         private static ImageDescriptor[] LinuxTestData = new ImageDescriptor[]
@@ -236,7 +237,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string imageVersion, DotNetImageType imageType, string osVariant, bool isArm = false)
         {
             string variantName = Enum.GetName(typeof(DotNetImageType), imageType).ToLowerInvariant().Replace('_', '-');
-            string imageName = $"microsoft/dotnet-nightly:{imageVersion}-{variantName}";
+            string imageName = $"{RepoOwner}/dotnet-nightly:{imageVersion}-{variantName}";
             if (!string.IsNullOrEmpty(osVariant))
             {
                 imageName += $"-{osVariant}";

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -7,7 +7,8 @@
 param(
     [string]$VersionFilter,
     [string]$ArchitectureFilter,
-    [string]$OSFilter
+    [string]$OSFilter,
+    [string]$RepoOwner
 )
 
 Set-StrictMode -Version Latest
@@ -54,6 +55,7 @@ Try {
     $env:IMAGE_ARCH_FILTER = $ArchitectureFilter
     $env:IMAGE_OS_FILTER = $OSFilter
     $env:IMAGE_VERSION_FILTER = $VersionFilter
+    $env:REPO_OWNER = $RepoOwner
 
     & $DotnetInstallDir/dotnet test -v n
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/docker-tools/issues/21

- Updated image builder to latest.  Required renaming `--test-var` to `--var`.
- Updated pipebuild to latest in order to make use of functionality to pass any variables with `PB_` prefix.
- Added PB_image-builder_queueCustomArgs variable to build defs to flow custom args such as `--repo-owner`