### PR TITLE
Rename build queues and the 'buildPath' variable

### DIFF
--- a/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
@@ -14,21 +14,21 @@ phases:
       repo: dotnet-samples
       matrixLinuxAmd64:
         Build:
-          buildPath: '*'
+          dotnetVersion: '*'
           osVersion: '*'
       matrixLinuxArm32v7:
         Build:
-          buildPath: '*'
+          dotnetVersion: '*'
           osVersion: '*'
       matrixWindowsSac2016Amd64:
         Build:
-          buildPath: '*'
+          dotnetVersion: '*'
           osVersion: nanoserver-sac2016
       matrixWindows1709Amd64:
         Build:
-          buildPath: '*'
+          dotnetVersion: '*'
           osVersion: nanoserver-1709
       matrixWindows1803Amd64:
         Build:
-          buildPath: '*'
+          dotnetVersion: '*'
           osVersion: nanoserver-1803

--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -5,60 +5,60 @@ parameters:
   manifest: manifest.json
   repo: null
   matrixLinuxAmd64:
-    Build_2_1_Alpine:
-      buildPath: 2.1*
+    2_1_Alpine:
+      dotnetVersion: 2.1*
       osVersion: alpine*
-    Build_2_1_Bionic:
-      buildPath: 2.1*
+    2_1_Bionic:
+      dotnetVersion: 2.1*
       osVersion: bionic*
-    Build_2_1_Buster:
-      buildPath: 2.1*
+    2_1_Buster:
+      dotnetVersion: 2.1*
       osVersion: buster*
-    Build_2_1_Stretch:
-      buildPath: 2.1*
+    2_1_Stretch:
+      dotnetVersion: 2.1*
       osVersion: stretch*
-    Build_2_0_Jessie:
-      buildPath: 2.0*
+    2_0_Jessie:
+      dotnetVersion: 2.0*
       osVersion: jessie
-    Build_2_0_Stretch:
-      buildPath: 2.0*
+    2_0_Stretch:
+      dotnetVersion: 2.0*
       osVersion: stretch
-    Build_1_*_Jessie:
-      buildPath: 1.*
+    1_*_Jessie:
+      dotnetVersion: 1.*
       osVersion: jessie
   matrixLinuxArm32v7:
-    Build_2_1_Bionic:
-      buildPath: 2.1*
+    2_1_Bionic:
+      dotnetVersion: 2.1*
       osVersion: bionic*
-    Build_2_1_Buster:
-      buildPath: 2.1*
+    2_1_Buster:
+      dotnetVersion: 2.1*
       osVersion: buster*
-    Build_2_1_Stretch:
-      buildPath: 2.1*
+    2_1_Stretch:
+      dotnetVersion: 2.1*
       osVersion: stretch*
   matrixWindowsSac2016Amd64:
-    Build_2_1:
-      buildPath: 2.1*
+    2_1:
+      dotnetVersion: 2.1*
       osVersion: nanoserver-sac2016
-    Build_2_0:
-      buildPath: 2.0*
+    2_0:
+      dotnetVersion: 2.0*
       osVersion: nanoserver-sac2016
-    Build_1_*:
-      buildPath: 1.*
+    1_*:
+      dotnetVersion: 1.*
       osVersion: nanoserver-sac2016
   matrixWindows1709Amd64:
-    Build_2_1:
-      buildPath: 2.1*
+    2_1:
+      dotnetVersion: 2.1*
       osVersion: nanoserver-1709
-    Build_2_0:
-      buildPath: 2.0*
+    2_0:
+      dotnetVersion: 2.0*
       osVersion: nanoserver-1709
   matrixWindows1803Amd64:
-    Build_2_1:
-      buildPath: 2.1*
+    2_1:
+      dotnetVersion: 2.1*
       osVersion: nanoserver-1803
-    Build_2_0:
-      buildPath: 2.0*
+    2_0:
+      dotnetVersion: 2.0*
       osVersion: nanoserver-1803
 phases:
   ################################################################################

--- a/.vsts-pipelines/phases/build-linux-amd64.yml
+++ b/.vsts-pipelines/phases/build-linux-amd64.yml
@@ -25,5 +25,5 @@ phases:
         displayName: Build Images
         inputs:
           filename: docker
-          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) build --manifest $(manifest) --path $(buildPath)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/build-linux-arm32v7.yml
@@ -38,7 +38,7 @@ phases:
         displayName: Clone Repo
       - script: docker run $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
         displayName: Checkout Source
-      - script: docker run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(buildPath)*$(osVersion)* --architecture arm --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: docker run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --architecture arm --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - script: docker run $(docker.commonRunArgs) --name cleanup_$(docker.baseArtifactName) --entrypoint docker $(imageBuilder.image) system prune -a -f
         displayName: Cleanup ARM Docker

--- a/.vsts-pipelines/phases/build-windows-amd64.yml
+++ b/.vsts-pipelines/phases/build-windows-amd64.yml
@@ -30,6 +30,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test --path $(buildPath) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test --path $(dotnetVersion) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/copy-images-linux.yml
+++ b/.vsts-pipelines/phases/copy-images-linux.yml
@@ -30,5 +30,5 @@ phases:
         displayName: Copy Images
         inputs:
           filename: docker
-          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(buildPath)*$(osVersion)* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(dotnetVersion)*$(osVersion)* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/copy-images-windows.yml
+++ b/.vsts-pipelines/phases/copy-images-windows.yml
@@ -32,6 +32,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(buildPath) --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(dotnetVersion) --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/test-linux-amd64.yml
+++ b/.vsts-pipelines/phases/test-linux-amd64.yml
@@ -28,7 +28,7 @@ phases:
         displayName: Test Images
         inputs:
           filename: docker
-          arguments: exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(buildPath) -OSFilter $(osVersion) -ArchitectureFilter amd64 -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+          arguments: exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -ArchitectureFilter amd64 -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
       - script: docker exec $(testRunner.Container) docker logout
         displayName: Docker logout
         condition: always()

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -42,7 +42,7 @@ phases:
         displayName: Start Test Runner Container
       - script: docker exec $(testRunner.Container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-      - script: docker exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(buildPath) -OSFilter $(osVersion) -ArchitectureFilter arm -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) -DisableHttpVerification
+      - script: docker exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -ArchitectureFilter arm -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) -DisableHttpVerification
         displayName: Test Images
       - script: docker exec $(testRunner.Container) docker logout
         displayName: Docker logout

--- a/.vsts-pipelines/phases/test-windows-amd64.yml
+++ b/.vsts-pipelines/phases/test-windows-amd64.yml
@@ -20,7 +20,7 @@ phases:
       - template: ../steps/docker-cleanup-windows.yml
       - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-      - powershell: ./tests/run-tests.ps1 -VersionFilter $(buildPath) -OSFilter $(osVersion) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - powershell: ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Test Images
       - script: docker logout
         displayName: Docker logout


### PR DESCRIPTION
* Renamed the `buildPath` variable to `dotnetVersion` as it more accurately describes what the variable contains.  It is used for more than the imageBuilder `path` option.
* Dropped the `Build_` prefix from the build queue names.  The `Build_` prefix was confusing to see in the build output for the Test and Copy phases - e.g. `Test_Linux_amd64 Build_2_0_Jessie`