### PR TITLE
Combine ENV instructions to reduce number of layers

### DIFF
--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -3,12 +3,13 @@ FROM microsoft/dotnet:2.1-runtime-deps-alpine
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache icu-libs
 
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    DOTNET_SDK_VERSION=2.1.300-preview1-008174 \
+    NUGET_XMLDOC_MODE=skip
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview1-008174
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
@@ -21,7 +22,6 @@ RUN apk add --no-cache --virtual .build-deps \
     && rm dotnet.tar.gz \
     && apk del .build-deps
 
-ENV NUGET_XMLDOC_MODE skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview1-008174
+ENV DOTNET_SDK_VERSION=2.1.300-preview1-008174 \
+    NUGET_XMLDOC_MODE=skip
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='3030d6876eef6770c54e6d1e23f1be544b72dfe171915d2e55e00e40faacec0035fe4f9d72a6dc5fc5fb29b768ff64c57dcce0b9fddd8f1b7f7ce8389f535da9' \
@@ -27,7 +28,6 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-ENV NUGET_XMLDOC_MODE skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.1/sdk/stretch/amd64/Dockerfile
+++ b/2.1/sdk/stretch/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview1-008174
+ENV DOTNET_SDK_VERSION=2.1.300-preview1-008174 \
+    NUGET_XMLDOC_MODE=skip
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='3030d6876eef6770c54e6d1e23f1be544b72dfe171915d2e55e00e40faacec0035fe4f9d72a6dc5fc5fb29b768ff64c57dcce0b9fddd8f1b7f7ce8389f535da9' \
@@ -27,7 +28,6 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-ENV NUGET_XMLDOC_MODE skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help


### PR DESCRIPTION
The SDK Dockerfiles use multiple ENV instructions (especially the Alpine images) which cause multiple layers to be created. [Docker's guidance](https://docs.docker.com/engine/reference/builder/#env) recommends using the multiple-variable form of the ENV instruction to reduce the number of intermediate layers.

I've changed the SDK Dockerfiles for 2.1 to use the recommended form.

I've only done this in the 2.1 preview images to start with, if it's wanted I can change the previous versions too.