### PR TITLE
Add retry logic to tests that pull images

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -378,7 +378,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        public static string GetDotNetImage(DotNetImageType imageType, ImageData imageData)
+        public string GetDotNetImage(DotNetImageType imageType, ImageData imageData)
         {
             string imageVersion;
             string osVariant;
@@ -416,7 +416,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
             else
             {
-                DockerHelper.Pull(imageName);
+                _dockerHelper.Pull(imageName);
             }
 
             return imageName;


### PR DESCRIPTION
The unit test will fail periodically in the official builds when pulling images from ACR.  This retry logic should help eliminate this issue.