### PR TITLE
Use ContainerAdministrator USER in nanoserver containers

### DIFF
--- a/2.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Enable detection of running in a container
 ENV DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.0/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver-1803/amd64/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Enable detection of running in a container
 ENV DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Enable detection of running in a container
 ENV DOTNET_RUNNING_IN_CONTAINER=true `

--- a/2.0/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver-1803/amd64/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Enable detection of running in a container
 ENV DOTNET_RUNNING_IN_CONTAINER=true `

--- a/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `

--- a/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -29,7 +29,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -27,7 +27,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `

--- a/2.1/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1803/amd64/Dockerfile
@@ -27,7 +27,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -27,7 +27,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `

--- a/2.1/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1803/amd64/Dockerfile
@@ -27,7 +27,6 @@ COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-USER ContainerUser
 
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `

--- a/scripts/update-dependencies/Dockerfile
+++ b/scripts/update-dependencies/Dockerfile
@@ -33,7 +33,6 @@ FROM microsoft/dotnet:2.0-runtime-nanoserver-1709
 COPY --from=installer-env ["git", "C:\\Program Files\\git"]
 USER ContainerAdministrator 
 RUN setx /M PATH "%PATH%;C:\Program Files\git\cmd"
-USER ContainerUser
 
 # copy update-dependencies
 WORKDIR /update-dependencies


### PR DESCRIPTION
This should fix the issue (https://github.com/dotnet/corefx/issues/25717) when X509Certificate2 instances cannot be created inside Nanoserver containers.

The issue was found by the Microsoft's Support team and changes in the PR are based on a workaround that was suggested.