### PR TITLE
Update libicu on buster images to libicu60

### DIFF
--- a/2.1/runtime-deps/buster-slim/amd64/Dockerfile
+++ b/2.1/runtime-deps/buster-slim/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
     libc6 \
     libgcc1 \
     libgssapi-krb5-2 \
-    libicu57 \
+    libicu60 \
     liblttng-ust0 \
     libssl1.0.2 \
     libstdc++6 \

--- a/2.1/runtime-deps/buster-slim/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/buster-slim/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
     libc6 \
     libgcc1 \
     libgssapi-krb5-2 \
-    libicu57 \
+    libicu60 \
     liblttng-ust0 \
     libssl1.0.2 \
     libstdc++6 \

--- a/2.1/sdk/buster/amd64/Dockerfile
+++ b/2.1/sdk/buster/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     libc6 \
     libgcc1 \
     libgssapi-krb5-2 \
-    libicu57 \
+    libicu60 \
     liblttng-ust0 \
     libssl1.0.2 \
     libstdc++6 \

--- a/2.1/sdk/buster/arm32v7/Dockerfile
+++ b/2.1/sdk/buster/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     libc6 \
     libgcc1 \
     libgssapi-krb5-2 \
-    libicu57 \
+    libicu60 \
     liblttng-ust0 \
     libssl1.0.2 \
     libstdc++6 \


### PR DESCRIPTION
`libicu57` is no longer in the default `buster` package cache, upgrading to `libicu60`.