### PR TITLE
Update 1.* tags to be consistent with 2.*

### DIFF
--- a/1.0/runtime/jessie/amd64/Dockerfile
+++ b/1.0/runtime/jessie/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:1.0-runtime-deps
+FROM microsoft/dotnet-nightly:1.0-runtime-deps-jessie
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/1.1/runtime/jessie/amd64/Dockerfile
+++ b/1.1/runtime/jessie/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:1.0-runtime-deps
+FROM microsoft/dotnet-nightly:1.0-runtime-deps-jessie
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 - [`2.0.7-runtime-jessie`, `2.0-runtime-jessie` (*2.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/jessie/amd64/Dockerfile)
 - [`2.0.7-runtime-deps-stretch`, `2.0-runtime-deps-stretch`, `2.0.7-runtime-deps`, `2.0-runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/stretch/amd64/Dockerfile)
 - [`2.0.7-runtime-deps-jessie`, `2.0-runtime-deps-jessie` (*2.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime-deps/jessie/amd64/Dockerfile)
-- [`1.1.8-sdk-1.1.9-jessie`, `1.1.8-sdk-1.1.9`, `1.1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/jessie/amd64/Dockerfile)
-- [`1.1.8-runtime-jessie`, `1.1.8-runtime`, `1.1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/jessie/amd64/Dockerfile)
-- [`1.0.11-runtime-jessie`, `1.0.11-runtime`, `1.0-runtime` (*1.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/jessie/amd64/Dockerfile)
-- [`1.0.11-runtime-deps-jessie`, `1.0.11-runtime-deps`, `1.0-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
+- [`1.1.8-sdk-1.1.9-jessie`, `1.1-sdk-jessie`, `1.1.8-sdk-1.1.9`, `1.1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/jessie/amd64/Dockerfile)
+- [`1.1.8-runtime-jessie`, `1.1-runtime-jessie`, `1.1.8-runtime`, `1.1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/jessie/amd64/Dockerfile)
+- [`1.0.11-runtime-jessie`, `1.0-runtime-jessie`, `1.0.11-runtime`, `1.0-runtime` (*1.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/jessie/amd64/Dockerfile)
+- [`1.0.11-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.11-runtime-deps`, `1.0-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
 
 # Windows Server, version 1803 amd64 tags
 
@@ -84,9 +84,9 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 - [`2.1.0-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.0-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.0.7-sdk-2.1.200-nanoserver-sac2016`, `2.0-sdk-nanoserver-sac2016`, `2.0.7-sdk-2.1.200`, `2.0-sdk` (*2.0/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.0.7-runtime-nanoserver-sac2016`, `2.0-runtime-nanoserver-sac2016`, `2.0.7-runtime`, `2.0-runtime` (*2.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.8-sdk-1.1.9-nanoserver-sac2016`, `1.1.8-sdk-1.1.9`, `1.1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.8-runtime-nanoserver-sac2016`, `1.1.8-runtime`, `1.1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.0.11-runtime-nanoserver-sac2016`, `1.0.11-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.8-sdk-1.1.9-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.8-sdk-1.1.9`, `1.1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.8-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.8-runtime`, `1.1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.0.11-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.11-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
 # Linux arm32 tags
 

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -70,9 +70,6 @@ try {
             ForEach-Object {
                 $dockerfilePath = $_.dockerfile
                 $tags = [array]($_.Tags | ForEach-Object { $_.PSobject.Properties })
-                if ([bool]($images.PSobject.Properties.name -match "sharedtags")) {
-                    $tags += [array]($images.sharedtags | ForEach-Object { $_.PSobject.Properties })
-                }
                 $qualifiedTags = $tags | ForEach-Object { $manifestRepo.Name + ':' + $_.Name}
                 $formattedTags = $qualifiedTags -join ', '
                 Write-Host "--- Building $formattedTags from $dockerfilePath ---"

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
               "os": "linux",
               "tags": {
                 "1.0.11-runtime-deps-jessie": {},
+                "1.0-runtime-deps-jessie": {},
                 "1.0-core-deps": {
                   "isUndocumented": true
                 },
@@ -54,6 +55,7 @@
               "os": "linux",
               "tags": {
                 "1.0.11-runtime-jessie": {},
+                "1.0-runtime-jessie": {},
                 "1.0-core": {
                   "isUndocumented": true
                 }
@@ -65,6 +67,7 @@
               "osVersion": "nanoserver-sac2016",
               "tags": {
                 "1.0.11-runtime-nanoserver-sac2016": {},
+                "1.0-runtime-nanoserver-sac2016": {},
                 "1.0-runtime-nanoserver": {
                   "isUndocumented": true
                 }
@@ -86,6 +89,7 @@
               "os": "linux",
               "tags": {
                 "1.1.8-runtime-jessie": {},
+                "1.1-runtime-jessie": {},
                 "1-core": {
                   "isUndocumented": true
                 },
@@ -100,6 +104,7 @@
               "osVersion": "nanoserver-sac2016",
               "tags": {
                 "1.1.8-runtime-nanoserver-sac2016": {},
+                "1.1-runtime-nanoserver-sac2016": {},
                 "1.1-runtime-nanoserver": {
                   "isUndocumented": true
                 },
@@ -129,7 +134,8 @@
               "dockerfile": "1.1/sdk/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.1.8-sdk-1.1.9-jessie": {}
+                "1.1.8-sdk-1.1.9-jessie": {},
+                "1.1-sdk-jessie": {}
               }
             },
             {
@@ -138,6 +144,7 @@
               "osVersion": "nanoserver-sac2016",
               "tags": {
                 "1.1.8-sdk-1.1.9-nanoserver-sac2016": {},
+                "1.1-sdk-nanoserver-sac2016": {},
                 "1.1-sdk-nanoserver": {
                   "isUndocumented": true
                 },

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -368,12 +368,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     throw new NotSupportedException($"Unsupported image type '{variantName}'");
             }
 
-            string imageName = $"{s_repoOwner}/{s_repoName}:{imageVersion}-{variantName}";
-
-            if (!imageData.DotNetVersion.StartsWith("1."))
-            {
-                imageName += $"-{osVariant}";
-            }
+            string imageName = $"{s_repoOwner}/{s_repoName}:{imageVersion}-{variantName}-{osVariant}";
 
             if (imageData.IsArm)
             {


### PR DESCRIPTION
Update 1.* tags to include <major>-<minor>-<image variant>-<os> tags.  This is to be consistent with the tags produced for 2.*.  I also updated the FROM instructions in the 1.* runtime images to utilize the new tags.  The previous references were somewhat confusing/incorrect as they utilizing a manifest tag.  This allows the build/test infrastructure to be consistent across all the version produced.