### PR TITLE
Create aspnetcore runtime images for 2.1 nightly

### DIFF
--- a/2.1/aspnetcore-runtime/alpine/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine/amd64/Dockerfile
@@ -1,0 +1,20 @@
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
+
+# Workaround https://github.com/aspnet/libuv-package/issues/23
+# Install libuv globally and link it so coreclr can laod it
+RUN apk add --no-cache libuv \
+    && ln -s /usr/lib/libuv.so.1 /usr/lib/libuv.so
+
+# Install ASP.NET Core
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30478
+
+RUN apk add --no-cache --virtual .build-deps \
+        openssl \
+    && wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-alpine.3.6-x64.tar.gz \
+    && aspnetcore_sha512='5e6844dc42121bcd8910fa22bd7d3ab20145f1ed63f375ddabbda3124eb8f49278bb4b02c7e23371d700580047b026f3e01d0ea79084e8223d193ff316e5297d' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
+    && rm aspnetcore.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && apk del .build-deps

--- a/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-bionic
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30478
+
+RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
+    && aspnetcore_sha512='58b7db2b719df13bb33b9dc37857b26b5edb603bac9846da2ba7bb222545d4784ede0284bd5df7b16ddacec1619f7c6175eb91dff1deae57d90023b8ad2f7f69' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
+    && rm aspnetcore.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+

--- a/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -1,0 +1,36 @@
+# escape=`
+
+# Installer image
+FROM microsoft/windowsservercore:1709 AS installer-env
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Install ASP.NET Core Runtime
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30478
+
+RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
+    $aspnetcore_sha512 = '9314f95d64cccd36f406cca73d5ee547b9ada9874e26ec928d78dae00d96834da1c407a59dd5366da0003e4d50bb367aa467a0e50814c6e2fb102bb19f7a7c09'; `
+    if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    Remove-Item -Force aspnetcore.zip
+
+# Runtime image
+FROM microsoft/nanoserver:1709
+
+# Note: Runtime image's SHELL is the CMD shell (different than the installer image).
+
+COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+# Configure web servers to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINERS=true

--- a/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -1,0 +1,23 @@
+# escape=`
+FROM microsoft/nanoserver:sac2016
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Install ASP.NET Core Runtime
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30478
+
+RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
+    $aspnetcore_sha512 = '9314f95d64cccd36f406cca73d5ee547b9ada9874e26ec928d78dae00d96834da1c407a59dd5366da0003e4d50bb367aa467a0e50814c6e2fb102bb19f7a7c09'; `
+    if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive aspnetcore.zip -DestinationPath  $Env:ProgramFiles\dotnet; `
+    Remove-Item -Force aspnetcore.zip
+RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
+
+# Configure web servers to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINERS=true

--- a/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
@@ -1,0 +1,17 @@
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-stretch-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install ASP.NET Core
+ENV ASPNETCORE_VERSION 2.1.0-preview2-30478
+
+RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
+    && aspnetcore_sha512='58b7db2b719df13bb33b9dc37857b26b5edb603bac9846da2ba7bb222545d4784ede0284bd5df7b16ddacec1619f7c6175eb91dff1deae57d90023b8ad2f7f69' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
+    && rm aspnetcore.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/2.1/runtime/alpine/amd64/Dockerfile
+++ b/2.1/runtime/alpine/amd64/Dockerfile
@@ -1,12 +1,12 @@
 FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.0-preview2-26325-03
+ENV DOTNET_VERSION 2.1.0-preview2-26326-03
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-alpine.3.6-x64.tar.gz \
-    && dotnet_sha512='5ed2d2ae62173e9491f54fae4c5df3fc4a6172b4b0d635e5222b6776ff3650d532d99906ed9c413666ef92fec07251445bd52913619ea3e6b17a225cc478b524' \
+    && dotnet_sha512='7c1c121f62bba2c35aa1620dd01fd7d13ca01d33c33c2eb2103aa59b63c0b388365cc55fab1ee81f5dfef7ad31b5daf8985bef769e2f9004599a509a7de36bde' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/runtime/bionic/amd64/Dockerfile
+++ b/2.1/runtime/bionic/amd64/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.0-preview2-26325-03
+ENV DOTNET_VERSION 2.1.0-preview2-26326-03
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='0c7fc613e1d8d03f9caa4788667b012af49a261c1859816b701e6727820df5cea6f9897ed9ce183597bf76fb2af91d884f939b5e03764ad69b4fd6ab3eb2be38' \
+    && dotnet_sha512='a2858a6efedd57da820681a690332cb78c449fb171dfef430bbfdc47048fdedcee24de432f2daaee1290aa77252c1e469e94fe41365257879024243d7310d2fd' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime/bionic/arm32v7/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.0-preview2-26325-03
+ENV DOTNET_VERSION 2.1.0-preview2-26326-03
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='0870ebdf19eafc73f755716239277b635c539e22197156bea056b2117a17570096b3fdd7eec4fe9a38f10c4b5a7a56fe1ed9435125823611d4022c574eddc138' \
+    && dotnet_sha512='a231b85a127e236db10a6c4c4f103edb28a6057e3675a0942934c4ed62fefff23d645efed446211532372113ef4671e68cbf794b0c979bf1539ff3d7f4346f44' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.0-preview2-26325-03
+ENV DOTNET_VERSION 2.1.0-preview2-26326-03
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = 'e090f2fa2e0ee5fb4981960ec9d487ce0a4d7b48ce835657a8648ba238ff5d70d22a806e59e49db7aa664dadd05e346a2113b900f5e24fed5f90b09b6e78ebc0'; `
+    $dotnet_sha512 = '3b5f2fbfeac3d127ecef5b743689079872b3acdcd0d1066d968689e7ff557e2a6eae9b8018968202955dd64fa177f09bdd9023b7d5afa749b5e41b376a57ebf5'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM microsoft/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.0-preview2-26325-03
+ENV DOTNET_VERSION 2.1.0-preview2-26326-03
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = 'e090f2fa2e0ee5fb4981960ec9d487ce0a4d7b48ce835657a8648ba238ff5d70d22a806e59e49db7aa664dadd05e346a2113b900f5e24fed5f90b09b6e78ebc0'; `
+    $dotnet_sha512 = '3b5f2fbfeac3d127ecef5b743689079872b3acdcd0d1066d968689e7ff557e2a6eae9b8018968202955dd64fa177f09bdd9023b7d5afa749b5e41b376a57ebf5'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime/stretch-slim/amd64/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.0-preview2-26325-03
+ENV DOTNET_VERSION 2.1.0-preview2-26326-03
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='0c7fc613e1d8d03f9caa4788667b012af49a261c1859816b701e6727820df5cea6f9897ed9ce183597bf76fb2af91d884f939b5e03764ad69b4fd6ab3eb2be38' \
+    && dotnet_sha512='a2858a6efedd57da820681a690332cb78c449fb171dfef430bbfdc47048fdedcee24de432f2daaee1290aa77252c1e469e94fe41365257879024243d7310d2fd' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime/stretch-slim/arm32v7/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.0-preview2-26325-03
+ENV DOTNET_VERSION 2.1.0-preview2-26326-03
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='0870ebdf19eafc73f755716239277b635c539e22197156bea056b2117a17570096b3fdd7eec4fe9a38f10c4b5a7a56fe1ed9435125823611d4022c574eddc138' \
+    && dotnet_sha512='a231b85a127e236db10a6c4c4f103edb28a6057e3675a0942934c4ed62fefff23d645efed446211532372113ef4671e68cbf794b0c979bf1539ff3d7f4346f44' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -8,12 +8,12 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview2-008396
+ENV DOTNET_SDK_VERSION 2.1.300-preview2-008407
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-alpine.3.6-x64.tar.gz \
-    && dotnet_sha512='9fb5103b43a9b54585b9c712b3bfaa2ce26bb4816ca3cb17d1c06982e77b545c1a4bec022ba21cba5c48b8dce3685365d1d42e53cca54d35266eccae41f21b68' \
+    && dotnet_sha512='8e1eba77847217d8aa1018f23437abc9112ba95ab9c0b4b9dfef83317b665590cee2c4214a5bac682b3269a1ae00aaf77798092ebecf6ba943df30efa0aed2f5' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview2-008396
+ENV DOTNET_SDK_VERSION 2.1.300-preview2-008407
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='4672d39c1e183105e14dfac9e39dfa450232d517dca6cced9a60d11d582121a1808fad798d2d85f146c3aff2fa147aeb452b74041ed50df973cfb6dd18290a2c' \
+    && dotnet_sha512='bc2b312f5fe8e1c2e095ef138794e392d7d2dd5a5a407b04e31c57f995ec414b75bcbcd09537481347c5979808f7606363e4148f3500b2d7940c45f1e88a6c40' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview2-008396
+ENV DOTNET_SDK_VERSION 2.1.300-preview2-008407
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = 'd015f934b1f2c0850429f44c7d0e32edefc576cf5d1939d79953b7fb200afc239966bc1e534551541d3bb682174bcce481261227fbab58fdf0c8cbb8a23e2a2c'; `
+    $dotnet_sha512 = '2c768e725a89b3071a611906014b93886fb5e58c7fef0b42d7b440f684123e6e8dd32028a52b98055a5764752d97922c71f11433295b5ac5996274ec6a7fbefb'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM microsoft/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview2-008396
+ENV DOTNET_SDK_VERSION 2.1.300-preview2-008407
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = 'd015f934b1f2c0850429f44c7d0e32edefc576cf5d1939d79953b7fb200afc239966bc1e534551541d3bb682174bcce481261227fbab58fdf0c8cbb8a23e2a2c'; `
+    $dotnet_sha512 = '2c768e725a89b3071a611906014b93886fb5e58c7fef0b42d7b440f684123e6e8dd32028a52b98055a5764752d97922c71f11433295b5ac5996274ec6a7fbefb'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/stretch/amd64/Dockerfile
+++ b/2.1/sdk/stretch/amd64/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.300-preview2-008396
+ENV DOTNET_SDK_VERSION 2.1.300-preview2-008407
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='4672d39c1e183105e14dfac9e39dfa450232d517dca6cced9a60d11d582121a1808fad798d2d85f146c3aff2fa147aeb452b74041ed50df973cfb6dd18290a2c' \
+    && dotnet_sha512='bc2b312f5fe8e1c2e095ef138794e392d7d2dd5a5a407b04e31c57f995ec414b75bcbcd09537481347c5979808f7606363e4148f3500b2d7940c45f1e88a6c40' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for image
 - [`2.1.300-preview2-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
 - [`2.1.300-preview2-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine/amd64/Dockerfile)
 - [`2.1.300-preview2-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.1.0-preview2-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.0-preview2-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.0-preview2-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine/amd64/Dockerfile)
+- [`2.1.0-preview2-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
@@ -35,6 +38,7 @@ See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for image
 **.NET Core 2.1 Preview 1 tags**
 
 - [`2.1.300-preview2-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.0-preview2-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.0-preview2-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
 # Windows Server 2016 amd64 tags
@@ -48,6 +52,7 @@ See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for image
 **.NET Core 2.1 Preview 1 tags**
 
 - [`2.1.300-preview2-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.0-preview2-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.0-preview2-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
 # Linux arm32 tags

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 [cmdletbinding()]
 param(
     [switch]$UseImageCache,

--- a/manifest.json
+++ b/manifest.json
@@ -385,6 +385,39 @@
         },
         {
           "sharedTags": {
+            "2.1.0-preview2-aspnetcore-runtime": {},
+            "2.1-aspnetcore-runtime": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview2-aspnetcore-runtime-stretch-slim": {},
+                "2.1-aspnetcore-runtime-stretch-slim": {}
+              }
+            },
+            {
+              "dockerfile": "2.1/aspnetcore-runtime/nanoserver-sac2016/amd64",
+              "os": "windows",
+              "tags": {
+                "2.1.0-preview2-aspnetcore-runtime-nanoserver-sac2016": {},
+                "2.1-aspnetcore-runtime-nanoserver-sac2016": {}
+              }
+            },
+            {
+              "dockerfile": "2.1/aspnetcore-runtime/nanoserver-1709/amd64",
+              "os": "windows",
+              "osVersion": "1709",
+              "tags": {
+                "2.1.0-preview2-aspnetcore-runtime-nanoserver-1709": {},
+                "2.1-aspnetcore-runtime-nanoserver-1709": {}
+              }
+            }
+          ]
+        },
+        {
+          "sharedTags": {
             "2.1.300-preview2-sdk": {},
             "2.1-sdk": {}
           },
@@ -443,6 +476,18 @@
         {
           "platforms": [
             {
+              "dockerfile": "2.1/aspnetcore-runtime/alpine/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview2-aspnetcore-runtime-alpine": {},
+                "2.1-aspnetcore-runtime-alpine": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
               "dockerfile": "2.1/sdk/alpine/amd64",
               "os": "linux",
               "tags": {
@@ -460,6 +505,18 @@
               "tags": {
                 "2.1.0-preview2-runtime-deps-bionic": {},
                 "2.1-runtime-deps-bionic": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/aspnetcore-runtime/bionic/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview2-aspnetcore-runtime-bionic": {},
+                "2.1-aspnetcore-runtime-bionic": {}
               }
             }
           ]

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 param(
     [string]$Branch,
     [string]$Manifest='manifest.json',

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -16,6 +16,9 @@ $(TagDoc:1.0.10-runtime-deps-jessie)
 $(TagDoc:2.1.300-preview2-sdk-stretch)
 $(TagDoc:2.1.300-preview2-sdk-alpine)
 $(TagDoc:2.1.300-preview2-sdk-bionic)
+$(TagDoc:2.1.0-preview2-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1.0-preview2-aspnetcore-runtime-alpine)
+$(TagDoc:2.1.0-preview2-aspnetcore-runtime-bionic)
 $(TagDoc:2.1.0-preview2-runtime-stretch-slim)
 $(TagDoc:2.1.0-preview2-runtime-alpine)
 $(TagDoc:2.1.0-preview2-runtime-bionic)
@@ -31,6 +34,7 @@ $(TagDoc:2.0.6-runtime-nanoserver-1709)
 **.NET Core 2.1 Preview 1 tags**
 
 $(TagDoc:2.1.300-preview2-sdk-nanoserver-1709)
+$(TagDoc:2.1.0-preview2-aspnetcore-runtime-nanoserver-1709)
 $(TagDoc:2.1.0-preview2-runtime-nanoserver-1709)
 
 # Windows Server 2016 amd64 tags
@@ -44,6 +48,7 @@ $(TagDoc:1.0.10-runtime-nanoserver-sac2016)
 **.NET Core 2.1 Preview 1 tags**
 
 $(TagDoc:2.1.300-preview2-sdk-nanoserver-sac2016)
+$(TagDoc:2.1.0-preview2-aspnetcore-runtime-nanoserver-sac2016)
 $(TagDoc:2.1.0-preview2-runtime-nanoserver-sac2016)
 
 # Linux arm32 tags

--- a/scripts/update-dependencies/DockerfileShaUpdater.cs
+++ b/scripts/update-dependencies/DockerfileShaUpdater.cs
@@ -22,7 +22,7 @@ namespace Dotnet.Docker
         {
             Path = dockerfilePath;
             string envShaPattern = "ENV (?<name>DOTNET_[\\S]*DOWNLOAD_SHA) (?<value>[\\S]*)";
-            string varShaPattern = "[ \\$](?<name>dotnet_sha512)( )*=( )*'(?<value>[^'\\s]*)'";
+            string varShaPattern = "[ \\$](?<name>(dotnet_|aspnetcore_)sha512)( )*=( )*'(?<value>[^'\\s]*)'";
             Regex = new Regex($"({envShaPattern})|({varShaPattern})");
             VersionGroupName = "value";
         }
@@ -37,7 +37,7 @@ namespace Dotnet.Docker
             Trace.TraceInformation($"DockerfileShaUpdater is processing '{Path}'.");
             string dockerfile = File.ReadAllText(Path);
 
-            Regex versionRegex = new Regex($"ENV (?<name>DOTNET_[\\S]*VERSION) (?<value>[\\S]*)");
+            Regex versionRegex = new Regex($"ENV (?<name>(DOTNET_|ASPNETCORE_)[\\S]*VERSION) (?<value>[\\S]*)");
             Match versionMatch = versionRegex.Match(dockerfile);
             if (versionMatch.Success)
             {

--- a/scripts/update-dependencies/Program.cs
+++ b/scripts/update-dependencies/Program.cs
@@ -23,6 +23,7 @@ namespace Dotnet.Docker
         private static Options Options { get; } = new Options();
         private static string RepoRoot { get; } = Directory.GetCurrentDirectory();
         private const string RuntimeBuildInfoName = "Runtime";
+        private const string AspNetCoreBuildInfoName = "AspNetCore";
         private const string SdkBuildInfoName = "Sdk";
 
         public static async Task Main(string[] args)
@@ -78,11 +79,14 @@ namespace Dotnet.Docker
                     .First(build => string.Equals(build.Name, "cli", StringComparison.OrdinalIgnoreCase));
                 BuildIdentity coreSetupBuild = buildInfo.Builds
                     .First(build => string.Equals(build.Name, "core-setup", StringComparison.OrdinalIgnoreCase));
+                BuildIdentity aspnetBuild = buildInfo.Builds
+                    .First(build => string.Equals(build.Name, "aspnet", StringComparison.OrdinalIgnoreCase));
 
                 return new[]
                 {
                     CreateDependencyBuildInfo(SdkBuildInfoName, sdkBuild.ProductVersion),
                     CreateDependencyBuildInfo(RuntimeBuildInfoName, coreSetupBuild.ProductVersion),
+                    CreateDependencyBuildInfo(AspNetCoreBuildInfoName, aspnetBuild.ProductVersion),
                 };
             };
         }
@@ -138,6 +142,7 @@ namespace Dotnet.Docker
 
             return dockerfiles
                 .Select(path => CreateDockerfileEnvUpdater(path, "DOTNET_SDK_VERSION", SdkBuildInfoName))
+                .Concat(dockerfiles.Select(path => CreateDockerfileEnvUpdater(path, "ASPNETCORE_VERSION", AspNetCoreBuildInfoName)))
                 .Concat(dockerfiles.Select(path => CreateDockerfileEnvUpdater(path, "DOTNET_VERSION", RuntimeBuildInfoName)))
                 .Concat(dockerfiles.Select(path => new DockerfileShaUpdater(path)));
         }

--- a/test/Dockerfile.linux.testrunner
+++ b/test/Dockerfile.linux.testrunner
@@ -3,5 +3,6 @@
 
 FROM microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
 
+ENV RUNNING_TESTS_IN_CONTAINER=true
 WORKDIR src
 COPY . .

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.testapp
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.testapp
@@ -1,11 +1,13 @@
 ARG base_image
 FROM $base_image
-
 ARG netcoreapp_version
 ARG optional_new_args
 ARG optional_restore_args
+ARG template_name
+
+EXPOSE 80
 
 WORKDIR testApp
-RUN dotnet new console --framework netcoreapp$netcoreapp_version $optional_new_args
+RUN dotnet new $template_name --framework netcoreapp$netcoreapp_version $optional_new_args
 RUN dotnet restore $optional_restore_args
 RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.testapp.selfcontained
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.testapp.selfcontained
@@ -4,4 +4,6 @@ FROM $base_image
 ARG rid
 ARG optional_restore_args
 
+EXPOSE 80
+
 RUN dotnet restore -r $rid $optional_restore_args

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.testapp
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.testapp
@@ -8,8 +8,11 @@ SHELL ["cmd", "/S", "/C"]
 ARG netcoreapp_version
 ARG optional_new_args=" "
 ARG optional_restore_args=" "
+ARG template_name
+
+EXPOSE 80
 
 WORKDIR testApp
-RUN dotnet new console --framework netcoreapp%netcoreapp_version% %optional_new_args%
+RUN dotnet new %template_name% --framework netcoreapp%netcoreapp_version% %optional_new_args%
 RUN dotnet restore %optional_restore_args%
 RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/DotNetImageType.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DotNetImageType.cs
@@ -9,5 +9,6 @@ namespace Microsoft.DotNet.Docker.Tests
         SDK,
         Runtime,
         Runtime_Deps,
+        AspNetCore_Runtime,
     }
 }

--- a/test/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public string Architecture { get; set; } = "amd64";
         public string DotNetVersion { get; set; }
         public bool HasNoSdk { get; set; }
+        public bool IsWeb { get; set; }
         public bool IsAlpine { get => String.Equals(OS.Alpine, OsVariant, StringComparison.OrdinalIgnoreCase); }
         public bool IsArm { get => String.Equals("arm", Architecture, StringComparison.OrdinalIgnoreCase); }
         public string OsVariant { get; set; }

--- a/test/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/test/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -6,10 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1"/>
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 #
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -57,7 +58,8 @@ Try {
     $env:IMAGE_VERSION_FILTER = $VersionFilter
     $env:REPO_OWNER = $RepoOwner
 
-    & $DotnetInstallDir/dotnet test -v n
+    & $DotnetInstallDir/dotnet build -v n
+    & $DotnetInstallDir/dotnet xunit -nobuild -verbose
 
     if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }
 }


### PR DESCRIPTION
Part of https://github.com/aspnet/aspnet-docker/issues/403

Create the following images for `microsoft/dotnet(-nightly)`
 - 2.1-aspnetcore-runtime-nanoserver-sac2016
 - 2.1-aspnetcore-runtime-nanoserver-1709
 - 2.1-aspnetcore-runtime-alpine
 - 2.1-aspnetcore-runtime-bionic
 - 2.1-aspnetcore-runtime-stretch-slim

(Also, I updated currently 2.1 nightlies to yesterday's build)

CC @glennc @richlander @MichaelSimons 