### PR TITLE
Refactor manifest.json and readme templates for easier maintainability

### DIFF
--- a/TAGS.md
+++ b/TAGS.md
@@ -23,7 +23,7 @@
 - [`1.0.12-runtime-jessie`, `1.0-runtime-jessie`, `1.0.12-runtime`, `1.0-runtime` (*1.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/jessie/amd64/Dockerfile)
 - [`1.0.12-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.12-runtime-deps`, `1.0-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
 - [`2.2.100-preview3-sdk-stretch`, `2.2-sdk-stretch`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/amd64/Dockerfile)
 - [`2.2.100-preview3-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.100-preview3-sdk-alpine`, `2.2-sdk-alpine` (*2.2/sdk/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/alpine3.8/amd64/Dockerfile)
@@ -38,7 +38,7 @@
 - [`2.2.0-preview3-runtime-deps-alpine3.8`, `2.2-runtime-deps-alpine3.8`, `2.2.0-preview3-runtime-deps-alpine`, `2.2-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
 - [`2.2.0-preview3-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-alpha1-sdk-stretch`, `3.0-sdk-stretch`, `3.0.100-alpha1-sdk`, `3.0-sdk` (*3.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/amd64/Dockerfile)
 - [`3.0.100-alpha1-sdk-alpine3.8`, `3.0-sdk-alpine3.8`, `3.0.100-alpha1-sdk-alpine`, `3.0-sdk-alpine` (*3.0/sdk/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/alpine3.8/amd64/Dockerfile)
@@ -59,13 +59,13 @@
 - [`2.1.5-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
 - [`2.1.5-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
 - [`2.2.100-preview3-sdk-nanoserver-1803`, `2.2-sdk-nanoserver-1803`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1803/amd64/Dockerfile)
 - [`2.2.0-preview3-aspnetcore-runtime-nanoserver-1803`, `2.2-aspnetcore-runtime-nanoserver-1803`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
 - [`2.2.0-preview3-runtime-nanoserver-1803`, `2.2-runtime-nanoserver-1803`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1803/amd64/Dockerfile)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-alpha1-sdk-nanoserver-1803`, `3.0-sdk-nanoserver-1803`, `3.0.100-alpha1-sdk`, `3.0-sdk` (*3.0/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-1803/amd64/Dockerfile)
 - [`3.0.0-alpha1-aspnetcore-runtime-nanoserver-1803`, `3.0-aspnetcore-runtime-nanoserver-1803`, `3.0.0-alpha1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
@@ -77,13 +77,13 @@
 - [`2.1.5-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
 - [`2.1.5-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
 - [`2.2.100-preview3-sdk-nanoserver-1709`, `2.2-sdk-nanoserver-1709`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1709/amd64/Dockerfile)
 - [`2.2.0-preview3-aspnetcore-runtime-nanoserver-1709`, `2.2-aspnetcore-runtime-nanoserver-1709`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
 - [`2.2.0-preview3-runtime-nanoserver-1709`, `2.2-runtime-nanoserver-1709`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1709/amd64/Dockerfile)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-alpha1-sdk-nanoserver-1709`, `3.0-sdk-nanoserver-1709`, `3.0.100-alpha1-sdk`, `3.0-sdk` (*3.0/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-1709/amd64/Dockerfile)
 - [`3.0.0-alpha1-aspnetcore-runtime-nanoserver-1709`, `3.0-aspnetcore-runtime-nanoserver-1709`, `3.0.0-alpha1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
@@ -98,13 +98,13 @@
 - [`1.1.9-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.9-runtime`, `1.1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.0.12-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.12-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
 - [`2.2.100-preview3-sdk-nanoserver-sac2016`, `2.2-sdk-nanoserver-sac2016`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.2.0-preview3-aspnetcore-runtime-nanoserver-sac2016`, `2.2-aspnetcore-runtime-nanoserver-sac2016`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.2.0-preview3-runtime-nanoserver-sac2016`, `2.2-runtime-nanoserver-sac2016`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-alpha1-sdk-nanoserver-sac2016`, `3.0-sdk-nanoserver-sac2016`, `3.0.100-alpha1-sdk`, `3.0-sdk` (*3.0/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`3.0.0-alpha1-aspnetcore-runtime-nanoserver-sac2016`, `3.0-aspnetcore-runtime-nanoserver-sac2016`, `3.0.0-alpha1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
@@ -121,7 +121,7 @@
 - [`2.1.5-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.5-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.5-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
 - [`2.2.100-preview3-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
 - [`2.2.100-preview3-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*2.2/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
@@ -132,7 +132,7 @@
 - [`2.2.0-preview3-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.0-preview3-runtime-deps`, `2.2-runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`2.2.0-preview3-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-alpha1-sdk-stretch-arm32v7`, `3.0-sdk-stretch-arm32v7`, `3.0.100-alpha1-sdk`, `3.0-sdk` (*3.0/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm32v7/Dockerfile)
 - [`3.0.100-alpha1-sdk-bionic-arm32v7`, `3.0-sdk-bionic-arm32v7` (*3.0/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm32v7/Dockerfile)

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,17 @@
       "powershell -NoProfile -Command .\\tests\\run-tests.ps1 -VersionFilter $(VersionFilter) -OSFilter $(System:OsVersion) -RepoOwner $(System:RepoOwner)"
     ]
   },
+  "variables": {
+    "1.0-RuntimeVersion": "1.0.12",
+    "1.1-RuntimeVersion": "1.1.9",
+    "1.1-SdkVersion": "1.1.10",
+    "2.1-RuntimeVersion": "2.1.5",
+    "2.1-SdkVersion": "2.1.403",
+    "2.2-RuntimeVersion": "2.2.0-preview3",
+    "2.2-SdkVersion": "2.2.100-preview3",
+    "3.0-RuntimeVersion": "3.0.0-alpha1",
+    "3.0-SdkVersion": "3.0.100-alpha1"
+  },
   "repos": [
     {
       "name": "microsoft/dotnet-nightly",
@@ -15,7 +26,7 @@
       "images": [
         {
           "sharedTags": {
-            "1.0.12-runtime-deps": {},
+            "$(1.0-RuntimeVersion)-runtime-deps": {},
             "1.0-runtime-deps": {},
             "1-runtime-deps": {
               "isUndocumented": true
@@ -29,7 +40,7 @@
               "dockerfile": "1.0/runtime-deps/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.0.12-runtime-deps-jessie": {},
+                "$(1.0-RuntimeVersion)-runtime-deps-jessie": {},
                 "1.0-runtime-deps-jessie": {},
                 "1.0-core-deps": {
                   "isUndocumented": true
@@ -46,7 +57,7 @@
         },
         {
           "sharedTags": {
-            "1.0.12-runtime": {},
+            "$(1.0-RuntimeVersion)-runtime": {},
             "1.0-runtime": {}
           },
           "platforms": [
@@ -54,7 +65,7 @@
               "dockerfile": "1.0/runtime/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.0.12-runtime-jessie": {},
+                "$(1.0-RuntimeVersion)-runtime-jessie": {},
                 "1.0-runtime-jessie": {},
                 "1.0-core": {
                   "isUndocumented": true
@@ -66,7 +77,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "1.0.12-runtime-nanoserver-sac2016": {},
+                "$(1.0-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "1.0-runtime-nanoserver-sac2016": {},
                 "1.0-runtime-nanoserver": {
                   "isUndocumented": true
@@ -77,7 +88,7 @@
         },
         {
           "sharedTags": {
-            "1.1.9-runtime": {},
+            "$(1.1-RuntimeVersion)-runtime": {},
             "1.1-runtime": {},
             "1-runtime": {
               "isUndocumented": true
@@ -88,7 +99,7 @@
               "dockerfile": "1.1/runtime/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.1.9-runtime-jessie": {},
+                "$(1.1-RuntimeVersion)-runtime-jessie": {},
                 "1.1-runtime-jessie": {},
                 "1-core": {
                   "isUndocumented": true
@@ -103,7 +114,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "1.1.9-runtime-nanoserver-sac2016": {},
+                "$(1.1-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "1.1-runtime-nanoserver-sac2016": {},
                 "1.1-runtime-nanoserver": {
                   "isUndocumented": true
@@ -120,7 +131,7 @@
         },
         {
           "sharedTags": {
-            "1.1.9-sdk-1.1.10": {},
+            "$(1.1-RuntimeVersion)-sdk-$(1.1-SdkVersion)": {},
             "1.1-sdk": {},
             "1-sdk": {
               "isUndocumented": true
@@ -134,7 +145,7 @@
               "dockerfile": "1.1/sdk/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.1.9-sdk-1.1.10-jessie": {},
+                "$(1.1-RuntimeVersion)-sdk-$(1.1-SdkVersion)-jessie": {},
                 "1.1-sdk-jessie": {}
               }
             },
@@ -143,7 +154,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "1.1.9-sdk-1.1.10-nanoserver-sac2016": {},
+                "$(1.1-RuntimeVersion)-sdk-$(1.1-SdkVersion)-nanoserver-sac2016": {},
                 "1.1-sdk-nanoserver-sac2016": {},
                 "1.1-sdk-nanoserver": {
                   "isUndocumented": true
@@ -166,9 +177,9 @@
         },
         {
           "sharedTags": {
-            "2.1.5-runtime-deps": {},
+            "$(2.1-RuntimeVersion)-runtime-deps": {},
             "2.1-runtime-deps": {},
-            "2.2.0-preview3-runtime-deps": {},
+            "$(2.2-RuntimeVersion)-runtime-deps": {},
             "2.2-runtime-deps": {},
             "runtime-deps": {},
             "2-runtime-deps": {
@@ -180,9 +191,9 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-stretch-slim": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-stretch-slim": {},
                 "2.1-runtime-deps-stretch-slim": {},
-                "2.2.0-preview3-runtime-deps-stretch-slim": {},
+                "$(2.2-RuntimeVersion)-runtime-deps-stretch-slim": {},
                 "2.2-runtime-deps-stretch-slim": {}
               }
             },
@@ -191,9 +202,9 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-stretch-slim-arm32v7": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-stretch-slim-arm32v7": {},
                 "2.1-runtime-deps-stretch-slim-arm32v7": {},
-                "2.2.0-preview3-runtime-deps-stretch-slim-arm32v7": {},
+                "$(2.2-RuntimeVersion)-runtime-deps-stretch-slim-arm32v7": {},
                 "2.2-runtime-deps-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -202,7 +213,7 @@
         },
         {
           "sharedTags": {
-            "2.1.5-runtime": {},
+            "$(2.1-RuntimeVersion)-runtime": {},
             "2.1-runtime": {},
             "runtime": {},
             "2-runtime": {
@@ -214,7 +225,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-stretch-slim": {},
+                "$(2.1-RuntimeVersion)-runtime-stretch-slim": {},
                 "2.1-runtime-stretch-slim": {}
               }
             },
@@ -223,7 +234,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-stretch-slim-arm32v7": {},
+                "$(2.1-RuntimeVersion)-runtime-stretch-slim-arm32v7": {},
                 "2.1-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -233,7 +244,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.5-runtime-nanoserver-sac2016": {},
+                "$(2.1-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "2.1-runtime-nanoserver-sac2016": {},
                 "2-runtime-nanoserver": {
                   "isUndocumented": true
@@ -245,7 +256,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.5-runtime-nanoserver-1709": {},
+                "$(2.1-RuntimeVersion)-runtime-nanoserver-1709": {},
                 "2.1-runtime-nanoserver-1709": {}
               }
             },
@@ -254,7 +265,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.5-runtime-nanoserver-1803": {},
+                "$(2.1-RuntimeVersion)-runtime-nanoserver-1803": {},
                 "2.1-runtime-nanoserver-1803": {}
               }
             }
@@ -262,7 +273,7 @@
         },
         {
           "sharedTags": {
-            "2.1.5-aspnetcore-runtime": {},
+            "$(2.1-RuntimeVersion)-aspnetcore-runtime": {},
             "2.1-aspnetcore-runtime": {},
             "aspnetcore-runtime": {},
             "2-aspnetcore-runtime": {
@@ -274,7 +285,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-stretch-slim": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-stretch-slim": {},
                 "2.1-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -283,7 +294,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-stretch-slim-arm32v7": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-stretch-slim-arm32v7": {},
                 "2.1-aspnetcore-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -293,7 +304,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.5-aspnetcore-runtime-nanoserver-sac2016": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-nanoserver-sac2016": {},
                 "2.1-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -302,7 +313,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.5-aspnetcore-runtime-nanoserver-1709": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-nanoserver-1709": {},
                 "2.1-aspnetcore-runtime-nanoserver-1709": {}
               }
             },
@@ -311,7 +322,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.5-aspnetcore-runtime-nanoserver-1803": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-nanoserver-1803": {},
                 "2.1-aspnetcore-runtime-nanoserver-1803": {}
               }
             }
@@ -319,7 +330,7 @@
         },
         {
           "sharedTags": {
-            "2.1.403-sdk": {},
+            "$(2.1-SdkVersion)-sdk": {},
             "2.1-sdk": {},
             "sdk": {},
             "latest": {},
@@ -332,7 +343,7 @@
               "dockerfile": "2.1/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-stretch": {},
+                "$(2.1-SdkVersion)-sdk-stretch": {},
                 "2.1-sdk-stretch": {}
               }
             },
@@ -341,7 +352,7 @@
               "dockerfile": "2.1/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-stretch-arm32v7": {},
+                "$(2.1-SdkVersion)-sdk-stretch-arm32v7": {},
                 "2.1-sdk-stretch-arm32v7": {}
               },
               "variant": "v7"
@@ -351,7 +362,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.403-sdk-nanoserver-sac2016": {},
+                "$(2.1-SdkVersion)-sdk-nanoserver-sac2016": {},
                 "2.1-sdk-nanoserver-sac2016": {},
                 "2-sdk-nanoserver": {
                   "isUndocumented": true
@@ -363,7 +374,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.403-sdk-nanoserver-1709": {},
+                "$(2.1-SdkVersion)-sdk-nanoserver-1709": {},
                 "2.1-sdk-nanoserver-1709": {}
               }
             },
@@ -372,7 +383,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.403-sdk-nanoserver-1803": {},
+                "$(2.1-SdkVersion)-sdk-nanoserver-1803": {},
                 "2.1-sdk-nanoserver-1803": {}
               }
             }
@@ -384,7 +395,7 @@
               "dockerfile": "2.1/runtime-deps/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-alpine3.7": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-alpine3.7": {},
                 "2.1-runtime-deps-alpine3.7": {}
               }
             }
@@ -396,7 +407,7 @@
               "dockerfile": "2.1/runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-alpine3.7": {},
+                "$(2.1-RuntimeVersion)-runtime-alpine3.7": {},
                 "2.1-runtime-alpine3.7": {}
               }
             }
@@ -408,7 +419,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-alpine3.7": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-alpine3.7": {},
                 "2.1-aspnetcore-runtime-alpine3.7": {}
               }
             }
@@ -420,7 +431,7 @@
               "dockerfile": "2.1/sdk/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-alpine3.7": {},
+                "$(2.1-SdkVersion)-sdk-alpine3.7": {},
                 "2.1-sdk-alpine3.7": {}
               }
             }
@@ -432,13 +443,13 @@
               "dockerfile": "2.1/runtime-deps/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-alpine3.8": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-alpine3.8": {},
                 "2.1-runtime-deps-alpine3.8": {},
-                "2.2.0-preview3-runtime-deps-alpine3.8": {},
+                "$(2.2-RuntimeVersion)-runtime-deps-alpine3.8": {},
                 "2.2-runtime-deps-alpine3.8": {},
-                "2.1.5-runtime-deps-alpine": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-alpine": {},
                 "2.1-runtime-deps-alpine": {},
-                "2.2.0-preview3-runtime-deps-alpine": {},
+                "$(2.2-RuntimeVersion)-runtime-deps-alpine": {},
                 "2.2-runtime-deps-alpine": {}
               }
             }
@@ -450,9 +461,9 @@
               "dockerfile": "2.1/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-alpine3.8": {},
+                "$(2.1-RuntimeVersion)-runtime-alpine3.8": {},
                 "2.1-runtime-alpine3.8": {},
-                "2.1.5-runtime-alpine": {},
+                "$(2.1-RuntimeVersion)-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
               }
             }
@@ -464,9 +475,9 @@
               "dockerfile": "2.1/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-alpine3.8": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-alpine3.8": {},
                 "2.1-aspnetcore-runtime-alpine3.8": {},
-                "2.1.5-aspnetcore-runtime-alpine": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-alpine": {},
                 "2.1-aspnetcore-runtime-alpine": {}
               }
             }
@@ -478,9 +489,9 @@
               "dockerfile": "2.1/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-alpine3.8": {},
+                "$(2.1-SdkVersion)-sdk-alpine3.8": {},
                 "2.1-sdk-alpine3.8": {},
-                "2.1.403-sdk-alpine": {},
+                "$(2.1-SdkVersion)-sdk-alpine": {},
                 "2.1-sdk-alpine": {}
               }
             }
@@ -492,9 +503,9 @@
               "dockerfile": "2.1/runtime-deps/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-bionic": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-bionic": {},
                 "2.1-runtime-deps-bionic": {},
-                "2.2.0-preview3-runtime-deps-bionic": {},
+                "$(2.2-RuntimeVersion)-runtime-deps-bionic": {},
                 "2.2-runtime-deps-bionic": {}
               }
             }
@@ -506,7 +517,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-bionic": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-bionic": {},
                 "2.1-aspnetcore-runtime-bionic": {}
               }
             }
@@ -518,7 +529,7 @@
               "dockerfile": "2.1/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-bionic": {},
+                "$(2.1-RuntimeVersion)-runtime-bionic": {},
                 "2.1-runtime-bionic": {}
               }
             }
@@ -530,7 +541,7 @@
               "dockerfile": "2.1/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-bionic": {},
+                "$(2.1-SdkVersion)-sdk-bionic": {},
                 "2.1-sdk-bionic": {}
               }
             }
@@ -543,9 +554,9 @@
               "dockerfile": "2.1/runtime-deps/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-bionic-arm32v7": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-bionic-arm32v7": {},
                 "2.1-runtime-deps-bionic-arm32v7": {},
-                "2.2.0-preview3-runtime-deps-bionic-arm32v7": {},
+                "$(2.2-RuntimeVersion)-runtime-deps-bionic-arm32v7": {},
                 "2.2-runtime-deps-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -559,7 +570,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-bionic-arm32v7": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.1-aspnetcore-runtime-bionic-arm32v7": {}
               }
             }
@@ -572,7 +583,7 @@
               "dockerfile": "2.1/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-bionic-arm32v7": {},
+                "$(2.1-RuntimeVersion)-runtime-bionic-arm32v7": {},
                 "2.1-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -586,7 +597,7 @@
               "dockerfile": "2.1/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-bionic-arm32v7": {},
+                "$(2.1-SdkVersion)-sdk-bionic-arm32v7": {},
                 "2.1-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -595,7 +606,7 @@
         },
         {
           "sharedTags": {
-            "2.2.0-preview3-runtime": {},
+            "$(2.2-RuntimeVersion)-runtime": {},
             "2.2-runtime": {}
           },
           "platforms": [
@@ -603,7 +614,7 @@
               "dockerfile": "2.2/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-stretch-slim": {},
+                "$(2.2-RuntimeVersion)-runtime-stretch-slim": {},
                 "2.2-runtime-stretch-slim": {}
               }
             },
@@ -612,7 +623,7 @@
               "dockerfile": "2.2/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-stretch-slim-arm32v7": {},
+                "$(2.2-RuntimeVersion)-runtime-stretch-slim-arm32v7": {},
                 "2.2-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -622,7 +633,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.2.0-preview3-runtime-nanoserver-sac2016": {},
+                "$(2.2-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "2.2-runtime-nanoserver-sac2016": {}
               }
             },
@@ -631,7 +642,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.2.0-preview3-runtime-nanoserver-1709": {},
+                "$(2.2-RuntimeVersion)-runtime-nanoserver-1709": {},
                 "2.2-runtime-nanoserver-1709": {}
               }
             },
@@ -640,7 +651,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.2.0-preview3-runtime-nanoserver-1803": {},
+                "$(2.2-RuntimeVersion)-runtime-nanoserver-1803": {},
                 "2.2-runtime-nanoserver-1803": {}
               }
             }
@@ -648,7 +659,7 @@
         },
         {
           "sharedTags": {
-            "2.2.0-preview3-aspnetcore-runtime": {},
+            "$(2.2-RuntimeVersion)-aspnetcore-runtime": {},
             "2.2-aspnetcore-runtime": {}
           },
           "platforms": [
@@ -656,7 +667,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-stretch-slim": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-stretch-slim": {},
                 "2.2-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -665,7 +676,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-stretch-slim-arm32v7": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-stretch-slim-arm32v7": {},
                 "2.2-aspnetcore-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -675,7 +686,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-nanoserver-sac2016": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-nanoserver-sac2016": {},
                 "2.2-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -684,7 +695,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-nanoserver-1709": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-nanoserver-1709": {},
                 "2.2-aspnetcore-runtime-nanoserver-1709": {}
               }
             },
@@ -693,7 +704,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-nanoserver-1803": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-nanoserver-1803": {},
                 "2.2-aspnetcore-runtime-nanoserver-1803": {}
               }
             }
@@ -701,7 +712,7 @@
         },
         {
           "sharedTags": {
-            "2.2.100-preview3-sdk": {},
+            "$(2.2-SdkVersion)-sdk": {},
             "2.2-sdk": {}
           },
           "platforms": [
@@ -709,7 +720,7 @@
               "dockerfile": "2.2/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-stretch": {},
+                "$(2.2-SdkVersion)-sdk-stretch": {},
                 "2.2-sdk-stretch": {}
               }
             },
@@ -718,7 +729,7 @@
               "dockerfile": "2.2/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-stretch-arm32v7": {},
+                "$(2.2-SdkVersion)-sdk-stretch-arm32v7": {},
                 "2.2-sdk-stretch-arm32v7": {}
               },
               "variant": "v7"
@@ -728,7 +739,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.2.100-preview3-sdk-nanoserver-sac2016": {},
+                "$(2.2-SdkVersion)-sdk-nanoserver-sac2016": {},
                 "2.2-sdk-nanoserver-sac2016": {}
               }
             },
@@ -737,7 +748,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.2.100-preview3-sdk-nanoserver-1709": {},
+                "$(2.2-SdkVersion)-sdk-nanoserver-1709": {},
                 "2.2-sdk-nanoserver-1709": {}
               }
             },
@@ -746,7 +757,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.2.100-preview3-sdk-nanoserver-1803": {},
+                "$(2.2-SdkVersion)-sdk-nanoserver-1803": {},
                 "2.2-sdk-nanoserver-1803": {}
               }
             }
@@ -758,9 +769,9 @@
               "dockerfile": "2.2/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-alpine3.8": {},
+                "$(2.2-RuntimeVersion)-runtime-alpine3.8": {},
                 "2.2-runtime-alpine3.8": {},
-                "2.2.0-preview3-runtime-alpine": {},
+                "$(2.2-RuntimeVersion)-runtime-alpine": {},
                 "2.2-runtime-alpine": {}
               }
             }
@@ -772,9 +783,9 @@
               "dockerfile": "2.2/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-alpine3.8": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-alpine3.8": {},
                 "2.2-aspnetcore-runtime-alpine3.8": {},
-                "2.2.0-preview3-aspnetcore-runtime-alpine": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-alpine": {},
                 "2.2-aspnetcore-runtime-alpine": {}
               }
             }
@@ -786,9 +797,9 @@
               "dockerfile": "2.2/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-alpine3.8": {},
+                "$(2.2-SdkVersion)-sdk-alpine3.8": {},
                 "2.2-sdk-alpine3.8": {},
-                "2.2.100-preview3-sdk-alpine": {},
+                "$(2.2-SdkVersion)-sdk-alpine": {},
                 "2.2-sdk-alpine": {}
               }
             }
@@ -800,7 +811,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-bionic": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-bionic": {},
                 "2.2-aspnetcore-runtime-bionic": {}
               }
             }
@@ -812,7 +823,7 @@
               "dockerfile": "2.2/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-bionic": {},
+                "$(2.2-RuntimeVersion)-runtime-bionic": {},
                 "2.2-runtime-bionic": {}
               }
             }
@@ -824,7 +835,7 @@
               "dockerfile": "2.2/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-bionic": {},
+                "$(2.2-SdkVersion)-sdk-bionic": {},
                 "2.2-sdk-bionic": {}
               }
             }
@@ -837,7 +848,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.2-aspnetcore-runtime-bionic-arm32v7": {}
               }
             }
@@ -850,7 +861,7 @@
               "dockerfile": "2.2/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-bionic-arm32v7": {},
+                "$(2.2-RuntimeVersion)-runtime-bionic-arm32v7": {},
                 "2.2-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -864,7 +875,7 @@
               "dockerfile": "2.2/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-bionic-arm32v7": {},
+                "$(2.2-SdkVersion)-sdk-bionic-arm32v7": {},
                 "2.2-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -873,7 +884,7 @@
         },
         {
           "sharedTags": {
-            "3.0.0-alpha1-runtime-deps": {},
+            "$(3.0-RuntimeVersion)-runtime-deps": {},
             "3.0-runtime-deps": {}
           },
           "platforms": [
@@ -881,7 +892,7 @@
               "dockerfile": "3.0/runtime-deps/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-deps-stretch-slim": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-stretch-slim": {},
                 "3.0-runtime-deps-stretch-slim": {}
               }
             },
@@ -890,7 +901,7 @@
               "dockerfile": "3.0/runtime-deps/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-deps-stretch-slim-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-stretch-slim-arm32v7": {},
                 "3.0-runtime-deps-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -899,7 +910,7 @@
         },
         {
           "sharedTags": {
-            "3.0.0-alpha1-runtime": {},
+            "$(3.0-RuntimeVersion)-runtime": {},
             "3.0-runtime": {}
           },
           "platforms": [
@@ -907,7 +918,7 @@
               "dockerfile": "3.0/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-stretch-slim": {},
+                "$(3.0-RuntimeVersion)-runtime-stretch-slim": {},
                 "3.0-runtime-stretch-slim": {}
               }
             },
@@ -916,7 +927,7 @@
               "dockerfile": "3.0/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-stretch-slim-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-stretch-slim-arm32v7": {},
                 "3.0-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -926,7 +937,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "3.0.0-alpha1-runtime-nanoserver-sac2016": {},
+                "$(3.0-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "3.0-runtime-nanoserver-sac2016": {}
               }
             },
@@ -935,7 +946,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "3.0.0-alpha1-runtime-nanoserver-1709": {},
+                "$(3.0-RuntimeVersion)-runtime-nanoserver-1709": {},
                 "3.0-runtime-nanoserver-1709": {}
               }
             },
@@ -944,7 +955,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "3.0.0-alpha1-runtime-nanoserver-1803": {},
+                "$(3.0-RuntimeVersion)-runtime-nanoserver-1803": {},
                 "3.0-runtime-nanoserver-1803": {}
               }
             }
@@ -952,7 +963,7 @@
         },
         {
           "sharedTags": {
-            "3.0.0-alpha1-aspnetcore-runtime": {},
+            "$(3.0-RuntimeVersion)-aspnetcore-runtime": {},
             "3.0-aspnetcore-runtime": {}
           },
           "platforms": [
@@ -960,7 +971,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-stretch-slim": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-stretch-slim": {},
                 "3.0-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -969,7 +980,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-stretch-slim-arm32v7": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-stretch-slim-arm32v7": {},
                 "3.0-aspnetcore-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -979,7 +990,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-nanoserver-sac2016": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-nanoserver-sac2016": {},
                 "3.0-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -988,7 +999,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-nanoserver-1709": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-nanoserver-1709": {},
                 "3.0-aspnetcore-runtime-nanoserver-1709": {}
               }
             },
@@ -997,7 +1008,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-nanoserver-1803": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-nanoserver-1803": {},
                 "3.0-aspnetcore-runtime-nanoserver-1803": {}
               }
             }
@@ -1005,7 +1016,7 @@
         },
         {
           "sharedTags": {
-            "3.0.100-alpha1-sdk": {},
+            "$(3.0-SdkVersion)-sdk": {},
             "3.0-sdk": {}
           },
           "platforms": [
@@ -1013,7 +1024,7 @@
               "dockerfile": "3.0/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "3.0.100-alpha1-sdk-stretch": {},
+                "$(3.0-SdkVersion)-sdk-stretch": {},
                 "3.0-sdk-stretch": {}
               }
             },
@@ -1022,7 +1033,7 @@
               "dockerfile": "3.0/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.100-alpha1-sdk-stretch-arm32v7": {},
+                "$(3.0-SdkVersion)-sdk-stretch-arm32v7": {},
                 "3.0-sdk-stretch-arm32v7": {}
               },
               "variant": "v7"
@@ -1032,7 +1043,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "3.0.100-alpha1-sdk-nanoserver-sac2016": {},
+                "$(3.0-SdkVersion)-sdk-nanoserver-sac2016": {},
                 "3.0-sdk-nanoserver-sac2016": {}
               }
             },
@@ -1041,7 +1052,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "3.0.100-alpha1-sdk-nanoserver-1709": {},
+                "$(3.0-SdkVersion)-sdk-nanoserver-1709": {},
                 "3.0-sdk-nanoserver-1709": {}
               }
             },
@@ -1050,7 +1061,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "3.0.100-alpha1-sdk-nanoserver-1803": {},
+                "$(3.0-SdkVersion)-sdk-nanoserver-1803": {},
                 "3.0-sdk-nanoserver-1803": {}
               }
             }
@@ -1062,9 +1073,9 @@
               "dockerfile": "3.0/runtime-deps/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-deps-alpine3.8": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-alpine3.8": {},
                 "3.0-runtime-deps-alpine3.8": {},
-                "3.0.0-alpha1-runtime-deps-alpine": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-alpine": {},
                 "3.0-runtime-deps-alpine": {}
               }
             }
@@ -1076,9 +1087,9 @@
               "dockerfile": "3.0/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-alpine3.8": {},
+                "$(3.0-RuntimeVersion)-runtime-alpine3.8": {},
                 "3.0-runtime-alpine3.8": {},
-                "3.0.0-alpha1-runtime-alpine": {},
+                "$(3.0-RuntimeVersion)-runtime-alpine": {},
                 "3.0-runtime-alpine": {}
               }
             }
@@ -1090,9 +1101,9 @@
               "dockerfile": "3.0/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-alpine3.8": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-alpine3.8": {},
                 "3.0-aspnetcore-runtime-alpine3.8": {},
-                "3.0.0-alpha1-aspnetcore-runtime-alpine": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-alpine": {},
                 "3.0-aspnetcore-runtime-alpine": {}
               }
             }
@@ -1104,9 +1115,9 @@
               "dockerfile": "3.0/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.100-alpha1-sdk-alpine3.8": {},
+                "$(3.0-SdkVersion)-sdk-alpine3.8": {},
                 "3.0-sdk-alpine3.8": {},
-                "3.0.100-alpha1-sdk-alpine": {},
+                "$(3.0-SdkVersion)-sdk-alpine": {},
                 "3.0-sdk-alpine": {}
               }
             }
@@ -1118,7 +1129,7 @@
               "dockerfile": "3.0/runtime-deps/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-deps-bionic": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-bionic": {},
                 "3.0-runtime-deps-bionic": {}
               }
             }
@@ -1130,7 +1141,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-bionic": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-bionic": {},
                 "3.0-aspnetcore-runtime-bionic": {}
               }
             }
@@ -1142,7 +1153,7 @@
               "dockerfile": "3.0/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-bionic": {},
+                "$(3.0-RuntimeVersion)-runtime-bionic": {},
                 "3.0-runtime-bionic": {}
               }
             }
@@ -1154,7 +1165,7 @@
               "dockerfile": "3.0/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.100-alpha1-sdk-bionic": {},
+                "$(3.0-SdkVersion)-sdk-bionic": {},
                 "3.0-sdk-bionic": {}
               }
             }
@@ -1167,7 +1178,7 @@
               "dockerfile": "3.0/runtime-deps/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-deps-bionic-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-bionic-arm32v7": {},
                 "3.0-runtime-deps-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -1181,7 +1192,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-aspnetcore-runtime-bionic-arm32v7": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-bionic-arm32v7": {},
                 "3.0-aspnetcore-runtime-bionic-arm32v7": {}
               }
             }
@@ -1194,7 +1205,7 @@
               "dockerfile": "3.0/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-alpha1-runtime-bionic-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-bionic-arm32v7": {},
                 "3.0-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -1208,7 +1219,7 @@
               "dockerfile": "3.0/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.100-alpha1-sdk-bionic-arm32v7": {},
+                "$(3.0-SdkVersion)-sdk-bionic-arm32v7": {},
                 "3.0-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -2,26 +2,26 @@
 
 # Linux amd64 tags
 
-$(TagDoc:2.1.403-sdk-stretch)
-$(TagDoc:2.1.403-sdk-alpine3.7)
-$(TagDoc:2.1.403-sdk-alpine3.8)
-$(TagDoc:2.1.403-sdk-bionic)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.5-aspnetcore-runtime-alpine3.7)
-$(TagDoc:2.1.5-aspnetcore-runtime-alpine3.8)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic)
-$(TagDoc:2.1.5-runtime-stretch-slim)
-$(TagDoc:2.1.5-runtime-alpine3.7)
-$(TagDoc:2.1.5-runtime-alpine3.8)
-$(TagDoc:2.1.5-runtime-bionic)
+$(TagDoc:2.1-sdk-stretch)
+$(TagDoc:2.1-sdk-alpine3.7)
+$(TagDoc:2.1-sdk-alpine3.8)
+$(TagDoc:2.1-sdk-bionic)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.7)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.8)
+$(TagDoc:2.1-aspnetcore-runtime-bionic)
+$(TagDoc:2.1-runtime-stretch-slim)
+$(TagDoc:2.1-runtime-alpine3.7)
+$(TagDoc:2.1-runtime-alpine3.8)
+$(TagDoc:2.1-runtime-bionic)
 $(TagDocList:2.1.5-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
 $(TagDocList:2.1.5-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7)
 $(TagDocList:2.1.5-runtime-deps-alpine3.8|2.1-runtime-deps-alpine3.8|2.1.5-runtime-deps-alpine|2.1-runtime-deps-alpine)
 $(TagDocList:2.1.5-runtime-deps-bionic|2.1-runtime-deps-bionic)
-$(TagDoc:1.1.9-sdk-1.1.10-jessie)
-$(TagDoc:1.1.9-runtime-jessie)
-$(TagDoc:1.0.12-runtime-jessie)
-$(TagDoc:1.0.12-runtime-deps-jessie)
+$(TagDoc:1.1-sdk-jessie)
+$(TagDoc:1.1-runtime-jessie)
+$(TagDoc:1.0-runtime-jessie)
+$(TagDoc:1.0-runtime-deps-jessie)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -29,9 +29,9 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server, version 1803 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1803)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.1.5-runtime-nanoserver-1803)
+$(TagDoc:2.1-sdk-nanoserver-1803)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.1-runtime-nanoserver-1803)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -39,9 +39,9 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server, version 1709 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1709)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.1.5-runtime-nanoserver-1709)
+$(TagDoc:2.1-sdk-nanoserver-1709)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.1-runtime-nanoserver-1709)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -49,12 +49,12 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server 2016 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-sac2016)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.1.5-runtime-nanoserver-sac2016)
-$(TagDoc:1.1.9-sdk-1.1.10-nanoserver-sac2016)
-$(TagDoc:1.1.9-runtime-nanoserver-sac2016)
-$(TagDoc:1.0.12-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-sdk-nanoserver-sac2016)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.1-sdk-nanoserver-sac2016)
+$(TagDoc:1.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.0-runtime-nanoserver-sac2016)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -62,12 +62,12 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Linux arm32 tags
 
-$(TagDoc:2.1.403-sdk-stretch-arm32v7)
-$(TagDoc:2.1.403-sdk-bionic-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.1.5-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-runtime-bionic-arm32v7)
+$(TagDoc:2.1-sdk-stretch-arm32v7)
+$(TagDoc:2.1-sdk-bionic-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-bionic-arm32v7)
 $(TagDocList:2.1.5-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
 $(TagDocList:2.1.5-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
 

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -2,145 +2,145 @@
 
 # Linux amd64 tags
 
-$(TagDoc:2.1.403-sdk-stretch)
-$(TagDoc:2.1.403-sdk-alpine3.7)
-$(TagDoc:2.1.403-sdk-alpine3.8)
-$(TagDoc:2.1.403-sdk-bionic)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.5-aspnetcore-runtime-alpine3.7)
-$(TagDoc:2.1.5-aspnetcore-runtime-alpine3.8)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic)
-$(TagDoc:2.1.5-runtime-stretch-slim)
-$(TagDoc:2.1.5-runtime-alpine3.7)
-$(TagDoc:2.1.5-runtime-alpine3.8)
-$(TagDoc:2.1.5-runtime-bionic)
+$(TagDoc:2.1-sdk-stretch)
+$(TagDoc:2.1-sdk-alpine3.7)
+$(TagDoc:2.1-sdk-alpine3.8)
+$(TagDoc:2.1-sdk-bionic)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.7)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.8)
+$(TagDoc:2.1-aspnetcore-runtime-bionic)
+$(TagDoc:2.1-runtime-stretch-slim)
+$(TagDoc:2.1-runtime-alpine3.7)
+$(TagDoc:2.1-runtime-alpine3.8)
+$(TagDoc:2.1-runtime-bionic)
 $(TagDocList:2.1.5-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
 $(TagDocList:2.1.5-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7)
 $(TagDocList:2.1.5-runtime-deps-alpine3.8|2.1-runtime-deps-alpine3.8|2.1.5-runtime-deps-alpine|2.1-runtime-deps-alpine)
 $(TagDocList:2.1.5-runtime-deps-bionic|2.1-runtime-deps-bionic)
-$(TagDoc:1.1.9-sdk-1.1.10-jessie)
-$(TagDoc:1.1.9-runtime-jessie)
-$(TagDoc:1.0.12-runtime-jessie)
-$(TagDoc:1.0.12-runtime-deps-jessie)
+$(TagDoc:1.1-sdk-jessie)
+$(TagDoc:1.1-runtime-jessie)
+$(TagDoc:1.0-runtime-jessie)
+$(TagDoc:1.0-runtime-deps-jessie)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-stretch)
-$(TagDoc:2.2.100-preview3-sdk-alpine3.8)
-$(TagDoc:2.2.100-preview3-sdk-bionic)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-alpine3.8)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-bionic)
-$(TagDoc:2.2.0-preview3-runtime-stretch-slim)
-$(TagDoc:2.2.0-preview3-runtime-alpine3.8)
-$(TagDoc:2.2.0-preview3-runtime-bionic)
+$(TagDoc:2.2-sdk-stretch)
+$(TagDoc:2.2-sdk-alpine3.8)
+$(TagDoc:2.2-sdk-bionic)
+$(TagDoc:2.2-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.2-aspnetcore-runtime-alpine3.8)
+$(TagDoc:2.2-aspnetcore-runtime-bionic)
+$(TagDoc:2.2-runtime-stretch-slim)
+$(TagDoc:2.2-runtime-alpine3.8)
+$(TagDoc:2.2-runtime-bionic)
 $(TagDocList:2.2.0-preview3-runtime-deps-stretch-slim|2.2-runtime-deps-stretch-slim|2.2.0-preview3-runtime-deps|2.2-runtime-deps)
 $(TagDocList:2.2.0-preview3-runtime-deps-alpine3.8|2.2-runtime-deps-alpine3.8|2.2.0-preview3-runtime-deps-alpine|2.2-runtime-deps-alpine)
 $(TagDocList:2.2.0-preview3-runtime-deps-bionic|2.2-runtime-deps-bionic)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-alpha1-sdk-stretch)
-$(TagDoc:3.0.100-alpha1-sdk-alpine3.8)
-$(TagDoc:3.0.100-alpha1-sdk-bionic)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-stretch-slim)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-alpine3.8)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-bionic)
-$(TagDoc:3.0.0-alpha1-runtime-stretch-slim)
-$(TagDoc:3.0.0-alpha1-runtime-alpine3.8)
-$(TagDoc:3.0.0-alpha1-runtime-bionic)
-$(TagDoc:3.0.0-alpha1-runtime-deps-stretch-slim)
-$(TagDoc:3.0.0-alpha1-runtime-deps-alpine3.8)
-$(TagDoc:3.0.0-alpha1-runtime-deps-bionic)
+$(TagDoc:3.0-sdk-stretch)
+$(TagDoc:3.0-sdk-alpine3.8)
+$(TagDoc:3.0-sdk-bionic)
+$(TagDoc:3.0-aspnetcore-runtime-stretch-slim)
+$(TagDoc:3.0-aspnetcore-runtime-alpine3.8)
+$(TagDoc:3.0-aspnetcore-runtime-bionic)
+$(TagDoc:3.0-runtime-stretch-slim)
+$(TagDoc:3.0-runtime-alpine3.8)
+$(TagDoc:3.0-runtime-bionic)
+$(TagDoc:3.0-runtime-deps-stretch-slim)
+$(TagDoc:3.0-runtime-deps-alpine3.8)
+$(TagDoc:3.0-runtime-deps-bionic)
 
 # Windows Server, version 1803 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1803)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.1.5-runtime-nanoserver-1803)
+$(TagDoc:2.1-sdk-nanoserver-1803)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.1-runtime-nanoserver-1803)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-nanoserver-1803)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.2.0-preview3-runtime-nanoserver-1803)
+$(TagDoc:2.2-sdk-nanoserver-1803)
+$(TagDoc:2.2-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.2-runtime-nanoserver-1803)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-alpha1-sdk-nanoserver-1803)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:3.0.0-alpha1-runtime-nanoserver-1803)
+$(TagDoc:3.0-sdk-nanoserver-1803)
+$(TagDoc:3.0-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:3.0-runtime-nanoserver-1803)
 
 # Windows Server, version 1709 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1709)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.1.5-runtime-nanoserver-1709)
+$(TagDoc:2.1-sdk-nanoserver-1709)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.1-runtime-nanoserver-1709)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-nanoserver-1709)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.2.0-preview3-runtime-nanoserver-1709)
+$(TagDoc:2.2-sdk-nanoserver-1709)
+$(TagDoc:2.2-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.2-runtime-nanoserver-1709)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-alpha1-sdk-nanoserver-1709)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:3.0.0-alpha1-runtime-nanoserver-1709)
+$(TagDoc:3.0-sdk-nanoserver-1709)
+$(TagDoc:3.0-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:3.0-runtime-nanoserver-1709)
 
 # Windows Server 2016 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-sac2016)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.1.5-runtime-nanoserver-sac2016)
-$(TagDoc:1.1.9-sdk-1.1.10-nanoserver-sac2016)
-$(TagDoc:1.1.9-runtime-nanoserver-sac2016)
-$(TagDoc:1.0.12-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-sdk-nanoserver-sac2016)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.1-sdk-nanoserver-sac2016)
+$(TagDoc:1.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.0-runtime-nanoserver-sac2016)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-nanoserver-sac2016)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.2.0-preview3-runtime-nanoserver-sac2016)
+$(TagDoc:2.2-sdk-nanoserver-sac2016)
+$(TagDoc:2.2-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.2-runtime-nanoserver-sac2016)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-alpha1-sdk-nanoserver-sac2016)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:3.0.0-alpha1-runtime-nanoserver-sac2016)
+$(TagDoc:3.0-sdk-nanoserver-sac2016)
+$(TagDoc:3.0-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:3.0-runtime-nanoserver-sac2016)
 
 # Linux arm32 tags
 
-$(TagDoc:2.1.403-sdk-stretch-arm32v7)
-$(TagDoc:2.1.403-sdk-bionic-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.1.5-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-runtime-bionic-arm32v7)
+$(TagDoc:2.1-sdk-stretch-arm32v7)
+$(TagDoc:2.1-sdk-bionic-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-bionic-arm32v7)
 $(TagDocList:2.1.5-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
 $(TagDocList:2.1.5-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
 
-**.NET Core 2.2 Preview 3 tags**
+**.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-stretch-arm32v7)
-$(TagDoc:2.2.100-preview3-sdk-bionic-arm32v7)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.2.0-preview3-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.2.0-preview3-runtime-bionic-arm32v7)
+$(TagDoc:2.2-sdk-stretch-arm32v7)
+$(TagDoc:2.2-sdk-bionic-arm32v7)
+$(TagDoc:2.2-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.2-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.2-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.2-runtime-bionic-arm32v7)
 $(TagDocList:2.2.0-preview3-runtime-deps-stretch-slim-arm32v7|2.2-runtime-deps-stretch-slim-arm32v7|2.2.0-preview3-runtime-deps|2.2-runtime-deps)
 $(TagDocList:2.2.0-preview3-runtime-deps-bionic-arm32v7|2.2-runtime-deps-bionic-arm32v7)
 
-**.NET Core 3.0 Alpha 1 tags**
+**.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-alpha1-sdk-stretch-arm32v7)
-$(TagDoc:3.0.100-alpha1-sdk-bionic-arm32v7)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:3.0.0-alpha1-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:3.0.0-alpha1-runtime-stretch-slim-arm32v7)
-$(TagDoc:3.0.0-alpha1-runtime-bionic-arm32v7)
-$(TagDoc:3.0.0-alpha1-runtime-deps-stretch-slim-arm32v7)
-$(TagDoc:3.0.0-alpha1-runtime-deps-bionic-arm32v7)
+$(TagDoc:3.0-sdk-stretch-arm32v7)
+$(TagDoc:3.0-sdk-bionic-arm32v7)
+$(TagDoc:3.0-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:3.0-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:3.0-runtime-stretch-slim-arm32v7)
+$(TagDoc:3.0-runtime-bionic-arm32v7)
+$(TagDoc:3.0-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:3.0-runtime-deps-bionic-arm32v7)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).


### PR DESCRIPTION
Refactored the manifest.json to utilize variables for the full version numbers.  This will make it easier to make and review the changes to introduce a new patch version.  Similarly the readme templates were refactored to use the `major.minor` tags where possible.  There are a few places that need to list out explicit tags due to the fact that `runtime-deps` images are shared across versions.