### PR TITLE
Refactor docker-cleanup-linux for remote docker scenarios

### DIFF
--- a/.vsts-pipelines/steps/docker-cleanup-linux.yml
+++ b/.vsts-pipelines/steps/docker-cleanup-linux.yml
@@ -1,4 +1,5 @@
 parameters:
+  remoteDockerCleanup: false
   remoteDockerCleanupImage: null
 steps:
   ################################################################################
@@ -6,18 +7,20 @@ steps:
   ################################################################################
   - ${{ if ne(parameters.remoteDockerCleanupImage, 'null') }}:
     - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $remoteDockerCleanupImage system prune -a -f --volumes
-      displayName: Cleanup ARM Docker
+      displayName: Cleanup Remote Docker
       condition: always()
       continueOnError: true
       env:
         remoteDockerCleanupImage: ${{ parameters.remoteDockerCleanupImage }}
+  - ${{ if or( eq(parameters.remoteDockerCleanup, 'true'), ne(parameters.remoteDockerCleanupImage, 'null') ) }}:
     # Don't stop any running containers as multiple build agents are used on a single host machine for remote docker scenarios
     - script: docker system prune -a -f --volumes
+      displayName: Cleanup Local Docker
 
   ################################################################################
   # Cleanup Local Docker
   ################################################################################
-  - ${{ if eq(parameters.remoteDockerCleanupImage, 'null') }}:
+  - ${{ if and( eq(parameters.remoteDockerCleanup, 'false'), eq(parameters.remoteDockerCleanupImage, 'null') ) }}:
     - script: $(Build.Repository.LocalPath)/scripts/cleanup-docker.sh
       displayName: Cleanup Docker
       condition: always()

--- a/.vsts-pipelines/steps/docker-cleanup-linux.yml
+++ b/.vsts-pipelines/steps/docker-cleanup-linux.yml
@@ -3,7 +3,7 @@ parameters:
   remoteDockerCleanupImage: null
 steps:
   ################################################################################
-  # Cleanup Remote Docker
+  # Cleanup for remote Docker usage
   ################################################################################
   - ${{ if ne(parameters.remoteDockerCleanupImage, 'null') }}:
     - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $remoteDockerCleanupImage system prune -a -f --volumes
@@ -18,7 +18,7 @@ steps:
       displayName: Cleanup Local Docker
 
   ################################################################################
-  # Cleanup Local Docker
+  # Cleanup for non-remote Docker usage
   ################################################################################
   - ${{ if and( eq(parameters.remoteDockerCleanup, 'false'), eq(parameters.remoteDockerCleanupImage, 'null') ) }}:
     - script: $(Build.Repository.LocalPath)/scripts/cleanup-docker.sh

--- a/.vsts-pipelines/steps/docker-init-linux.yml
+++ b/.vsts-pipelines/steps/docker-init-linux.yml
@@ -8,6 +8,8 @@ steps:
   # Cleanup Docker Resources
   ################################################################################
   - template: docker-cleanup-linux.yml
+    parameters:
+      remoteDockerCleanup: ${{ parameters.setupRemoteDocker }}
 
   ################################################################################
   # Setup Repo Volume


### PR DESCRIPTION
One more change is needed to be able to run multiple build agent on a single host.  The cleanup logic when invoked during init, shouldn't be doing the full cleanup.  It should only be removing unused local docker resources.

The YAML constructs make this a little ugly.  I am open to suggestions on how to make this cleaner.

@dotnet-bot skip ci please