### PR TITLE
[WIP] Add Centos 6 sample

### DIFF
--- a/samples/centos6/Dockerfile
+++ b/samples/centos6/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:6
+
+RUN yum -y update && \
+    yum clean all && \
+    yum -y install epel-release && \
+    yum -y install openssl libidn libuuid lttng-ust zlib libunwind libnghttp2
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.1.0-preview3-26319-04
+
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-rhel.6-x64.tar.gz \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT true
+
+# Configure Kestrel web server to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80


### PR DESCRIPTION
Creating a 2.1 sample based off of [How to use .NET Core on RHEL 6 / CentOS 6](https://github.com/dotnet/core/blob/master/Documentation/build-and-install-rhel6-prerequisites.md).

Work left:

* [ ] Validate dependencies for 2.1
* [x] Test with dotnetapp
* [ ] Test with HttpSockerHandler
* [ ] Add ASP.NET Core
* [ ] Test with ASP.NET Core
* [ ] Document how to build applications with MSB or with #434 for use with this Dockerfile
* [ ] Consider doing same for Centos 7