### PR TITLE
Remove unused 2.0 ARM build leg

### DIFF
--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -42,12 +42,6 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB_imageBuilder_path": "2.0*"
-          }
-        },
-        {
-          "Name": "dotnet-docker-linux-arm32v7-images",
-          "Parameters": {
             "PB_imageBuilder_path": "2.1*"
           }
         }


### PR DESCRIPTION
This was overlooked as part of the changes for #515.  The build leg was running and was no-oping because there are no 2.0 arm images to build.