### PR TITLE
Refactor test cleanup logic

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -15,15 +15,17 @@ function Invoke-CleanupDocker($ActiveOS)
 {
     if ($CleanupDocker) {
         if ("$ActiveOS" -eq "windows") {
+            docker ps -a -q | ForEach-Object { docker rm -f $_ }
+
             # Windows base images are large, preserve them to avoid the overhead of pulling each time.
             docker images |
-            Where-Object {
-                -Not ($_.StartsWith("microsoft/nanoserver ")`
-                -Or $_.StartsWith("microsoft/windowsservercore ")`
-                -Or $_.StartsWith("REPOSITORY ")) } |
-            ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2] } |
-            Select-Object -Unique |
-            ForEach-Object { docker rmi -f $_ }
+                Where-Object {
+                    -Not ($_.StartsWith("microsoft/nanoserver ")`
+                    -Or $_.StartsWith("microsoft/windowsservercore ")`
+                    -Or $_.StartsWith("REPOSITORY ")) } |
+                ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2] } |
+                Select-Object -Unique |
+                ForEach-Object { docker rmi -f $_ }
         }
         else {
             docker system prune -a -f

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -36,6 +36,20 @@ namespace Microsoft.DotNet.Docker.Tests
             ExecuteWithLogging($"build -t {tag} {buildArgsOption} -f {dockerfile} .");
         }
 
+        public static bool ContainerExists(string container)
+        {
+            return ResourceExists("container", container);
+        }
+
+        public void DeleteContainer(string container)
+        {
+            if (ContainerExists(container))
+            {
+                ExecuteWithLogging($"logs {container}", ignoreErrors: true);
+                ExecuteWithLogging($"container rm -f {container}");
+            }
+        }
+
         public void DeleteImage(string tag)
         {
             if (ImageExists(tag))
@@ -149,12 +163,6 @@ namespace Microsoft.DotNet.Docker.Tests
         public static bool VolumeExists(string name)
         {
             return ResourceExists("volume", $"-f \"name={name}\"");
-        }
-
-        public void Kill(string containerName)
-        {
-            ExecuteWithLogging($"logs {containerName}", ignoreErrors: true);
-            ExecuteWithLogging($"kill {containerName}", ignoreErrors: true);
         }
     }
 }

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -299,9 +299,10 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             var retries = 60;
             var client = new HttpClient();
-            var url = Environment.GetEnvironmentVariable("RUNNING_TESTS_IN_CONTAINER") == null && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                          ? "http://localhost:5000"
-                          : "http://" + DockerHelper.GetContainerAddress(containerName);
+            var isRunningInContainer = Environment.GetEnvironmentVariable("RUNNING_TESTS_IN_CONTAINER") != null;
+            var url = !isRunningInContainer && DockerHelper.IsLinuxContainerModeEnabled
+                ? $"http://localhost:{DockerHelper.GetContainerHostPort(containerName)}"
+                : $"http://{DockerHelper.GetContainerAddress(containerName)}";
 
             while (retries > 0)
             {

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
             finally
             {
-                DockerHelper.Kill(appSdkImage);
+                DockerHelper.DeleteContainer(appSdkImage);
             }
         }
 
@@ -233,7 +233,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
             finally
             {
-                DockerHelper.Kill(frameworkDepAppId);
+                DockerHelper.DeleteContainer(frameworkDepAppId);
                 DockerHelper.DeleteVolume(frameworkDepAppId);
             }
         }
@@ -285,7 +285,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 }
                 finally
                 {
-                    DockerHelper.Kill(selfContainedAppId);
+                    DockerHelper.DeleteContainer(selfContainedAppId);
                     DockerHelper.DeleteVolume(selfContainedAppId);
                 }
             }


### PR DESCRIPTION
Builds have been failing frequently due to DockerHelper.Kill failing to remove the container.  This is an attempt to cleanup the container in a more robust fashion.