### PR TITLE
(Replaced by #680) Consistent environment variable names for DOTNET_RUNNING_IN_CONTAINER

### DIFF
--- a/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -34,4 +34,4 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -20,4 +20,4 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -33,4 +33,4 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -34,4 +34,4 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -20,4 +20,4 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true


### PR DESCRIPTION
This PR is a potential fix for issue #677 

I am however, not sure about the side effects of this change. It will potentially break any existing application that expects the old behavior. We could provide both for backward compatibility giving time for people to make code changes.

Another option is to fix this problem only in newer versions.
