### PR TITLE
Refactor update-dependencies to support additional scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ artifacts/
 # Visual Studio Code cache/options directory
 .vscode/
 
+# Visual Studio debug profile
+**/launchSettings.json
+
 # Test files
 *.trx
 

--- a/scripts/update-dependencies/DockerfileShaUpdater.cs
+++ b/scripts/update-dependencies/DockerfileShaUpdater.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.VersionTools.Dependencies;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Dotnet.Docker
 {
@@ -18,64 +18,136 @@ namespace Dotnet.Docker
     /// </summary>
     public class DockerfileShaUpdater : FileRegexUpdater
     {
+        private const string EnvNameGroupName = "envName";
+        private const string ValueGroupName = "value";
+
+        private static readonly string s_envVersionPattern =
+            $"ENV (?<{EnvNameGroupName}>(DOTNET|ASPNETCORE)_[\\S]*VERSION) (?<{ValueGroupName}>[\\S]*)";
+        private static readonly string s_envShaPattern =
+            $"ENV (?<{EnvNameGroupName}> DOTNET_[\\S]*DOWNLOAD_SHA) (?<{ValueGroupName}>[\\S]*)";
+        private static readonly string s_envDownloadUrlPattern = $"ENV (DOTNET_[\\S]*DOWNLOAD_URL) (?<{ValueGroupName}>[\\S]*)";
+        private static readonly string s_inlineUrlPattern = 
+            $"(?<{ValueGroupName}>https://dotnetcli.blob.core.windows.net/[^;\\s]*)";
+        private static readonly string s_varShaPattern =
+            $"[ \\$](?<{EnvNameGroupName}>(dotnet_|aspnetcore_)sha512)( )*=( )*'(?<{ValueGroupName}>[^'\\s]*)'";
+
+        private static readonly Regex s_downloadUrlRegex = new Regex($"({s_envDownloadUrlPattern})|{s_inlineUrlPattern}");
+        private static readonly Regex s_shaRegex = new Regex($"({s_envShaPattern})|({s_varShaPattern})");
+        private static readonly Regex s_versionRegex = new Regex(s_envVersionPattern);
+
         public DockerfileShaUpdater(string dockerfilePath) : base()
         {
             Path = dockerfilePath;
-            string envShaPattern = "ENV (?<name>DOTNET_[\\S]*DOWNLOAD_SHA) (?<value>[\\S]*)";
-            string varShaPattern = "[ \\$](?<name>(dotnet_|aspnetcore_)sha512)( )*=( )*'(?<value>[^'\\s]*)'";
-            Regex = new Regex($"({envShaPattern})|({varShaPattern})");
-            VersionGroupName = "value";
+            Regex = s_shaRegex;
+            VersionGroupName = ValueGroupName;
         }
 
         protected override string TryGetDesiredValue(
-            IEnumerable<IDependencyInfo> dependencyBuildInfos,
-            out IEnumerable<IDependencyInfo> usedBuildInfos)
+            IEnumerable<IDependencyInfo> dependencyBuildInfos, out IEnumerable<IDependencyInfo> usedBuildInfos)
         {
-            string sha = null;
             usedBuildInfos = Enumerable.Empty<IDependencyInfo>();
 
             Trace.TraceInformation($"DockerfileShaUpdater is processing '{Path}'.");
             string dockerfile = File.ReadAllText(Path);
+            return GetArtifactShaAsync(dockerfile).Result;
+        }
 
-            Regex versionRegex = new Regex($"ENV (?<name>(DOTNET_|ASPNETCORE_)[\\S]*VERSION) (?<value>[\\S]*)");
-            Match versionMatch = versionRegex.Match(dockerfile);
-            if (versionMatch.Success)
+        private static async Task<string> GetArtifactShaAsync(string dockerfile)
+        {
+            string sha = null;
+
+            if (TryGetDotNetVersion(dockerfile, out (string Version, string EnvName) versionInfo))
             {
-                string versionEnvName = versionMatch.Groups["name"].Value;
-                string version = versionMatch.Groups["value"].Value;
-
-                string envUrlPattern = "ENV (DOTNET_[\\S]*DOWNLOAD_URL) (?<value>[\\S]*)";
-                string inlineUrlPattern = "(?<value>https://dotnetcli.blob.core.windows.net/[^;\\s]*)";
-                Regex shaRegex = new Regex($"({envUrlPattern})|{inlineUrlPattern}");
-                Match shaMatch = shaRegex.Match(dockerfile);
-                if (shaMatch.Success)
+                if (TryGetDotNetDownloadUrl(dockerfile, out string downloadUrl))
                 {
-                    // TODO:  Cleanup differences in sha extensions - https://github.com/dotnet/cli/issues/6724
-                    string shaExt = versionEnvName.Contains("SDK") ? ".sha" : ".sha512";
-                    string shaUrl = shaMatch.Groups["value"].Value
-                        .Replace("dotnetcli", "dotnetclichecksums")
-                        .Replace($"${versionEnvName}", version)     // *nix ENV var reference format
-                        .Replace($"$Env:{versionEnvName}", version) // Windows ENV var reference format
-                        + shaExt;
-
-                    Trace.TraceInformation($"Downloading '{shaUrl}'.");
-                    using (Stream shaStream = new HttpClient().GetStreamAsync(shaUrl).Result)
-                    using (StreamReader reader = new StreamReader(shaStream))
-                    {
-                        sha = reader.ReadToEnd().ToLowerInvariant();
-                    }
+                    downloadUrl = SubstituteEnvRef(downloadUrl, versionInfo.EnvName, versionInfo.Version);
+                    sha = await GetDotNetCliChecksumsShaAsync(downloadUrl, versionInfo.EnvName)
+                        ?? await GetDotNetReleaseChecksumsShaAsync(downloadUrl, versionInfo.EnvName, versionInfo.Version);
+                    sha = sha?.ToLower();
                 }
                 else
                 {
-                    Trace.TraceInformation($"DockerfileShaUpdater no-op - checksum url not found.");
+                    Trace.TraceInformation($"DockerfileShaUpdater no-op - .NET download url not found.");
                 }
             }
             else
             {
-                Trace.TraceInformation($"DockerfileShaUpdater no-op - dotnet url not found.");
+                Trace.TraceInformation($"DockerfileShaUpdater no-op - .NET product found.");
             }
 
             return sha;
+        }
+
+        private static async Task<string> GetDotNetCliChecksumsShaAsync(string productDownloadUrl, string envName)
+        {
+            string sha = null;
+            string shaExt = envName.Contains("SDK") ? ".sha" : ".sha512";
+            string shaUrl = productDownloadUrl.Replace("dotnetcli", "dotnetclichecksums") + shaExt;
+
+            Trace.TraceInformation($"Downloading '{shaUrl}'.");
+            using (HttpClient client = new HttpClient())
+            using (HttpResponseMessage response = await client.GetAsync(shaUrl))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    sha = await response.Content.ReadAsStringAsync();
+                }
+                else
+                {
+                    Trace.TraceInformation($"Failed to find `dotnetclichecksums` sha");
+                }
+            };
+
+            return sha;
+        }
+
+        private static async Task<string> GetDotNetReleaseChecksumsShaAsync(
+            string productDownloadUrl, string envName, string productVersion)
+        {
+            string sha = null;
+            string product = envName == "DOTNET_SDK_VERSION" ? "sdk" : "runtime";
+            string uri = $"https://dotnetcli.blob.core.windows.net/dotnet/checksums/{productVersion}-{product}-sha.txt";
+
+            Trace.TraceInformation($"Downloading '{uri}'.");
+            using (HttpClient client = new HttpClient())
+            {
+                string checksums = await client.GetStringAsync(uri);
+                string installerFileName = productDownloadUrl.Substring(productDownloadUrl.LastIndexOf('/') + 1);
+
+                Regex shaRegex = new Regex($"(?<sha>[\\S]+)[\\s]+{Regex.Escape(installerFileName)}");
+                Match shaMatch = shaRegex.Match(checksums);
+                if (shaMatch.Success)
+                {
+                    sha = shaMatch.Groups["sha"].Value;
+                }
+                else
+                {
+                    Trace.TraceInformation($"Failed to find `{installerFileName}` sha");
+                }
+            };
+
+            return sha;
+        }
+
+        private static bool TryGetDotNetDownloadUrl(string dockerfile, out string downloadUrl)
+        {
+            Match match = s_downloadUrlRegex.Match(dockerfile);
+            downloadUrl = match.Success ? match.Groups[ValueGroupName].Value : null;
+            return match.Success;
+        }
+
+        private static bool TryGetDotNetVersion(string dockerfile, out (string Version, string EnvName) versionInfo)
+        {
+            Match match = s_versionRegex.Match(dockerfile);
+            versionInfo = match.Success ? (match.Groups[ValueGroupName].Value, match.Groups[EnvNameGroupName].Value) : (null, null);
+            return match.Success;
+        }
+
+        private static string SubstituteEnvRef(string value, string envName, string envValue)
+        {
+            return value
+                .Replace($"${envName}", envValue)       // *nix ENV var reference format
+                .Replace($"$Env:{envName}", envValue);  // Windows ENV var reference format
         }
     }
 }

--- a/scripts/update-dependencies/DockerfileShaUpdater.cs
+++ b/scripts/update-dependencies/DockerfileShaUpdater.cs
@@ -63,7 +63,7 @@ namespace Dotnet.Docker
                     downloadUrl = SubstituteEnvRef(downloadUrl, versionInfo.EnvName, versionInfo.Version);
                     sha = await GetDotNetCliChecksumsShaAsync(downloadUrl, versionInfo.EnvName)
                         ?? await GetDotNetReleaseChecksumsShaAsync(downloadUrl, versionInfo.EnvName, versionInfo.Version);
-                    sha = sha?.ToLower();
+                    sha = sha?.ToLowerInvariant();
                 }
                 else
                 {
@@ -96,7 +96,7 @@ namespace Dotnet.Docker
                 {
                     Trace.TraceInformation($"Failed to find `dotnetclichecksums` sha");
                 }
-            };
+            }
 
             return sha;
         }
@@ -124,7 +124,7 @@ namespace Dotnet.Docker
                 {
                     Trace.TraceInformation($"Failed to find `{installerFileName}` sha");
                 }
-            };
+            }
 
             return sha;
         }

--- a/scripts/update-dependencies/Options.cs
+++ b/scripts/update-dependencies/Options.cs
@@ -8,7 +8,7 @@ namespace Dotnet.Docker
 {
     public class Options
     {
-        public string BuildInfoUrl { get; private set; }
+        public Uri BuildInfoUrl { get; private set; }
         public string GitHubEmail { get; private set; }
         public string GitHubPassword { get; private set; }
         public string GitHubProject => "dotnet-docker";
@@ -42,10 +42,11 @@ namespace Dotnet.Docker
                     "GitHub user used to make PR (if not specified, a PR will not be created)");
                 GitHubUser = gitHubUser;
 
-                string buildInfoUrl = null;
+                Uri buildInfoUrl = null;
                 syntax.DefineParameter(
                     "build-info",
                     ref buildInfoUrl,
+                    (value) => new Uri(value),
                     "URL of the build info to update the Dockerfiles with");
                 BuildInfoUrl = buildInfoUrl;
             });

--- a/scripts/update-dependencies/Options.cs
+++ b/scripts/update-dependencies/Options.cs
@@ -47,7 +47,7 @@ namespace Dotnet.Docker
                     "build-info",
                     ref buildInfoUrl,
                     (value) => new Uri(value),
-                    "URL of the build info to update the Dockerfiles with");
+                    "URL of the build info to update the Dockerfiles with (http(s):// or file://)");
                 BuildInfoUrl = buildInfoUrl;
             });
 

--- a/scripts/update-dependencies/Program.cs
+++ b/scripts/update-dependencies/Program.cs
@@ -82,7 +82,7 @@ namespace Dotnet.Docker
                 using (Stream stream = await client.GetStreamAsync(Options.BuildInfoUrl))
                 {
                     buildInfoXml = XDocument.Load(stream);
-                };
+                }
             }
 
             OrchestratedBuildModel buildInfo = OrchestratedBuildModel.Parse(buildInfoXml.Root);

--- a/scripts/update-dependencies/Program.cs
+++ b/scripts/update-dependencies/Program.cs
@@ -20,11 +20,12 @@ namespace Dotnet.Docker
 {
     public static class Program
     {
+        private const string AspNetCoreBuildInfoName = "aspnet";
+        private const string RuntimeBuildInfoName = "core-setup";
+        private const string SdkBuildInfoName = "cli";
+
         private static Options Options { get; } = new Options();
         private static string RepoRoot { get; } = Directory.GetCurrentDirectory();
-        private const string RuntimeBuildInfoName = "Runtime";
-        private const string AspNetCoreBuildInfoName = "AspNetCore";
-        private const string SdkBuildInfoName = "Sdk";
 
         public static async Task Main(string[] args)
         {
@@ -59,8 +60,8 @@ namespace Dotnet.Docker
 
         private static DependencyUpdateResults UpdateFiles(IEnumerable<IDependencyInfo> buildInfos)
         {
-            string sdkVersion = buildInfos.GetBuildVersion(SdkBuildInfoName);
-            string dockerfileVersion = sdkVersion.Substring(0, sdkVersion.LastIndexOf('.'));
+            string runtimeVersion = buildInfos.GetBuildVersion(RuntimeBuildInfoName);
+            string dockerfileVersion = runtimeVersion.Substring(0, runtimeVersion.LastIndexOf('.'));
             IEnumerable<IDependencyUpdater> updaters = GetUpdaters(dockerfileVersion);
 
             return DependencyUpdateUtils.Update(updaters, buildInfos);
@@ -70,34 +71,39 @@ namespace Dotnet.Docker
         {
             Trace.TraceInformation($"Retrieving build info from '{Options.BuildInfoUrl}'");
 
-            using (HttpClient client = new HttpClient())
-            using (Stream stream = await client.GetStreamAsync(Options.BuildInfoUrl))
+            XDocument buildInfoXml;
+            if (File.Exists(Options.BuildInfoUrl.LocalPath))
             {
-                XDocument buildInfoXml = XDocument.Load(stream);
-                OrchestratedBuildModel buildInfo = OrchestratedBuildModel.Parse(buildInfoXml.Root);
-                BuildIdentity sdkBuild = buildInfo.Builds
-                    .First(build => string.Equals(build.Name, "cli", StringComparison.OrdinalIgnoreCase));
-                BuildIdentity coreSetupBuild = buildInfo.Builds
-                    .First(build => string.Equals(build.Name, "core-setup", StringComparison.OrdinalIgnoreCase));
-                BuildIdentity aspnetBuild = buildInfo.Builds
-                    .First(build => string.Equals(build.Name, "aspnet", StringComparison.OrdinalIgnoreCase));
-
-                return new[]
+                buildInfoXml = XDocument.Load(Options.BuildInfoUrl.LocalPath);
+            }
+            else
+            {
+                using (HttpClient client = new HttpClient())
+                using (Stream stream = await client.GetStreamAsync(Options.BuildInfoUrl))
                 {
-                    CreateDependencyBuildInfo(SdkBuildInfoName, sdkBuild.ProductVersion),
-                    CreateDependencyBuildInfo(RuntimeBuildInfoName, coreSetupBuild.ProductVersion),
-                    CreateDependencyBuildInfo(AspNetCoreBuildInfoName, aspnetBuild.ProductVersion),
+                    buildInfoXml = XDocument.Load(stream);
                 };
+            }
+
+            OrchestratedBuildModel buildInfo = OrchestratedBuildModel.Parse(buildInfoXml.Root);
+
+            return new[]
+            {
+                CreateDependencyBuildInfo(SdkBuildInfoName, buildInfo.Builds),
+                CreateDependencyBuildInfo(RuntimeBuildInfoName, buildInfo.Builds),
+                CreateDependencyBuildInfo(AspNetCoreBuildInfoName, buildInfo.Builds),
             };
         }
 
-        private static IDependencyInfo CreateDependencyBuildInfo(string name, string latestReleaseVersion)
+        private static IDependencyInfo CreateDependencyBuildInfo(string name, IEnumerable<BuildIdentity> builds)
         {
+            BuildIdentity buildId = builds.First(build => string.Equals(build.Name, name, StringComparison.OrdinalIgnoreCase));
+
             return new BuildDependencyInfo(
                 new BuildInfo()
                 {
                     Name = name,
-                    LatestReleaseVersion = latestReleaseVersion,
+                    LatestReleaseVersion = buildId.ProductVersion,
                     LatestPackages = new Dictionary<string, string>()
                 },
                 false,


### PR DESCRIPTION
* Add support for reading local build info file.
* Add support for 2.0 sdk scenarios where the sdk version does not align with the dockerfile version folder layout.  Runtime version info is used to find Dockerfiles now.
* Add support for reading checksums from `https://dotnetcli.blob.core.windows.net/dotnet/checksums` if not found in `https://dotnetclichecksums.blob.core.windows.net`

@dotnet-bot skip ci please