### PR TITLE
Update aspnetcore-docker-https-development.md

### DIFF
--- a/samples/aspnetapp/aspnetcore-docker-https-development.md
+++ b/samples/aspnetapp/aspnetcore-docker-https-development.md
@@ -71,6 +71,8 @@ dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Deve
 
 > Note: The password must match the password used for the certificate.
 
+> Note: The certificate name, in this case *aspnetapp*.pfx must match the project assembly name.
+
 Build a container image:
 
 ```console

--- a/samples/aspnetapp/aspnetcore-docker-https-development.md
+++ b/samples/aspnetapp/aspnetcore-docker-https-development.md
@@ -61,6 +61,8 @@ dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p crypticp
 dotnet dev-certs https --trust
 ```
 
+> Note: The certificate name, in this case *aspnetapp*.pfx must match the project assembly name.
+
 > Note: `crypticpassword` is used as a stand-in for a password of your own choosing.
 
 Configure application secrets, for the certificate:
@@ -70,8 +72,6 @@ dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Deve
 ```
 
 > Note: The password must match the password used for the certificate.
-
-> Note: The certificate name, in this case *aspnetapp*.pfx must match the project assembly name.
 
 Build a container image:
 

--- a/samples/aspnetapp/aspnetcore-docker-https-development.md
+++ b/samples/aspnetapp/aspnetcore-docker-https-development.md
@@ -100,6 +100,8 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p crypticpasswor
 dotnet dev-certs https --trust
 ```
 
+> Note: The certificate name, in this case *aspnetapp*.pfx must match the project assembly name.
+
 > Note: `crypticpassword` is used as a stand-in for a password of your own choosing.
 
 Configure application secrets, for the certificate:
@@ -138,6 +140,8 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p crypticpasswor
 
 > Note: `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distro. It is likely that you need to trust the certificate in your browser.
 
+> Note: The certificate name, in this case *aspnetapp*.pfx must match the project assembly name.
+
 > Note: `crypticpassword` is used as a stand-in for a password of your own choosing.
 
 Build a container image:
@@ -168,6 +172,8 @@ Generate cert and configure local machine:
 dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p crypticpassword
 dotnet dev-certs https --trust
 ```
+
+> Note: The certificate name, in this case *aspnetapp*.pfx must match the project assembly name.
 
 > Note: `crypticpassword` is used as a stand-in for a password of your own choosing.
 


### PR DESCRIPTION
Make clear the default configuration naming implications for certificates.