### PR TITLE
Update 2.1 tags to align with the product versions (preview2 -> rc1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 **.NET Core 2.1 Preview 2 tags**
 
-- [`2.1.300-preview2-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.300-preview2-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine/amd64/Dockerfile)
-- [`2.1.300-preview2-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
-- [`2.1.0-preview2-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.0-preview2-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.0-preview2-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine/amd64/Dockerfile)
-- [`2.1.0-preview2-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.0-preview2-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`2.1.300-rc1-sdk-stretch`, `2.1-sdk-stretch`, `2.1.300-rc1-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.300-rc1-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine/amd64/Dockerfile)
+- [`2.1.300-rc1-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.1.0-rc1-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.0-rc1-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.0-rc1-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine/amd64/Dockerfile)
+- [`2.1.0-rc1-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.0-rc1-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.0-rc1-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
 
 # Windows Server, version 1709 amd64 tags
 
@@ -68,9 +68,9 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 **.NET Core 2.1 Preview 2 tags**
 
-- [`2.1.300-preview2-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.0-preview2-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.0-preview2-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.300-rc1-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.300-rc1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.0-rc1-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.0-rc1-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.0-rc1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
 # Windows Server 2016 amd64 tags
 
@@ -82,9 +82,9 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 **.NET Core 2.1 Preview 2 tags**
 
-- [`2.1.300-preview2-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.0-preview2-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.0-preview2-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.0-preview2-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.300-rc1-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.300-rc1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.0-rc1-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.0-rc1-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.0-rc1-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.0-rc1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
 # Linux arm32 tags
 
@@ -93,12 +93,12 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 **.NET Core 2.1 Preview 2 tags**
 
-- [`2.1.300-preview2-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.300-preview2-sdk`, `2.1-sdk` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.300-preview2-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
-- [`2.1.0-preview2-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.0-preview2-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.0-preview2-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.0-preview2-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.0-preview2-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.0-preview2-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.300-rc1-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.300-rc1-sdk`, `2.1-sdk` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.300-rc1-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.1.0-rc1-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.0-rc1-runtime`, `2.1-runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.0-rc1-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.0-rc1-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.0-rc1-runtime-deps`, `2.1-runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.0-rc1-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls?utf8=%E2%9C%93&q=).
 

--- a/manifest.json
+++ b/manifest.json
@@ -316,7 +316,7 @@
         },
         {
           "sharedTags": {
-            "2.1.0-preview2-runtime-deps": {},
+            "2.1.0-rc1-runtime-deps": {},
             "2.1-runtime-deps": {}
           },
           "platforms": [
@@ -324,7 +324,7 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-deps-stretch-slim": {},
+                "2.1.0-rc1-runtime-deps-stretch-slim": {},
                 "2.1-runtime-deps-stretch-slim": {}
               }
             },
@@ -333,7 +333,7 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-deps-stretch-slim-arm32v7": {},
+                "2.1.0-rc1-runtime-deps-stretch-slim-arm32v7": {},
                 "2.1-runtime-deps-stretch-slim-arm32v7": {}
               },
               "variant": "armv7"
@@ -342,7 +342,7 @@
         },
         {
           "sharedTags": {
-            "2.1.0-preview2-runtime": {},
+            "2.1.0-rc1-runtime": {},
             "2.1-runtime": {}
           },
           "platforms": [
@@ -350,7 +350,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-stretch-slim": {},
+                "2.1.0-rc1-runtime-stretch-slim": {},
                 "2.1-runtime-stretch-slim": {}
               }
             },
@@ -359,7 +359,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-stretch-slim-arm32v7": {},
+                "2.1.0-rc1-runtime-stretch-slim-arm32v7": {},
                 "2.1-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "armv7"
@@ -368,7 +368,7 @@
               "dockerfile": "2.1/runtime/nanoserver-sac2016/amd64",
               "os": "windows",
               "tags": {
-                "2.1.0-preview2-runtime-nanoserver-sac2016": {},
+                "2.1.0-rc1-runtime-nanoserver-sac2016": {},
                 "2.1-runtime-nanoserver-sac2016": {}
               }
             },
@@ -377,7 +377,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.1.0-preview2-runtime-nanoserver-1709": {},
+                "2.1.0-rc1-runtime-nanoserver-1709": {},
                 "2.1-runtime-nanoserver-1709": {}
               }
             }
@@ -385,7 +385,7 @@
         },
         {
           "sharedTags": {
-            "2.1.0-preview2-aspnetcore-runtime": {},
+            "2.1.0-rc1-aspnetcore-runtime": {},
             "2.1-aspnetcore-runtime": {}
           },
           "platforms": [
@@ -393,7 +393,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-aspnetcore-runtime-stretch-slim": {},
+                "2.1.0-rc1-aspnetcore-runtime-stretch-slim": {},
                 "2.1-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -401,7 +401,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/nanoserver-sac2016/amd64",
               "os": "windows",
               "tags": {
-                "2.1.0-preview2-aspnetcore-runtime-nanoserver-sac2016": {},
+                "2.1.0-rc1-aspnetcore-runtime-nanoserver-sac2016": {},
                 "2.1-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -410,7 +410,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.1.0-preview2-aspnetcore-runtime-nanoserver-1709": {},
+                "2.1.0-rc1-aspnetcore-runtime-nanoserver-1709": {},
                 "2.1-aspnetcore-runtime-nanoserver-1709": {}
               }
             }
@@ -418,7 +418,7 @@
         },
         {
           "sharedTags": {
-            "2.1.300-preview2-sdk": {},
+            "2.1.300-rc1-sdk": {},
             "2.1-sdk": {}
           },
           "platforms": [
@@ -426,7 +426,7 @@
               "dockerfile": "2.1/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "2.1.300-preview2-sdk-stretch": {},
+                "2.1.300-rc1-sdk-stretch": {},
                 "2.1-sdk-stretch": {}
               }
             },
@@ -435,7 +435,7 @@
               "dockerfile": "2.1/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.300-preview2-sdk-stretch-arm32v7": {},
+                "2.1.300-rc1-sdk-stretch-arm32v7": {},
                 "2.1-sdk-stretch-arm32v7": {}
               },
               "variant": "armv7"
@@ -444,7 +444,7 @@
               "dockerfile": "2.1/sdk/nanoserver-sac2016/amd64",
               "os": "windows",
               "tags": {
-                "2.1.300-preview2-sdk-nanoserver-sac2016": {},
+                "2.1.300-rc1-sdk-nanoserver-sac2016": {},
                 "2.1-sdk-nanoserver-sac2016": {}
               }
             },
@@ -453,7 +453,7 @@
               "os": "windows",
               "osVersion": "1709",
               "tags": {
-                "2.1.300-preview2-sdk-nanoserver-1709": {},
+                "2.1.300-rc1-sdk-nanoserver-1709": {},
                 "2.1-sdk-nanoserver-1709": {}
               }
             }
@@ -465,7 +465,7 @@
               "dockerfile": "2.1/runtime-deps/alpine/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-deps-alpine": {},
+                "2.1.0-rc1-runtime-deps-alpine": {},
                 "2.1-runtime-deps-alpine": {}
               }
             }
@@ -477,7 +477,7 @@
               "dockerfile": "2.1/runtime/alpine/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-alpine": {},
+                "2.1.0-rc1-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
               }
             }
@@ -489,7 +489,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/alpine/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-aspnetcore-runtime-alpine": {},
+                "2.1.0-rc1-aspnetcore-runtime-alpine": {},
                 "2.1-aspnetcore-runtime-alpine": {}
               }
             }
@@ -501,7 +501,7 @@
               "dockerfile": "2.1/sdk/alpine/amd64",
               "os": "linux",
               "tags": {
-                "2.1.300-preview2-sdk-alpine": {},
+                "2.1.300-rc1-sdk-alpine": {},
                 "2.1-sdk-alpine": {}
               }
             }
@@ -513,7 +513,7 @@
               "dockerfile": "2.1/runtime-deps/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-deps-bionic": {},
+                "2.1.0-rc1-runtime-deps-bionic": {},
                 "2.1-runtime-deps-bionic": {}
               }
             }
@@ -525,7 +525,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-aspnetcore-runtime-bionic": {},
+                "2.1.0-rc1-aspnetcore-runtime-bionic": {},
                 "2.1-aspnetcore-runtime-bionic": {}
               }
             }
@@ -537,7 +537,7 @@
               "dockerfile": "2.1/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-bionic": {},
+                "2.1.0-rc1-runtime-bionic": {},
                 "2.1-runtime-bionic": {}
               }
             }
@@ -549,7 +549,7 @@
               "dockerfile": "2.1/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.300-preview2-sdk-bionic": {},
+                "2.1.300-rc1-sdk-bionic": {},
                 "2.1-sdk-bionic": {}
               }
             }
@@ -562,7 +562,7 @@
               "dockerfile": "2.1/runtime-deps/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-deps-bionic-arm32v7": {},
+                "2.1.0-rc1-runtime-deps-bionic-arm32v7": {},
                 "2.1-runtime-deps-bionic-arm32v7": {}
               },
               "variant": "armv7"
@@ -576,7 +576,7 @@
               "dockerfile": "2.1/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.0-preview2-runtime-bionic-arm32v7": {},
+                "2.1.0-rc1-runtime-bionic-arm32v7": {},
                 "2.1-runtime-bionic-arm32v7": {}
               },
               "variant": "armv7"
@@ -590,7 +590,7 @@
               "dockerfile": "2.1/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.300-preview2-sdk-bionic-arm32v7": {},
+                "2.1.300-rc1-sdk-bionic-arm32v7": {},
                 "2.1-sdk-bionic-arm32v7": {}
               },
               "variant": "armv7"

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -13,18 +13,18 @@ $(TagDoc:1.0.11-runtime-deps-jessie)
 
 **.NET Core 2.1 Preview 2 tags**
 
-$(TagDoc:2.1.300-preview2-sdk-stretch)
-$(TagDoc:2.1.300-preview2-sdk-alpine)
-$(TagDoc:2.1.300-preview2-sdk-bionic)
-$(TagDoc:2.1.0-preview2-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.0-preview2-aspnetcore-runtime-alpine)
-$(TagDoc:2.1.0-preview2-aspnetcore-runtime-bionic)
-$(TagDoc:2.1.0-preview2-runtime-stretch-slim)
-$(TagDoc:2.1.0-preview2-runtime-alpine)
-$(TagDoc:2.1.0-preview2-runtime-bionic)
-$(TagDoc:2.1.0-preview2-runtime-deps-stretch-slim)
-$(TagDoc:2.1.0-preview2-runtime-deps-alpine)
-$(TagDoc:2.1.0-preview2-runtime-deps-bionic)
+$(TagDoc:2.1.300-rc1-sdk-stretch)
+$(TagDoc:2.1.300-rc1-sdk-alpine)
+$(TagDoc:2.1.300-rc1-sdk-bionic)
+$(TagDoc:2.1.0-rc1-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1.0-rc1-aspnetcore-runtime-alpine)
+$(TagDoc:2.1.0-rc1-aspnetcore-runtime-bionic)
+$(TagDoc:2.1.0-rc1-runtime-stretch-slim)
+$(TagDoc:2.1.0-rc1-runtime-alpine)
+$(TagDoc:2.1.0-rc1-runtime-bionic)
+$(TagDoc:2.1.0-rc1-runtime-deps-stretch-slim)
+$(TagDoc:2.1.0-rc1-runtime-deps-alpine)
+$(TagDoc:2.1.0-rc1-runtime-deps-bionic)
 
 # Windows Server, version 1709 amd64 tags
 
@@ -33,9 +33,9 @@ $(TagDoc:2.0.7-runtime-nanoserver-1709)
 
 **.NET Core 2.1 Preview 2 tags**
 
-$(TagDoc:2.1.300-preview2-sdk-nanoserver-1709)
-$(TagDoc:2.1.0-preview2-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.1.0-preview2-runtime-nanoserver-1709)
+$(TagDoc:2.1.300-rc1-sdk-nanoserver-1709)
+$(TagDoc:2.1.0-rc1-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.1.0-rc1-runtime-nanoserver-1709)
 
 # Windows Server 2016 amd64 tags
 
@@ -47,9 +47,9 @@ $(TagDoc:1.0.11-runtime-nanoserver-sac2016)
 
 **.NET Core 2.1 Preview 2 tags**
 
-$(TagDoc:2.1.300-preview2-sdk-nanoserver-sac2016)
-$(TagDoc:2.1.0-preview2-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.1.0-preview2-runtime-nanoserver-sac2016)
+$(TagDoc:2.1.300-rc1-sdk-nanoserver-sac2016)
+$(TagDoc:2.1.0-rc1-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.1.0-rc1-runtime-nanoserver-sac2016)
 
 # Linux arm32 tags
 
@@ -58,10 +58,10 @@ $(TagDoc:2.0.7-runtime-deps-stretch-arm32v7)
 
 **.NET Core 2.1 Preview 2 tags**
 
-$(TagDoc:2.1.300-preview2-sdk-stretch-arm32v7)
-$(TagDoc:2.1.300-preview2-sdk-bionic-arm32v7)
-$(TagDoc:2.1.0-preview2-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.0-preview2-runtime-bionic-arm32v7)
-$(TagDoc:2.1.0-preview2-runtime-deps-stretch-slim-arm32v7)
-$(TagDoc:2.1.0-preview2-runtime-deps-bionic-arm32v7)
+$(TagDoc:2.1.300-rc1-sdk-stretch-arm32v7)
+$(TagDoc:2.1.300-rc1-sdk-bionic-arm32v7)
+$(TagDoc:2.1.0-rc1-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1.0-rc1-runtime-bionic-arm32v7)
+$(TagDoc:2.1.0-rc1-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:2.1.0-rc1-runtime-deps-bionic-arm32v7)
 


### PR DESCRIPTION
In response to https://github.com/dotnet/dotnet-docker/pull/494 and https://github.com/dotnet/cli/pull/9101