### PR TITLE
Set RestoreUseSkipNonexistentTargets=false in the 2.0 SDK image to workaround changes between 2.1.4 and 2.1.101

### DIFF
--- a/2.0/sdk/jessie/amd64/Dockerfile
+++ b/2.0/sdk/jessie/amd64/Dockerfile
@@ -36,3 +36,8 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -37,3 +37,8 @@ RUN mkdir warmup `
     && dotnet new `
     && cd .. `
     && rmdir /s /q warmup
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -27,3 +27,8 @@ RUN New-Item -Type Directory warmup; `
     dotnet new; `
     cd ..; `
     Remove-Item -Force -Recurse warmup
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false

--- a/2.0/sdk/stretch/amd64/Dockerfile
+++ b/2.0/sdk/stretch/amd64/Dockerfile
@@ -36,3 +36,8 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch
+
+# Workaround for https://github.com/Microsoft/DockerTools/issues/87. This instructs NuGet to use 4.5 behavior in which
+# all errors when attempting to restore a project are ignored and treated as warnings instead. This allows the VS
+# tooling to use -nowarn:MSB3202 to ignore issues with the .dcproj project
+ENV RestoreUseSkipNonexistentTargets false


### PR DESCRIPTION
Workaround https://github.com/Microsoft/DockerTools/issues/87.

Fixes https://github.com/dotnet/dotnet-docker/issues/429

Please review @natemcmaster, @glennc