### PR TITLE
Add NuGet cache to arm sdk images

### DIFF
--- a/2.1/sdk/bionic/arm32v7/Dockerfile
+++ b/2.1/sdk/bionic/arm32v7/Dockerfile
@@ -22,7 +22,11 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    # Add NuGet cache (ARM SDK doesn't include it)
+    && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
+    && lzma_sha512='3e755a7e7d8bf5cbf71795c6b300c7deca373f1e2c2ee6c5c62b0f83f84949e618b20e5bdc0eb5180d273395660e295aaca3de78ed7df6138306500618fcad10' \
+    && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/2.1/sdk/buster/arm32v7/Dockerfile
+++ b/2.1/sdk/buster/arm32v7/Dockerfile
@@ -22,7 +22,11 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    # Add NuGet cache (ARM SDK doesn't include it)
+    && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
+    && lzma_sha512='3e755a7e7d8bf5cbf71795c6b300c7deca373f1e2c2ee6c5c62b0f83f84949e618b20e5bdc0eb5180d273395660e295aaca3de78ed7df6138306500618fcad10' \
+    && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/2.1/sdk/stretch/arm32v7/Dockerfile
+++ b/2.1/sdk/stretch/arm32v7/Dockerfile
@@ -22,7 +22,11 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    # Add NuGet cache (ARM SDK doesn't include it)
+    && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
+    && lzma_sha512='3e755a7e7d8bf5cbf71795c6b300c7deca373f1e2c2ee6c5c62b0f83f84949e618b20e5bdc0eb5180d273395660e295aaca3de78ed7df6138306500618fcad10' \
+    && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/scripts/update-dependencies/Program.cs
+++ b/scripts/update-dependencies/Program.cs
@@ -150,7 +150,8 @@ namespace Dotnet.Docker
                 .Select(path => CreateDockerfileEnvUpdater(path, "DOTNET_SDK_VERSION", SdkBuildInfoName))
                 .Concat(dockerfiles.Select(path => CreateDockerfileEnvUpdater(path, "ASPNETCORE_VERSION", AspNetCoreBuildInfoName)))
                 .Concat(dockerfiles.Select(path => CreateDockerfileEnvUpdater(path, "DOTNET_VERSION", RuntimeBuildInfoName)))
-                .Concat(dockerfiles.Select(path => new DockerfileShaUpdater(path)));
+                .Concat(dockerfiles.Select(path => DockerfileShaUpdater.CreateProductShaUpdater(path)))
+                .Concat(dockerfiles.Select(path => DockerfileShaUpdater.CreateLzmaShaUpdater(path)));
         }
 
         private static IDependencyUpdater CreateDockerfileEnvUpdater(string path, string envName, string buildInfoName)


### PR DESCRIPTION
- Updated ARM 2.1 Dockerfiles to include the NuGet package cache.
- Updated the update-dependencies tool to handle updating the LZMA sha.

Fixes #546 
