### PR TITLE
Correct capitalization of Release configuration.

### DIFF
--- a/samples/aspnetapp/Dockerfile
+++ b/samples/aspnetapp/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet restore
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /app/aspnetapp
-RUN dotnet publish -c release -o out
+RUN dotnet publish -c Release -o out
 
 
 FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -9,7 +9,7 @@ RUN dotnet restore
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /app/aspnetapp
-RUN dotnet publish -c release -o out
+RUN dotnet publish -c Release -o out
 
 
 FROM microsoft/dotnet:2.1-aspnetcore-runtime-alpine AS runtime

--- a/samples/aspnetapp/Dockerfile.nanoserver-sac2016
+++ b/samples/aspnetapp/Dockerfile.nanoserver-sac2016
@@ -9,7 +9,7 @@ RUN dotnet restore
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /app/aspnetapp
-RUN dotnet publish -c release -o out
+RUN dotnet publish -c Release -o out
 
 
 FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-sac2016 AS runtime

--- a/samples/aspnetapp/Dockerfile.preview
+++ b/samples/aspnetapp/Dockerfile.preview
@@ -10,7 +10,7 @@ RUN dotnet restore
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /app/aspnetapp
-RUN dotnet publish -c release -o out
+RUN dotnet publish -c Release -o out
 
 
 FROM microsoft/dotnet-nightly:2.1-aspnetcore-runtime AS runtime

--- a/samples/aspnetapp/README.md
+++ b/samples/aspnetapp/README.md
@@ -121,7 +121,7 @@ After the application starts, visit `http://localhost:5000` in your web browser.
 You can produce an application that is ready to deploy to production locally using the following command.
 
 ```console
-dotnet publish -c release -o out
+dotnet publish -c Release -o out
 ```
 
 You can run the application using the following commands.
@@ -131,7 +131,7 @@ cd out
 dotnet aspnetapp.dll
 ```
 
-Note: The `-c release` argument builds the application in release mode (the default is debug mode). See the [dotnet publish reference](https://docs.microsoft.com/dotnet/core/tools/dotnet-publish) for more information on commandline parameters.
+Note: The `-c Release` argument builds the application in release mode (the default is debug mode). See the [dotnet publish reference](https://docs.microsoft.com/dotnet/core/tools/dotnet-publish) for more information on commandline parameters.
 
 ## .NET Core Resources
 

--- a/samples/dotnetapp/README.md
+++ b/samples/dotnetapp/README.md
@@ -117,7 +117,7 @@ dotnet run Hello .NET Core
 You can produce an application that is ready to deploy to production using the following command.
 
 ```console
-dotnet publish -c release -o out
+dotnet publish -c Release -o out
 ```
 
 You can run the published application using the following command:
@@ -127,7 +127,7 @@ cd out
 dotnet dotnetapp.dll
 ```
 
-Note: The `-c release` argument builds the application in release mode (the default is debug mode). See the [dotnet publish reference](https://docs.microsoft.com/dotnet/core/tools/dotnet-publish) for more information on commandline parameters.
+Note: The `-c Release` argument builds the application in release mode (the default is debug mode). See the [dotnet publish reference](https://docs.microsoft.com/dotnet/core/tools/dotnet-publish) for more information on commandline parameters.
 
 ## .NET Resources
 

--- a/samples/dotnetapp/dotnet-docker-dev-in-container.md
+++ b/samples/dotnetapp/dotnet-docker-dev-in-container.md
@@ -88,19 +88,19 @@ The instructions assume that you are in the root of the repository. You can use 
 ### Windows using Linux containers
 
 ```console
-docker run --rm -v c:\git\dotnet-docker\samples\dotnetapp:/app -w /app/dotnetapp microsoft/dotnet:2.1-sdk dotnet publish -c release -o out
+docker run --rm -v c:\git\dotnet-docker\samples\dotnetapp:/app -w /app/dotnetapp microsoft/dotnet:2.1-sdk dotnet publish -c Release -o out
 ```
 
 ### Linux or macOS using Linux containers
 
 ```console
-docker run --rm -v ~/git/dotnet-docker/samples/dotnetapp:/app -w /app/dotnetapp microsoft/dotnet:2.1-sdk dotnet publish -c release -o out
+docker run --rm -v ~/git/dotnet-docker/samples/dotnetapp:/app -w /app/dotnetapp microsoft/dotnet:2.1-sdk dotnet publish -c Release -o out
 ```
 
 ### Windows using Windows containers
 
 ```console
-docker run --rm -v c:\git\dotnet-docker\samples\dotnetapp:c:\app -w c:\app\dotnetapp microsoft/dotnet:2.1-sdk dotnet publish -c release -o out
+docker run --rm -v c:\git\dotnet-docker\samples\dotnetapp:c:\app -w c:\app\dotnetapp microsoft/dotnet:2.1-sdk dotnet publish -c Release -o out
 ```
 
 ## More Samples


### PR DESCRIPTION
The aspnet docker samples and docs have been using `-c release` while the dotnet ones have already been using `-c Release`.

This PR corrects the capitalisation to `Release`.  since `release` may cause issues like https://github.com/dotnet/cli/issues/8920

To reproduce:
Use VS project property pages to enable documentation file generation. VS will change the csproj to:

```xml
  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
    <DocumentationFile>bin\Debug\netcoreapp2.1\WebApplication9.xml</DocumentationFile>
  </PropertyGroup>

  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
    <DocumentationFile>bin\Release\netcoreapp2.1\WebApplication9.xml</DocumentationFile>
  </PropertyGroup>
```

which will now fail to build on *nix with `-c release` due to MSBuild comparing case insensitive but not creating a `bin/Release` directory so the build will fail with:

```
CSC : error CS0016: Could not write to output file '/app/WebApplication9/bin/Release/netcoreapp2.1/WebApplication9.xml' -- 'Could not find a part of the path '/app/WebApplication9/bin/Release/netcoreapp2.1/WebApplication9.xml'.' [/app/WebApplication9/WebApplication9.csproj]
The command '/bin/sh -c dotnet publish -c release -o out' returned a non-zero code: 1
```