### PR TITLE
Resolve documentation typo for the aspnetcore-runtime docker image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ It contains the .NET Core SDK which is comprised of two parts:
 
 Use this image for your development process (developing, building and testing applications).
 
-### `microsoft/dotnet:<version>-aspnet-core-runtime`
+### `microsoft/dotnet:<version>-aspnetcore-runtime`
 
 This image contains the ASP.NET Core and .NET Core runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 


### PR DESCRIPTION
Looks like a documentation typo on the correct asp.net core runtime image when compared to the docker hub repository:
![image](https://user-images.githubusercontent.com/9809236/41472726-4f4461b2-7085-11e8-8389-5bf7bace6c82.png)
