### PR TITLE
[WIP] Add dotnet global tools directory  on the PATH

### DIFF
--- a/2.2/sdk/alpine3.8/amd64/Dockerfile
+++ b/2.2/sdk/alpine3.8/amd64/Dockerfile
@@ -12,16 +12,20 @@ ENV DOTNET_SDK_VERSION 2.2.100-preview3-009423
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='e9a7231759e844932fa114ab2749dcee101011e3426c70e00e38fb3fff28e9632d2106b217dc9670ba6c77b81522f5b7c19258ba8325f777fb5b4087df05a316' \
-    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
 
 # Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER=true \ 
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/alpine3.8/amd64/Dockerfile
+++ b/2.2/sdk/alpine3.8/amd64/Dockerfile
@@ -12,7 +12,7 @@ ENV DOTNET_SDK_VERSION 2.2.100-preview3-009428
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='47e36e567e841ccd9c1f4ef3ac40ef488a995f0e547dce8247786bfe63f3ad63465fcfbfd407c723d3a3e8a2d93fa84222fd34dacc3effb612beb837f39175e2' \
-    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \

--- a/2.2/sdk/bionic/amd64/Dockerfile
+++ b/2.2/sdk/bionic/amd64/Dockerfile
@@ -31,7 +31,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/bionic/arm32v7/Dockerfile
+++ b/2.2/sdk/bionic/arm32v7/Dockerfile
@@ -35,7 +35,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1709/amd64/Dockerfile
@@ -36,7 +36,9 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip `
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=C:/Users/Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1709/amd64/Dockerfile
@@ -38,7 +38,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # Set dotnet sdk home path
-    DOTNET_CLI_HOME=C:/Users/Public
+    DOTNET_CLI_HOME=C:\Users\Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1803/amd64/Dockerfile
@@ -36,7 +36,9 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip `
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=C:/Users/Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1803/amd64/Dockerfile
@@ -38,7 +38,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # Set dotnet sdk home path
-    DOTNET_CLI_HOME=C:/Users/Public
+    DOTNET_CLI_HOME=C:\Users\Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -28,7 +28,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # Set dotnet sdk home path
-    DOTNET_CLI_HOME=C:/Users/Public
+    DOTNET_CLI_HOME=C:\Users\Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -26,7 +26,9 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip `
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=C:/Users/Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/stretch/amd64/Dockerfile
+++ b/2.2/sdk/stretch/amd64/Dockerfile
@@ -32,7 +32,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/2.2/sdk/stretch/arm32v7/Dockerfile
+++ b/2.2/sdk/stretch/arm32v7/Dockerfile
@@ -35,7 +35,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/alpine3.8/amd64/Dockerfile
+++ b/3.0/sdk/alpine3.8/amd64/Dockerfile
@@ -21,7 +21,11 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DO
 # Enable correct mode for dotnet watch (only mode supported in a container)
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true \ 
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/bionic/amd64/Dockerfile
+++ b/3.0/sdk/bionic/amd64/Dockerfile
@@ -31,7 +31,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/bionic/arm32v7/Dockerfile
+++ b/3.0/sdk/bionic/arm32v7/Dockerfile
@@ -35,7 +35,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -36,7 +36,9 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip `
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=C:\Users\Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1803/amd64/Dockerfile
@@ -36,7 +36,9 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip `
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=C:\Users\Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -26,7 +26,9 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip `
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=C:\Users\Public
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/stretch/amd64/Dockerfile
+++ b/3.0/sdk/stretch/amd64/Dockerfile
@@ -32,7 +32,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/3.0/sdk/stretch/arm32v7/Dockerfile
+++ b/3.0/sdk/stretch/arm32v7/Dockerfile
@@ -35,7 +35,11 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Set dotnet sdk home path
+    DOTNET_CLI_HOME=/var/cache \
+    # Append dotnet global tools path to PATH
+    PATH=${PATH}:/var/cache/.dotnet/tools
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.globaltools
+++ b/tests/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.globaltools
@@ -1,0 +1,5 @@
+ARG base_image
+FROM $base_image
+
+# install dotnetsay global tool
+RUN dotnet tool install -g dotnetsay

--- a/tests/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.globaltools
+++ b/tests/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.globaltools
@@ -1,0 +1,9 @@
+ARG base_image
+FROM $base_image
+
+# Switch to cmd shell to have consistency since this Dockerfile is used across multiple
+# sdk versions which have different shells (due to nanoserver base image).
+SHELL ["cmd", "/S", "/C"]
+
+# install dotnetsay global tool
+RUN dotnet tool install -g dotnetsay


### PR DESCRIPTION
Fixes : https://github.com/dotnet/dotnet-docker/issues/520

This eliminates the step required by user to manually add dotnet global tool directory to PATH . 
