### PR TITLE
Update 2.1 Alpine 3.6 images to 3.7

### DIFF
--- a/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.7
 
 # Workaround https://github.com/aspnet/libuv-package/issues/23
 # Install libuv globally and link it so coreclr can laod it

--- a/2.1/runtime-deps/alpine3.7/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine3.7/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk add --no-cache \
         ca-certificates \

--- a/2.1/runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/runtime/alpine3.7/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.7
 
 # Install .NET Core
 ENV DOTNET_VERSION 2.1.0-preview2-26406-04

--- a/2.1/sdk/alpine3.7/amd64/Dockerfile
+++ b/2.1/sdk/alpine3.7/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.7
 
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache icu-libs

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 **.NET Core 2.1 Preview 2 tags**
 
 - [`2.1.300-preview2-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.300-preview2-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine/amd64/Dockerfile)
+- [`2.1.300-preview2-sdk-alpine3.7`, `2.1-sdk-alpine3.7`, `2.1.300-preview2-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
 - [`2.1.300-preview2-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
 - [`2.1.0-preview2-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.0-preview2-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.0-preview2-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine/amd64/Dockerfile)
+- [`2.1.0-preview2-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7`, `2.1.0-preview2-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
 - [`2.1.0-preview2-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine/amd64/Dockerfile)
+- [`2.1.0-preview2-runtime-alpine3.7`, `2.1-runtime-alpine3.7`, `2.1.0-preview2-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.7/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.0-preview2-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine/amd64/Dockerfile)
+- [`2.1.0-preview2-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7`, `2.1.0-preview2-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
 - [`2.1.0-preview2-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
 
 # Windows Server, version 1709 amd64 tags
@@ -88,8 +88,8 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 # Linux arm32 tags
 
-- [`2.0.6-runtime-stretch-arm32v7`, `2.0-runtime-stretch-arm32v7`, `2.0.6-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/stretch/arm32v7/Dockerfile)
-- [`2.0.6-runtime-deps-stretch-arm32v7`, `2.0-runtime-deps-stretch-arm32v7`, `2.0.6-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/stretch/arm32v7/Dockerfile)
+- [`2.0.7-runtime-stretch-arm32v7`, `2.0-runtime-stretch-arm32v7`, `2.0.7-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/stretch/arm32v7/Dockerfile)
+- [`2.0.7-runtime-deps-stretch-arm32v7`, `2.0-runtime-deps-stretch-arm32v7`, `2.0.7-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/stretch/arm32v7/Dockerfile)
 
 **.NET Core 2.1 Preview 2 tags**
 

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -76,7 +76,7 @@ try {
                 $qualifiedTags = $tags | ForEach-Object { $manifestRepo.Name + ':' + $_.Name}
                 $formattedTags = $qualifiedTags -join ', '
                 Write-Host "--- Building $formattedTags from $dockerfilePath ---"
-                Invoke-Expression "docker build $optionalDockerBuildArgs --pull -t $($qualifiedTags -join ' -t ') $dockerfilePath"
+                Invoke-Expression "docker build $optionalDockerBuildArgs -t $($qualifiedTags -join ' -t ') $dockerfilePath"
                 if ($LastExitCode -ne 0) {
                     throw "Failed building $formattedTags"
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -462,9 +462,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "2.1/runtime-deps/alpine/amd64",
+              "dockerfile": "2.1/runtime-deps/alpine3.7/amd64",
               "os": "linux",
               "tags": {
+                "2.1.0-preview2-runtime-deps-alpine3.7": {},
+                "2.1-runtime-deps-alpine3.7": {},
                 "2.1.0-preview2-runtime-deps-alpine": {},
                 "2.1-runtime-deps-alpine": {}
               }
@@ -474,9 +476,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "2.1/runtime/alpine/amd64",
+              "dockerfile": "2.1/runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
+                "2.1.0-preview2-runtime-alpine3.7": {},
+                "2.1-runtime-alpine3.7": {},
                 "2.1.0-preview2-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
               }
@@ -486,9 +490,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "2.1/aspnetcore-runtime/alpine/amd64",
+              "dockerfile": "2.1/aspnetcore-runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
+                "2.1.0-preview2-aspnetcore-runtime-alpine3.7": {},
+                "2.1-aspnetcore-runtime-alpine3.7": {},
                 "2.1.0-preview2-aspnetcore-runtime-alpine": {},
                 "2.1-aspnetcore-runtime-alpine": {}
               }
@@ -498,9 +504,11 @@
         {
           "platforms": [
             {
-              "dockerfile": "2.1/sdk/alpine/amd64",
+              "dockerfile": "2.1/sdk/alpine3.7/amd64",
               "os": "linux",
               "tags": {
+                "2.1.300-preview2-sdk-alpine3.7": {},
+                "2.1-sdk-alpine3.7": {},
                 "2.1.300-preview2-sdk-alpine": {},
                 "2.1-sdk-alpine": {}
               }

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -14,16 +14,16 @@ $(TagDoc:1.0.11-runtime-deps-jessie)
 **.NET Core 2.1 Preview 2 tags**
 
 $(TagDoc:2.1.300-preview2-sdk-stretch)
-$(TagDoc:2.1.300-preview2-sdk-alpine)
+$(TagDoc:2.1.300-preview2-sdk-alpine3.7)
 $(TagDoc:2.1.300-preview2-sdk-bionic)
 $(TagDoc:2.1.0-preview2-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.0-preview2-aspnetcore-runtime-alpine)
+$(TagDoc:2.1.0-preview2-aspnetcore-runtime-alpine3.7)
 $(TagDoc:2.1.0-preview2-aspnetcore-runtime-bionic)
 $(TagDoc:2.1.0-preview2-runtime-stretch-slim)
-$(TagDoc:2.1.0-preview2-runtime-alpine)
+$(TagDoc:2.1.0-preview2-runtime-alpine3.7)
 $(TagDoc:2.1.0-preview2-runtime-bionic)
 $(TagDoc:2.1.0-preview2-runtime-deps-stretch-slim)
-$(TagDoc:2.1.0-preview2-runtime-deps-alpine)
+$(TagDoc:2.1.0-preview2-runtime-deps-alpine3.7)
 $(TagDoc:2.1.0-preview2-runtime-deps-bionic)
 
 # Windows Server, version 1709 amd64 tags

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -402,7 +402,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
             else if (imageData.IsAlpine)
             {
-                rid = "alpine.3.6-x64";
+                rid = "alpine.3.7-x64";
             }
             else if (imageData.DotNetVersion.StartsWith("1."))
             {


### PR DESCRIPTION
As part of this I am proposing the introduction of fixed `alpine3.7` suffixed tags along with the stable `alpine` tags.  This aligns with what is done in the official Docker repos.  This will afford us the opportunity to upgrade Alpine versions within any given .NET release.

Related to #488