### PR TITLE
Refactor how the os-filter is used within build infra

### DIFF
--- a/.vsts.pipelines/microsoft-dotnet-samples.yml
+++ b/.vsts.pipelines/microsoft-dotnet-samples.yml
@@ -21,12 +21,15 @@ phases:
       matrixWindowsSac2016Amd64:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: --os-version sac2016
+          imageBuilder.customArgs: ''
+          osVersion: nanoserver-sac2016
       matrixWindows1709Amd64:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: --os-version 1709
+          imageBuilder.customArgs: ''
+          osVersion: nanoserver-1709
       matrixWindows1803Amd64:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: --os-version 1803
+          imageBuilder.customArgs: ''
+          osVersion: nanoserver-1803

--- a/.vsts.pipelines/templates/build-all.yml
+++ b/.vsts.pipelines/templates/build-all.yml
@@ -1,6 +1,6 @@
 parameters:
-  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180522205353
-  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180522135321
+  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180601162756
+  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180601092731
   manifest: manifest.json
   matrixLinuxAmd64:
     Build_1_*:
@@ -14,28 +14,28 @@ parameters:
       buildPath: 2.1*
   matrixWindowsSac2016Amd64:
     Build_1_*:
-      buildPath: 1.*/nanoserver-sac2016/*
-      imageBuilder.customArgs: --var VersionFilter=1.* --var OSFilter=nanoserver-sac2016
+      buildPath: 1.*
+      osVersion: nanoserver-sac2016
     Build_2_0:
-      buildPath: 2.0*/nanoserver-sac2016/*
-      imageBuilder.customArgs: --var VersionFilter=2.0 --var OSFilter=nanoserver-sac2016
+      buildPath: 2.0*
+      osVersion: nanoserver-sac2016
     Build_2_1:
-      buildPath: 2.1*/nanoserver-sac2016/*
-      imageBuilder.customArgs: --var VersionFilter=2.1 --var OSFilter=nanoserver-sac2016
+      buildPath: 2.1*
+      osVersion: nanoserver-sac2016
   matrixWindows1709Amd64:
     Build_2_0:
-      buildPath: 2.0*/nanoserver-1709/*
-      imageBuilder.customArgs: --var VersionFilter=2.0 --var OSFilter=nanoserver-1709
+      buildPath: 2.0*
+      osVersion: nanoserver-1709
     Build_2_1:
-      buildPath: 2.1*/nanoserver-1709/*
-      imageBuilder.customArgs: --var VersionFilter=2.1 --var OSFilter=nanoserver-1709
+      buildPath: 2.1*
+      osVersion: nanoserver-1709
   matrixWindows1803Amd64:
     Build_2_0:
-      buildPath: 2.0*/nanoserver-1803/*
-      imageBuilder.customArgs: --var VersionFilter=2.0 --var OSFilter=nanoserver-1803
+      buildPath: 2.0*
+      osVersion: nanoserver-1803
     Build_2_1:
-      buildPath: 2.1*/nanoserver-1803/*
-      imageBuilder.customArgs: --var VersionFilter=2.1 --var OSFilter=nanoserver-1803
+      buildPath: 2.1*
+      osVersion: nanoserver-1803
 phases:
   - template: build-linux-amd64.yml
     parameters:

--- a/.vsts.pipelines/templates/build-windows-amd64.yml
+++ b/.vsts.pipelines/templates/build-windows-amd64.yml
@@ -15,6 +15,7 @@ phases:
     variables:
       docker.baseArtifactName: $(Build.BuildId)
       docker.setupContainerName: setup_$(docker.baseArtifactName)
+      imageBuilder.customArgs: --var VersionFilter=$(buildPath)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
     steps:
@@ -28,6 +29,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --path $(buildPath) --push --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.customArgs) $(imageBuilder.queueArgs)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --path $(buildPath) --os-version $(osVersion) --push --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.customArgs) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: docker-cleanup-windows.yml

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
       "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File ./test/run-test.ps1 -VersionFilter $(VersionFilter) -ArchitectureFilter $(ArchitectureFilter) -RepoOwner $(System:RepoOwner)"
     ],
     "windows": [
-      "powershell -NoProfile -Command .\\test\\run-test.ps1 -VersionFilter $(VersionFilter) -OSFilter $(OSFilter) -RepoOwner $(System:RepoOwner)"
+      "powershell -NoProfile -Command .\\test\\run-test.ps1 -VersionFilter $(VersionFilter) -OSFilter $(System:OsVersion) -RepoOwner $(System:RepoOwner)"
     ]
   },
   "repos": [
@@ -62,6 +62,7 @@
             {
               "dockerfile": "1.0/runtime/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "1.0.11-runtime-nanoserver-sac2016": {},
                 "1.0-runtime-nanoserver": {
@@ -96,6 +97,7 @@
             {
               "dockerfile": "1.1/runtime/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "1.1.8-runtime-nanoserver-sac2016": {},
                 "1.1-runtime-nanoserver": {
@@ -133,6 +135,7 @@
             {
               "dockerfile": "1.1/sdk/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "1.1.8-sdk-1.1.9-nanoserver-sac2016": {},
                 "1.1-sdk-nanoserver": {
@@ -187,6 +190,7 @@
             {
               "dockerfile": "2.0/runtime/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "2.0.7-runtime-nanoserver-sac2016": {},
                 "2.0-runtime-nanoserver-sac2016": {},
@@ -198,7 +202,7 @@
             {
               "dockerfile": "2.0/runtime/nanoserver-1709/amd64",
               "os": "windows",
-              "osVersion": "1709",
+              "osVersion": "nanoserver-1709",
               "tags": {
                 "2.0.7-runtime-nanoserver-1709": {},
                 "2.0-runtime-nanoserver-1709": {}
@@ -207,7 +211,7 @@
             {
               "dockerfile": "2.0/runtime/nanoserver-1803/amd64",
               "os": "windows",
-              "osVersion": "1803",
+              "osVersion": "nanoserver-1803",
               "tags": {
                 "2.0.7-runtime-nanoserver-1803": {},
                 "2.0-runtime-nanoserver-1803": {}
@@ -232,6 +236,7 @@
             {
               "dockerfile": "2.0/sdk/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "2.0.7-sdk-2.1.200-nanoserver-sac2016": {},
                 "2.0-sdk-nanoserver-sac2016": {},
@@ -243,7 +248,7 @@
             {
               "dockerfile": "2.0/sdk/nanoserver-1709/amd64",
               "os": "windows",
-              "osVersion": "1709",
+              "osVersion": "nanoserver-1709",
               "tags": {
                 "2.0.7-sdk-2.1.200-nanoserver-1709": {},
                 "2.0-sdk-nanoserver-1709": {}
@@ -252,7 +257,7 @@
             {
               "dockerfile": "2.0/sdk/nanoserver-1803/amd64",
               "os": "windows",
-              "osVersion": "1803",
+              "osVersion": "nanoserver-1803",
               "tags": {
                 "2.0.7-sdk-2.1.200-nanoserver-1803": {},
                 "2.0-sdk-nanoserver-1803": {}
@@ -366,6 +371,7 @@
             {
               "dockerfile": "2.1/runtime/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "2.1.0-runtime-nanoserver-sac2016": {},
                 "2.1-runtime-nanoserver-sac2016": {},
@@ -377,7 +383,7 @@
             {
               "dockerfile": "2.1/runtime/nanoserver-1709/amd64",
               "os": "windows",
-              "osVersion": "1709",
+              "osVersion": "nanoserver-1709",
               "tags": {
                 "2.1.0-runtime-nanoserver-1709": {},
                 "2.1-runtime-nanoserver-1709": {}
@@ -386,7 +392,7 @@
             {
               "dockerfile": "2.1/runtime/nanoserver-1803/amd64",
               "os": "windows",
-              "osVersion": "1803",
+              "osVersion": "nanoserver-1803",
               "tags": {
                 "2.1.0-runtime-nanoserver-1803": {},
                 "2.1-runtime-nanoserver-1803": {}
@@ -425,6 +431,7 @@
             {
               "dockerfile": "2.1/aspnetcore-runtime/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "2.1.0-aspnetcore-runtime-nanoserver-sac2016": {},
                 "2.1-aspnetcore-runtime-nanoserver-sac2016": {}
@@ -433,7 +440,7 @@
             {
               "dockerfile": "2.1/aspnetcore-runtime/nanoserver-1709/amd64",
               "os": "windows",
-              "osVersion": "1709",
+              "osVersion": "nanoserver-1709",
               "tags": {
                 "2.1.0-aspnetcore-runtime-nanoserver-1709": {},
                 "2.1-aspnetcore-runtime-nanoserver-1709": {}
@@ -442,7 +449,7 @@
             {
               "dockerfile": "2.1/aspnetcore-runtime/nanoserver-1803/amd64",
               "os": "windows",
-              "osVersion": "1803",
+              "osVersion": "nanoserver-1803",
               "tags": {
                 "2.1.0-aspnetcore-runtime-nanoserver-1803": {},
                 "2.1-aspnetcore-runtime-nanoserver-1803": {}
@@ -482,6 +489,7 @@
             {
               "dockerfile": "2.1/sdk/nanoserver-sac2016/amd64",
               "os": "windows",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "2.1.300-sdk-nanoserver-sac2016": {},
                 "2.1-sdk-nanoserver-sac2016": {},
@@ -493,7 +501,7 @@
             {
               "dockerfile": "2.1/sdk/nanoserver-1709/amd64",
               "os": "windows",
-              "osVersion": "1709",
+              "osVersion": "nanoserver-1709",
               "tags": {
                 "2.1.300-sdk-nanoserver-1709": {},
                 "2.1-sdk-nanoserver-1709": {}
@@ -502,7 +510,7 @@
             {
               "dockerfile": "2.1/sdk/nanoserver-1803/amd64",
               "os": "windows",
-              "osVersion": "1803",
+              "osVersion": "nanoserver-1803",
               "tags": {
                 "2.1.300-sdk-nanoserver-1803": {},
                 "2.1-sdk-nanoserver-1803": {}

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -20,7 +20,7 @@
             {
               "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "windows",
-              "osVersion": "sac2016",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "dotnetapp-nanoserver-sac2016": {}
               }
@@ -28,7 +28,7 @@
             {
               "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "windows",
-              "osVersion": "1709",
+              "osVersion": "nanoserver-1709",
               "tags": {
                 "dotnetapp-nanoserver-1709": {}
               }
@@ -36,7 +36,7 @@
             {
               "dockerfile": "samples/dotnetapp/Dockerfile",
               "os": "windows",
-              "osVersion": "1803",
+              "osVersion": "nanoserver-1803",
               "tags": {
                 "dotnetapp-nanoserver-1803": {}
               }
@@ -67,7 +67,7 @@
             {
               "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "windows",
-              "osVersion": "sac2016",
+              "osVersion": "nanoserver-sac2016",
               "tags": {
                 "aspnetapp-nanoserver-sac2016": {}
               }
@@ -75,7 +75,7 @@
             {
               "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "windows",
-              "osVersion": "1709",
+              "osVersion": "nanoserver-1709",
               "tags": {
                 "aspnetapp-nanoserver-1709": {}
               }
@@ -83,7 +83,7 @@
             {
               "dockerfile": "samples/aspnetapp/Dockerfile",
               "os": "windows",
-              "osVersion": "1803",
+              "osVersion": "nanoserver-1803",
               "tags": {
                 "aspnetapp-nanoserver-1803": {}
               }

--- a/test/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -21,7 +21,6 @@ namespace Microsoft.DotNet.Docker.Tests
         public bool IsAlpine { get => String.Equals(OS.Alpine, OsVariant, StringComparison.OrdinalIgnoreCase); }
         public bool IsArm { get => String.Equals("arm", Architecture, StringComparison.OrdinalIgnoreCase); }
         public string OsVariant { get; set; }
-        public string PlatformOS { get; set; }
 
         public string RuntimeDepsVersion
         {

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -26,16 +26,16 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static readonly ImageData[] s_linuxTestData =
         {
-            new ImageData { DotNetVersion = "1.0", SdkVersion = "1.1" },
-            new ImageData { DotNetVersion = "1.1", RuntimeDepsVersion = "1.0" },
-            new ImageData { DotNetVersion = "2.0" },
+            new ImageData { DotNetVersion = "1.0", OsVariant = OS.Jessie, SdkVersion = "1.1" },
+            new ImageData { DotNetVersion = "1.1", OsVariant = OS.Jessie, RuntimeDepsVersion = "1.0" },
+            new ImageData { DotNetVersion = "2.0", OsVariant = OS.Stretch },
             new ImageData { DotNetVersion = "2.0", OsVariant = OS.Jessie },
-            new ImageData { DotNetVersion = "2.1" },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.Bionic },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.Alpine },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, Architecture = "arm" },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.Bionic, Architecture = "arm" },
-            new ImageData { DotNetVersion = "2.1", IsWeb = true },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, IsWeb = true },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.Bionic, IsWeb = true },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.Alpine, IsWeb = true },
             new ImageData { DotNetVersion = "2.1", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, Architecture = "arm", IsWeb = true },
@@ -43,17 +43,17 @@ namespace Microsoft.DotNet.Docker.Tests
         };
         private static readonly ImageData[] s_windowsTestData =
         {
-            new ImageData { DotNetVersion = "1.0", PlatformOS = OS.NanoServerSac2016, SdkVersion = "1.1" },
-            new ImageData { DotNetVersion = "1.1", PlatformOS = OS.NanoServerSac2016 },
-            new ImageData { DotNetVersion = "2.0", PlatformOS = OS.NanoServerSac2016 },
-            new ImageData { DotNetVersion = "2.0", PlatformOS = OS.NanoServer1709 },
-            new ImageData { DotNetVersion = "2.0", PlatformOS = OS.NanoServer1803 },
-            new ImageData { DotNetVersion = "2.1", PlatformOS = OS.NanoServerSac2016 },
-            new ImageData { DotNetVersion = "2.1", PlatformOS = OS.NanoServer1709 },
-            new ImageData { DotNetVersion = "2.1", PlatformOS = OS.NanoServer1803 },
-            new ImageData { DotNetVersion = "2.1", PlatformOS = OS.NanoServerSac2016, IsWeb = true },
-            new ImageData { DotNetVersion = "2.1", PlatformOS = OS.NanoServer1709, IsWeb = true },
-            new ImageData { DotNetVersion = "2.1", PlatformOS = OS.NanoServer1803, IsWeb = true },
+            new ImageData { DotNetVersion = "1.0", OsVariant = OS.NanoServerSac2016, SdkVersion = "1.1" },
+            new ImageData { DotNetVersion = "1.1", OsVariant = OS.NanoServerSac2016 },
+            new ImageData { DotNetVersion = "2.0", OsVariant = OS.NanoServerSac2016 },
+            new ImageData { DotNetVersion = "2.0", OsVariant = OS.NanoServer1709 },
+            new ImageData { DotNetVersion = "2.0", OsVariant = OS.NanoServer1803 },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.NanoServerSac2016 },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.NanoServer1709 },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.NanoServer1803 },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.NanoServerSac2016, IsWeb = true },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.NanoServer1709, IsWeb = true },
+            new ImageData { DotNetVersion = "2.1", OsVariant = OS.NanoServer1803, IsWeb = true },
         };
 
         private readonly DockerHelper _dockerHelper;
@@ -76,8 +76,8 @@ namespace Microsoft.DotNet.Docker.Tests
                 .Where(imageData => archFilterPattern == null
                     || Regex.IsMatch(imageData.Architecture, archFilterPattern, RegexOptions.IgnoreCase))
                 .Where(imageData => osFilterPattern == null
-                    || (imageData.PlatformOS != null
-                        && Regex.IsMatch(imageData.PlatformOS, osFilterPattern, RegexOptions.IgnoreCase)))
+                    || (imageData.OsVariant != null
+                        && Regex.IsMatch(imageData.OsVariant, osFilterPattern, RegexOptions.IgnoreCase)))
                 .Where(imageData => versionFilterPattern == null
                     || Regex.IsMatch(imageData.DotNetVersion, versionFilterPattern, RegexOptions.IgnoreCase))
                 .Select(imageData => new object[] { imageData });
@@ -203,8 +203,8 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             string frameworkDepAppId = GetIdentifier(imageData.DotNetVersion, "framework-dependent-app");
             bool isRunAsContainerAdministrator = 
-                String.Equals("nanoserver-1709", imageData.PlatformOS, StringComparison.OrdinalIgnoreCase)
-                || String.Equals("nanoserver-1803", imageData.PlatformOS, StringComparison.OrdinalIgnoreCase);
+                String.Equals("nanoserver-1709", imageData.OsVariant, StringComparison.OrdinalIgnoreCase)
+                || String.Equals("nanoserver-1803", imageData.OsVariant, StringComparison.OrdinalIgnoreCase);
             string publishCmd = GetPublishArgs(imageData);
 
             try
@@ -369,7 +369,8 @@ namespace Microsoft.DotNet.Docker.Tests
             }
 
             string imageName = $"{s_repoOwner}/{s_repoName}:{imageVersion}-{variantName}";
-            if (!string.IsNullOrEmpty(osVariant))
+
+            if (!imageData.DotNetVersion.StartsWith("1."))
             {
                 imageName += $"-{osVariant}";
             }


### PR DESCRIPTION
- Combined the PlatformOS and OSVariant concepts within the unit tests.
- Simplified the build inputs by utilizing the `os-version` functionality within Image-Builder.  This eliminates the version filter and os filter from being specified multiple times.