### PR TITLE
Changes to address intermittent build failueres

### DIFF
--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -1,6 +1,6 @@
 parameters:
-  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180627140652
-  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180627070723
+  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180712175314
+  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180712112709
   testRunnerLinuxImage: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   manifest: manifest.json
   repo: null

--- a/.vsts-pipelines/phases/build-linux-amd64.yml
+++ b/.vsts-pipelines/phases/build-linux-amd64.yml
@@ -5,7 +5,7 @@ parameters:
   matrix: {}
 phases:
   - phase: Build_Linux_amd64
-    condition: and(succeeded(), eq(variables['startingPhase'], 'build'))
+    condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
     queue:
       name: DotNet-Build
       demands:
@@ -16,15 +16,16 @@ phases:
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      repoVolume: build-repo-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-linux.yml
-      - template: ../steps/docker-create-repo-volume-linux.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(imageBuilder.image)
+          repoVolume: $(repoVolume)
       # The script task does not currently work (curl ssl issues), using CmdLine as workaround.
       - task: CmdLine@1
         displayName: Build Images
         inputs:
           filename: docker
-          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v repo-$(Build.BuildId):/repo -w /repo $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+          arguments: run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(imageBuilder.image) build --manifest $(manifest) --path $(dotnetVersion)*$(osVersion)* --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/build-linux-arm32v7.yml
@@ -5,7 +5,7 @@ parameters:
   matrix: {}
 phases:
   - phase: Build_Linux_arm32v7
-    condition: and(succeeded(), eq(variables['startingPhase'], 'build'))
+    condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
     queue:
       name: DotNetCore-Infra
       demands:
@@ -14,15 +14,16 @@ phases:
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.commonRunArgs: --rm -v repo-$(Build.BuildId):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
+      docker.commonRunArgs: --rm -v $(repoVolume):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      repoVolume: build-repo-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-linux.yml
-      - template: ../steps/docker-create-repo-volume-linux.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(imageBuilder.image)
+          repoVolume: $(repoVolume)
       # The script task does not currently work (curl ssl issues), using CmdLine as workaround.
       - task: CmdLine@1
         displayName: Build Images

--- a/.vsts-pipelines/phases/build-windows-amd64.yml
+++ b/.vsts-pipelines/phases/build-windows-amd64.yml
@@ -7,7 +7,7 @@ parameters:
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: and(succeeded(), eq(variables['startingPhase'], 'build'))
+    condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
     queue:
       name: DotNetCore-Infra
       demands: ${{ parameters.demands }}
@@ -19,9 +19,9 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
     steps:
-      - template: ../steps/docker-cleanup-windows.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
+      - template: ../steps/docker-init-windows.yml
+        parameters:
+          image: $(imageBuilder.image)
       - script: docker create --name $(docker.setupContainerName) $(imageBuilder.image)
         displayName: Create Setup Container
       - script: docker cp $(docker.setupContainerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder

--- a/.vsts-pipelines/phases/copy-images-linux.yml
+++ b/.vsts-pipelines/phases/copy-images-linux.yml
@@ -7,7 +7,7 @@ parameters:
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))
+    condition: or(eq(variables['singlePhase'], 'publish'), and(eq(variables['singlePhase'], ''), or(succeeded(), and(eq(variables['repo'], 'dotnet-samples'), eq(variables['singlePhase'], ''), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))))
     dependsOn:
       - Test_Linux_amd64
       - Test_Linux_arm32v7
@@ -25,10 +25,12 @@ phases:
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      repoVolume: copy-repo-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-linux.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
-      - script: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(dotnetVersion)\*$(osVersion)\* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(imageBuilder.image)
+          repoVolume: $(repoVolume)
+      - script: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(imageBuilder.image) copyImages --manifest $(manifest) --architecture $(architecture) --path $(dotnetVersion)\*$(osVersion)\* --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts-pipelines/phases/copy-images-windows.yml
+++ b/.vsts-pipelines/phases/copy-images-windows.yml
@@ -7,7 +7,7 @@ parameters:
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-samples'), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))
+    condition: or(eq(variables['singlePhase'], 'publish'), and(eq(variables['singlePhase'], ''), or(succeeded(), and(eq(variables['repo'], 'dotnet-samples'), eq(variables['singlePhase'], ''), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))))
     dependsOn:
       - Test_Linux_amd64
       - Test_Linux_arm32v7
@@ -26,9 +26,9 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
     steps:
-      - template: ../steps/docker-cleanup-windows.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
+      - template: ../steps/docker-init-windows.yml
+        parameters:
+          image: $(imageBuilder.image)
       - script: docker create --name $(docker.setupContainerName) $(imageBuilder.image)
         displayName: Create Setup Container
       - script: docker cp $(docker.setupContainerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder

--- a/.vsts-pipelines/phases/publish-finalize.yml
+++ b/.vsts-pipelines/phases/publish-finalize.yml
@@ -15,14 +15,16 @@ phases:
       demands:
         - agent.os -equals linux
     variables:
-      docker.commonRunArgs: --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image)
+      docker.commonRunArgs: --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(imageBuilder.image)
       imageBuilder.commonCmdArgs: --manifest $(manifest) --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
+      repoVolume: publish-repo-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-linux.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(imageBuilder.image)
+          repoVolume: $(repoVolume)
       - script: docker run $(docker.commonRunArgs) publishManifest $(imageBuilder.commonCmdArgs)
         displayName: Publish Manifest
       - script: docker run $(docker.commonRunArgs) updateReadme $(imageBuilder.commonCmdArgs)

--- a/.vsts-pipelines/phases/test-linux-amd64.yml
+++ b/.vsts-pipelines/phases/test-linux-amd64.yml
@@ -4,7 +4,7 @@ parameters:
   matrix: {}
 phases:
   - phase: Test_Linux_amd64
-    condition: and(ne(variables['repo'], 'dotnet-samples'), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    condition: and(ne(variables['repo'], 'dotnet-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
     dependsOn: Build_Linux_amd64
     queue:
       name: DotNet-Build
@@ -14,14 +14,15 @@ phases:
       matrix: ${{ parameters.matrix }}
     variables:
       repo: ${{ parameters.repo }}
+      repoVolume: test-repo-$(Build.BuildId)
       testrunner.image: ${{ parameters.testRunnerLinuxImage }}
       testRunner.container: testrunner-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-linux.yml
-      - template: ../steps/docker-create-repo-volume-linux.yml
-      - script: docker pull $(testrunner.image)
-        displayName: Pull testrunner Image
-      - script: docker run -t -d  -v /var/run/docker.sock:/var/run/docker.sock -v repo-$(Build.BuildId):/repo -w /repo -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.container) $(testrunner.image)
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(testrunner.image)
+          repoVolume: $(repoVolume)
+      - script: docker run -t -d  -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.container) $(testrunner.image)
         displayName: Start Test Runner Container
       - script: docker exec $(testRunner.container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -4,7 +4,7 @@ parameters:
   matrix: {}
 phases:
   - phase: Test_Linux_arm32v7
-    condition: and(ne(variables['repo'], 'dotnet-samples'), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    condition: and(ne(variables['repo'], 'dotnet-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
     dependsOn: Build_Linux_arm32v7
     queue:
       name: DotNetCore-Infra
@@ -15,15 +15,16 @@ phases:
       matrix: ${{ parameters.matrix }}
     variables:
       docker.baseArtifactName: test_$(Build.BuildId)
-      docker.commonRunArgs: -v repo-$(Build.BuildId):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
+      docker.commonRunArgs: -v $(repoVolume):/repo -v /docker-certs:/docker-certs -w /repo -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376
       repo: ${{ parameters.repo }}
+      repoVolume: test-repo-$(Build.BuildId)
       testrunner.image: ${{ parameters.testRunnerLinuxImage }}
       testRunner.container: testrunner-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-linux.yml
-      - template: ../steps/docker-create-repo-volume-linux.yml
-      - script: docker pull $(testrunner.image)
-        displayName: Pull testrunner Image
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(testrunner.image)
+          repoVolume: $(repoVolume)
       - script: docker run -t -d  $(docker.commonRunArgs) -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.container) $(testrunner.image)
         displayName: Start Test Runner Container
       - script: docker exec $(testRunner.container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)

--- a/.vsts-pipelines/phases/test-windows-amd64.yml
+++ b/.vsts-pipelines/phases/test-windows-amd64.yml
@@ -6,7 +6,7 @@ parameters:
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: and(ne(variables['repo'], 'dotnet-samples'), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    condition: and(ne(variables['repo'], 'dotnet-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
     dependsOn: ${{ parameters.dependsOn }}
     queue:
       name: DotNetCore-Infra

--- a/.vsts-pipelines/steps/docker-create-repo-volume-linux.yml
+++ b/.vsts-pipelines/steps/docker-create-repo-volume-linux.yml
@@ -1,5 +1,0 @@
-steps:
-  - script: docker run --rm -v repo-$(Build.BuildId):/repo buildpack-deps:stretch-scm git clone https://github.com/dotnet/dotnet-docker.git /repo
-    displayName: Clone Repo
-  - script: docker run --rm -v repo-$(Build.BuildId):/repo -w /repo buildpack-deps:stretch-scm git checkout $(Build.SourceVersion)
-    displayName: Checkout Source

--- a/.vsts-pipelines/steps/docker-init-linux.yml
+++ b/.vsts-pipelines/steps/docker-init-linux.yml
@@ -1,0 +1,23 @@
+parameters:
+  image: null
+  repoVolume: ''
+
+steps:
+  - template: docker-cleanup-linux.yml
+
+  - ${{ if ne(parameters.repoVolume, '') }}:
+    - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh buildpack-deps:stretch-scm
+      displayName: Pull Image buildpack-deps:stretch-scm
+    - script: docker run --rm -v $repoVolume:/repo buildpack-deps:stretch-scm git clone https://github.com/dotnet/dotnet-docker.git /repo
+      displayName: Clone Repo
+      env:
+        repoVolume: ${{ parameters.repoVolume }}
+    - script: docker run --rm -v $repoVolume:/repo -w /repo buildpack-deps:stretch-scm git checkout $(Build.SourceVersion)
+      displayName: Checkout Source
+      env:
+        repoVolume: ${{ parameters.repoVolume }}
+
+  - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $image
+    displayName: ${{ format('Pull Image {0}', parameters.image) }}
+    env:
+      image: ${{ parameters.image }}

--- a/.vsts-pipelines/steps/docker-init-windows.yml
+++ b/.vsts-pipelines/steps/docker-init-windows.yml
@@ -1,0 +1,9 @@
+parameters:
+  image: null
+
+steps:
+  - template: docker-cleanup-windows.yml
+  - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 $env:image
+    displayName: ${{ format('Pull Image {0}', parameters.image) }}
+    env:
+      image: ${{ parameters.image }}

--- a/scripts/Invoke-PullImage.ps1
+++ b/scripts/Invoke-PullImage.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+[cmdletbinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Image
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Executes a command and retries if it fails.
+function Exec {
+    param (
+        [Parameter(Mandatory = $true)][scriptblock]$cmd,
+        [Parameter(Mandatory = $false)][int]$retries = 5,
+        [Parameter(Mandatory = $false)][int]$waitFactor = 6
+    )
+
+    $count = 0
+    $completed = $false
+
+    while (-not $completed) {
+        & $cmd
+        $exit = $LASTEXITCODE
+        $count++
+
+        if ($exit -eq 0) {
+            $completed = $true
+        }
+        else {
+            if ($count -lt $retries) {
+                $wait = [Math]::Pow($waitFactor, $count - 1)
+                Write-Output "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+                Start-Sleep $wait
+            }
+            else {
+                Write-Output "Retry $count/$retries exited $exit, no more retries left."
+                $completed = $true
+            }
+        }
+    }
+}
+
+Exec { docker pull $Image }

--- a/scripts/pull-image.sh
+++ b/scripts/pull-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+say_err() {
+    printf "%b\n" "Error: $1" >&2
+}
+
+# Executes a command and retries if it fails.
+execute() {
+    local count=0
+    until "$@"; do
+        local exit=$?
+        count=$(( $count + 1 ))
+        if [ $count -lt $retries ]; then
+            local wait=$(( waitFactor ** (( count - 1 )) ))
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else    
+            say_err "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+
+    return 0
+}
+
+scriptName=$0
+retries=5
+waitFactor=6
+image=$1
+
+echo "Pulling Docker image $image"
+execute docker pull $image


### PR DESCRIPTION
- Use latest image builder with fix for https://github.com/dotnet/docker-tools/issues/105
- Add retry logic when pulling Docker images
- Refactor `startingPhase` into `singlePhase`.  This provides more robust control such as being able to only perform a build.

@dotnet-bot skip ci please