### PR TITLE
[2.1 alpine-edge] remove 'virtual' openssl from aspnet and runtime dockerfiles

### DIFF
--- a/2.1/aspnetcore-runtime/alpine-edge/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine-edge/amd64/Dockerfile
@@ -3,13 +3,10 @@ FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine-edge
 # Install ASP.NET Core
 ENV ASPNETCORE_VERSION 2.1.1
 
-RUN apk add --no-cache --virtual .build-deps \
-    openssl \
-    && wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
+RUN wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='b8d3ac5c1970b2a6d6fe812c66b55ff74b1a130010889d6b828a031296355c7b507b7289a90c149d5f710f93847609c6264fec0da5d196df6c2aab3100a8797f' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
     && rm aspnetcore.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && apk del .build-deps
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/2.1/runtime/alpine-edge/amd64/Dockerfile
+++ b/2.1/runtime/alpine-edge/amd64/Dockerfile
@@ -3,13 +3,10 @@ FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine-edge
 # Install .NET Core
 ENV DOTNET_VERSION 2.1.1
 
-RUN apk add --no-cache --virtual .build-deps \
-    openssl \
-    && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
+RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='5bb938b012d86bcecac42e3c4e915cded051ffeffcdb4122ce41cfd53896395b952d61ef10e22e37d330a78eeb861550e0c73d0595ae001228a03bb0d94bd286' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz \
-    && apk del .build-deps
+    && rm dotnet.tar.gz

--- a/2.1/sdk/alpine-edge/amd64/Dockerfile
+++ b/2.1/sdk/alpine-edge/amd64/Dockerfile
@@ -10,16 +10,13 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 2.1.301
 
-RUN apk add --no-cache --virtual .build-deps \
-    openssl \
-    && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
+RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='86e288cce53999b719ced7959f5ba652f667b8c1e0aec266c3012c9870380e5142e3f5ac103f03691d4426158d9da4d7c89f0739dee5815419a6150c8ee84a12' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz \
-    && apk del .build-deps
+    && rm dotnet.tar.gz
 
 # Enable correct mode for dotnet watch (only mode supported in a container)
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true \ 


### PR DESCRIPTION
A suitable version of openssl is getting previously installed by libressl2.7-libcrypto-2.7.4-r0 which is causing a conflict.

This issue is blocking the build.