### PR TITLE
Refactor build to utilize a staging registry

### DIFF
--- a/.vsts.pipelines/builds/microsoft-dotnet-nightly.yml
+++ b/.vsts.pipelines/builds/microsoft-dotnet-nightly.yml
@@ -8,3 +8,5 @@ trigger:
       - manifest.samples.json
 phases:
   - template: ../phases/build-all.yml
+    parameters:
+      repo: dotnet-nightly

--- a/.vsts.pipelines/builds/microsoft-dotnet-samples.yml
+++ b/.vsts.pipelines/builds/microsoft-dotnet-samples.yml
@@ -9,27 +9,26 @@ trigger:
 phases:
   - template: ../phases/build-all.yml
     parameters:
+      excludeTests: true
       manifest: manifest.samples.json
+      repo: dotnet-samples
       matrixLinuxAmd64:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: ''
+          osVersion: '*'
       matrixLinuxArm32v7:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: ''
+          osVersion: '*'
       matrixWindowsSac2016Amd64:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: ''
           osVersion: nanoserver-sac2016
       matrixWindows1709Amd64:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: ''
           osVersion: nanoserver-1709
       matrixWindows1803Amd64:
         Build:
           buildPath: '*'
-          imageBuilder.customArgs: ''
           osVersion: nanoserver-1803

--- a/.vsts.pipelines/builds/microsoft-dotnet.yml
+++ b/.vsts.pipelines/builds/microsoft-dotnet.yml
@@ -1,2 +1,4 @@
 phases:
   - template: ../phases/build-all.yml
+    parameters:
+      repo: dotnet

--- a/.vsts.pipelines/phases/build-all.yml
+++ b/.vsts.pipelines/phases/build-all.yml
@@ -1,18 +1,41 @@
 parameters:
-  buildLegTimeoutInMinutes: 90
-  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180607190320
-  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180601092731
+  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180627140652
+  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180627070723
+  excludeTests: false
   manifest: manifest.json
+  repo: null
   matrixLinuxAmd64:
-    Build_2_1:
+    Build_2_1_Alpine:
       buildPath: 2.1*
-    Build_2_0:
+      osVersion: alpine*
+    Build_2_1_Bionic:
+      buildPath: 2.1*
+      osVersion: bionic*
+    Build_2_1_Buster:
+      buildPath: 2.1*
+      osVersion: buster*
+    Build_2_1_Stretch:
+      buildPath: 2.1*
+      osVersion: stretch*
+    Build_2_0_Jessie:
       buildPath: 2.0*
-    Build_1_*:
+      osVersion: jessie
+    Build_2_0_Stretch:
+      buildPath: 2.0*
+      osVersion: stretch
+    Build_1_*_Jessie:
       buildPath: 1.*
+      osVersion: jessie
   matrixLinuxArm32v7:
-    Build_2_1:
+    Build_2_1_Bionic:
       buildPath: 2.1*
+      osVersion: bionic*
+    Build_2_1_Buster:
+      buildPath: 2.1*
+      osVersion: buster*
+    Build_2_1_Stretch:
+      buildPath: 2.1*
+      osVersion: stretch*
   matrixWindowsSac2016Amd64:
     Build_2_1:
       buildPath: 2.1*
@@ -33,51 +56,148 @@ parameters:
   matrixWindows1803Amd64:
     Build_2_1:
       buildPath: 2.1*
-      osVersion: nanoserver-1803  
+      osVersion: nanoserver-1803
     Build_2_0:
       buildPath: 2.0*
       osVersion: nanoserver-1803
 phases:
+  ################################################################################
+  # Build Images
+  ################################################################################
   - template: build-linux-amd64.yml
     parameters:
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}
-      timeoutInMinutes: ${{ parameters.buildLegTimeoutInMinutes }}
+      repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxAmd64 }}
   - template: build-linux-arm32v7.yml
     parameters:
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}
-      timeoutInMinutes: ${{ parameters.buildLegTimeoutInMinutes }}
+      repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxArm32v7 }}
   - template: build-windows-amd64.yml
     parameters:
-      phase: NanoServerSac2016_amd64
+      phase: Build_NanoServerSac2016_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
-      timeoutInMinutes: ${{ parameters.buildLegTimeoutInMinutes }}
+      repo: ${{ parameters.repo }}
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
       matrix: ${{ parameters.matrixWindowsSac2016Amd64 }}
   - template: build-windows-amd64.yml
     parameters:
-      phase: NanoServer1709_amd64
+      phase: Build_NanoServer1709_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
-      timeoutInMinutes: ${{ parameters.buildLegTimeoutInMinutes }}
+      repo: ${{ parameters.repo }}
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
       matrix: ${{ parameters.matrixWindows1709Amd64 }}
   - template: build-windows-amd64.yml
     parameters:
-      phase: NanoServer1803_amd64
+      phase: Build_NanoServer1803_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
-      timeoutInMinutes: ${{ parameters.buildLegTimeoutInMinutes }}
+      repo: ${{ parameters.repo }}
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
       matrix: ${{ parameters.matrixWindows1803Amd64 }}
-  - template: build-finalize.yml
+
+  ################################################################################
+  # Test Images
+  ################################################################################
+  - template: test-linux-amd64.yml
+    parameters:
+      excludeTests: ${{ parameters.excludeTests }}
+      repo: ${{ parameters.repo }}
+      matrix: ${{ parameters.matrixLinuxAmd64 }}
+  - template: test-linux-arm32v7.yml
+    parameters:
+      excludeTests: ${{ parameters.excludeTests }}
+      repo: ${{ parameters.repo }}
+      matrix: ${{ parameters.matrixLinuxArm32v7 }}
+  - template: test-windows-amd64.yml
+    parameters:
+      phase: Test_NanoServerSac2016_amd64
+      excludeTests: ${{ parameters.excludeTests }}
+      dependsOn: Build_NanoServerSac2016_amd64
+      repo: ${{ parameters.repo }}
+      demands:
+        - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+      matrix: ${{ parameters.matrixWindowsSac2016Amd64 }}
+  - template: test-windows-amd64.yml
+    parameters:
+      phase: Test_NanoServer1709_amd64
+      excludeTests: ${{ parameters.excludeTests }}
+      dependsOn: Build_NanoServer1709_amd64
+      repo: ${{ parameters.repo }}
+      demands:
+        - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
+      matrix: ${{ parameters.matrixWindows1709Amd64 }}
+  - template: test-windows-amd64.yml
+    parameters:
+      phase: Test_NanoServer1803_amd64
+      excludeTests: ${{ parameters.excludeTests }}
+      dependsOn: Build_NanoServer1803_amd64
+      repo: ${{ parameters.repo }}
+      demands:
+        - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
+      matrix: ${{ parameters.matrixWindows1803Amd64 }}
+
+  ################################################################################
+  # Publish Images
+  ################################################################################
+  - template: copy-images-linux.yml
+    parameters:
+      phase: Copy_Images_Linux_amd64
+      imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
+      manifest: ${{ parameters.manifest }}
+      architecture: amd64
+      dependsOn: Test_Linux_amd64
+      repo: ${{ parameters.repo }}
+      matrix: ${{ parameters.matrixLinuxAmd64 }}
+  - template: copy-images-linux.yml
+    parameters:
+      phase: Copy_Images_Linux_arm32v7
+      imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
+      manifest: ${{ parameters.manifest }}
+      architecture: arm
+      dependsOn: Test_Linux_arm32v7
+      repo: ${{ parameters.repo }}
+      matrix: ${{ parameters.matrixLinuxArm32v7 }}
+  - template: copy-images-windows.yml
+    parameters:
+      phase: Copy_Images_NanoServerSac2016_amd64
+      imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
+      manifest: ${{ parameters.manifest }}
+      dependsOn: Test_NanoServerSac2016_amd64
+      repo: ${{ parameters.repo }}
+      demands:
+        - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+      matrix: ${{ parameters.matrixWindowsSac2016Amd64 }}
+  - template: copy-images-windows.yml
+    parameters:
+      phase: Copy_Images_NanoServer1709_amd64
+      imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
+      manifest: ${{ parameters.manifest }}
+      dependsOn: Test_NanoServer1709_amd64
+      repo: ${{ parameters.repo }}
+      demands:
+        - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
+      matrix: ${{ parameters.matrixWindows1709Amd64 }}
+  - template: copy-images-windows.yml
+    parameters:
+      phase: Copy_Images_NanoServer1803_amd64
+      imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
+      manifest: ${{ parameters.manifest }}
+      dependsOn: Test_NanoServer1803_amd64
+      repo: ${{ parameters.repo }}
+      demands:
+        - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
+      matrix: ${{ parameters.matrixWindows1803Amd64 }}
+
+  - template: publish-finalize.yml
     parameters:
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}

--- a/.vsts.pipelines/phases/build-linux-amd64.yml
+++ b/.vsts.pipelines/phases/build-linux-amd64.yml
@@ -1,21 +1,22 @@
 parameters:
   imageBuilderImage: null
   manifest: null
+  repo: null
   timeoutInMinutes: null
   matrix: {}
 phases:
-  - phase: Linux_amd64
+  - phase: Build_Linux_amd64
+    condition: and(succeeded(), eq(variables['startingPhase'], 'build'))
     queue:
       name: DotNet-Build
-      timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
       demands:
         - agent.os -equals linux
-      parallel: 3
+      parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      imageBuilder.customArgs: --var VersionFilter=$(buildPath) --var ArchitectureFilter=amd64
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
+      repo: ${{ parameters.repo }}
     steps:
       - template: ../steps/docker-cleanup-linux.yml
       - script: docker pull $(imageBuilder.image)
@@ -25,5 +26,5 @@ phases:
         displayName: Build Images
         inputs:
           filename: docker
-          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) build --manifest $(manifest) --path $(buildPath) --push --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.customArgs) $(imageBuilder.queueArgs)
+          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) build --manifest $(manifest) --path $(buildPath)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts.pipelines/phases/build-linux-amd64.yml
+++ b/.vsts.pipelines/phases/build-linux-amd64.yml
@@ -2,7 +2,6 @@ parameters:
   imageBuilderImage: null
   manifest: null
   repo: null
-  timeoutInMinutes: null
   matrix: {}
 phases:
   - phase: Build_Linux_amd64

--- a/.vsts.pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts.pipelines/phases/build-linux-arm32v7.yml
@@ -2,7 +2,6 @@ parameters:
   imageBuilderImage: null
   manifest: null
   repo: null
-  timeoutInMinutes: null
   matrix: {}
 phases:
   - phase: Build_Linux_arm32v7

--- a/.vsts.pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts.pipelines/phases/build-linux-arm32v7.yml
@@ -1,17 +1,18 @@
 parameters:
   imageBuilderImage: null
   manifest: null
+  repo: null
   timeoutInMinutes: null
   matrix: {}
 phases:
-  - phase: Linux_arm32v7
+  - phase: Build_Linux_arm32v7
+    condition: and(succeeded(), eq(variables['startingPhase'], 'build'))
     queue:
       name: DotNetCore-Infra
-      timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
       demands:
         - VSTS_OS -equals Windows_10_Enterprise
         - DockerVersion
-      parallel: 2
+      parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
       docker.baseArtifactName: $(Build.BuildId)
@@ -20,9 +21,9 @@ phases:
       docker.gitEnabledimage: buildpack-deps:stretch-scm
       docker.repoVolumeName: repo_$(docker.baseArtifactName)
       docker.setupContainerName: setup_$(docker.baseArtifactName)
-      imageBuilder.customArgs: --var VersionFilter=$(buildPath) --var ArchitectureFilter=arm
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
+      repo: ${{ parameters.repo }}
     steps:
       - template: ../steps/docker-cleanup-windows.yml
       - script: docker pull $(imageBuilder.image)
@@ -38,7 +39,7 @@ phases:
         displayName: Clone Repo
       - script: docker run $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
         displayName: Checkout Source
-      - script: docker run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(buildPath) --architecture arm --skip-test --push --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.customArgs) $(imageBuilder.queueArgs)
+      - script: docker run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(buildPath)*$(osVersion)* --architecture arm --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - script: docker run $(docker.commonRunArgs) --name cleanup_$(docker.baseArtifactName) --entrypoint docker $(imageBuilder.image) system prune -a -f
         displayName: Cleanup ARM Docker

--- a/.vsts.pipelines/phases/build-windows-amd64.yml
+++ b/.vsts.pipelines/phases/build-windows-amd64.yml
@@ -3,7 +3,6 @@ parameters:
   imageBuilderImage: null
   manifest: null
   repo: null
-  timeoutInMinutes: null
   demands: []
   matrix: {}
 phases:
@@ -31,6 +30,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test --path $(buildPath) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test --path $(buildPath) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts.pipelines/phases/copy-images-linux.yml
+++ b/.vsts.pipelines/phases/copy-images-linux.yml
@@ -1,0 +1,34 @@
+parameters:
+  phase: null
+  imageBuilderImage: null
+  manifest: null
+  dependsOn: null
+  repo: null
+  architecture: null
+  matrix: {}
+phases:
+  - phase: ${{ parameters.phase }}
+    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'))
+    dependsOn: ${{ parameters.dependsOn }}
+    queue:
+      name: DotNet-Build
+      demands:
+        - agent.os -equals linux
+      parallel: 100
+      matrix: ${{ parameters.matrix }}
+    variables:
+      imageBuilder.image: ${{ parameters.imageBuilderImage }}
+      manifest: ${{ parameters.manifest }}
+      repo: ${{ parameters.repo }}
+      architecture: ${{ parameters.architecture }}
+    steps:
+      - template: ../steps/docker-cleanup-linux.yml
+      - script: docker pull $(imageBuilder.image)
+        displayName: Pull Image Builder
+        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      - task: CmdLine@1
+        displayName: Copy Images
+        inputs:
+          filename: docker
+          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(buildPath)*$(osVersion)* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts.pipelines/phases/copy-images-windows.yml
+++ b/.vsts.pipelines/phases/copy-images-windows.yml
@@ -2,20 +2,21 @@ parameters:
   phase: null
   imageBuilderImage: null
   manifest: null
+  dependsOn: null
   repo: null
-  timeoutInMinutes: null
   demands: []
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: and(succeeded(), eq(variables['startingPhase'], 'build'))
+    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'))
+    dependsOn: ${{ parameters.dependsOn }}
     queue:
       name: DotNetCore-Infra
       demands: ${{ parameters.demands }}
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.baseArtifactName: $(Build.BuildId)
+      docker.baseArtifactName: publish-$(Build.BuildId)
       docker.setupContainerName: setup_$(docker.baseArtifactName)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
@@ -31,6 +32,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test --path $(buildPath) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
-        displayName: Build Images
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(buildPath) --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+        displayName: Copy Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts.pipelines/phases/publish-finalize.yml
+++ b/.vsts.pipelines/phases/publish-finalize.yml
@@ -2,13 +2,14 @@ parameters:
   imageBuilderImage: null
   manifest: null
 phases:
-  - phase: Finalize
+  - phase: Publish_Finalize
+    condition: and(succeeded('Copy_Images_Linux_amd64'), succeeded('Copy_Images_Linux_arm32v7'), succeeded('Copy_Images_NanoServerSac2016_amd64'), succeeded('Copy_Images_NanoServer1709_amd64'), succeeded('Copy_Images_NanoServer1803_amd64'))
     dependsOn:
-      - Linux_amd64
-      - Linux_arm32v7
-      - NanoServerSac2016_amd64
-      - NanoServer1709_amd64
-      - NanoServer1803_amd64
+      - Copy_Images_Linux_amd64
+      - Copy_Images_Linux_arm32v7
+      - Copy_Images_NanoServerSac2016_amd64
+      - Copy_Images_NanoServer1709_amd64
+      - Copy_Images_NanoServer1803_amd64
     queue:
       name: DotNet-Build
       demands:

--- a/.vsts.pipelines/phases/test-linux-amd64.yml
+++ b/.vsts.pipelines/phases/test-linux-amd64.yml
@@ -1,0 +1,37 @@
+parameters:
+  excludeTests: false
+  repo: null
+  timeoutInMinutes: null
+  matrix: {}
+phases:
+  - phase: Test_Linux_amd64
+    condition: and(not(variables['excludeTests']), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    dependsOn: Build_Linux_amd64
+    queue:
+      name: DotNet-Build
+      demands:
+        - agent.os -equals linux
+      parallel: 100
+      matrix: ${{ parameters.matrix }}
+    variables:
+      repo: ${{ parameters.repo }}
+      testRunner.Container: testrunner-$(Build.BuildId)
+    steps:
+      - template: ../steps/docker-cleanup-linux.yml
+      - script: docker build --rm -t testrunner -f ./test/Dockerfile.linux.testrunner .
+        displayName: Pull testrunner Image
+      - script: docker run -t -d  -v /var/run/docker.sock:/var/run/docker.sock --name $(testRunner.Container) testrunner
+        displayName: Start Test Runner Container
+      - script: docker exec $(testRunner.Container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+        displayName: Docker login
+        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      - task: CmdLine@1
+        displayName: Test Images
+        inputs:
+          filename: docker
+          arguments: exec $(testRunner.Container) pwsh -File ./test/run-test.ps1 -VersionFilter $(buildPath) -OSFilter $(osVersion) -ArchitectureFilter amd64 -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: docker exec $(testRunner.Container) docker logout
+        displayName: Docker logout
+        condition: always()
+        continueOnError: true
+      - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts.pipelines/phases/test-linux-amd64.yml
+++ b/.vsts.pipelines/phases/test-linux-amd64.yml
@@ -1,7 +1,6 @@
 parameters:
   excludeTests: false
   repo: null
-  timeoutInMinutes: null
   matrix: {}
 phases:
   - phase: Test_Linux_amd64

--- a/.vsts.pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts.pipelines/phases/test-linux-arm32v7.yml
@@ -1,0 +1,56 @@
+parameters:
+  excludeTests: false
+  repo: null
+  timeoutInMinutes: null
+  matrix: {}
+phases:
+  - phase: Test_Linux_arm32v7
+    condition: and(not(variables['excludeTests']), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    dependsOn: Build_Linux_arm32v7
+    queue:
+      name: DotNetCore-Infra
+      demands:
+        - VSTS_OS -equals Windows_10_Enterprise
+        - DockerVersion
+      parallel: 100
+      matrix: ${{ parameters.matrix }}
+    variables:
+      docker.baseArtifactName: test_$(Build.BuildId)
+      docker.certVolumeArg: -v cert_$(docker.baseArtifactName):/docker-certs
+      docker.commonRunArgs: -v $(docker.repoVolumeName):/repo -w /repo $(docker.certVolumeArg) -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PiIp):2376
+      docker.gitEnabledimage: buildpack-deps:stretch-scm
+      docker.repoVolumeName: repo_$(docker.baseArtifactName)
+      docker.setupContainerName: setup_$(docker.baseArtifactName)
+      testrunner.image: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
+      repo: ${{ parameters.repo }}
+      testRunner.Container: testrunner-$(Build.BuildId)
+    steps:
+      - template: ../steps/docker-cleanup-windows.yml
+      - script: docker pull $(testrunner.image)
+        displayName: Pull testrunner Image
+      - script: docker create $(docker.certVolumeArg) --name $(docker.setupContainerName) $(testrunner.image)
+        displayName: Create Setup Container
+      - script: docker cp c:/docker-certs $(docker.setupContainerName):/
+        displayName: Copy Docker Certs
+      - script: docker rm -f $(docker.setupContainerName)
+        displayName: Cleanup container
+        continueOnError: true
+      - script: docker run --rm $(docker.commonRunArgs) --name clone_$(docker.baseArtifactName) $(docker.gitEnabledimage) git clone https://github.com/dotnet/dotnet-docker.git /repo
+        displayName: Clone Repo
+      - script: docker run --rm $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
+        displayName: Checkout Source
+      - script: docker run -t -d  $(docker.commonRunArgs) -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.Container) $(testrunner.image)
+        displayName: Start Test Runner Container
+      - script: docker exec $(testRunner.Container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+        displayName: Docker login
+      - script: docker exec $(testRunner.Container) pwsh -File ./test/run-test.ps1 -VersionFilter $(buildPath) -OSFilter $(osVersion) -ArchitectureFilter arm -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) -DisableHttpVerification
+        displayName: Test Images
+      - script: docker exec $(testRunner.Container) docker logout
+        displayName: Docker logout
+        condition: always()
+        continueOnError: true 
+      - script: docker run $(docker.commonRunArgs) --name cleanup_$(docker.baseArtifactName) --entrypoint docker $(testrunner.image) system prune -a -f --volumes
+        displayName: Cleanup ARM Docker
+        condition: always()
+        continueOnError: true
+      - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts.pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts.pipelines/phases/test-linux-arm32v7.yml
@@ -1,7 +1,6 @@
 parameters:
   excludeTests: false
   repo: null
-  timeoutInMinutes: null
   matrix: {}
 phases:
   - phase: Test_Linux_arm32v7

--- a/.vsts.pipelines/phases/test-windows-amd64.yml
+++ b/.vsts.pipelines/phases/test-windows-amd64.yml
@@ -1,0 +1,30 @@
+parameters:
+  phase: null
+  excludeTests: false
+  dependsOn: null
+  repo: null
+  timeoutInMinutes: null
+  demands: []
+  matrix: {}
+phases:
+  - phase: ${{ parameters.phase }}
+    condition: and(not(variables['excludeTests']), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    dependsOn: ${{ parameters.dependsOn }}
+    queue:
+      name: DotNetCore-Infra
+      demands: ${{ parameters.demands }}
+      parallel: 100
+      matrix: ${{ parameters.matrix }}
+    variables:
+      repo: ${{ parameters.repo }}
+    steps:
+      - template: ../steps/docker-cleanup-windows.yml
+      - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+        displayName: Docker login
+      - powershell: ./test/run-test.ps1 -VersionFilter $(buildPath) -OSFilter $(osVersion) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+        displayName: Test Images
+      - script: docker logout
+        displayName: Docker logout
+        condition: always()
+        continueOnError: true
+      - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts.pipelines/phases/test-windows-amd64.yml
+++ b/.vsts.pipelines/phases/test-windows-amd64.yml
@@ -3,7 +3,6 @@ parameters:
   excludeTests: false
   dependsOn: null
   repo: null
-  timeoutInMinutes: null
   demands: []
   matrix: {}
 phases:

--- a/.vsts.pipelines/steps/docker-cleanup-linux.yml
+++ b/.vsts.pipelines/steps/docker-cleanup-linux.yml
@@ -1,5 +1,5 @@
 steps:
-  - script: docker system prune -a -f
+  - script: docker system prune -a -f --volumes
     displayName: Cleanup Docker
     condition: always()
     continueOnError: true

--- a/.vsts.pipelines/steps/docker-cleanup-windows.yml
+++ b/.vsts.pipelines/steps/docker-cleanup-windows.yml
@@ -1,7 +1,11 @@
 steps:
+  - script: docker system prune -f --volumes
+    displayName: Cleanup Dangling Docker Artifacts and All Volumes
+    condition: always()
+    continueOnError: true
   - powershell: |
       docker ps -a -q | %{docker rm -f $_}
       docker images | where {-Not ($_.StartsWith("microsoft/nanoserver ") -Or $_.StartsWith("microsoft/windowsservercore ") -Or $_.StartsWith("REPOSITORY "))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}
-    displayName: Cleanup Docker
+    displayName: Cleanup Docker Images
     condition: always()
     continueOnError: true

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -82,7 +82,7 @@ try {
             }
     }
 
-    ./test/run-test.ps1 -VersionFilter $VersionFilter -ArchitectureFilter $ArchitectureFilter -OSFilter $OSFilter
+    ./test/run-test.ps1 -VersionFilter $VersionFilter -ArchitectureFilter $ArchitectureFilter -OSFilter $OSFilter -IsLocalRun
     Write-Host "Tags built and tested:`n$($builtTags | Out-String)"
 }
 finally {

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -145,6 +145,11 @@ namespace Microsoft.DotNet.Docker.Tests
             return ResourceExists("image", tag);
         }
 
+        public static void Pull(string image)
+        {
+            Execute($"pull {image}");
+        }
+
         private static bool ResourceExists(string type, string filterArg)
         {
             string output = Execute($"{type} ls -q {filterArg}", true);

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -9,7 +9,9 @@ param(
     [string]$VersionFilter,
     [string]$ArchitectureFilter,
     [string]$OSFilter,
-    [string]$RepoOwner
+    [string]$Repo,
+    [switch]$DisableHttpVerification,
+    [switch]$IsLocalRun
 )
 
 Set-StrictMode -Version Latest
@@ -52,11 +54,17 @@ Try {
     if ([string]::IsNullOrWhiteSpace($ArchitectureFilter)) {
         $ArchitectureFilter = "amd64"
     }
+    if ($DisableHttpVerification) {
+        $env:DISABLE_HTTP_VERIFICATION = 1
+    }
+    if ($IsLocalRun) {
+        $env:LOCAL_RUN = 1
+    }
 
     $env:IMAGE_ARCH_FILTER = $ArchitectureFilter
     $env:IMAGE_OS_FILTER = $OSFilter
     $env:IMAGE_VERSION_FILTER = $VersionFilter
-    $env:REPO_OWNER = $RepoOwner
+    $env:REPO = $Repo
 
     $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
     $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1


### PR DESCRIPTION
These changes refactor the VSTS build definition to do the following:
- Break the build into build, test, and publish phases.  This allows the build to be distributed into smaller units which provides better scaling capabilities.
- Utilizes a staging ACR during the build prior to final publish
- Allows the build to be started at either the build, test or publish phases.

Future work:
- Generate the queue matrix dynamically to eliminate the maintenance issue and to further break the build down into smaller units.
- General cleanup once VSTS support yaml global variables
- Better support for re-queuing a partial build - VSTS has some bugs that blocking this effort.