### PR TITLE
Update arm32 build legs to run on a linux client

### DIFF
--- a/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
@@ -14,21 +14,21 @@ phases:
       repo: dotnet-samples
       matrixLinuxAmd64:
         Build:
-          dotnetVersion: '*'
-          osVersion: '*'
+          dotnetVersion: ''
+          osVersion: ''
       matrixLinuxArm32v7:
         Build:
-          dotnetVersion: '*'
-          osVersion: '*'
+          dotnetVersion: ''
+          osVersion: ''
       matrixWindowsSac2016Amd64:
         Build:
-          dotnetVersion: '*'
+          dotnetVersion: ''
           osVersion: nanoserver-sac2016
       matrixWindows1709Amd64:
         Build:
-          dotnetVersion: '*'
+          dotnetVersion: ''
           osVersion: nanoserver-1709
       matrixWindows1803Amd64:
         Build:
-          dotnetVersion: '*'
+          dotnetVersion: ''
           osVersion: nanoserver-1803

--- a/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
@@ -9,7 +9,6 @@ trigger:
 phases:
   - template: ../phases/build-all.yml
     parameters:
-      excludeTests: true
       manifest: manifest.samples.json
       repo: dotnet-samples
       matrixLinuxAmd64:

--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -1,64 +1,65 @@
 parameters:
   imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180627140652
   imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180627070723
+  testRunnerLinuxImage: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   excludeTests: false
   manifest: manifest.json
   repo: null
   matrixLinuxAmd64:
     2_1_Alpine:
-      dotnetVersion: 2.1*
-      osVersion: alpine*
+      dotnetVersion: 2.1
+      osVersion: alpine
     2_1_Bionic:
-      dotnetVersion: 2.1*
-      osVersion: bionic*
+      dotnetVersion: 2.1
+      osVersion: bionic
     2_1_Buster:
-      dotnetVersion: 2.1*
-      osVersion: buster*
+      dotnetVersion: 2.1
+      osVersion: buster
     2_1_Stretch:
-      dotnetVersion: 2.1*
-      osVersion: stretch*
+      dotnetVersion: 2.1
+      osVersion: stretch
     2_0_Jessie:
-      dotnetVersion: 2.0*
+      dotnetVersion: 2.0
       osVersion: jessie
     2_0_Stretch:
-      dotnetVersion: 2.0*
+      dotnetVersion: 2.0
       osVersion: stretch
     1_*_Jessie:
-      dotnetVersion: 1.*
+      dotnetVersion: 1.
       osVersion: jessie
   matrixLinuxArm32v7:
     2_1_Bionic:
-      dotnetVersion: 2.1*
-      osVersion: bionic*
+      dotnetVersion: 2.1
+      osVersion: bionic
     2_1_Buster:
-      dotnetVersion: 2.1*
-      osVersion: buster*
+      dotnetVersion: 2.1
+      osVersion: buster
     2_1_Stretch:
-      dotnetVersion: 2.1*
-      osVersion: stretch*
+      dotnetVersion: 2.1
+      osVersion: stretch
   matrixWindowsSac2016Amd64:
     2_1:
-      dotnetVersion: 2.1*
+      dotnetVersion: 2.1
       osVersion: nanoserver-sac2016
     2_0:
-      dotnetVersion: 2.0*
+      dotnetVersion: 2.0
       osVersion: nanoserver-sac2016
     1_*:
-      dotnetVersion: 1.*
+      dotnetVersion: 1.
       osVersion: nanoserver-sac2016
   matrixWindows1709Amd64:
     2_1:
-      dotnetVersion: 2.1*
+      dotnetVersion: 2.1
       osVersion: nanoserver-1709
     2_0:
-      dotnetVersion: 2.0*
+      dotnetVersion: 2.0
       osVersion: nanoserver-1709
   matrixWindows1803Amd64:
     2_1:
-      dotnetVersion: 2.1*
+      dotnetVersion: 2.1
       osVersion: nanoserver-1803
     2_0:
-      dotnetVersion: 2.0*
+      dotnetVersion: 2.0
       osVersion: nanoserver-1803
 phases:
   ################################################################################
@@ -109,11 +110,13 @@ phases:
   ################################################################################
   - template: test-linux-amd64.yml
     parameters:
+      testRunnerLinuxImage: ${{ parameters.testRunnerLinuxImage }}
       excludeTests: ${{ parameters.excludeTests }}
       repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxAmd64 }}
   - template: test-linux-arm32v7.yml
     parameters:
+      testRunnerLinuxImage: ${{ parameters.testRunnerLinuxImage }}
       excludeTests: ${{ parameters.excludeTests }}
       repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxArm32v7 }}
@@ -121,8 +124,8 @@ phases:
     parameters:
       phase: Test_NanoServerSac2016_amd64
       excludeTests: ${{ parameters.excludeTests }}
-      dependsOn: Build_NanoServerSac2016_amd64
       repo: ${{ parameters.repo }}
+      dependsOn: Build_NanoServerSac2016_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
       matrix: ${{ parameters.matrixWindowsSac2016Amd64 }}
@@ -130,8 +133,8 @@ phases:
     parameters:
       phase: Test_NanoServer1709_amd64
       excludeTests: ${{ parameters.excludeTests }}
-      dependsOn: Build_NanoServer1709_amd64
       repo: ${{ parameters.repo }}
+      dependsOn: Build_NanoServer1709_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
       matrix: ${{ parameters.matrixWindows1709Amd64 }}
@@ -139,8 +142,8 @@ phases:
     parameters:
       phase: Test_NanoServer1803_amd64
       excludeTests: ${{ parameters.excludeTests }}
-      dependsOn: Build_NanoServer1803_amd64
       repo: ${{ parameters.repo }}
+      dependsOn: Build_NanoServer1803_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
       matrix: ${{ parameters.matrixWindows1803Amd64 }}
@@ -153,26 +156,26 @@ phases:
       phase: Copy_Images_Linux_amd64
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}
+      repo: ${{ parameters.repo }}
       architecture: amd64
       dependsOn: Test_Linux_amd64
-      repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxAmd64 }}
   - template: copy-images-linux.yml
     parameters:
       phase: Copy_Images_Linux_arm32v7
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}
+      repo: ${{ parameters.repo }}
       architecture: arm
       dependsOn: Test_Linux_arm32v7
-      repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxArm32v7 }}
   - template: copy-images-windows.yml
     parameters:
       phase: Copy_Images_NanoServerSac2016_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
-      dependsOn: Test_NanoServerSac2016_amd64
       repo: ${{ parameters.repo }}
+      dependsOn: Test_NanoServerSac2016_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
       matrix: ${{ parameters.matrixWindowsSac2016Amd64 }}
@@ -181,8 +184,8 @@ phases:
       phase: Copy_Images_NanoServer1709_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
-      dependsOn: Test_NanoServer1709_amd64
       repo: ${{ parameters.repo }}
+      dependsOn: Test_NanoServer1709_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
       matrix: ${{ parameters.matrixWindows1709Amd64 }}
@@ -191,8 +194,8 @@ phases:
       phase: Copy_Images_NanoServer1803_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
-      dependsOn: Test_NanoServer1803_amd64
       repo: ${{ parameters.repo }}
+      dependsOn: Test_NanoServer1803_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
       matrix: ${{ parameters.matrixWindows1803Amd64 }}

--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -2,7 +2,6 @@ parameters:
   imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180627140652
   imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180627070723
   testRunnerLinuxImage: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
-  excludeTests: false
   manifest: manifest.json
   repo: null
   matrixLinuxAmd64:
@@ -111,19 +110,16 @@ phases:
   - template: test-linux-amd64.yml
     parameters:
       testRunnerLinuxImage: ${{ parameters.testRunnerLinuxImage }}
-      excludeTests: ${{ parameters.excludeTests }}
       repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxAmd64 }}
   - template: test-linux-arm32v7.yml
     parameters:
       testRunnerLinuxImage: ${{ parameters.testRunnerLinuxImage }}
-      excludeTests: ${{ parameters.excludeTests }}
       repo: ${{ parameters.repo }}
       matrix: ${{ parameters.matrixLinuxArm32v7 }}
   - template: test-windows-amd64.yml
     parameters:
       phase: Test_NanoServerSac2016_amd64
-      excludeTests: ${{ parameters.excludeTests }}
       repo: ${{ parameters.repo }}
       dependsOn: Build_NanoServerSac2016_amd64
       demands:
@@ -132,7 +128,6 @@ phases:
   - template: test-windows-amd64.yml
     parameters:
       phase: Test_NanoServer1709_amd64
-      excludeTests: ${{ parameters.excludeTests }}
       repo: ${{ parameters.repo }}
       dependsOn: Build_NanoServer1709_amd64
       demands:
@@ -141,7 +136,6 @@ phases:
   - template: test-windows-amd64.yml
     parameters:
       phase: Test_NanoServer1803_amd64
-      excludeTests: ${{ parameters.excludeTests }}
       repo: ${{ parameters.repo }}
       dependsOn: Build_NanoServer1803_amd64
       demands:
@@ -159,6 +153,7 @@ phases:
       repo: ${{ parameters.repo }}
       architecture: amd64
       dependsOn: Test_Linux_amd64
+      buildDependsOn: Build_Linux_amd64
       matrix: ${{ parameters.matrixLinuxAmd64 }}
   - template: copy-images-linux.yml
     parameters:
@@ -168,6 +163,7 @@ phases:
       repo: ${{ parameters.repo }}
       architecture: arm
       dependsOn: Test_Linux_arm32v7
+      buildDependsOn: Build_Linux_arm32v7
       matrix: ${{ parameters.matrixLinuxArm32v7 }}
   - template: copy-images-windows.yml
     parameters:
@@ -176,6 +172,7 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
       dependsOn: Test_NanoServerSac2016_amd64
+      buildDependsOn: Build_NanoServerSac2016_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
       matrix: ${{ parameters.matrixWindowsSac2016Amd64 }}
@@ -186,6 +183,7 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
       dependsOn: Test_NanoServer1709_amd64
+      buildDependsOn: Build_NanoServer1709_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
       matrix: ${{ parameters.matrixWindows1709Amd64 }}
@@ -196,6 +194,7 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
       dependsOn: Test_NanoServer1803_amd64
+      buildDependsOn: Build_NanoServer1803_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
       matrix: ${{ parameters.matrixWindows1803Amd64 }}

--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -152,8 +152,6 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
       architecture: amd64
-      dependsOn: Test_Linux_amd64
-      buildDependsOn: Build_Linux_amd64
       matrix: ${{ parameters.matrixLinuxAmd64 }}
   - template: copy-images-linux.yml
     parameters:
@@ -162,8 +160,6 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
       architecture: arm
-      dependsOn: Test_Linux_arm32v7
-      buildDependsOn: Build_Linux_arm32v7
       matrix: ${{ parameters.matrixLinuxArm32v7 }}
   - template: copy-images-windows.yml
     parameters:
@@ -171,8 +167,6 @@ phases:
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
-      dependsOn: Test_NanoServerSac2016_amd64
-      buildDependsOn: Build_NanoServerSac2016_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
       matrix: ${{ parameters.matrixWindowsSac2016Amd64 }}
@@ -182,8 +176,6 @@ phases:
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
-      dependsOn: Test_NanoServer1709_amd64
-      buildDependsOn: Build_NanoServer1709_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
       matrix: ${{ parameters.matrixWindows1709Amd64 }}
@@ -193,8 +185,6 @@ phases:
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
-      dependsOn: Test_NanoServer1803_amd64
-      buildDependsOn: Build_NanoServer1803_amd64
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
       matrix: ${{ parameters.matrixWindows1803Amd64 }}

--- a/.vsts-pipelines/phases/build-linux-amd64.yml
+++ b/.vsts-pipelines/phases/build-linux-amd64.yml
@@ -18,12 +18,13 @@ phases:
       repo: ${{ parameters.repo }}
     steps:
       - template: ../steps/docker-cleanup-linux.yml
+      - template: ../steps/docker-create-repo-volume-linux.yml
       - script: docker pull $(imageBuilder.image)
         displayName: Pull Image Builder
-        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      # The script task does not currently work (curl ssl issues), using CmdLine as workaround.
       - task: CmdLine@1
         displayName: Build Images
         inputs:
           filename: docker
-          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v repo-$(Build.BuildId):/repo -w /repo $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/build-linux-arm32v7.yml
@@ -9,40 +9,34 @@ phases:
     queue:
       name: DotNetCore-Infra
       demands:
-        - VSTS_OS -equals Windows_10_Enterprise
-        - DockerVersion
+        - agent.os -equals linux
+        - DockerArch -equals arm32v7
       parallel: 100
-      timeoutInMinutes: 90
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.baseArtifactName: $(Build.BuildId)
-      docker.certVolumeArg: -v cert_$(docker.baseArtifactName):/docker-certs
-      docker.commonRunArgs: --rm -v $(docker.repoVolumeName):/repo -w /repo $(docker.certVolumeArg) -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PiIp):2376
+      docker.baseArtifactName: build_$(Build.BuildId)
+      docker.commonRunArgs: --rm -v $(docker.repoVolumeName):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
       docker.gitEnabledimage: buildpack-deps:stretch-scm
       docker.repoVolumeName: repo_$(docker.baseArtifactName)
-      docker.setupContainerName: setup_$(docker.baseArtifactName)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
     steps:
-      - template: ../steps/docker-cleanup-windows.yml
+      - template: ../steps/docker-cleanup-linux.yml
       - script: docker pull $(imageBuilder.image)
         displayName: Pull Image Builder
-      - script: docker create $(docker.certVolumeArg) --name $(docker.setupContainerName) $(imageBuilder.image)
-        displayName: Create Setup Container
-      - script: docker cp c:/docker-certs $(docker.setupContainerName):/
-        displayName: Copy Docker Certs
-      - script: docker rm -f $(docker.setupContainerName)
-        displayName: Cleanup container
-        continueOnError: true
       - script: docker run $(docker.commonRunArgs) --name clone_$(docker.baseArtifactName) $(docker.gitEnabledimage) git clone https://github.com/dotnet/dotnet-docker.git /repo
         displayName: Clone Repo
       - script: docker run $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
         displayName: Checkout Source
-      - script: docker run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --architecture arm --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      - task: CmdLine@1
         displayName: Build Images
+        inputs:
+          filename: docker
+          arguments: run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
       - script: docker run $(docker.commonRunArgs) --name cleanup_$(docker.baseArtifactName) --entrypoint docker $(imageBuilder.image) system prune -a -f
         displayName: Cleanup ARM Docker
         condition: always()
         continueOnError: true
-      - template: ../steps/docker-cleanup-windows.yml
+      - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/build-linux-arm32v7.yml
@@ -14,28 +14,22 @@ phases:
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.baseArtifactName: build_$(Build.BuildId)
-      docker.commonRunArgs: --rm -v $(docker.repoVolumeName):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
-      docker.gitEnabledimage: buildpack-deps:stretch-scm
-      docker.repoVolumeName: repo_$(docker.baseArtifactName)
+      docker.commonRunArgs: --rm -v repo-$(Build.BuildId):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
     steps:
       - template: ../steps/docker-cleanup-linux.yml
+      - template: ../steps/docker-create-repo-volume-linux.yml
       - script: docker pull $(imageBuilder.image)
         displayName: Pull Image Builder
-      - script: docker run $(docker.commonRunArgs) --name clone_$(docker.baseArtifactName) $(docker.gitEnabledimage) git clone https://github.com/dotnet/dotnet-docker.git /repo
-        displayName: Clone Repo
-      - script: docker run $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
-        displayName: Checkout Source
-        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      # The script task does not currently work (curl ssl issues), using CmdLine as workaround.
       - task: CmdLine@1
         displayName: Build Images
         inputs:
           filename: docker
-          arguments: run $(docker.commonRunArgs) --name image_builder_$(docker.baseArtifactName) $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
-      - script: docker run $(docker.commonRunArgs) --name cleanup_$(docker.baseArtifactName) --entrypoint docker $(imageBuilder.image) system prune -a -f
+          arguments: run $(docker.commonRunArgs) $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: docker run $(docker.commonRunArgs) --entrypoint docker $(imageBuilder.image) system prune -a -f
         displayName: Cleanup ARM Docker
         condition: always()
         continueOnError: true

--- a/.vsts-pipelines/phases/build-windows-amd64.yml
+++ b/.vsts-pipelines/phases/build-windows-amd64.yml
@@ -14,8 +14,7 @@ phases:
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.baseArtifactName: build_$(Build.BuildId)
-      docker.setupContainerName: setup_$(docker.baseArtifactName)
+      docker.setupContainerName: setup_$(Build.BuildId)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
@@ -30,6 +29,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test --path $(dotnetVersion) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test --path $(dotnetVersion)* --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/build-windows-amd64.yml
+++ b/.vsts-pipelines/phases/build-windows-amd64.yml
@@ -14,7 +14,7 @@ phases:
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.baseArtifactName: $(Build.BuildId)
+      docker.baseArtifactName: build_$(Build.BuildId)
       docker.setupContainerName: setup_$(docker.baseArtifactName)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}

--- a/.vsts-pipelines/phases/copy-images-linux.yml
+++ b/.vsts-pipelines/phases/copy-images-linux.yml
@@ -5,10 +5,11 @@ parameters:
   repo: null
   architecture: null
   dependsOn: null
+  buildDependsOn: null
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'))
+    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded(variables['buildDependsOn'])))
     dependsOn: ${{ parameters.dependsOn }}
     queue:
       name: DotNet-Build
@@ -18,6 +19,7 @@ phases:
       matrix: ${{ parameters.matrix }}
     variables:
       architecture: ${{ parameters.architecture }}
+      buildDependsOn: ${{ parameters.buildDependsOn }}
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
@@ -25,6 +27,6 @@ phases:
       - template: ../steps/docker-cleanup-linux.yml
       - script: docker pull $(imageBuilder.image)
         displayName: Pull Image Builder
-      - script: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(dotnetVersion)\*$(osVersion)\* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(dotnetVersion)\*$(osVersion)\* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/copy-images-linux.yml
+++ b/.vsts-pipelines/phases/copy-images-linux.yml
@@ -4,13 +4,16 @@ parameters:
   manifest: null
   repo: null
   architecture: null
-  dependsOn: null
-  buildDependsOn: null
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded(variables['buildDependsOn'])))
-    dependsOn: ${{ parameters.dependsOn }}
+    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))
+    dependsOn:
+      - Test_Linux_amd64
+      - Test_Linux_arm32v7
+      - Test_NanoServerSac2016_amd64
+      - Test_NanoServer1709_amd64
+      - Test_NanoServer1803_amd64
     queue:
       name: DotNet-Build
       demands:
@@ -19,7 +22,6 @@ phases:
       matrix: ${{ parameters.matrix }}
     variables:
       architecture: ${{ parameters.architecture }}
-      buildDependsOn: ${{ parameters.buildDependsOn }}
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}

--- a/.vsts-pipelines/phases/copy-images-linux.yml
+++ b/.vsts-pipelines/phases/copy-images-linux.yml
@@ -2,9 +2,9 @@ parameters:
   phase: null
   imageBuilderImage: null
   manifest: null
-  dependsOn: null
   repo: null
   architecture: null
+  dependsOn: null
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
@@ -17,18 +17,14 @@ phases:
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
+      architecture: ${{ parameters.architecture }}
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
-      architecture: ${{ parameters.architecture }}
     steps:
       - template: ../steps/docker-cleanup-linux.yml
       - script: docker pull $(imageBuilder.image)
         displayName: Pull Image Builder
-        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
-      - task: CmdLine@1
+      - script: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(dotnetVersion)\*$(osVersion)\* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
-        inputs:
-          filename: docker
-          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name image_builder_$(Build.BuildId) $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(dotnetVersion)*$(osVersion)* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/copy-images-windows.yml
+++ b/.vsts-pipelines/phases/copy-images-windows.yml
@@ -3,21 +3,23 @@ parameters:
   imageBuilderImage: null
   manifest: null
   repo: null
-  dependsOn: null
-  buildDependsOn: null
   demands: []
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded(variables['buildDependsOn'])))
-    dependsOn: ${{ parameters.dependsOn }}
+    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))
+    dependsOn:
+      - Test_Linux_amd64
+      - Test_Linux_arm32v7
+      - Test_NanoServerSac2016_amd64
+      - Test_NanoServer1709_amd64
+      - Test_NanoServer1803_amd64
     queue:
       name: DotNetCore-Infra
       demands: ${{ parameters.demands }}
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      buildDependsOn: ${{ parameters.buildDependsOn }}
       docker.baseArtifactName: publish-$(Build.BuildId)
       docker.setupContainerName: setup_$(docker.baseArtifactName)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}

--- a/.vsts-pipelines/phases/copy-images-windows.yml
+++ b/.vsts-pipelines/phases/copy-images-windows.yml
@@ -2,8 +2,8 @@ parameters:
   phase: null
   imageBuilderImage: null
   manifest: null
-  dependsOn: null
   repo: null
+  dependsOn: null
   demands: []
   matrix: {}
 phases:
@@ -32,6 +32,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(dotnetVersion) --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(dotnetVersion)* --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/copy-images-windows.yml
+++ b/.vsts-pipelines/phases/copy-images-windows.yml
@@ -4,11 +4,12 @@ parameters:
   manifest: null
   repo: null
   dependsOn: null
+  buildDependsOn: null
   demands: []
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'))
+    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded(variables['buildDependsOn'])))
     dependsOn: ${{ parameters.dependsOn }}
     queue:
       name: DotNetCore-Infra
@@ -16,6 +17,7 @@ phases:
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
+      buildDependsOn: ${{ parameters.buildDependsOn }}
       docker.baseArtifactName: publish-$(Build.BuildId)
       docker.setupContainerName: setup_$(docker.baseArtifactName)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
@@ -32,6 +34,6 @@ phases:
       - script: docker rm -f $(docker.setupContainerName)
         displayName: Cleanup Setup Container
         continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(dotnetVersion)* --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(dotnetVersion)* --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/publish-finalize.yml
+++ b/.vsts-pipelines/phases/publish-finalize.yml
@@ -15,7 +15,6 @@ phases:
       demands:
         - agent.os -equals linux
     variables:
-      docker.baseArtifactName: $(Build.BuildId)
       docker.commonRunArgs: --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image)
       imageBuilder.commonCmdArgs: --manifest $(manifest) --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
@@ -24,8 +23,8 @@ phases:
       - template: ../steps/docker-cleanup-linux.yml
       - script: docker pull $(imageBuilder.image)
         displayName: Pull Image Builder
-      - script: docker run --name publish_$(docker.baseArtifactName) $(docker.commonRunArgs) publishManifest $(imageBuilder.commonCmdArgs)
+      - script: docker run $(docker.commonRunArgs) publishManifest $(imageBuilder.commonCmdArgs)
         displayName: Publish Manifest
-      - script: docker run --name readme_$(docker.baseArtifactName) $(docker.commonRunArgs) updateReadme $(imageBuilder.commonCmdArgs)
+      - script: docker run $(docker.commonRunArgs) updateReadme $(imageBuilder.commonCmdArgs)
         displayName: Update Readme
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/publish-finalize.yml
+++ b/.vsts-pipelines/phases/publish-finalize.yml
@@ -16,7 +16,7 @@ phases:
         - agent.os -equals linux
     variables:
       docker.commonRunArgs: --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image)
-      imageBuilder.commonCmdArgs: --manifest $(manifest) --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs)
+      imageBuilder.commonCmdArgs: --manifest $(manifest) --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
     steps:

--- a/.vsts-pipelines/phases/test-linux-amd64.yml
+++ b/.vsts-pipelines/phases/test-linux-amd64.yml
@@ -1,4 +1,5 @@
 parameters:
+  testRunnerLinuxImage: null
   excludeTests: false
   repo: null
   matrix: {}
@@ -14,26 +15,28 @@ phases:
       matrix: ${{ parameters.matrix }}
     variables:
       repo: ${{ parameters.repo }}
-      testRunner.Container: testrunner-$(Build.BuildId)
+      testrunner.image: ${{ parameters.testRunnerLinuxImage }}
+      testRunner.container: testrunner-$(Build.BuildId)
     steps:
       - template: ../steps/docker-cleanup-linux.yml
-      - script: docker build --rm -t testrunner -f ./tests/Dockerfile.linux.testrunner .
+      - template: ../steps/docker-create-repo-volume-linux.yml
+      - script: docker pull $(testrunner.image)
         displayName: Pull testrunner Image
-      - script: docker run -t -d  -v /var/run/docker.sock:/var/run/docker.sock --name $(testRunner.Container) testrunner
+      - script: docker run -t -d  -v /var/run/docker.sock:/var/run/docker.sock -v repo-$(Build.BuildId):/repo -w /repo -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.container) $(testrunner.image)
         displayName: Start Test Runner Container
-      - script: docker exec $(testRunner.Container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+      - script: docker exec $(testRunner.container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      # The script task does not currently work (curl ssl issues), using CmdLine as workaround.
       - task: CmdLine@1
         displayName: Test Images
         inputs:
           filename: docker
-          arguments: exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -ArchitectureFilter amd64 -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
-      - script: docker exec $(testRunner.Container) docker logout
+          arguments: exec $(testRunner.container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion)* -OSFilter $(osVersion)* -ArchitectureFilter amd64 -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: docker exec $(testRunner.container) docker logout
         displayName: Docker logout
         condition: always()
         continueOnError: true
-      - script: docker cp $(testRunner.Container):/src/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
+      - script: docker cp $(testRunner.container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
         displayName: Copy Test Results
         condition: always()
         continueOnError: true
@@ -47,7 +50,7 @@ phases:
           searchFolder: $(Common.TestResultsDirectory)
           mergeTestResults: true
           testRunTitle: Linux $(buildPath) $(osVersion) amd64
-      - script: docker stop $(testRunner.Container)
+      - script: docker stop $(testRunner.container)
         displayName: Stop TestRunner Container
         condition: always()
         continueOnError: true

--- a/.vsts-pipelines/phases/test-linux-amd64.yml
+++ b/.vsts-pipelines/phases/test-linux-amd64.yml
@@ -1,11 +1,10 @@
 parameters:
   testRunnerLinuxImage: null
-  excludeTests: false
   repo: null
   matrix: {}
 phases:
   - phase: Test_Linux_amd64
-    condition: and(not(variables['excludeTests']), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    condition: and(ne(variables['repo'], 'dotnet-samples'), or(succeeded(), eq(variables['startingPhase'], 'test')))
     dependsOn: Build_Linux_amd64
     queue:
       name: DotNet-Build

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -9,32 +9,22 @@ phases:
     queue:
       name: DotNetCore-Infra
       demands:
-        - VSTS_OS -equals Windows_10_Enterprise
-        - DockerVersion
+        - agent.os -equals linux
+        - DockerArch -equals arm32v7
       parallel: 100
-      timeoutInMinutes: 90
       matrix: ${{ parameters.matrix }}
     variables:
       docker.baseArtifactName: test_$(Build.BuildId)
-      docker.certVolumeArg: -v cert_$(docker.baseArtifactName):/docker-certs
-      docker.commonRunArgs: -v $(docker.repoVolumeName):/repo -w /repo $(docker.certVolumeArg) -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PiIp):2376
+      docker.commonRunArgs: -v $(docker.repoVolumeName):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
       docker.gitEnabledimage: buildpack-deps:stretch-scm
       docker.repoVolumeName: repo_$(docker.baseArtifactName)
-      docker.setupContainerName: setup_$(docker.baseArtifactName)
-      testrunner.image: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
       repo: ${{ parameters.repo }}
+      testrunner.image: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
       testRunner.Container: testrunner-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-windows.yml
+      - template: ../steps/docker-cleanup-linux.yml
       - script: docker pull $(testrunner.image)
         displayName: Pull testrunner Image
-      - script: docker create $(docker.certVolumeArg) --name $(docker.setupContainerName) $(testrunner.image)
-        displayName: Create Setup Container
-      - script: docker cp c:/docker-certs $(docker.setupContainerName):/
-        displayName: Copy Docker Certs
-      - script: docker rm -f $(docker.setupContainerName)
-        displayName: Cleanup container
-        continueOnError: true
       - script: docker run --rm $(docker.commonRunArgs) --name clone_$(docker.baseArtifactName) $(docker.gitEnabledimage) git clone https://github.com/dotnet/dotnet-docker.git /repo
         displayName: Clone Repo
       - script: docker run --rm $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
@@ -43,8 +33,12 @@ phases:
         displayName: Start Test Runner Container
       - script: docker exec $(testRunner.Container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-      - script: docker exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -ArchitectureFilter arm -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) -DisableHttpVerification
+        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      - task: CmdLine@1
         displayName: Test Images
+        inputs:
+          filename: docker
+          arguments: exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -ArchitectureFilter arm -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) -DisableHttpVerification
       - script: docker exec $(testRunner.Container) docker logout
         displayName: Docker logout
         condition: always()
@@ -71,4 +65,4 @@ phases:
         displayName: Cleanup ARM Docker
         condition: always()
         continueOnError: true
-      - template: ../steps/docker-cleanup-windows.yml
+      - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -1,4 +1,5 @@
 parameters:
+  testRunnerLinuxImage: null
   excludeTests: false
   repo: null
   matrix: {}
@@ -15,35 +16,30 @@ phases:
       matrix: ${{ parameters.matrix }}
     variables:
       docker.baseArtifactName: test_$(Build.BuildId)
-      docker.commonRunArgs: -v $(docker.repoVolumeName):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
-      docker.gitEnabledimage: buildpack-deps:stretch-scm
-      docker.repoVolumeName: repo_$(docker.baseArtifactName)
+      docker.commonRunArgs: -v repo-$(Build.BuildId):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
       repo: ${{ parameters.repo }}
-      testrunner.image: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
-      testRunner.Container: testrunner-$(Build.BuildId)
+      testrunner.image: ${{ parameters.testRunnerLinuxImage }}
+      testRunner.container: testrunner-$(Build.BuildId)
     steps:
       - template: ../steps/docker-cleanup-linux.yml
+      - template: ../steps/docker-create-repo-volume-linux.yml
       - script: docker pull $(testrunner.image)
         displayName: Pull testrunner Image
-      - script: docker run --rm $(docker.commonRunArgs) --name clone_$(docker.baseArtifactName) $(docker.gitEnabledimage) git clone https://github.com/dotnet/dotnet-docker.git /repo
-        displayName: Clone Repo
-      - script: docker run --rm $(docker.commonRunArgs) --name checkout_$(docker.baseArtifactName) $(docker.gitEnabledimage) git checkout $(Build.SourceVersion)
-        displayName: Checkout Source
-      - script: docker run -t -d  $(docker.commonRunArgs) -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.Container) $(testrunner.image)
+      - script: docker run -t -d  $(docker.commonRunArgs) -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.container) $(testrunner.image)
         displayName: Start Test Runner Container
-      - script: docker exec $(testRunner.Container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+      - script: docker exec $(testRunner.container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-        # The script task does not currently work for Build Images on Linux (curl ssl issues), using CmdLine as workaround.
+      # The script task does not currently work (curl ssl issues), using CmdLine as workaround.
       - task: CmdLine@1
         displayName: Test Images
         inputs:
           filename: docker
-          arguments: exec $(testRunner.Container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -ArchitectureFilter arm -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) -DisableHttpVerification
-      - script: docker exec $(testRunner.Container) docker logout
+          arguments: exec $(testRunner.container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion)* -OSFilter $(osVersion)* -ArchitectureFilter arm -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) -DisableHttpVerification
+      - script: docker exec $(testRunner.container) docker logout
         displayName: Docker logout
         condition: always()
         continueOnError: true
-      - script: docker cp $(testRunner.Container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
+      - script: docker cp $(testRunner.container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
         displayName: Copy Test Results
         condition: always()
         continueOnError: true
@@ -57,7 +53,7 @@ phases:
           searchFolder: $(Common.TestResultsDirectory)
           mergeTestResults: true
           testRunTitle: Linux $(buildPath) $(osVersion) arm32v7
-      - script: docker stop $(testRunner.Container)
+      - script: docker stop $(testRunner.container)
         displayName: Stop TestRunner Container
         condition: always()
         continueOnError: true

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -1,11 +1,10 @@
 parameters:
   testRunnerLinuxImage: null
-  excludeTests: false
   repo: null
   matrix: {}
 phases:
   - phase: Test_Linux_arm32v7
-    condition: and(not(variables['excludeTests']), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    condition: and(ne(variables['repo'], 'dotnet-samples'), or(succeeded(), eq(variables['startingPhase'], 'test')))
     dependsOn: Build_Linux_arm32v7
     queue:
       name: DotNetCore-Infra

--- a/.vsts-pipelines/phases/test-windows-amd64.yml
+++ b/.vsts-pipelines/phases/test-windows-amd64.yml
@@ -1,13 +1,12 @@
 parameters:
   phase: null
-  excludeTests: false
   repo: null
   dependsOn: null
   demands: []
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: and(not(variables['excludeTests']), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    condition: and(ne(variables['repo'], 'dotnet-samples'), or(succeeded(), eq(variables['startingPhase'], 'test')))
     dependsOn: ${{ parameters.dependsOn }}
     queue:
       name: DotNetCore-Infra

--- a/.vsts-pipelines/phases/test-windows-amd64.yml
+++ b/.vsts-pipelines/phases/test-windows-amd64.yml
@@ -1,8 +1,8 @@
 parameters:
   phase: null
   excludeTests: false
-  dependsOn: null
   repo: null
+  dependsOn: null
   demands: []
   matrix: {}
 phases:
@@ -20,7 +20,7 @@ phases:
       - template: ../steps/docker-cleanup-windows.yml
       - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-      - powershell: ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - powershell: ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion)* -OSFilter $(osVersion) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Test Images
       - script: docker logout
         displayName: Docker logout

--- a/.vsts-pipelines/steps/docker-create-repo-volume-linux.yml
+++ b/.vsts-pipelines/steps/docker-create-repo-volume-linux.yml
@@ -1,0 +1,5 @@
+steps:
+  - script: docker run --rm -v repo-$(Build.BuildId):/repo buildpack-deps:stretch-scm git clone https://github.com/dotnet/dotnet-docker.git /repo
+    displayName: Clone Repo
+  - script: docker run --rm -v repo-$(Build.BuildId):/repo -w /repo buildpack-deps:stretch-scm git checkout $(Build.SourceVersion)
+    displayName: Checkout Source


### PR DESCRIPTION
* Update arm32 build legs to run on a linux client. Currently a Windows 10 machine is used as the Docker client.  This has proven to be very unstable.  Note: A remote client must be used because the VSTS build agent doesn't currently support arm.
* Refactored how tests were skipped for the samples repo.
* Fixed an issue with the publish logic in that it wouldn't skip all legs if there were any failures in build/tests.
* General simplification cleanup by removing some unnecessary parameters and variables.