### PR TITLE
Updates to support multiple build agents running on a single host

### DIFF
--- a/.vsts-pipelines/phases/build-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/build-linux-arm32v7.yml
@@ -12,9 +12,9 @@ phases:
     steps:
       - template: ../steps/docker-init-linux.yml
         parameters:
-          setupArm: true
+          setupRemoteDocker: true
       - script: $(runImageBuilderCmd) build --manifest $(manifest) $(imageBuilderPaths) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-linux.yml
         parameters:
-          armCleanupImage: $(imageBuilder.image)
+          remoteDockerCleanupImage: $(imageBuilder.image)

--- a/.vsts-pipelines/phases/test-linux-amd64.yml
+++ b/.vsts-pipelines/phases/test-linux-amd64.yml
@@ -10,7 +10,7 @@ phases:
       parallel: 100
       matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxAmd64'] ]
     variables:
-      testRunner.container: testrunner-$(Build.BuildId)
+      testRunner.container: testrunner-$(System.JobId)
     steps:
       - template: ../steps/docker-init-linux.yml
         parameters:

--- a/.vsts-pipelines/phases/test-linux-arm32v7.yml
+++ b/.vsts-pipelines/phases/test-linux-arm32v7.yml
@@ -12,11 +12,11 @@ phases:
       parallel: 100
       matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxArm32v7'] ]
     variables:
-      testRunner.container: testrunner-$(Build.BuildId)
+      testRunner.container: testrunner-$(System.JobId)
     steps:
       - template: ../steps/docker-init-linux.yml
         parameters:
-          setupArm: true
+          setupRemoteDocker: true
           setupImageBuilder: false
           setupTestRunner: true
       - script: docker run -t -d -v $(repoVolume):/repo -w /repo $(dockerArmRunArgs) -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.container) $(testrunner.image)
@@ -50,4 +50,4 @@ phases:
         continueOnError: true
       - template: ../steps/docker-cleanup-linux.yml
         parameters:
-          armCleanupImage: $(testrunner.image)
+          remoteDockerCleanupImage: $(testrunner.image)

--- a/.vsts-pipelines/steps/docker-cleanup-linux.yml
+++ b/.vsts-pipelines/steps/docker-cleanup-linux.yml
@@ -1,21 +1,24 @@
 parameters:
-  armCleanupImage: null
+  remoteDockerCleanupImage: null
 steps:
   ################################################################################
-  # Cleanup Arm Env (Optional)
+  # Cleanup Remote Docker
   ################################################################################
-  - ${{ if ne(parameters.armCleanupImage, 'null') }}:
-    - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $armCleanupImage system prune -a -f --volumes
+  - ${{ if ne(parameters.remoteDockerCleanupImage, 'null') }}:
+    - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $remoteDockerCleanupImage system prune -a -f --volumes
       displayName: Cleanup ARM Docker
       condition: always()
       continueOnError: true
       env:
-        armCleanupImage: ${{ parameters.armCleanupImage }}
+        remoteDockerCleanupImage: ${{ parameters.remoteDockerCleanupImage }}
+    # Don't stop any running containers as multiple build agents are used on a single host machine for remote docker scenarios
+    - script: docker system prune -a -f --volumes
 
   ################################################################################
-  # Cleanup Docker Resources
+  # Cleanup Local Docker
   ################################################################################
-  - script: $(Build.Repository.LocalPath)/scripts/cleanup-docker.sh
-    displayName: Cleanup Docker
-    condition: always()
-    continueOnError: true
+  - ${{ if eq(parameters.remoteDockerCleanupImage, 'null') }}:
+    - script: $(Build.Repository.LocalPath)/scripts/cleanup-docker.sh
+      displayName: Cleanup Docker
+      condition: always()
+      continueOnError: true

--- a/.vsts-pipelines/steps/docker-init-linux.yml
+++ b/.vsts-pipelines/steps/docker-init-linux.yml
@@ -1,5 +1,5 @@
 parameters:
-  setupArm: false
+  setupRemoteDocker: false
   setupImageBuilder: true
   setupTestRunner: false
 
@@ -22,10 +22,10 @@ steps:
     displayName: Checkout Source
 
   ################################################################################
-  # Setup Arm Env (Optional)
+  # Setup Remote Docker (Optional)
   ################################################################################
   - ${{ if eq(parameters.setupArm, 'true') }}:
-    - script: echo "##vso[task.setvariable variable=dockerArmRunArgs] -v /docker-certs:/docker-certs -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(PIIP):2376"
+    - script: echo "##vso[task.setvariable variable=dockerArmRunArgs] -v $(DOCKER_CERTS_PATH):/docker-certs -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376"
       displayName: Define dockerArmRunArgs Variable
 
   ################################################################################

--- a/.vsts-pipelines/steps/docker-init-windows.yml
+++ b/.vsts-pipelines/steps/docker-init-windows.yml
@@ -15,14 +15,14 @@ steps:
       displayName: Define imageBuilder.image Variable
     - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 '$(imageBuilder.image)'
       displayName: Pull Image Builder
-    - script: docker create --name setupImageBuilder_$(Build.BuildId) $(imageBuilder.image)
+    - script: docker create --name setupImageBuilder_$(System.JobId) $(imageBuilder.image)
       displayName: Create Setup Container
     - script: rmdir /q /s $(Build.BinariesDirectory)\Microsoft.DotNet.ImageBuilder
       displayName: Cleanup Image Builder
       continueOnError: true
-    - script: docker cp setupImageBuilder_$(Build.BuildId):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
+    - script: docker cp setupImageBuilder_$(System.JobId):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
       displayName: Copy Image Builder
-    - script: docker rm -f setupImageBuilder_$(Build.BuildId)
+    - script: docker rm -f setupImageBuilder_$(System.JobId)
       displayName: Cleanup Setup Container
       condition: always()
       continueOnError: true


### PR DESCRIPTION
Our build agents for arm builds aren't doing much because they utilize a remote arm docker daemon for most of the work.  As such we can get by with running multiple agents on a single host to reduce our costs.  In order to do this some build changes are necessary.

@ilyas1974 - I'm proposing two changes within /data/agent/.env of our arm build agents.
1. Duplicate the value of PIIP and call it DOCKER_HOST_IP.  We will eventually remove PIIP, but this PR has to flow to all of our branches first.  PIIP was a poor choice on my part.  DOCKER_HOST_IP is more meaningful and doesn't assume the type of the remote docker machine.
2. Add DOCKER_CERTS_PATH and set the value to the agent specific location on the machine of where the certs are stored.  I think /data/docker-certs/<docker machine name> is a good location.  Currently the certs are stored in /docker_certs.  They will have to stay there until these changes flow to all of our branches.
