### PR TITLE
Consistent environment variable names for DOTNET_RUNNING_IN_CONTAINER

### DIFF
--- a/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -33,4 +33,6 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINERS=true `
+    # Enable detection of running in a container (compatible with linux distributions)
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -33,6 +33,6 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true `
-    # Enable detection of running in a container (compatible with linux distributions)
-    DOTNET_RUNNING_IN_CONTAINER=true
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677
+    DOTNET_RUNNING_IN_CONTAINERS=true

--- a/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -34,4 +34,6 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINERS=true `
+    # Enable detection of running in a container (compatible with linux distributions)
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -34,6 +34,6 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true `
-    # Enable detection of running in a container (compatible with linux distributions)
-    DOTNET_RUNNING_IN_CONTAINER=true
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677
+    DOTNET_RUNNING_IN_CONTAINERS=true

--- a/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -20,4 +20,6 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINERS=true `
+    # Enable detection of running in a container (compatible with linux distributions)
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -20,6 +20,6 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true `
-    # Enable detection of running in a container (compatible with linux distributions)
-    DOTNET_RUNNING_IN_CONTAINER=true
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677
+    DOTNET_RUNNING_IN_CONTAINERS=true

--- a/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -33,4 +33,4 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -34,4 +34,4 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -20,4 +20,4 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -33,4 +33,4 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -34,4 +34,4 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -20,4 +20,4 @@ RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINERS=true
+    DOTNET_RUNNING_IN_CONTAINER=true


### PR DESCRIPTION
This PR is a potential fix for issue #677

- 2.1 images for windows declare both environment variables (DOTNET_RUNNING_IN_CONTAINERS and DOTNET_RUNNING_IN_CONTAINER)
- 2.2 and 3.0 images declare only DOTNET_RUNNING_IN_CONTAINER (breaking change)

