### PR TITLE
Update bionic images to include libcurl4

### DIFF
--- a/2.1/runtime-deps/bionic/amd64/Dockerfile
+++ b/2.1/runtime-deps/bionic/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         \
 # .NET Core dependencies
         libc6 \
-        libcurl3 \
+        libcurl4 \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \

--- a/2.1/runtime-deps/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/bionic/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         \
 # .NET Core dependencies
         libc6 \
-        libcurl3 \
+        libcurl4 \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -4,7 +4,7 @@ FROM buildpack-deps:bionic-scm
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libc6 \
-        libcurl3 \
+        libcurl4 \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \


### PR DESCRIPTION
Related to #416.

libcurl3 and libcurl4 both install libcurl.so.4.5.0 which is what dotnet runtime depends on.  This is why both versions cannot be installed at once (installing one removes the other).  