### PR TITLE
Fix broken arm samples build and update to build non-preview Dockerfiles

### DIFF
--- a/build-pipeline/pipeline-samples.json
+++ b/build-pipeline/pipeline-samples.json
@@ -30,8 +30,7 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "imageBuilder.manifest": "manifest.samples.json",
-            "docker.dockerConfigArgs": "-v /var/run/docker.sock:/var/run/docker.sock"
+            "imageBuilder.manifest": "manifest.samples.json"
           }
         }
       ]

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -11,14 +11,14 @@
           },
           "platforms": [
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile.preview",
+              "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "linux",
               "tags": {
                 "dotnetapp-stretch": {}
               }
             },
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile.preview",
+              "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "windows",
               "osVersion": "sac2016",
               "tags": {
@@ -26,7 +26,7 @@
               }
             },
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile.preview",
+              "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "windows",
               "osVersion": "1709",
               "tags": {
@@ -34,7 +34,7 @@
               }
             },
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile.preview",
+              "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "windows",
               "osVersion": "1803",
               "tags": {
@@ -43,11 +43,12 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/dotnetapp/Dockerfile.preview",
+              "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "linux",
               "tags": {
                 "dotnetapp-stretch-arm32v7": {}
-              }
+              },
+              "variant": "v7"
             }
           ]
         },
@@ -57,14 +58,14 @@
           },
           "platforms": [
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile.preview",
+              "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "linux",
               "tags": {
                 "aspnetapp-stretch": {}
               }
             },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile.preview",
+              "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "windows",
               "osVersion": "sac2016",
               "tags": {
@@ -72,7 +73,7 @@
               }
             },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile.preview",
+              "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "windows",
               "osVersion": "1709",
               "tags": {
@@ -80,7 +81,7 @@
               }
             },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile.preview",
+              "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "windows",
               "osVersion": "1803",
               "tags": {
@@ -89,11 +90,12 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/aspnetapp/Dockerfile.preview",
+              "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "linux",
               "tags": {
                 "aspnetapp-stretch-arm32v7": {}
-              }
+              },
+              "variant": "v7"
             }
           ]
         }


### PR DESCRIPTION
This change is dependent on the changes contained in #541.

The issue with the broken arm build, is that the Dockerfile.preview base image is a manifest tag and the build was picking up the amd64 base image.  This change forces the build to run on arm hardware.