### PR TITLE
Fix GRPC issue - Add libc6-compat to base image

### DIFF
--- a/2.1/runtime-deps/alpine3.7/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine3.7/amd64/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
         tzdata \
         userspace-rcu \
         zlib \
+        libc6-compat \
     && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
         lttng-ust
 


### PR DESCRIPTION
Running a GRPC server on alpine throws an error as follows :

```
Error loading native library "/app/runtimes/linux/native/libgrpc_csharp_ext.x64.so"
   at Grpc.Core.Internal.UnmanagedLibrary..ctor(String[] libraryPathAlternatives)
   at Grpc.Core.Internal.NativeExtension.LoadUnmanagedLibrary()
   at Grpc.Core.Internal.NativeExtension.LoadNativeMethods()
   at Grpc.Core.Internal.NativeExtension..ctor()
   at Grpc.Core.Internal.NativeExtension.Get()
   at Grpc.Core.GrpcEnvironment.GrpcNativeInit()
   at Grpc.Core.GrpcEnvironment..ctor()
   at Grpc.Core.GrpcEnvironment.AddRef()
   at Grpc.Core.Channel..ctor(String target, ChannelCredentials credentials, IEnumerable`1 options)
   at WebApplication2.Startup.ConfigureServices(IServiceCollection services) in /WebApplication2/Startup.cs:line 16
```

Dependency  **libc6-compat** has been added which fixes the same.