### PR TITLE
Add build steps to publish tests results

### DIFF
--- a/.vsts-pipelines/phases/test-linux-amd64.yml
+++ b/.vsts-pipelines/phases/test-linux-amd64.yml
@@ -33,4 +33,22 @@ phases:
         displayName: Docker logout
         condition: always()
         continueOnError: true
+      - script: docker cp $(testRunner.Container):/src/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
+        displayName: Copy Test Results
+        condition: always()
+        continueOnError: true
+      - task: PublishTestResults@2
+        displayName: Publish Test Results
+        condition: always()
+        continueOnError: true
+        inputs:
+          testRunner: vSTest
+          testResultsFiles: '**/*.trx'
+          searchFolder: $(Common.TestResultsDirectory)
+          mergeTestResults: true
+          testRunTitle: Linux $(buildPath) $(osVersion) amd64
+      - script: docker stop $(testRunner.Container)
+        displayName: Stop TestRunner Container
+        condition: always()
+        continueOnError: true
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -12,6 +12,7 @@ phases:
         - VSTS_OS -equals Windows_10_Enterprise
         - DockerVersion
       parallel: 100
+      timeoutInMinutes: 90
       matrix: ${{ parameters.matrix }}
     variables:
       docker.baseArtifactName: test_$(Build.BuildId)
@@ -47,7 +48,25 @@ phases:
       - script: docker exec $(testRunner.Container) docker logout
         displayName: Docker logout
         condition: always()
-        continueOnError: true 
+        continueOnError: true
+      - script: docker cp $(testRunner.Container):/src/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
+        displayName: Copy Test Results
+        condition: always()
+        continueOnError: true
+      - task: PublishTestResults@2
+        displayName: Publish Test Results
+        condition: always()
+        continueOnError: true
+        inputs:
+          testRunner: vSTest
+          testResultsFiles: '**/*.trx'
+          searchFolder: $(Common.TestResultsDirectory)
+          mergeTestResults: true
+          testRunTitle: Linux $(buildPath) $(osVersion) arm32v7
+      - script: docker stop $(testRunner.Container)
+        displayName: Stop TestRunner Container
+        condition: always()
+        continueOnError: true
       - script: docker run $(docker.commonRunArgs) --name cleanup_$(docker.baseArtifactName) --entrypoint docker $(testrunner.image) system prune -a -f --volumes
         displayName: Cleanup ARM Docker
         condition: always()

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -49,7 +49,7 @@ phases:
         displayName: Docker logout
         condition: always()
         continueOnError: true
-      - script: docker cp $(testRunner.Container):/src/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
+      - script: docker cp $(testRunner.Container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
         displayName: Copy Test Results
         condition: always()
         continueOnError: true

--- a/.vsts-pipelines/phases/test-windows-amd64.yml
+++ b/.vsts-pipelines/phases/test-windows-amd64.yml
@@ -26,4 +26,13 @@ phases:
         displayName: Docker logout
         condition: always()
         continueOnError: true
+      - task: PublishTestResults@2
+        displayName: Publish Test Results
+        condition: always()
+        continueOnError: true
+        inputs:
+          testRunner: vSTest
+          testResultsFiles: 'tests/**/*.trx'
+          mergeTestResults: true
+          testRunTitle: Windows $(buildPath) $(osVersion) amd64
       - template: ../steps/docker-cleanup-windows.yml

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -39,10 +39,10 @@ if (!(Test-Path $DotnetInstallScript)) {
 
 if ($IsRunningOnUnix) {
     & chmod +x $DotnetInstallDir/$DotnetInstallScript
-    & $DotnetInstallDir/$DotnetInstallScript --channel "2.0" --version "latest" --architecture x64 --install-dir $DotnetInstallDir
+    & $DotnetInstallDir/$DotnetInstallScript --channel "2.1" --version "latest" --architecture x64 --install-dir $DotnetInstallDir
 }
 else {
-    & $DotnetInstallDir/$DotnetInstallScript -Channel "2.0" -Version "latest" -Architecture x64 -InstallDir $DotnetInstallDir
+    & $DotnetInstallDir/$DotnetInstallScript -Channel "2.1" -Version "latest" -Architecture x64 -InstallDir $DotnetInstallDir
 }
 
 if ($LASTEXITCODE -ne 0) { throw "Failed to install the .NET Core SDK" }
@@ -70,7 +70,7 @@ Try {
     $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
     $env:DOTNET_MULTILEVEL_LOOKUP = '0'
 
-    & $DotnetInstallDir/dotnet test -v n
+    & $DotnetInstallDir/dotnet test --logger:trx
 
     if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }
 }


### PR DESCRIPTION
* Upgrade tests to be based on .NET Core 2.1
* Update run-tests.ps1 to emit trx files with the test results
* Added build steps to publish the test results.  This makes them accessible in the `tests` tab in the VSTS build results.