### PR TITLE
Use multi-variable syntax rather than multiple ENV instructions

### DIFF
--- a/2.1/runtime-deps/alpine/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine/amd64/Dockerfile
@@ -18,10 +18,8 @@ RUN apk add --no-cache \
         lttng-ust
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
-
-# Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT true
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/2.1/runtime-deps/bionic/amd64/Dockerfile
+++ b/2.1/runtime-deps/bionic/amd64/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/runtime-deps/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/bionic/arm32v7/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -30,7 +30,6 @@ RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
+ENV ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -20,7 +20,6 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
+ENV ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -3,9 +3,9 @@ FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache icu-libs
 
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
 
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 2.1.300-preview2-008380
@@ -22,9 +22,9 @@ RUN apk add --no-cache --virtual .build-deps \
     && apk del .build-deps
 
 # Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER true
-
-ENV NUGET_XMLDOC_MODE skip
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true \ 
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -27,15 +27,13 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
-
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER true
-
-ENV NUGET_XMLDOC_MODE skip
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -30,15 +30,13 @@ RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
-
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER true
-
-ENV NUGET_XMLDOC_MODE skip
+ENV ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -20,15 +20,13 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
-
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER true
-
-ENV NUGET_XMLDOC_MODE skip
+ENV ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.1/sdk/stretch/amd64/Dockerfile
+++ b/2.1/sdk/stretch/amd64/Dockerfile
@@ -27,15 +27,13 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Configure Kestrel web server to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true
-
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER true
-
-ENV NUGET_XMLDOC_MODE skip
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help


### PR DESCRIPTION
This is the result of the discussion in https://github.com/dotnet/dotnet-docker/pull/433.

cc @richlander, @markrendle, @JRAlexander, @dleeapho 