### PR TITLE
Merge build changes from nightly into master

### DIFF
--- a/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
@@ -4,38 +4,3 @@ phases:
     parameters:
       manifest: manifest.samples.json
       repo: dotnet-samples
-      buildPublishMatrixLinuxAmd64:
-        Samples:
-          imageBuilderPaths: --path *
-      buildPublishMatrixLinuxArm32v7:
-        Samples:
-          imageBuilderPaths: --path *
-      buildPublishMatrixWindowsSac2016Amd64:
-        Samples:
-          imageBuilderPaths: --path *nanoserver-sac2016*
-      buildPublishMatrixWindows1709Amd64:
-        Samples:
-          imageBuilderPaths: --path *nanoserver-1709*
-      buildPublishMatrixWindows1803Amd64:
-        Samples:
-          imageBuilderPaths: --path *nanoserver-1803*
-      testMatrixLinuxAmd64:
-        Samples:
-          dotnetVersion: ''
-          osVersion: ''
-      testMatrixLinuxArm32v7:
-        Samples:
-          dotnetVersion: ''
-          osVersion: ''
-      testMatrixWindowsSac2016Amd64:
-        Samples:
-          dotnetVersion: ''
-          osVersion: nanoserver-sac2016
-      testMatrixWindows1709Amd64:
-        Samples:
-          dotnetVersion: ''
-          osVersion: nanoserver-1709
-      testMatrixWindows1803Amd64:
-        Samples:
-          dotnetVersion: ''
-          osVersion: nanoserver-1803

--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -1,184 +1,33 @@
 parameters:
-  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180723194508
-  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180723124501
+  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180904220918
+  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180904151412
   testRunnerLinuxImage: microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   manifest: manifest.json
   repo: null
-  buildMatrixLinuxArm32v7:
-    2.1-runtime-deps-stretch-slim-graph:
-      imageBuilderPaths: --path 2.1/runtime-deps/stretch-slim/arm32v7 --path 2.1/runtime/stretch-slim/arm32v7 --path 2.1/aspnetcore-runtime/stretch-slim/arm32v7 --path 2.2/runtime/stretch-slim/arm32v7 --path 2.2/aspnetcore-runtime/stretch-slim/arm32v7
-    2.1-sdk-stretch:
-      imageBuilderPaths: --path 2.1/sdk/stretch/arm32v7
-    2.1-runtime-deps-bionic-graph:
-      imageBuilderPaths: --path 2.1/runtime-deps/bionic/arm32v7 --path 2.1/aspnetcore-runtime/bionic/arm32v7 --path 2.1/runtime/bionic/arm32v7 --path 2.2/aspnetcore-runtime/bionic/arm32v7 --path 2.2/runtime/bionic/arm32v7
-    2.1-sdk-bionic:
-      imageBuilderPaths: --path 2.1/sdk/bionic/arm32v7
-    2.2-sdk-stretch:
-      imageBuilderPaths: --path 2.2/sdk/stretch/arm32v7
-    2.2-sdk-bionic:
-      imageBuilderPaths: --path 2.2/sdk/bionic/arm32v7
-  buildMatrixLinuxAmd64:
-    1.0-runtime-deps-jessie-graph:
-      imageBuilderPaths: --path 1.0/runtime-deps/jessie/amd64 --path 1.0/runtime/jessie/amd64 --path 1.1/runtime/jessie/amd64
-    1.1-sdk-jessie:
-      imageBuilderPaths: --path 1.1/sdk/jessie/amd64
-    2.0-runtime-deps-stretch-graph:
-      imageBuilderPaths: --path 2.0/runtime-deps/stretch/amd64 --path 2.0/runtime/stretch/amd64
-    2.0-sdk-stretch:
-      imageBuilderPaths: --path 2.0/sdk/stretch/amd64
-    2.0-runtime-deps-jessie-graph:
-      imageBuilderPaths: --path 2.0/runtime-deps/jessie/amd64 --path 2.0/runtime/jessie/amd64
-    2.0-sdk-jessie:
-      imageBuilderPaths: --path 2.0/sdk/jessie/amd64
-    2.1-runtime-deps-stretch-slim-graph:
-      imageBuilderPaths: --path 2.1/runtime-deps/stretch-slim/amd64 --path 2.1/runtime/stretch-slim/amd64 --path 2.1/aspnetcore-runtime/stretch-slim/amd64 --path 2.2/runtime/stretch-slim/amd64 --path 2.2/aspnetcore-runtime/stretch-slim/amd64
-    2.1-sdk-stretch:
-      imageBuilderPaths: --path 2.1/sdk/stretch/amd64
-    2.1-runtime-deps-alpine3.7-graph:
-      imageBuilderPaths: --path 2.1/runtime-deps/alpine3.7/amd64 --path 2.1/runtime/alpine3.7/amd64 --path 2.1/aspnetcore-runtime/alpine3.7/amd64 --path 2.1/sdk/alpine3.7/amd64
-    2.1-runtime-deps-bionic-graph:
-      imageBuilderPaths: --path 2.1/runtime-deps/bionic/amd64 --path 2.1/aspnetcore-runtime/bionic/amd64 --path 2.1/runtime/bionic/amd64 --path 2.2/aspnetcore-runtime/bionic/amd64 --path 2.2/runtime/bionic/amd64
-    2.1-sdk-bionic:
-      imageBuilderPaths: --path 2.1/sdk/bionic/amd64
-    2.2-sdk-stretch:
-      imageBuilderPaths: --path 2.2/sdk/stretch/amd64
-    2.2-runtime-deps-alpine3.8-graph:
-      imageBuilderPaths: --path 2.2/runtime-deps/alpine3.8/amd64 --path 2.2/runtime/alpine3.8/amd64 --path 2.2/aspnetcore-runtime/alpine3.8/amd64 --path 2.2/sdk/alpine3.8/amd64
-    2.2-sdk-bionic:
-      imageBuilderPaths: --path 2.2/sdk/bionic/amd64
-  buildMatrixNanoserverSac2016Amd64:
-    1.0-runtime:
-      imageBuilderPaths: --path 1.0/runtime/nanoserver-sac2016/amd64
-    1.1-runtime:
-      imageBuilderPaths: --path 1.1/runtime/nanoserver-sac2016/amd64
-    1.1-sdk:
-      imageBuilderPaths: --path 1.1/sdk/nanoserver-sac2016/amd64
-    2.0-runtime:
-      imageBuilderPaths: --path 2.0/runtime/nanoserver-sac2016/amd64
-    2.0-sdk:
-      imageBuilderPaths: --path 2.0/sdk/nanoserver-sac2016/amd64
-    2.1-runtime:
-      imageBuilderPaths: --path 2.1/runtime/nanoserver-sac2016/amd64
-    2.1-aspnetcore-runtime:
-      imageBuilderPaths: --path 2.1/aspnetcore-runtime/nanoserver-sac2016/amd64
-    2.1-sdk:
-      imageBuilderPaths: --path 2.1/sdk/nanoserver-sac2016/amd64
-    2.2-runtime:
-      imageBuilderPaths: --path 2.2/runtime/nanoserver-sac2016/amd64
-    2.2-aspnetcore-runtime:
-      imageBuilderPaths: --path 2.2/aspnetcore-runtime/nanoserver-sac2016/amd64
-    2.2-sdk:
-      imageBuilderPaths: --path 2.2/sdk/nanoserver-sac2016/amd64
-  buildMatrixNanoserver1803Amd64:
-    2.0-runtime:
-      imageBuilderPaths: --path 2.0/runtime/nanoserver-1803/amd64
-    2.0-sdk:
-      imageBuilderPaths: --path 2.0/sdk/nanoserver-1803/amd64
-    2.1-runtime:
-      imageBuilderPaths: --path 2.1/runtime/nanoserver-1803/amd64
-    2.1-aspnetcore-runtime:
-      imageBuilderPaths: --path 2.1/aspnetcore-runtime/nanoserver-1803/amd64
-    2.1-sdk:
-      imageBuilderPaths: --path 2.1/sdk/nanoserver-1803/amd64
-    2.2-runtime:
-      imageBuilderPaths: --path 2.2/runtime/nanoserver-1803/amd64
-    2.2-aspnetcore-runtime:
-      imageBuilderPaths: --path 2.2/aspnetcore-runtime/nanoserver-1803/amd64
-    2.2-sdk:
-      imageBuilderPaths: --path 2.2/sdk/nanoserver-1803/amd64
-  buildMatrixNanoserver1709Amd64:
-    2.0-runtime:
-      imageBuilderPaths: --path 2.0/runtime/nanoserver-1709/amd64
-    2.0-sdk:
-      imageBuilderPaths: --path 2.0/sdk/nanoserver-1709/amd64
-    2.1-runtime:
-      imageBuilderPaths: --path 2.1/runtime/nanoserver-1709/amd64
-    2.1-aspnetcore-runtime:
-      imageBuilderPaths: --path 2.1/aspnetcore-runtime/nanoserver-1709/amd64
-    2.1-sdk:
-      imageBuilderPaths: --path 2.1/sdk/nanoserver-1709/amd64
-    2.2-runtime:
-      imageBuilderPaths: --path 2.2/runtime/nanoserver-1709/amd64
-    2.2-aspnetcore-runtime:
-      imageBuilderPaths: --path 2.2/aspnetcore-runtime/nanoserver-1709/amd64
-    2.2-sdk:
-      imageBuilderPaths: --path 2.2/sdk/nanoserver-1709/amd64
-  testMatrixLinuxAmd64:
-    2_2_Alpine:
-      dotnetVersion: 2.2
-      osVersion: alpine
-    2_2_Bionic:
-      dotnetVersion: 2.2
-      osVersion: bionic
-    2_2_Stretch:
-      dotnetVersion: 2.2
-      osVersion: stretch
-    2_1_Alpine:
-      dotnetVersion: 2.1
-      osVersion: alpine
-    2_1_Bionic:
-      dotnetVersion: 2.1
-      osVersion: bionic
-    2_1_Stretch:
-      dotnetVersion: 2.1
-      osVersion: stretch
-    2_0_Jessie:
-      dotnetVersion: 2.0
-      osVersion: jessie
-    2_0_Stretch:
-      dotnetVersion: 2.0
-      osVersion: stretch
-    1_*_Jessie:
-      dotnetVersion: 1.
-      osVersion: jessie
-  testMatrixLinuxArm32v7:
-    2_2_Bionic:
-      dotnetVersion: 2.2
-      osVersion: bionic
-    2_2_Stretch:
-      dotnetVersion: 2.2
-      osVersion: stretch
-    2_1_Bionic:
-      dotnetVersion: 2.1
-      osVersion: bionic
-    2_1_Stretch:
-      dotnetVersion: 2.1
-      osVersion: stretch
-  testMatrixWindowsSac2016Amd64:
-    2_2:
-      dotnetVersion: 2.2
-      osVersion: nanoserver-sac2016
-    2_1:
-      dotnetVersion: 2.1
-      osVersion: nanoserver-sac2016
-    2_0:
-      dotnetVersion: 2.0
-      osVersion: nanoserver-sac2016
-    1_*:
-      dotnetVersion: 1.
-      osVersion: nanoserver-sac2016
-  testMatrixWindows1709Amd64:
-    2_2:
-      dotnetVersion: 2.2
-      osVersion: nanoserver-1709
-    2_1:
-      dotnetVersion: 2.1
-      osVersion: nanoserver-1709
-    2_0:
-      dotnetVersion: 2.0
-      osVersion: nanoserver-1709
-  testMatrixWindows1803Amd64:
-    2_2:
-      dotnetVersion: 2.2
-      osVersion: nanoserver-1803
-    2_1:
-      dotnetVersion: 2.1
-      osVersion: nanoserver-1803
-    2_0:
-      dotnetVersion: 2.0
-      osVersion: nanoserver-1803
-
 phases:
+  ################################################################################
+  # Initialization - Generate the VSTS build matrix
+  ################################################################################
+  - phase: GenerateMatrices
+    queue:
+      name: DotNet-Build
+      demands:
+        - agent.os -equals linux
+    variables:
+      imageBuilder.image: ${{ parameters.imageBuilderLinuxImage }}
+      manifest: ${{ parameters.manifest }}
+      repoVolume: matrix-repo-$(Build.BuildId)
+    steps:
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(imageBuilder.image)
+          repoVolume: $(repoVolume)
+      - script: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(imageBuilder.image) generateBuildMatrix --manifest $(manifest) --type build
+        name: buildMatrix
+      - script: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(imageBuilder.image) generateBuildMatrix --manifest $(manifest) --type test
+        name: testMatrix
+      - template: ../steps/docker-cleanup-linux.yml
+
   ################################################################################
   # Build Images
   ################################################################################
@@ -187,40 +36,43 @@ phases:
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
-      matrix: ${{ parameters.buildMatrixLinuxAmd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64'] ]
   - template: build-linux-arm32v7.yml
     parameters:
       imageBuilderImage: ${{ parameters.imageBuilderLinuxImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
-      matrix: ${{ parameters.buildMatrixLinuxArm32v7 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm32v7'] ]
   - template: build-windows-amd64.yml
     parameters:
       phase: Build_NanoServerSac2016_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: nanoserver-sac2016
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: ${{ parameters.buildMatrixNanoserverSac2016Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserverSac2016Amd64'] ]
   - template: build-windows-amd64.yml
     parameters:
       phase: Build_NanoServer1709_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: nanoserver-1709
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-      matrix: ${{ parameters.buildMatrixNanoserver1709Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64'] ]
   - template: build-windows-amd64.yml
     parameters:
       phase: Build_NanoServer1803_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: nanoserver-1803
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-      matrix: ${{ parameters.buildMatrixNanoserver1803Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64'] ]
 
   ################################################################################
   # Test Images
@@ -229,36 +81,42 @@ phases:
     parameters:
       testRunnerLinuxImage: ${{ parameters.testRunnerLinuxImage }}
       repo: ${{ parameters.repo }}
-      matrix: ${{ parameters.testMatrixLinuxAmd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxAmd64'] ]
   - template: test-linux-arm32v7.yml
     parameters:
       testRunnerLinuxImage: ${{ parameters.testRunnerLinuxImage }}
       repo: ${{ parameters.repo }}
-      matrix: ${{ parameters.testMatrixLinuxArm32v7 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxArm32v7'] ]
   - template: test-windows-amd64.yml
     parameters:
       phase: Test_NanoServerSac2016_amd64
       repo: ${{ parameters.repo }}
-      dependsOn: Build_NanoServerSac2016_amd64
+      dependsOn:
+        - Build_NanoServerSac2016_amd64
+        - GenerateMatrices
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: ${{ parameters.testMatrixWindowsSac2016Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserverSac2016Amd64'] ]
   - template: test-windows-amd64.yml
     parameters:
       phase: Test_NanoServer1709_amd64
       repo: ${{ parameters.repo }}
-      dependsOn: Build_NanoServer1709_amd64
+      dependsOn:
+        - Build_NanoServer1709_amd64
+        - GenerateMatrices
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-      matrix: ${{ parameters.testMatrixWindows1709Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1709Amd64'] ]
   - template: test-windows-amd64.yml
     parameters:
       phase: Test_NanoServer1803_amd64
       repo: ${{ parameters.repo }}
-      dependsOn: Build_NanoServer1803_amd64
+      dependsOn:
+        - Build_NanoServer1803_amd64
+        - GenerateMatrices
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-      matrix: ${{ parameters.testMatrixWindows1803Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1803Amd64'] ]
 
   ################################################################################
   # Publish Images
@@ -270,7 +128,7 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
       architecture: amd64
-      matrix: ${{ parameters.buildMatrixLinuxAmd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64'] ]
   - template: copy-images-linux.yml
     parameters:
       phase: Copy_Images_Linux_arm32v7
@@ -278,34 +136,37 @@ phases:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
       architecture: arm
-      matrix: ${{ parameters.buildMatrixLinuxArm32v7 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm32v7'] ]
   - template: copy-images-windows.yml
     parameters:
       phase: Copy_Images_NanoServerSac2016_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: nanoserver-sac2016
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: ${{ parameters.buildMatrixNanoserverSac2016Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserverSac2016Amd64'] ]
   - template: copy-images-windows.yml
     parameters:
       phase: Copy_Images_NanoServer1709_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: nanoserver-1709
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-      matrix: ${{ parameters.buildMatrixNanoserver1709Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64'] ]
   - template: copy-images-windows.yml
     parameters:
       phase: Copy_Images_NanoServer1803_amd64
       imageBuilderImage: ${{ parameters.imageBuilderWindowsImage }}
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: nanoserver-1803
       demands:
         - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-      matrix: ${{ parameters.buildMatrixNanoserver1803Amd64 }}
+      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64'] ]
 
   - template: publish-finalize.yml
     parameters:

--- a/.vsts-pipelines/phases/build-linux-amd64.yml
+++ b/.vsts-pipelines/phases/build-linux-amd64.yml
@@ -6,6 +6,7 @@ parameters:
 phases:
   - phase: Build_Linux_amd64
     condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
+    dependsOn: GenerateMatrices
     queue:
       name: DotNet-Build
       demands:

--- a/.vsts-pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/build-linux-arm32v7.yml
@@ -6,6 +6,7 @@ parameters:
 phases:
   - phase: Build_Linux_arm32v7
     condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
+    dependsOn: GenerateMatrices
     queue:
       name: DotNetCore-Infra
       demands:

--- a/.vsts-pipelines/phases/build-windows-amd64.yml
+++ b/.vsts-pipelines/phases/build-windows-amd64.yml
@@ -3,11 +3,13 @@ parameters:
   imageBuilderImage: null
   manifest: null
   repo: null
+  osVersion: null
   demands: []
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
     condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
+    dependsOn: GenerateMatrices
     queue:
       name: DotNetCore-Infra
       demands: ${{ parameters.demands }}
@@ -17,10 +19,11 @@ phases:
     variables:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: ${{ parameters.osVersion }}
     steps:
       - template: ../steps/docker-init-windows.yml
         parameters:
           imageBuilderImage: ${{ parameters.imageBuilderImage }}
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --skip-test $(imageBuilderPaths) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --os-version $(osVersion) --skip-test $(imageBuilderPaths) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/copy-images-linux.yml
+++ b/.vsts-pipelines/phases/copy-images-linux.yml
@@ -9,6 +9,7 @@ phases:
   - phase: ${{ parameters.phase }}
     condition: or(eq(variables['singlePhase'], 'publish'), and(eq(variables['singlePhase'], ''), or(succeeded(), and(eq(variables['repo'], 'dotnet-samples'), eq(variables['singlePhase'], ''), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))))
     dependsOn:
+      - GenerateMatrices
       - Test_Linux_amd64
       - Test_Linux_arm32v7
       - Test_NanoServerSac2016_amd64

--- a/.vsts-pipelines/phases/copy-images-windows.yml
+++ b/.vsts-pipelines/phases/copy-images-windows.yml
@@ -3,12 +3,14 @@ parameters:
   imageBuilderImage: null
   manifest: null
   repo: null
+  osVersion: null
   demands: []
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
     condition: or(eq(variables['singlePhase'], 'publish'), and(eq(variables['singlePhase'], ''), or(succeeded(), and(eq(variables['repo'], 'dotnet-samples'), eq(variables['singlePhase'], ''), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))))
     dependsOn:
+      - GenerateMatrices
       - Test_Linux_amd64
       - Test_Linux_arm32v7
       - Test_NanoServerSac2016_amd64
@@ -23,10 +25,11 @@ phases:
     variables:
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
+      osVersion: ${{ parameters.osVersion }}
     steps:
       - template: ../steps/docker-init-windows.yml
         parameters:
           imageBuilderImage: ${{ parameters.imageBuilderImage }}
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) $(imageBuilderPaths) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --os-version $(osVersion) $(imageBuilderPaths) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/test-linux-amd64.yml
+++ b/.vsts-pipelines/phases/test-linux-amd64.yml
@@ -5,7 +5,9 @@ parameters:
 phases:
   - phase: Test_Linux_amd64
     condition: and(ne(variables['repo'], 'dotnet-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
-    dependsOn: Build_Linux_amd64
+    dependsOn:
+      - Build_Linux_amd64
+      - GenerateMatrices
     queue:
       name: DotNet-Build
       demands:
@@ -50,6 +52,7 @@ phases:
           testResultsFiles: '**/*.trx'
           searchFolder: $(Common.TestResultsDirectory)
           mergeTestResults: true
+          publishRunAttachments: true
           testRunTitle: Linux $(dotnetVersion) $(osVersion) amd64
       - script: docker stop $(testRunner.container)
         displayName: Stop TestRunner Container

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -5,7 +5,9 @@ parameters:
 phases:
   - phase: Test_Linux_arm32v7
     condition: and(ne(variables['repo'], 'dotnet-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
-    dependsOn: Build_Linux_arm32v7
+    dependsOn:
+      - Build_Linux_arm32v7
+      - GenerateMatrices
     queue:
       name: DotNetCore-Infra
       demands:
@@ -53,6 +55,7 @@ phases:
           testResultsFiles: '**/*.trx'
           searchFolder: $(Common.TestResultsDirectory)
           mergeTestResults: true
+          publishRunAttachments: true
           testRunTitle: Linux $(dotnetVersion) $(osVersion) arm32v7
       - script: docker stop $(testRunner.container)
         displayName: Stop TestRunner Container

--- a/.vsts-pipelines/phases/test-windows-amd64.yml
+++ b/.vsts-pipelines/phases/test-windows-amd64.yml
@@ -34,5 +34,6 @@ phases:
           testRunner: vSTest
           testResultsFiles: 'tests/**/*.trx'
           mergeTestResults: true
+          publishRunAttachments: true
           testRunTitle: Windows $(dotnetVersion) $(osVersion) amd64
       - template: ../steps/docker-cleanup-windows.yml


### PR DESCRIPTION
This brings in the logic to dynamically produce the build matrix.  This should dramatically reduce the number of times the build needs to be updated as the manifest.json is the single place that defines the metadata the informs the build.