### PR TITLE
Add infrastructure to build and push samples to Docker Hub

### DIFF
--- a/build-pipeline/README.md
+++ b/build-pipeline/README.md
@@ -1,0 +1,1 @@
+The contents of the [build-pipeline](build-pipeline) folder are used by the .NET Core engineering infrastructure to build and publish the images to Docker Hub.

--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -124,8 +124,11 @@
     "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
+    "imageBuilder.manifest": {
+      "value": "manifest.json"
+    },
     "imageBuilder.args": {
-      "value": "build --manifest manifest.json --path $(PB_imageBuilder_path) --var VersionFilter=$(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
+      "value": "build --manifest $(imageBuilder.manifest) --path $(PB_imageBuilder_path) --var VersionFilter=$(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customArgs) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
     "imageBuilder.containerName": {
@@ -135,14 +138,15 @@
       "value": null,
       "isSecret": true
     },
-    "PB_imageBuilder_customVars": {
+    "PB_imageBuilder_customArgs": {
       "value": ""
     },
     "PB_imageBuilder_path": {
-      "value": ""
+      "value": "*"
     },
     "PB_imageBuilder_queueCustomArgs": {
-      "value": ""
+      "value": "",
+      "allowOverride": true
     }
   },
   "demands": [

--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "imageBuilder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180227221546"
     },
     "imageBuilder.manifest": {
       "value": "manifest.json"

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -200,12 +200,15 @@
     "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
+    "imageBuilder.manifest": {
+      "value": "manifest.json"
+    },
     "imageBuilder.commonArgs": {
-      "value": "build --manifest manifest.json $(PB_imageBuilder_queueCustomArgs)",
+      "value": "build --manifest $(imageBuilder.manifest) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
     "imageBuilder.armBuildArgs": {
-      "value": "$(imageBuilder.commonArgs) --path $(PB_imageBuilder_path) --architecture arm --skip-test --var VersionFilter=$(PB_imageBuilder_path) --var ArchitectureFilter=arm $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password)",
+      "value": "$(imageBuilder.commonArgs) --path $(PB_imageBuilder_path) --architecture arm --skip-test --var VersionFilter=$(PB_imageBuilder_path) --var ArchitectureFilter=arm $(PB_imageBuilder_customArgs) --push --username $(PB_docker_username) --password $(PB_docker_password)",
       "allowOverride": true
     },
     "imageBuilder.sdkBuildArgs": {
@@ -216,14 +219,15 @@
       "value": null,
       "isSecret": true
     },
-    "PB_imageBuilder_customVars": {
+    "PB_imageBuilder_customArgs": {
       "value": ""
     },
     "PB_imageBuilder_path": {
-      "value": ""
+      "value": "*"
     },
     "PB_imageBuilder_queueCustomArgs": {
-      "value": ""
+      "value": "",
+      "allowOverride": true
     }
   },
   "demands": [

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -198,7 +198,7 @@
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "imageBuilder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180227221546"
     },
     "imageBuilder.manifest": {
       "value": "manifest.json"

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -143,8 +143,11 @@
     "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
     },
+    "imageBuilder.manifest": {
+      "value": "manifest.json"
+    },
     "imageBuilder.common.args": {
-      "value": "--manifest manifest.json --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
+      "value": "--manifest $(imageBuilder.manifest) --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
     "imageBuilder.publishManifest.args": {

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "imageBuilder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180130154400"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180227221546"
     },
     "imageBuilder.manifest": {
       "value": "manifest.json"

--- a/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
@@ -185,8 +185,11 @@
     "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
     },
+    "imageBuilder.manifest": {
+      "value": "manifest.json"
+    },
     "imageBuilder.args": {
-      "value": "build --manifest manifest.json --path $(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
+      "value": "build --manifest $(imageBuilder.manifest) --path $(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customArgs) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
     "imageBuilder.containerName": {
@@ -196,14 +199,15 @@
       "value": null,
       "isSecret": true
     },
-    "PB_imageBuilder_customVars": {
+    "PB_imageBuilder_customArgs": {
       "value": ""
     },
     "PB_imageBuilder_path": {
-      "value": ""
+      "value": "*"
     },
     "PB_imageBuilder_queueCustomArgs": {
-      "value": ""
+      "value": "",
+      "allowOverride": true
     }
   },
   "demands": [

--- a/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-1709-amd64-images.json
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "imageBuilder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180227141513"
     },
     "imageBuilder.manifest": {
       "value": "manifest.json"

--- a/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
@@ -185,8 +185,11 @@
     "imageBuilder.imageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
     },
+    "imageBuilder.manifest": {
+      "value": "manifest.json"
+    },
     "imageBuilder.args": {
-      "value": "build --manifest manifest.json --path $(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customVars) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
+      "value": "build --manifest $(imageBuilder.manifest) --path $(PB_imageBuilder_path) --var ArchitectureFilter=amd64 $(PB_imageBuilder_customArgs) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_imageBuilder_queueCustomArgs)",
       "allowOverride": true
     },
     "imageBuilder.containerName": {
@@ -196,14 +199,15 @@
       "value": null,
       "isSecret": true
     },
-    "PB_imageBuilder_customVars": {
+    "PB_imageBuilder_customArgs": {
       "value": ""
     },
     "PB_imageBuilder_path": {
-      "value": ""
+      "value": "*"
     },
     "PB_imageBuilder_queueCustomArgs": {
-      "value": ""
+      "value": "",
+      "allowOverride": true
     }
   },
   "demands": [

--- a/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-sac2016-amd64-images.json
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "imageBuilder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180130074345"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180227141513"
     },
     "imageBuilder.manifest": {
       "value": "manifest.json"

--- a/build-pipeline/pipeline-samples.json
+++ b/build-pipeline/pipeline-samples.json
@@ -16,8 +16,7 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "imageBuilder.manifest": "manifest.samples.json",
-            "PB_imageBuilder_customArgs": "--skip-pulling"
+            "imageBuilder.manifest": "manifest.samples.json"
           }
         }
       ]
@@ -31,8 +30,7 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "imageBuilder.manifest": "manifest.samples.json",
-            "PB_imageBuilder_customArgs": "--skip-pulling"
+            "imageBuilder.manifest": "manifest.samples.json"
           }
         }
       ]
@@ -47,7 +45,7 @@
           "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
             "imageBuilder.manifest": "manifest.samples.json",
-            "PB_imageBuilder_customArgs": "--os-version 10.0.14393 --skip-pulling"
+            "PB_imageBuilder_customArgs": "--os-version 10.0.14393"
           }
         }
       ]
@@ -62,7 +60,7 @@
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
             "imageBuilder.manifest": "manifest.samples.json",
-            "PB_imageBuilder_customArgs": "--os-version 10.0.16299 --skip-pulling"
+            "PB_imageBuilder_customArgs": "--os-version 10.0.16299"
           }
         }
       ]

--- a/build-pipeline/pipeline-samples.json
+++ b/build-pipeline/pipeline-samples.json
@@ -1,0 +1,91 @@
+{
+  "Repository": "dotnet-docker",
+  "Definitions": {
+    "Path": ".",
+    "Type": "VSTS",
+    "BaseUrl": "https://devdiv.visualstudio.com/DefaultCollection",
+    "SkipBranchAndVersionOverrides": "false"
+  },
+  "Pipelines": [
+    {
+      "Name": "Build Linux AMD64 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-linux-amd64-images",
+          "Parameters": {
+            "imageBuilder.manifest": "manifest.samples.json",
+            "PB_imageBuilder_customArgs": "--skip-pulling"
+          }
+        }
+      ]
+    },
+    {
+      "Name": "Build Linux ARM32v7 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-linux-arm32v7-images",
+          "Parameters": {
+            "imageBuilder.manifest": "manifest.samples.json",
+            "PB_imageBuilder_customArgs": "--skip-pulling"
+          }
+        }
+      ]
+    },
+    {
+      "Name": "Build Windows sac2016 AMD64 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-windows-sac2016-amd64-images",
+          "Parameters": {
+            "imageBuilder.manifest": "manifest.samples.json",
+            "PB_imageBuilder_customArgs": "--os-version 10.0.14393 --skip-pulling"
+          }
+        }
+      ]
+    },
+    {
+      "Name": "Build Windows 1709 AMD64 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-windows-1709-amd64-images",
+          "Parameters": {
+            "imageBuilder.manifest": "manifest.samples.json",
+            "PB_imageBuilder_customArgs": "--os-version 10.0.16299 --skip-pulling"
+          }
+        }
+      ]
+    },
+    {
+      "Name": "Post Image Build",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-post-image-build",
+          "Parameters": {
+            "imageBuilder.manifest": "manifest.samples.json"
+          }
+        }
+      ],
+      "DependsOn": [
+        "Build Windows 1709 AMD64 Images",
+        "Build Windows sac2016 AMD64 Images",
+        "Build Linux AMD64 Images",
+        "Build Linux ARM32v7 Images"
+      ]
+    }
+  ]
+}

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -63,21 +63,21 @@
           "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
             "PB_imageBuilder_path": "1.*",
-            "PB_imageBuilder_customVars": "--var VersionFilter=1.* --var OSFilter=nanoserver-sac2016"
+            "PB_imageBuilder_customArgs": "--var VersionFilter=1.* --var OSFilter=nanoserver-sac2016"
           }
         },
         {
           "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
             "PB_imageBuilder_path": "2.0*/nanoserver-sac2016/*",
-            "PB_imageBuilder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-sac2016"
+            "PB_imageBuilder_customArgs": "--var VersionFilter=2.0* --var OSFilter=nanoserver-sac2016"
           }
         },
         {
           "Name": "dotnet-docker-windows-sac2016-amd64-images",
           "Parameters": {
             "PB_imageBuilder_path": "2.1*/nanoserver-sac2016/*",
-            "PB_imageBuilder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-sac2016"
+            "PB_imageBuilder_customArgs": "--var VersionFilter=2.1* --var OSFilter=nanoserver-sac2016"
           }
         }
       ]
@@ -92,14 +92,14 @@
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
             "PB_imageBuilder_path": "2.0*/nanoserver-1709/*",
-            "PB_imageBuilder_customVars": "--var VersionFilter=2.0* --var OSFilter=nanoserver-1709"
+            "PB_imageBuilder_customArgs": "--var VersionFilter=2.0* --var OSFilter=nanoserver-1709"
           }
         },
         {
           "Name": "dotnet-docker-windows-1709-amd64-images",
           "Parameters": {
             "PB_imageBuilder_path": "2.1*/nanoserver-1709/*",
-            "PB_imageBuilder_customVars": "--var VersionFilter=2.1* --var OSFilter=nanoserver-1709"
+            "PB_imageBuilder_customArgs": "--var VersionFilter=2.1* --var OSFilter=nanoserver-1709"
           }
         }
       ]

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -1,0 +1,87 @@
+{
+  "repos": [
+    {
+      "name": "microsoft/dotnet-samples",
+      "readmePath": "samples/README.DockerHub.md",
+      "images": [
+        {
+          "sharedTags": {
+            "dotnetapp": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "os": "linux",
+              "tags": {
+                "dotnetapp-stretch": {}
+              }
+            },
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "os": "windows",
+              "osVersion": "10.0.14393",
+              "tags": {
+                "dotnetapp-nanoserver-sac2016": {}
+              }
+            },
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "os": "windows",
+              "osVersion": "10.0.16299",
+              "tags": {
+                "dotnetapp-nanoserver-1709": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "samples/dotnetapp/Dockerfile.debian-arm32",
+              "os": "linux",
+              "tags": {
+                "dotnetapp-stretch-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "sharedTags": {
+            "aspnetapp": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "os": "linux",
+              "tags": {
+                "aspnetapp-stretch": {}
+              }
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "os": "windows",
+              "osVersion": "10.0.14393",
+              "tags": {
+                "aspnetapp-nanoserver-sac2016": {}
+              }
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "os": "windows",
+              "osVersion": "10.0.16299",
+              "tags": {
+                "aspnetapp-nanoserver-1709": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "samples/aspnetapp/Dockerfile.debian-arm32",
+              "os": "linux",
+              "tags": {
+                "aspnetapp-stretch-arm32v7": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/samples/README.DockerHub.md
+++ b/samples/README.DockerHub.md
@@ -1,22 +1,22 @@
 # Supported Linux amd64 tags
 
 - [`dotnetapp-stretch`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-stretch`, `aspnetapp`, `latest` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`aspnetapp-stretch`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
 
-# Supported Windows Server 2016, version 1709 (Fall Creators Update) amd64 tags
+# Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
 - [`dotnetapp-nanoserver-1709`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-nanoserver-1709`, `aspnetapp`, `latest` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`aspnetapp-nanoserver-1709`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
 
 # Supported Windows Server 2016 amd64 tags
 
 - [`dotnetapp-nanoserver-sac2016`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-nanoserver-sac2016`, `aspnetapp`, `latest` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`aspnetapp-nanoserver-sac2016`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
 
 # Supported Linux arm32 tags
 
-- [`dotnetapp-stretch-arm32v7`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile.debian.arm32*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile.debian.arm32)
-- [`aspnetapp-stretch-arm32v7`, `aspnetapp`, `latest` (*samples/aspnetapp/Dockerfile.debian.arm32*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile.debian.arm32)
+- [`dotnetapp-stretch-arm32v7`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile.debian-arm32*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile.debian-arm32)
+- [`aspnetapp-stretch-arm32v7`, `aspnetapp` (*samples/aspnetapp/Dockerfile.debian-arm32*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile.debian-arm32)
 
 # .NET Core Docker Samples
 

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -1,5 +1,6 @@
 param(
     [string]$Branch='master',
+    [string]$Manifest='manifest.json',
     [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171122115946',
     [string]$RepoName
 )
@@ -27,4 +28,4 @@ if ([String]::IsNullOrWhiteSpace($RepoName))
     -v "${repoRoot}:/repo" `
     -w /repo `
     $ImageBuilderImageName `
-    generateTagsReadme --update-readme "https://github.com/dotnet/${RepoName}/blob/${Branch}"
+    generateTagsReadme --update-readme --manifest ${Manifest} "https://github.com/dotnet/${RepoName}/blob/${Branch}"

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$Branch='master',
     [string]$Manifest='manifest.json',
-    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171122115946',
+    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180227221546',
     [string]$RepoName
 )
 


### PR DESCRIPTION
These changes were based on the existing [pipebuild in dotnet-docker-samples](https://github.com/dotnet/dotnet-docker-samples/tree/master/build-pipeline)

Fixes #384 
Related #396 