### PR TITLE
[Arm64] Add runtime-dep and runtime images

### DIFF
--- a/.vsts.pipelines/templates/build-all.yml
+++ b/.vsts.pipelines/templates/build-all.yml
@@ -12,6 +12,9 @@ parameters:
   matrixLinuxArm32v7:
     Build_2_1:
       buildPath: 2.1*
+  matrixLinuxArm64:
+    Build_2_2:
+      buildPath: 2.2*
   matrixWindowsSac2016Amd64:
     Build_1_*:
       buildPath: 1.*
@@ -47,6 +50,11 @@ phases:
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}
       matrix: ${{ parameters.matrixLinuxArm32v7 }}
+  - template: build-linux-arm64.yml
+    parameters:
+      imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
+      manifest: ${{ parameters.manifest }}
+      matrix: ${{ parameters.matrixLinuxArm64 }}
   - template: build-windows-amd64.yml
     parameters:
       phase: NanoServerSac2016_amd64

--- a/.vsts.pipelines/templates/build-finalize.yml
+++ b/.vsts.pipelines/templates/build-finalize.yml
@@ -6,6 +6,7 @@ phases:
     dependsOn:
       - Linux_amd64
       - Linux_arm32v7
+      - Linux_arm64
       - NanoServerSac2016_amd64
       - NanoServer1709_amd64
       - NanoServer1803_amd64

--- a/.vsts.pipelines/templates/build-linux-arm64.yml
+++ b/.vsts.pipelines/templates/build-linux-arm64.yml
@@ -1,0 +1,45 @@
+parameters:
+  imageBuilderImage: null
+  manifest: null
+  matrix: {}
+phases:
+  - phase: Linux_arm64
+    queue:
+      name: DotNetCore-Infra
+      demands:
+        - VSTS_OS -equals Windows_10_Enterprise
+        - DockerVersion
+      parallel: 2
+      matrix: ${{ parameters.matrix }}
+    variables:
+      docker.baseArtifactName: $(Build.BuildId)
+      docker.certVolumeArg: -v cert_$(docker.baseArtifactName):/docker-certs
+      docker.commonRunArgs: --rm -v $(docker.repoVolumeName):/repo -w /repo $(docker.certVolumeArg) -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PiIp):2376
+      docker.gitEnabledimage: buildpack-deps:stretch-scm
+      docker.repoVolumeName: repo_$(docker.baseArtifactName)
+      docker.setupContainerName: setup_$(docker.baseArtifactName)
+      imageBuilder.customArgs: --var VersionFilter=$(buildPath) --var ArchitectureFilter=arm64
+      imageBuilder.image: ${{ parameters.imageBuilderImage }}
+      manifest: ${{ parameters.manifest }}
+    steps:
+      - template: docker-cleanup-windows.yml
+      - script: docker pull $(imageBuilder.image)
+        displayName: Pull Image Builder
+      - script: docker create $(docker.certVolumeArg) --name $(docker.setupContainerName) $(imageBuilder.image)
+        displayName: Create Setup Container
+      - script: docker cp c:/docker-certs $(docker.setupContainerName):/
+        displayName: Copy Docker Certs
+      - script: docker rm -f $(docker.setupContainerName)
+        displayName: Cleanup container
+        continueOnError: true
+      - script: docker run $(docker.commonRunArgs) --name clone_$(docker.baseArtifactName) $(docker.gitEnabledimage) git clone https://github.com/dotnet/dotnet-docker.git /repo
+        displayName: Clone Repo
+      - script: docker run $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
+        displayName: Checkout Source
+      - script: docker run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(buildPath) --architecture arm64 --skip-test --push --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.customArgs) $(imageBuilder.queueArgs)
+        displayName: Build Images
+      - script: docker run $(docker.commonRunArgs) --name cleanup_$(docker.baseArtifactName) --entrypoint docker $(imageBuilder.image) system prune -a -f
+        displayName: Cleanup ARM64 Docker
+        condition: always()
+        continueOnError: true
+      - template: docker-cleanup-windows.yml

--- a/2.2/runtime-deps/bionic/arm64v8/Dockerfile
+++ b/2.2/runtime-deps/bionic/arm64v8/Dockerfile
@@ -1,0 +1,21 @@
+FROM arm64v8/ubuntu:bionic
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu60 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure Kestrel web server to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.2/runtime-deps/stretch-slim/arm64v8/Dockerfile
+++ b/2.2/runtime-deps/stretch-slim/arm64v8/Dockerfile
@@ -1,0 +1,21 @@
+FROM arm64v8/debian:stretch-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu57 \
+        liblttng-ust0 \
+        libssl1.0.2 \
+        libstdc++6 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure Kestrel web server to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.2/runtime/bionic/arm64v8/Dockerfile
+++ b/2.2/runtime/bionic/arm64v8/Dockerfile
@@ -1,0 +1,17 @@
+FROM microsoft/dotnet-nightly:2.2-runtime-deps-bionic-arm64v8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.2.0-preview1-26426-05
+
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz \
+    && dotnet_sha512='1671f698158011626884e651c194d42dfae2423eefe285502750d6d7cb33d3b038b33824c759540695dd8b4b61cc3eb956adfb05a5e94784147aadc45c8deaaa' \
+    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/2.2/runtime/stretch-slim/arm64v8/Dockerfile
+++ b/2.2/runtime/stretch-slim/arm64v8/Dockerfile
@@ -1,0 +1,17 @@
+FROM microsoft/dotnet-nightly:2.2-runtime-deps-stretch-slim-arm64v8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.2.0-preview1-26426-05
+
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz \
+    && dotnet_sha512='1671f698158011626884e651c194d42dfae2423eefe285502750d6d7cb33d3b038b33824c759540695dd8b4b61cc3eb956adfb05a5e94784147aadc45c8deaaa' \
+    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 - [`2.1.1-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.1-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.1-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
+# Linux arm64 tags
+
+**.NET Core 2.2 preview 1 tags**
+
+- [`2.2.0-preview1-runtime-stretch-slim-arm64v8`, `2.2-runtime-stretch-slim-arm64v8` (*2.2/runtime/stretch-slim/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm64v8/Dockerfile)
+- [`2.2.0-preview1-runtime-bionic-arm64v8`, `2.2-runtime-bionic-arm64v8` (*2.2/runtime/bionic/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm64v8/Dockerfile)
+- [`2.2.0-preview1-runtime-deps-stretch-slim-arm64v8`, `2.2-runtime-deps-stretch-slim-arm64v8` (*2.2/runtime-deps/stretch-slim/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime-deps/stretch-slim/arm64v8/Dockerfile)
+- [`2.2.0-preview1-runtime-deps-bionic-arm64v8`, `2.2-runtime-deps-bionic-arm64v8` (*2.2/runtime-deps/bionic/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime-deps/bionic/arm64v8/Dockerfile)
+
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 
 ## What is .NET Core?

--- a/manifest.json
+++ b/manifest.json
@@ -683,6 +683,58 @@
               "variant": "v7"
             }
           ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "2.2/runtime-deps/bionic/arm64v8",
+              "os": "linux",
+              "tags": {
+                "2.2.0-rc1-runtime-deps-bionic-arm64v8": {},
+                "2.2-runtime-deps-bionic-arm64v8": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "2.2/runtime/bionic/arm64v8",
+              "os": "linux",
+              "tags": {
+                "2.2.0-preview1-runtime-bionic-arm64v8": {},
+                "2.2-runtime-bionic-arm64v8": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "2.2/runtime-deps/stretch-slim/arm64v8",
+              "os": "linux",
+              "tags": {
+                "2.2.0-preview1-runtime-deps-stretch-slim-arm64v8": {},
+                "2.2-runtime-deps-stretch-slim-arm64v8": {}
+              }
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "2.2/runtime/stretch-slim/arm64v8",
+              "os": "linux",
+              "tags": {
+                "2.2.0-preview1-runtime-stretch-slim-arm64v8": {},
+                "2.2-runtime-stretch-slim-arm64v8": {}
+              }
+            }
+          ]
         }
       ]
     }

--- a/netci.groovy
+++ b/netci.groovy
@@ -19,7 +19,7 @@ platformList.each { platform ->
         versionList = ['1.', '2.0', '2.1']
     }
     else {
-        versionList = ['1.', '2.0', '2.1']
+        versionList = ['1.', '2.0', '2.1', '2.2']
     }
 
     versionList.each { version ->

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -61,3 +61,11 @@ $(TagDoc:2.1.1-runtime-bionic-arm32v7)
 $(TagDoc:2.1.1-runtime-deps-stretch-slim-arm32v7)
 $(TagDoc:2.1.1-runtime-deps-bionic-arm32v7)
 
+# Linux arm64 tags
+
+**.NET Core 2.2 preview 1 tags**
+
+$(TagDoc:2.2.0-preview1-runtime-stretch-slim-arm64v8)
+$(TagDoc:2.2.0-preview1-runtime-bionic-arm64v8)
+$(TagDoc:2.2.0-preview1-runtime-deps-stretch-slim-arm64v8)
+$(TagDoc:2.2.0-preview1-runtime-deps-bionic-arm64v8)

--- a/test/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public bool IsWeb { get; set; }
         public bool IsAlpine { get => String.Equals(OS.Alpine, OsVariant, StringComparison.OrdinalIgnoreCase); }
         public bool IsArm { get => String.Equals("arm", Architecture, StringComparison.OrdinalIgnoreCase); }
+        public bool IsArm64 { get => String.Equals("arm64", Architecture, StringComparison.OrdinalIgnoreCase); }
         public string OsVariant { get; set; }
 
         public string RuntimeDepsVersion

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -40,6 +40,8 @@ namespace Microsoft.DotNet.Docker.Tests
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.Alpine, IsWeb = true },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, Architecture = "arm", IsWeb = true },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.Bionic, Architecture = "arm", IsWeb = true },
+            new ImageData { DotNetVersion = "2.2", OsVariant = OS.StretchSlim, HasNoSdk = true, Architecture = "arm64" },
+            new ImageData { DotNetVersion = "2.2", OsVariant = OS.Bionic, HasNoSdk = true, Architecture = "arm64" },
         };
         private static readonly ImageData[] s_windowsTestData =
         {


### PR DESCRIPTION
@MichaelSimons This should add 2.1 arm64 runtime-dep and runtime images.

I didn't add SDK yet because last I checked it was not working.

I'll see if linux-arm64 sdk `2.1.300-rc1-008662` is working.

@richlander @petermarcu @russkeldorph  @dotnet/arm64-contrib FYI this is not intended to formally release linux-arm64, but to allow people to use docker to try arm64.