### PR TITLE
2.1 images

### DIFF
--- a/2.1/runtime-deps/bionic/amd64/Dockerfile
+++ b/2.1/runtime-deps/bionic/amd64/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu60 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*

--- a/2.1/runtime-deps/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/bionic/arm32v7/Dockerfile
@@ -1,0 +1,19 @@
+FROM arm32v7/ubuntu:bionic
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu60 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*

--- a/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stretch-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu57 \
+        liblttng-ust0 \
+        libssl1.0.2 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*

--- a/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile
@@ -1,0 +1,19 @@
+FROM arm32v7/debian:stretch-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu57 \
+        liblttng-ust0 \
+        libssl1.0.2 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*

--- a/2.1/runtime/bionic/amd64/Dockerfile
+++ b/2.1/runtime/bionic/amd64/Dockerfile
@@ -1,0 +1,17 @@
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-bionic
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.1.0-preview1-26218-02
+
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
+    && dotnet_sha512='65ae80d777d10e62b50c37939349fd4f39ee2274df76b4a9fa8a9e2ff57b420a11d044b226fb8d34d8b50af3c44724d5d4b83fb56e4ac16d8f54b4fce2832c89' \
+    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/2.1/runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime/bionic/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.0-runtime-deps
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-bionic-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -8,8 +8,8 @@ RUN apt-get update \
 # Install .NET Core
 ENV DOTNET_VERSION 2.1.0-preview1-26218-02
 
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='65ae80d777d10e62b50c37939349fd4f39ee2274df76b4a9fa8a9e2ff57b420a11d044b226fb8d34d8b50af3c44724d5d4b83fb56e4ac16d8f54b4fce2832c89' \
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
+    && dotnet_sha512='17299b0a77ce8b7d221b73336a5cfe9becbbf45b2207712bcb9b48de128ec0e7a42957208a5de0ced0038be2f13516240c2f9127fb780ba0b5d625529342f9c3' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.0-runtime-deps-stretch-arm32v7
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -8,8 +8,8 @@ RUN apt-get update \
 # Install .NET Core
 ENV DOTNET_VERSION 2.1.0-preview1-26218-02
 
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='17299b0a77ce8b7d221b73336a5cfe9becbbf45b2207712bcb9b48de128ec0e7a42957208a5de0ced0038be2f13516240c2f9127fb780ba0b5d625529342f9c3' \
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
+    && dotnet_sha512='65ae80d777d10e62b50c37939349fd4f39ee2274df76b4a9fa8a9e2ff57b420a11d044b226fb8d34d8b50af3c44724d5d4b83fb56e4ac16d8f54b4fce2832c89' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime/stretch-slim/arm32v7/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.0-preview1-26218-02
+ENV DOTNET_VERSION 2.1.0-preview1-26216-03
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='17299b0a77ce8b7d221b73336a5cfe9becbbf45b2207712bcb9b48de128ec0e7a42957208a5de0ced0038be2f13516240c2f9127fb780ba0b5d625529342f9c3' \
+    && dotnet_sha512='7f3dc8f25bc2df9068cbd0e9f0d564ec4a4885e79b45af7cbda2fecb56153340e192d3fa8029040b4fe844cdd129a94fd8ed8e727f6b05a1eff12fc1d6d43b0b' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime/stretch-slim/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.0-runtime-deps-jessie
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-stretch-slim-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -8,8 +8,8 @@ RUN apt-get update \
 # Install .NET Core
 ENV DOTNET_VERSION 2.1.0-preview1-26218-02
 
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='65ae80d777d10e62b50c37939349fd4f39ee2274df76b4a9fa8a9e2ff57b420a11d044b226fb8d34d8b50af3c44724d5d4b83fb56e4ac16d8f54b4fce2832c89' \
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
+    && dotnet_sha512='17299b0a77ce8b7d221b73336a5cfe9becbbf45b2207712bcb9b48de128ec0e7a42957208a5de0ced0038be2f13516240c2f9127fb780ba0b5d625529342f9c3' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie-scm
+FROM buildpack-deps:bionic-scm
 
 # Install .NET CLI dependencies
 RUN apt-get update \
@@ -7,7 +7,7 @@ RUN apt-get update \
         libcurl3 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu52 \
+        libicu60 \
         liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \

--- a/README.md
+++ b/README.md
@@ -8,18 +8,20 @@ See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for image
 - [`1.0.9-runtime-deps-jessie`, `1.0.9-runtime-deps`, `1.0-runtime-deps`, `1-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
 - [`1.1.6-runtime-jessie`, `1.1.6-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/jessie/amd64/Dockerfile)
 - [`1.1.6-sdk-1.1.7-jessie`, `1.1.6-sdk-1.1.7`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/jessie/amd64/Dockerfile)
-- [`2.0.5-runtime-stretch`, `2.0-runtime-stretch`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/stretch/amd64/Dockerfile)
 - [`2.0.5-runtime-jessie`, `2.0-runtime-jessie`, `2-runtime-jessie` (*2.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/jessie/amd64/Dockerfile)
-- [`2.0.5-runtime-deps-stretch`, `2.0-runtime-deps-stretch`, `2.0.5-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/stretch/amd64/Dockerfile)
+- [`2.0.5-runtime-stretch`, `2.0-runtime-stretch`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/stretch/amd64/Dockerfile)
 - [`2.0.5-runtime-deps-jessie`, `2.0-runtime-deps-jessie`, `2-runtime-deps-jessie` (*2.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/jessie/amd64/Dockerfile)
-- [`2.0.5-sdk-2.1.4-stretch`, `2.0-sdk-stretch`, `2.0.5-sdk-2.1.4`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/sdk/stretch/amd64/Dockerfile)
+- [`2.0.5-runtime-deps-stretch`, `2.0-runtime-deps-stretch`, `2.0.5-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/stretch/amd64/Dockerfile)
 - [`2.0.5-sdk-2.1.4-jessie`, `2.0-sdk-jessie`, `2-sdk-jessie` (*2.0/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/sdk/jessie/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-stretch`, `2.1-runtime-stretch`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch/amd64/Dockerfile)
+- [`2.0.5-sdk-2.1.4-stretch`, `2.0-sdk-stretch`, `2.0.5-sdk-2.1.4`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/sdk/stretch/amd64/Dockerfile)
 - [`2.1.0-preview1-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-jessie`, `2.1-runtime-jessie` (*2.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/jessie/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
 - [`2.1.0-preview1-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.0-preview1-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.1.300-preview1-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
 - [`2.1.300-preview1-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-preview1-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.300-preview1-sdk-jessie`, `2.1-sdk-jessie` (*2.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/jessie/amd64/Dockerfile)
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
@@ -42,7 +44,10 @@ See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for image
 
 - [`2.0.5-runtime-stretch-arm32v7`, `2.0-runtime-stretch-arm32v7`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/stretch/arm32v7/Dockerfile)
 - [`2.0.5-runtime-deps-stretch-arm32v7`, `2.0-runtime-deps-stretch-arm32v7`, `2.0.5-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/stretch/arm32v7/Dockerfile)
-- [`2.1.0-preview1-runtime-stretch-arm32v7`, `2.1-runtime-stretch-arm32v7`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch/arm32v7/Dockerfile)
+- [`2.1.0-preview1-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.0-preview1-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.0-preview1-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 
 >**Note:** .NET Core multi-arch tags, such as 2.0-runtime, have been updated to use nanoserver-1709 images if your host is Windows Server 2016 Version 1709 or higher or Windows 10 Fall Creators Update (Version 1709) or higher. You need Docker 17.10 or later to take advantage of these updated tags.
 

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -22,7 +22,13 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB_imageBuilder_path": "2.*"
+            "PB_imageBuilder_path": "2.0*"
+          }
+        },
+        {
+          "Name": "dotnet-docker-linux-amd64-images",
+          "Parameters": {
+            "PB_imageBuilder_path": "2.1*"
           }
         }
       ]
@@ -36,7 +42,13 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB_imageBuilder_path": "2.*"
+            "PB_imageBuilder_path": "2.0*"
+          }
+        },
+        {
+          "Name": "dotnet-docker-linux-arm32v7-images",
+          "Parameters": {
+            "PB_imageBuilder_path": "2.1*"
           }
         }
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -153,7 +153,7 @@
           ]
         },
         {
-          "readmeOrder": 6,
+          "readmeOrder": 7,
           "sharedTags": {
             "2.0.5-runtime-deps": {},
             "2.0-runtime-deps": {},
@@ -185,7 +185,7 @@
           ]
         },
         {
-          "readmeOrder": 4,
+          "readmeOrder": 5,
           "sharedTags": {
             "2.0.5-runtime": {},
             "2.0-runtime": {},
@@ -240,7 +240,7 @@
           ]
         },
         {
-          "readmeOrder": 8,
+          "readmeOrder": 9,
           "sharedTags": {
             "2.0.5-sdk-2.1.4": {},
             "2.0-sdk": {},
@@ -283,7 +283,7 @@
           ]
         },
         {
-          "readmeOrder": 7,
+          "readmeOrder": 6,
           "platforms": [
             {
               "dockerfile": "2.0/runtime-deps/jessie/amd64",
@@ -297,7 +297,7 @@
           ]
         },
         {
-          "readmeOrder": 5,
+          "readmeOrder": 4,
           "platforms": [
             {
               "dockerfile": "2.0/runtime/jessie/amd64",
@@ -311,7 +311,7 @@
           ]
         },
         {
-          "readmeOrder": 9,
+          "readmeOrder": 8,
           "platforms": [
             {
               "dockerfile": "2.0/sdk/jessie/amd64",
@@ -325,27 +325,54 @@
           ]
         },
         {
-          "readmeOrder": 10,
+          "readmeOrder": 17,
+          "sharedTags": {
+            "2.1.0-preview1-runtime-deps": {},
+            "2.1-runtime-deps": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime-deps/stretch-slim/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview1-runtime-deps-stretch-slim": {},
+                "2.1-runtime-deps-stretch-slim": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview1-runtime-deps-stretch-slim-arm32v7": {},
+                "2.1-runtime-deps-stretch-slim-arm32v7": {}
+              },
+              "variant": "armv7"
+            }
+          ]
+        },
+        {
+          "readmeOrder": 13,
           "sharedTags": {
             "2.1.0-preview1-runtime": {},
             "2.1-runtime": {}
           },
           "platforms": [
             {
-              "dockerfile": "2.1/runtime/stretch/amd64",
+              "dockerfile": "2.1/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview1-runtime-stretch": {},
-                "2.1-runtime-stretch": {}
+                "2.1.0-preview1-runtime-stretch-slim": {},
+                "2.1-runtime-stretch-slim": {}
               }
             },
             {
               "architecture": "arm",
-              "dockerfile": "2.1/runtime/stretch/arm32v7",
+              "dockerfile": "2.1/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.0-preview1-runtime-stretch-arm32v7": {},
-                "2.1-runtime-stretch-arm32v7": {}
+                "2.1.0-preview1-runtime-stretch-slim-arm32v7": {},
+                "2.1-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "armv7"
             },
@@ -369,7 +396,7 @@
           ]
         },
         {
-          "readmeOrder": 14,
+          "readmeOrder": 19,
           "sharedTags": {
             "2.1.300-preview1-sdk": {},
             "2.1-sdk": {}
@@ -403,33 +430,7 @@
           ]
         },
         {
-          "readmeOrder": 12,
-          "platforms": [
-            {
-              "dockerfile": "2.1/runtime/jessie/amd64",
-              "os": "linux",
-              "tags": {
-                "2.1.0-preview1-runtime-jessie": {},
-                "2.1-runtime-jessie": {}
-              }
-            }
-          ]
-        },
-        {
-          "readmeOrder": 15,
-          "platforms": [
-            {
-              "dockerfile": "2.1/sdk/jessie/amd64",
-              "os": "linux",
-              "tags": {
-                "2.1.300-preview1-sdk-jessie": {},
-                "2.1-sdk-jessie": {}
-              }
-            }
-          ]
-        },
-        {
-          "readmeOrder": 13,
+          "readmeOrder": 14,
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/alpine/amd64",
@@ -451,6 +452,75 @@
                 "2.1.0-preview1-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
               }
+            }
+          ]
+        },
+        {
+          "readmeOrder": 15,
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime-deps/bionic/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview1-runtime-deps-bionic": {},
+                "2.1-runtime-deps-bionic": {}
+              }
+            }
+          ]
+        },
+        {
+          "readmeOrder": 12,
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime/bionic/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview1-runtime-bionic": {},
+                "2.1-runtime-bionic": {}
+              }
+            }
+          ]
+        },
+        {
+          "readmeOrder": 18,
+          "platforms": [
+            {
+              "dockerfile": "2.1/sdk/bionic/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.300-preview1-sdk-bionic": {},
+                "2.1-sdk-bionic": {}
+              }
+            }
+          ]
+        },
+        {
+          "readmeOrder": 16,
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "2.1/runtime-deps/bionic/arm32v7",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview1-runtime-deps-bionic-arm32v7": {},
+                "2.1-runtime-deps-bionic-arm32v7": {}
+              },
+              "variant": "armv7"
+            }
+          ]
+        },
+        {
+          "readmeOrder": 10,
+          "platforms": [
+            {
+              "architecture": "arm",
+              "dockerfile": "2.1/runtime/bionic/arm32v7",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview1-runtime-bionic-arm32v7": {},
+                "2.1-runtime-bionic-arm32v7": {}
+              },
+              "variant": "armv7"
             }
           ]
         }

--- a/netci.groovy
+++ b/netci.groovy
@@ -16,7 +16,7 @@ platformList.each { platform ->
         versionList = ['1.', '2.0', '2.1']
     }
     else {
-        versionList = ['1.', '2.']
+        versionList = ['1.', '2.0', '2.1']
     }
 
     versionList.each { version ->

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -25,17 +25,11 @@ namespace Microsoft.DotNet.Docker.Tests
                 new ImageDescriptor { DotNetCoreVersion = "2.0" },
                 new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = OS.Jessie },
                 new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = OS.Stretch, SdkOsVariant = "", Architecture = "arm" },
-                new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0" },
-                new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0", OsVariant = OS.Jessie },
-                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Alpine, SdkOsVariant = "", },
-                new ImageDescriptor
-                {
-                    DotNetCoreVersion = "2.1",
-                    RuntimeDepsVersion = "2.0",
-                    OsVariant = OS.Stretch,
-                    SdkOsVariant = "",
-                    Architecture = "arm"
-                },
+                new ImageDescriptor { DotNetCoreVersion = "2.1" },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Bionic },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Alpine, SdkOsVariant = "" },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.StretchSlim, SdkOsVariant = "", Architecture = "arm" },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Bionic, SdkOsVariant = "", Architecture = "arm" },
             };
         private static ImageDescriptor[] WindowsTestData = new ImageDescriptor[]
             {

--- a/test/Microsoft.DotNet.Docker.Tests/OS.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/OS.cs
@@ -7,8 +7,10 @@ namespace Microsoft.DotNet.Docker.Tests
     public class OS
     {
         public const string Alpine = "alpine";
+        public const string Bionic = "bionic";
         public const string Jessie = "jessie";
         public const string Stretch = "stretch";
+        public const string StretchSlim = "stretch-slim";
         public const string NanoServerSac2016 = "nanoserver-sac2016";
         public const string NanoServer1709 = "nanoserver-1709";
     }


### PR DESCRIPTION
- Switch to `stretch-slim` instead of `stretch` for all runtime images. Keep SDK as-is (no buildpack-deps for slim images)
- Keep using Stretch for MA tags like `2-sdk`, `2.1-runtime` and `latest`
- Drop Jessie SDK and Runtime (X64)
- Add Ubuntu:18.04 (bionic) for SDK and Runtime (X64 and ARM)