### PR TITLE
Cleanup unused build triggers

### DIFF
--- a/.vsts-pipelines/builds/microsoft-dotnet-nightly.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-nightly.yml
@@ -1,11 +1,8 @@
 trigger:
+  batch: true
   branches:
     include:
       - nightly
-  paths:
-    exclude:
-      - samples/*
-      - manifest.samples.json
 phases:
   - template: ../phases/build-all.yml
     parameters:

--- a/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
@@ -1,11 +1,4 @@
-trigger:
-  branches:
-    include:
-      - master
-  paths:
-    include:
-      - samples/*
-      - manifest.samples.json
+trigger: none
 phases:
   - template: ../phases/build-all.yml
     parameters:


### PR DESCRIPTION
Path filters are only supported in VSTS git repos therefore they are not valid in this repo.  Cleaning them up.

@dotnet-bot skip ci please 