### PR TITLE
Refactor CI job names

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -3,7 +3,7 @@ import jobs.generation.Utilities
 def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
-def platformList = ['Ubuntu16.04:Debian', 'Windows_2016:NanoServer-sac2016', 'Windows_2016:NanoServer-1709', 'Windows_2016:NanoServer-1803']
+def platformList = ['Ubuntu16.04:Linux', 'Windows_2016:NanoServer-sac2016', 'Windows_2016:NanoServer-1709', 'Windows_2016:NanoServer-1803']
 
 platformList.each { platform ->
     def(hostOS, containerOS) = platform.tokenize(':')


### PR DESCRIPTION
Rename the `Debian - * Dockerfiles` CI jobs to `Linux - * Dockerfiles`.  The usage of `Debian` is from the time when the repo only supported Debian distro based images.  The repo now supports multiple distros so a more abstract name is appropriate.