### PR TITLE
Refactor ordering of tags in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,62 @@
-# Supported Linux amd64 tags
+# Linux amd64 tags
 
+- [`2.0.5-sdk-2.1.4-stretch`, `2.0-sdk-stretch`, `2.0.5-sdk-2.1.4`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/stretch/amd64/Dockerfile)
+- [`2.0.5-sdk-2.1.4-jessie`, `2.0-sdk-jessie`, `2-sdk-jessie` (*2.0/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/jessie/amd64/Dockerfile)
+- [`2.0.5-runtime-stretch`, `2.0-runtime-stretch`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/stretch/amd64/Dockerfile)
+- [`2.0.5-runtime-jessie`, `2.0-runtime-jessie`, `2-runtime-jessie` (*2.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/jessie/amd64/Dockerfile)
+- [`2.0.5-runtime-deps-stretch`, `2.0-runtime-deps-stretch`, `2.0.5-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/stretch/amd64/Dockerfile)
+- [`2.0.5-runtime-deps-jessie`, `2.0-runtime-deps-jessie`, `2-runtime-deps-jessie` (*2.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile)
+- [`1.1.6-sdk-1.1.7-jessie`, `1.1.6-sdk-1.1.7`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/amd64/Dockerfile)
+- [`1.1.6-runtime-jessie`, `1.1.6-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/jessie/amd64/Dockerfile)
 - [`1.0.9-runtime-jessie`, `1.0.9-runtime`, `1.0-runtime` (*1.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/jessie/amd64/Dockerfile)
 - [`1.0.9-runtime-deps-jessie`, `1.0.9-runtime-deps`, `1.0-runtime-deps`, `1-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime-deps/jessie/amd64/Dockerfile)
-- [`1.1.6-runtime-jessie`, `1.1.6-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/jessie/amd64/Dockerfile)
-- [`1.1.6-sdk-1.1.7-jessie`, `1.1.6-sdk-1.1.7`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/amd64/Dockerfile)
-- [`2.0.5-runtime-jessie`, `2.0-runtime-jessie`, `2-runtime-jessie` (*2.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/jessie/amd64/Dockerfile)
-- [`2.0.5-runtime-stretch`, `2.0-runtime-stretch`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/stretch/amd64/Dockerfile)
-- [`2.0.5-runtime-deps-jessie`, `2.0-runtime-deps-jessie`, `2-runtime-deps-jessie` (*2.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile)
-- [`2.0.5-runtime-deps-stretch`, `2.0-runtime-deps-stretch`, `2.0.5-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/stretch/amd64/Dockerfile)
-- [`2.0.5-sdk-2.1.4-jessie`, `2.0-sdk-jessie`, `2-sdk-jessie` (*2.0/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/jessie/amd64/Dockerfile)
-- [`2.0.5-sdk-2.1.4-stretch`, `2.0-sdk-stretch`, `2.0.5-sdk-2.1.4`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/stretch/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/alpine/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.0-preview1-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+
+**.NET Core 2.1 Preview 1 tags**
+
+- [`2.1.300-preview1-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-preview1-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/amd64/Dockerfile)
 - [`2.1.300-preview1-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/alpine/amd64/Dockerfile)
 - [`2.1.300-preview1-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/amd64/Dockerfile)
-- [`2.1.300-preview1-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-preview1-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/alpine/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.0-preview1-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
 
-# Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
+# Windows Server, version 1709 amd64 tags
 
-- [`2.0.5-runtime-nanoserver-1709`, `2.0-runtime-nanoserver-1709`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver-1709/amd64/Dockerfile)
 - [`2.0.5-sdk-2.1.4-nanoserver-1709`, `2.0-sdk-nanoserver-1709`, `2.0.5-sdk-2.1.4`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.0.5-runtime-nanoserver-1709`, `2.0-runtime-nanoserver-1709`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver-1709/amd64/Dockerfile)
+
+**.NET Core 2.1 Preview 1 tags**
+
 - [`2.1.300-preview1-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.300-preview1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
-# Supported Windows Server 2016 amd64 tags
+# Windows Server 2016 amd64 tags
 
-- [`1.0.9-runtime-nanoserver-sac2016`, `1.0.9-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.6-runtime-nanoserver-sac2016`, `1.1.6-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.6-sdk-1.1.7-nanoserver-sac2016`, `1.1.6-sdk-1.1.7`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.0.5-runtime-nanoserver-sac2016`, `2.0-runtime-nanoserver-sac2016`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.0.5-sdk-2.1.4-nanoserver-sac2016`, `2.0-sdk-nanoserver-sac2016`, `2.0.5-sdk-2.1.4`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.300-preview1-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.300-preview1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.0.5-runtime-nanoserver-sac2016`, `2.0-runtime-nanoserver-sac2016`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.6-sdk-1.1.7-nanoserver-sac2016`, `1.1.6-sdk-1.1.7`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.6-runtime-nanoserver-sac2016`, `1.1.6-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.0.9-runtime-nanoserver-sac2016`, `1.0.9-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
-# Supported Linux arm32 tags
+**.NET Core 2.1 Preview 1 tags**
+
+- [`2.1.300-preview1-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.300-preview1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+
+# Linux arm32 tags
 
 - [`2.0.5-runtime-stretch-arm32v7`, `2.0-runtime-stretch-arm32v7`, `2.0.5-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime/stretch/arm32v7/Dockerfile)
 - [`2.0.5-runtime-deps-stretch-arm32v7`, `2.0-runtime-deps-stretch-arm32v7`, `2.0.5-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/stretch/arm32v7/Dockerfile)
-- [`2.1.0-preview1-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/arm32v7/Dockerfile)
+
+**.NET Core 2.1 Preview 1 tags**
+
 - [`2.1.0-preview1-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.0-preview1-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.0-preview1-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/arm32v7/Dockerfile)
 - [`2.1.0-preview1-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.0-preview1-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.0-preview1-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 >**Note:** .NET Core multi-arch tags, such as 2.0-runtime, have been updated to use nanoserver-1709 images if your host is Windows Server 2016 Version 1709 or higher or Windows 10 Fall Creators Update (Version 1709) or higher. You need Docker 17.10 or later to take advantage of these updated tags.
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,6 @@
       "readmePath": "README.md",
       "images": [
         {
-          "readmeOrder": 1,
           "sharedTags": {
             "1.0.9-runtime-deps": {},
             "1.0-runtime-deps": {},
@@ -43,7 +42,6 @@
           ]
         },
         {
-          "readmeOrder": 0,
           "sharedTags": {
             "1.0.9-runtime": {},
             "1.0-runtime": {}
@@ -72,7 +70,6 @@
           ]
         },
         {
-          "readmeOrder": 2,
           "sharedTags": {
             "1.1.6-runtime": {},
             "1.1-runtime": {},
@@ -111,7 +108,6 @@
           ]
         },
         {
-          "readmeOrder": 3,
           "sharedTags": {
             "1.1.6-sdk-1.1.7": {},
             "1.1-sdk": {},
@@ -153,7 +149,6 @@
           ]
         },
         {
-          "readmeOrder": 7,
           "sharedTags": {
             "2.0.5-runtime-deps": {},
             "2.0-runtime-deps": {},
@@ -185,7 +180,6 @@
           ]
         },
         {
-          "readmeOrder": 5,
           "sharedTags": {
             "2.0.5-runtime": {},
             "2.0-runtime": {},
@@ -240,7 +234,6 @@
           ]
         },
         {
-          "readmeOrder": 9,
           "sharedTags": {
             "2.0.5-sdk-2.1.4": {},
             "2.0-sdk": {},
@@ -283,7 +276,6 @@
           ]
         },
         {
-          "readmeOrder": 6,
           "platforms": [
             {
               "dockerfile": "2.0/runtime-deps/jessie/amd64",
@@ -297,7 +289,6 @@
           ]
         },
         {
-          "readmeOrder": 4,
           "platforms": [
             {
               "dockerfile": "2.0/runtime/jessie/amd64",
@@ -311,7 +302,6 @@
           ]
         },
         {
-          "readmeOrder": 8,
           "platforms": [
             {
               "dockerfile": "2.0/sdk/jessie/amd64",
@@ -325,7 +315,6 @@
           ]
         },
         {
-          "readmeOrder": 17,
           "sharedTags": {
             "2.1.0-preview1-runtime-deps": {},
             "2.1-runtime-deps": {}
@@ -352,7 +341,6 @@
           ]
         },
         {
-          "readmeOrder": 13,
           "sharedTags": {
             "2.1.0-preview1-runtime": {},
             "2.1-runtime": {}
@@ -396,7 +384,6 @@
           ]
         },
         {
-          "readmeOrder": 20,
           "sharedTags": {
             "2.1.300-preview1-sdk": {},
             "2.1-sdk": {}
@@ -430,7 +417,6 @@
           ]
         },
         {
-          "readmeOrder": 14,
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/alpine/amd64",
@@ -443,7 +429,6 @@
           ]
         },
         {
-          "readmeOrder": 11,
           "platforms": [
             {
               "dockerfile": "2.1/runtime/alpine/amd64",
@@ -456,7 +441,6 @@
           ]
         },
         {
-          "readmeOrder": 18,
           "platforms": [
             {
               "dockerfile": "2.1/sdk/alpine/amd64",
@@ -469,7 +453,6 @@
           ]
         },
         {
-          "readmeOrder": 15,
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/bionic/amd64",
@@ -482,7 +465,6 @@
           ]
         },
         {
-          "readmeOrder": 12,
           "platforms": [
             {
               "dockerfile": "2.1/runtime/bionic/amd64",
@@ -495,7 +477,6 @@
           ]
         },
         {
-          "readmeOrder": 19,
           "platforms": [
             {
               "dockerfile": "2.1/sdk/bionic/amd64",
@@ -508,7 +489,6 @@
           ]
         },
         {
-          "readmeOrder": 16,
           "platforms": [
             {
               "architecture": "arm",
@@ -523,7 +503,6 @@
           ]
         },
         {
-          "readmeOrder": 10,
           "platforms": [
             {
               "architecture": "arm",

--- a/samples/README.DockerHub.md
+++ b/samples/README.DockerHub.md
@@ -1,19 +1,19 @@
-# Supported Linux amd64 tags
+# Linux amd64 tags
 
 - [`dotnetapp-stretch`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
 - [`aspnetapp-stretch`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
 
-# Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
+# Windows Server, version 1709 amd64 tags
 
 - [`dotnetapp-nanoserver-1709`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
 - [`aspnetapp-nanoserver-1709`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
 
-# Supported Windows Server 2016 amd64 tags
+# Windows Server 2016 amd64 tags
 
 - [`dotnetapp-nanoserver-sac2016`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
 - [`aspnetapp-nanoserver-sac2016`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
 
-# Supported Linux arm32 tags
+# Linux arm32 tags
 
 - [`dotnetapp-stretch-arm32v7`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile.debian-arm32*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile.debian-arm32)
 - [`aspnetapp-stretch-arm32v7`, `aspnetapp` (*samples/aspnetapp/Dockerfile.debian-arm32*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile.debian-arm32)

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -1,31 +1,34 @@
 param(
-    [string]$Branch='master',
+    [string]$Branch,
     [string]$Manifest='manifest.json',
-    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180227221546',
-    [string]$RepoName
+    [string]$Template='./scripts/TagsDocumentationTemplate.md',
+    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180306162116'
 )
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Path "$PSScriptRoot" -Parent
 
-if ([String]::IsNullOrWhiteSpace($RepoName))
-{
-    $remoteUrl = $null
-    if ([Uri]::TryCreate(((git config --get remote.origin.url) | Out-String), [UriKind]::Absolute, [ref]$remoteUrl))
-    {
-        $RepoName = [System.IO.Path]::GetFileNameWithoutExtension($remoteUrl.ToString())
+if (!$Branch) {
+    $manifestJson = Get-Content ${repoRoot}/${Manifest} | ConvertFrom-Json
+    $dockerHubRepo = $manifestJson.Repos[0].Name.Split('/')[1]
+    if ($dockerHubRepo -eq "dotnet") {
+        $Branch = "master"
     }
-    if ([String]::IsNullOrWhiteSpace($RepoName))
-    {
-        Write-Error 'Could not automatically determine repository name. Add -RepoName <REPO> to override.'
+    else {
+        $Branch = $dockerHubRepo
     }
+}
+
+if ($Template) {
+    $templateOption = "--template $Template"
 }
 
 & docker pull $ImageBuilderImageName
 
-& docker run --rm `
-    -v /var/run/docker.sock:/var/run/docker.sock `
-    -v "${repoRoot}:/repo" `
-    -w /repo `
-    $ImageBuilderImageName `
-    generateTagsReadme --update-readme --manifest ${Manifest} "https://github.com/dotnet/${RepoName}/blob/${Branch}"
+$dockerRunCmd = "docker run --rm" `
+    + " -v /var/run/docker.sock:/var/run/docker.sock" `
+    + " -v ${repoRoot}:/repo" `
+    + " -w /repo" `
+    + " $ImageBuilderImageName" `
+    + " generateTagsReadme --update-readme --manifest $Manifest $templateOption https://github.com/dotnet/dotnet-docker/blob/${Branch}"
+Invoke-Expression $dockerRunCmd

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -1,0 +1,60 @@
+# Linux amd64 tags
+
+$(TagDoc:2.0.5-sdk-2.1.4-stretch)
+$(TagDoc:2.0.5-sdk-2.1.4-jessie)
+$(TagDoc:2.0.5-runtime-stretch)
+$(TagDoc:2.0.5-runtime-jessie)
+$(TagDoc:2.0.5-runtime-deps-stretch)
+$(TagDoc:2.0.5-runtime-deps-jessie)
+$(TagDoc:1.1.6-sdk-1.1.7-jessie)
+$(TagDoc:1.1.6-runtime-jessie)
+$(TagDoc:1.0.9-runtime-jessie)
+$(TagDoc:1.0.9-runtime-deps-jessie)
+
+**.NET Core 2.1 Preview 1 tags**
+
+$(TagDoc:2.1.300-preview1-sdk-stretch)
+$(TagDoc:2.1.300-preview1-sdk-alpine)
+$(TagDoc:2.1.300-preview1-sdk-bionic)
+$(TagDoc:2.1.0-preview1-runtime-stretch-slim)
+$(TagDoc:2.1.0-preview1-runtime-alpine)
+$(TagDoc:2.1.0-preview1-runtime-bionic)
+$(TagDoc:2.1.0-preview1-runtime-deps-stretch-slim)
+$(TagDoc:2.1.0-preview1-runtime-deps-alpine)
+$(TagDoc:2.1.0-preview1-runtime-deps-bionic)
+
+# Windows Server, version 1709 amd64 tags
+
+$(TagDoc:2.0.5-sdk-2.1.4-nanoserver-1709)
+$(TagDoc:2.0.5-runtime-nanoserver-1709)
+
+**.NET Core 2.1 Preview 1 tags**
+
+$(TagDoc:2.1.300-preview1-sdk-nanoserver-1709)
+$(TagDoc:2.1.0-preview1-runtime-nanoserver-1709)
+
+# Windows Server 2016 amd64 tags
+
+$(TagDoc:2.0.5-sdk-2.1.4-nanoserver-sac2016)
+$(TagDoc:2.0.5-runtime-nanoserver-sac2016)
+$(TagDoc:1.1.6-sdk-1.1.7-nanoserver-sac2016)
+$(TagDoc:1.1.6-runtime-nanoserver-sac2016)
+$(TagDoc:1.0.9-runtime-nanoserver-sac2016)
+
+**.NET Core 2.1 Preview 1 tags**
+
+$(TagDoc:2.1.300-preview1-sdk-nanoserver-sac2016)
+$(TagDoc:2.1.0-preview1-runtime-nanoserver-sac2016)
+
+# Linux arm32 tags
+
+$(TagDoc:2.0.5-runtime-stretch-arm32v7)
+$(TagDoc:2.0.5-runtime-deps-stretch-arm32v7)
+
+**.NET Core 2.1 Preview 1 tags**
+
+$(TagDoc:2.1.0-preview1-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1.0-preview1-runtime-bionic-arm32v7)
+$(TagDoc:2.1.0-preview1-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:2.1.0-preview1-runtime-deps-bionic-arm32v7)
+


### PR DESCRIPTION
Fixes #337 
Fixes #397 

In order to support this new format, a template file was introduced that is input into the generateTagsReadme cmd of image-builder.  This will make it easier in the future to change the tags format of the readme.