### PR TITLE
Invert build leg order

### DIFF
--- a/.vsts.pipelines/phases/build-all.yml
+++ b/.vsts.pipelines/phases/build-all.yml
@@ -4,38 +4,38 @@ parameters:
   imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180601092731
   manifest: manifest.json
   matrixLinuxAmd64:
-    Build_1_*:
-      buildPath: 1.*
-    Build_2_0:
-      buildPath: 2.0*
     Build_2_1:
       buildPath: 2.1*
-  matrixLinuxArm32v7:
+    Build_2_0:
+      buildPath: 2.0*
+    Build_1_*:
+      buildPath: 1.*
+   matrixLinuxArm32v7:
     Build_2_1:
       buildPath: 2.1*
   matrixWindowsSac2016Amd64:
+    Build_2_1:
+      buildPath: 2.1*
+      osVersion: nanoserver-sac2016
+    Build_2_0:
+      buildPath: 2.0*
+      osVersion: nanoserver-sac2016
     Build_1_*:
       buildPath: 1.*
       osVersion: nanoserver-sac2016
-    Build_2_0:
-      buildPath: 2.0*
-      osVersion: nanoserver-sac2016
-    Build_2_1:
-      buildPath: 2.1*
-      osVersion: nanoserver-sac2016
   matrixWindows1709Amd64:
-    Build_2_0:
-      buildPath: 2.0*
-      osVersion: nanoserver-1709
     Build_2_1:
       buildPath: 2.1*
+      osVersion: nanoserver-1709
+    Build_2_0:
+      buildPath: 2.0*
       osVersion: nanoserver-1709
   matrixWindows1803Amd64:
-    Build_2_0:
-      buildPath: 2.0*
-      osVersion: nanoserver-1803
     Build_2_1:
       buildPath: 2.1*
+      osVersion: nanoserver-1803  
+    Build_2_0:
+      buildPath: 2.0*
       osVersion: nanoserver-1803
 phases:
   - template: build-linux-amd64.yml


### PR DESCRIPTION
We are always adding more Docker image variants, so this change will run the longest build legs first which is a decent optimization when build agents are limited.  e.g. Longer legs will get running first and when additional agents are available the shorter legs will run.

@dotnet-bot skip ci please