### PR TITLE
Build YAML formatting cleanup

### DIFF
--- a/.vsts-pipelines/builds/microsoft-dotnet-nightly.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-nightly.yml
@@ -2,9 +2,9 @@ trigger:
   batch: true
   branches:
     include:
-      - nightly
+    - nightly
 variables:
   manifest: manifest.json
   repo: dotnet-nightly
 jobs:
-  - template: ../jobs/build-all.yml
+- template: ../jobs/build-all.yml

--- a/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-samples.yml
@@ -3,4 +3,4 @@ variables:
   manifest: manifest.samples.json
   repo: dotnet-samples
 jobs:
-  - template: ../jobs/build-all.yml
+- template: ../jobs/build-all.yml

--- a/.vsts-pipelines/builds/microsoft-dotnet.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet.yml
@@ -3,4 +3,4 @@ variables:
   manifest: manifest.json
   repo: dotnet
 jobs:
-  - template: ../jobs/build-all.yml
+- template: ../jobs/build-all.yml

--- a/.vsts-pipelines/jobs/build-all.yml
+++ b/.vsts-pipelines/jobs/build-all.yml
@@ -2,122 +2,122 @@ jobs:
   ################################################################################
   # Initialization - Generate the VSTS build matrix
   ################################################################################
-  - job: GenerateMatrices
-    pool:
-      name: DotNet-Build
-      demands: agent.os -equals linux
-    workspace:
-      clean: all
-    steps:
-      - template: ../steps/init-docker-linux.yml
-      - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type build
-        name: buildMatrix
-      - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type test
-        name: testMatrix
-      - template: ../steps/cleanup-docker-linux.yml
+- job: GenerateMatrices
+  pool:
+    name: DotNet-Build
+    demands: agent.os -equals linux
+  workspace:
+    clean: all
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type build
+    name: buildMatrix
+  - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type test
+    name: testMatrix
+  - template: ../steps/cleanup-docker-linux.yml
 
   ################################################################################
   # Build Images
   ################################################################################
-  - template: build-images-linux-client.yml
-    parameters:
-      name: Build_Linux_amd64
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64'] ]
-  - template: build-images-linux-client.yml
-    parameters:
-      name: Build_Linux_arm32v7
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm32v7'] ]
-      useRemoteDockerServer: true
-      dockerServerDemands:
-        - RemoteDockerServerOS -equals linux
-        - RemoteDockerServerArch -equals arm32v7
-  - template: build-images-windows-client.yml
-    parameters:
-      name: Build_NanoServerSac2016_amd64
-      osVersion: nanoserver-sac2016
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserverSac2016Amd64'] ]
-  - template: build-images-windows-client.yml
-    parameters:
-      name: Build_NanoServer1709_amd64
-      osVersion: nanoserver-1709
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64'] ]
-  - template: build-images-windows-client.yml
-    parameters:
-      name: Build_NanoServer1803_amd64
-      osVersion: nanoserver-1803
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64'] ]
+- template: build-images-linux-client.yml
+  parameters:
+    name: Build_Linux_amd64
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64'] ]
+- template: build-images-linux-client.yml
+  parameters:
+    name: Build_Linux_arm32v7
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm32v7'] ]
+    useRemoteDockerServer: true
+    dockerServerDemands:
+    - RemoteDockerServerOS -equals linux
+    - RemoteDockerServerArch -equals arm32v7
+- template: build-images-windows-client.yml
+  parameters:
+    name: Build_NanoServerSac2016_amd64
+    osVersion: nanoserver-sac2016
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserverSac2016Amd64'] ]
+- template: build-images-windows-client.yml
+  parameters:
+    name: Build_NanoServer1709_amd64
+    osVersion: nanoserver-1709
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64'] ]
+- template: build-images-windows-client.yml
+  parameters:
+    name: Build_NanoServer1803_amd64
+    osVersion: nanoserver-1803
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64'] ]
 
   ################################################################################
   # Test Images
   ################################################################################
-  - template: test-images-linux-client.yml
-    parameters:
-      name: Test_Linux_amd64
-      buildDependencies: Build_Linux_amd64
-      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxAmd64'] ]
-      architecture: amd64
-  - template: test-images-linux-client.yml
-    parameters:
-      name: Test_Linux_arm32v7
-      buildDependencies: Build_Linux_arm32v7
-      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxArm32v7'] ]
-      useRemoteDockerServer: true
-      dockerServerDemands:
-        - RemoteDockerServerOS -equals linux
-        - RemoteDockerServerArch -equals arm32v7
-      architecture: arm
-  - template: test-images-windows-client.yml
-    parameters:
-      name: Test_NanoServerSac2016_amd64
-      buildDependencies: Build_NanoServerSac2016_amd64
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserverSac2016Amd64'] ]
-  - template: test-images-windows-client.yml
-    parameters:
-      name: Test_NanoServer1709_amd64
-      buildDependencies: Build_NanoServer1709_amd64
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1709Amd64'] ]
-  - template: test-images-windows-client.yml
-    parameters:
-      name: Test_NanoServer1803_amd64
-      buildDependencies: Build_NanoServer1803_amd64
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-      matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1803Amd64'] ]
+- template: test-images-linux-client.yml
+  parameters:
+    name: Test_Linux_amd64
+    buildDependencies: Build_Linux_amd64
+    matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxAmd64'] ]
+    architecture: amd64
+- template: test-images-linux-client.yml
+  parameters:
+    name: Test_Linux_arm32v7
+    buildDependencies: Build_Linux_arm32v7
+    matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxArm32v7'] ]
+    useRemoteDockerServer: true
+    dockerServerDemands:
+    - RemoteDockerServerOS -equals linux
+    - RemoteDockerServerArch -equals arm32v7
+    architecture: arm
+- template: test-images-windows-client.yml
+  parameters:
+    name: Test_NanoServerSac2016_amd64
+    buildDependencies: Build_NanoServerSac2016_amd64
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+    matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserverSac2016Amd64'] ]
+- template: test-images-windows-client.yml
+  parameters:
+    name: Test_NanoServer1709_amd64
+    buildDependencies: Build_NanoServer1709_amd64
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
+    matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1709Amd64'] ]
+- template: test-images-windows-client.yml
+  parameters:
+    name: Test_NanoServer1803_amd64
+    buildDependencies: Build_NanoServer1803_amd64
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
+    matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1803Amd64'] ]
 
   ################################################################################
   # Publish Images
   ################################################################################
-  - template: copy-images-linux.yml
-    parameters:
-      name: Copy_Images_Linux_amd64
-      architecture: amd64
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64'] ]
-  - template: copy-images-linux.yml
-    parameters:
-      name: Copy_Images_Linux_arm32v7
-      architecture: arm
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm32v7'] ]
-  - template: copy-images-windows.yml
-    parameters:
-      name: Copy_Images_NanoServerSac2016_amd64
-      osVersion: nanoserver-sac2016
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserverSac2016Amd64'] ]
-  - template: copy-images-windows.yml
-    parameters:
-      name: Copy_Images_NanoServer1709_amd64
-      osVersion: nanoserver-1709
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64'] ]
-  - template: copy-images-windows.yml
-    parameters:
-      name: Copy_Images_NanoServer1803_amd64
-      osVersion: nanoserver-1803
-      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-      matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64'] ]
+- template: copy-images-linux.yml
+  parameters:
+    name: Copy_Images_Linux_amd64
+    architecture: amd64
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64'] ]
+- template: copy-images-linux.yml
+  parameters:
+    name: Copy_Images_Linux_arm32v7
+    architecture: arm
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm32v7'] ]
+- template: copy-images-windows.yml
+  parameters:
+    name: Copy_Images_NanoServerSac2016_amd64
+    osVersion: nanoserver-sac2016
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserverSac2016Amd64'] ]
+- template: copy-images-windows.yml
+  parameters:
+    name: Copy_Images_NanoServer1709_amd64
+    osVersion: nanoserver-1709
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64'] ]
+- template: copy-images-windows.yml
+  parameters:
+    name: Copy_Images_NanoServer1803_amd64
+    osVersion: nanoserver-1803
+    demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64'] ]
 
-  - template: publish-finalize.yml
+- template: publish-finalize.yml

--- a/.vsts-pipelines/jobs/build-images-linux-client.yml
+++ b/.vsts-pipelines/jobs/build-images-linux-client.yml
@@ -4,37 +4,37 @@ parameters:
   dockerServerDemands: []
   useRemoteDockerServer: false
 jobs:
-  - job: ${{ parameters.name }}
-    condition: or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'build'))
-    dependsOn: GenerateMatrices
-    pool:
-      ${{ if eq(parameters.useRemoteDockerServer, 'false') }}:
-        name: DotNet-Build
-      ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
-        name: DotNetCore-Infra
-      demands:
-        - agent.os -equals linux
-        - ${{ parameters.dockerServerDemands }}
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    workspace:
-      clean: all
-    steps:
-      - template: ../steps/init-docker-linux.yml
-        parameters:
-          setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
-      - script: >
-          $(runImageBuilderCmd) build
-          --manifest $(manifest)
-          $(imageBuilderPaths)
-          --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix)
-          --skip-test
-          --push
-          --server $(acr.server)
-          --username $(acr.userName)
-          --password $(BotAccount-dotnet-docker-acr-bot-password)
-          $(imageBuilder.queueArgs)
-        displayName: Build Images
-      - template: ../steps/cleanup-docker-linux.yml
-        parameters:
-          cleanupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
+- job: ${{ parameters.name }}
+  condition: or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'build'))
+  dependsOn: GenerateMatrices
+  pool:
+    ${{ if eq(parameters.useRemoteDockerServer, 'false') }}:
+      name: DotNet-Build
+    ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
+      name: DotNetCore-Infra
+    demands:
+    - agent.os -equals linux
+    - ${{ parameters.dockerServerDemands }}
+  strategy:
+    matrix: ${{ parameters.matrix }}
+  workspace:
+    clean: all
+  steps:
+  - template: ../steps/init-docker-linux.yml
+    parameters:
+      setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
+  - script: >
+      $(runImageBuilderCmd) build
+      --manifest $(manifest)
+      $(imageBuilderPaths)
+      --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix)
+      --skip-test
+      --push
+      --server $(acr.server)
+      --username $(acr.userName)
+      --password $(BotAccount-dotnet-docker-acr-bot-password)
+      $(imageBuilder.queueArgs)
+    displayName: Build Images
+  - template: ../steps/cleanup-docker-linux.yml
+    parameters:
+      cleanupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}

--- a/.vsts-pipelines/jobs/build-images-linux-client.yml
+++ b/.vsts-pipelines/jobs/build-images-linux-client.yml
@@ -23,7 +23,17 @@ jobs:
       - template: ../steps/init-docker-linux.yml
         parameters:
           setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
-      - script: $(runImageBuilderCmd) build --manifest $(manifest) $(imageBuilderPaths) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: >
+          $(runImageBuilderCmd) build
+          --manifest $(manifest)
+          $(imageBuilderPaths)
+          --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix)
+          --skip-test
+          --push
+          --server $(acr.server)
+          --username $(acr.userName)
+          --password $(BotAccount-dotnet-docker-acr-bot-password)
+          $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/cleanup-docker-linux.yml
         parameters:

--- a/.vsts-pipelines/jobs/build-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/build-images-windows-client.yml
@@ -18,6 +18,17 @@ jobs:
       osVersion: ${{ parameters.osVersion }}
     steps:
       - template: ../steps/init-docker-windows.yml
-      - script: $(runImageBuilderCmd) build --manifest $(manifest) --os-version $(osVersion) --skip-test $(imageBuilderPaths) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: >
+          $(runImageBuilderCmd) build
+          --manifest $(manifest)
+          $(imageBuilderPaths)
+          --os-version $(osVersion)
+          --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix)
+          --skip-test
+          --push
+          --server $(acr.server)
+          --username $(acr.userName)
+          --password $(BotAccount-dotnet-docker-acr-bot-password)
+          $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/cleanup-docker-windows.yml

--- a/.vsts-pipelines/jobs/build-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/build-images-windows-client.yml
@@ -4,31 +4,31 @@ parameters:
   demands: []
   matrix: {}
 jobs:
-  - job: ${{ parameters.name }}
-    condition: or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'build'))
-    dependsOn: GenerateMatrices
-    pool:
-      name: DotNetCore-Infra
-      demands: ${{ parameters.demands }}
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    workspace:
-      clean: all
-    variables:
-      osVersion: ${{ parameters.osVersion }}
-    steps:
-      - template: ../steps/init-docker-windows.yml
-      - script: >
-          $(runImageBuilderCmd) build
-          --manifest $(manifest)
-          $(imageBuilderPaths)
-          --os-version $(osVersion)
-          --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix)
-          --skip-test
-          --push
-          --server $(acr.server)
-          --username $(acr.userName)
-          --password $(BotAccount-dotnet-docker-acr-bot-password)
-          $(imageBuilder.queueArgs)
-        displayName: Build Images
-      - template: ../steps/cleanup-docker-windows.yml
+- job: ${{ parameters.name }}
+  condition: or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'build'))
+  dependsOn: GenerateMatrices
+  pool:
+    name: DotNetCore-Infra
+    demands: ${{ parameters.demands }}
+  strategy:
+    matrix: ${{ parameters.matrix }}
+  workspace:
+    clean: all
+  variables:
+    osVersion: ${{ parameters.osVersion }}
+  steps:
+  - template: ../steps/init-docker-windows.yml
+  - script: >
+      $(runImageBuilderCmd) build
+      --manifest $(manifest)
+      $(imageBuilderPaths)
+      --os-version $(osVersion)
+      --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix)
+      --skip-test
+      --push
+      --server $(acr.server)
+      --username $(acr.userName)
+      --password $(BotAccount-dotnet-docker-acr-bot-password)
+      $(imageBuilder.queueArgs)
+    displayName: Build Images
+  - template: ../steps/cleanup-docker-windows.yml

--- a/.vsts-pipelines/jobs/copy-images-linux.yml
+++ b/.vsts-pipelines/jobs/copy-images-linux.yml
@@ -3,52 +3,52 @@ parameters:
   architecture: null
   matrix: {}
 jobs:
-  - job: ${{ parameters.name }}
-    condition: "
-      or(
-        eq(variables['singlePhase'], 'publish'),
-        and(
-          eq(variables['singlePhase'], ''),
-          or(
-            succeeded(),
-            and(
-              eq(variables['repo'], 'dotnet-samples'),
-              eq(variables['singlePhase'], ''),
-              succeeded('Build_Linux_amd64'),
-              succeeded('Build_Linux_arm32v7'),
-              succeeded('Build_NanoServerSac2016_amd64'),
-              succeeded('Build_NanoServer1709_amd64'),
-              succeeded('Build_NanoServer1803_amd64')))))"
-    dependsOn:
-      - GenerateMatrices
-      - Test_Linux_amd64
-      - Test_Linux_arm32v7
-      - Test_NanoServerSac2016_amd64
-      - Test_NanoServer1709_amd64
-      - Test_NanoServer1803_amd64
-    pool:
-      name: DotNet-Build
-      demands: agent.os -equals linux
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    workspace:
-      clean: all
-    variables:
-      architecture: ${{ parameters.architecture }}
-    steps:
-      - template: ../steps/init-docker-linux.yml
-      - script: >
-          $(runImageBuilderCmd) copyImages
-          --manifest $(manifest)
-          $(imageBuilderPaths)
-          --architecture $(architecture)
-          --source-server $(acr.server)
-          --source-username $(acr.userName)
-          --source-password $(BotAccount-dotnet-docker-acr-bot-password)
-          --destination-username $(dockerRegistry.userName)
-          --destination-password $(BotAccount-dotnet-dockerhub-bot-password)
-          $(imageBuilder.queueArgs)
-          $(imageBuilder.publishQueueArgs)
-          $(acr.server)/$(repo)-$(stagingRepo.suffix)
-        displayName: Copy Images
-      - template: ../steps/cleanup-docker-linux.yml
+- job: ${{ parameters.name }}
+  condition: "
+    or(
+      eq(variables['singlePhase'], 'publish'),
+      and(
+        eq(variables['singlePhase'], ''),
+        or(
+          succeeded(),
+          and(
+            eq(variables['repo'], 'dotnet-samples'),
+            eq(variables['singlePhase'], ''),
+            succeeded('Build_Linux_amd64'),
+            succeeded('Build_Linux_arm32v7'),
+            succeeded('Build_NanoServerSac2016_amd64'),
+            succeeded('Build_NanoServer1709_amd64'),
+            succeeded('Build_NanoServer1803_amd64')))))"
+  dependsOn:
+  - GenerateMatrices
+  - Test_Linux_amd64
+  - Test_Linux_arm32v7
+  - Test_NanoServerSac2016_amd64
+  - Test_NanoServer1709_amd64
+  - Test_NanoServer1803_amd64
+  pool:
+    name: DotNet-Build
+    demands: agent.os -equals linux
+  strategy:
+    matrix: ${{ parameters.matrix }}
+  workspace:
+    clean: all
+  variables:
+    architecture: ${{ parameters.architecture }}
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - script: >
+      $(runImageBuilderCmd) copyImages
+      --manifest $(manifest)
+      $(imageBuilderPaths)
+      --architecture $(architecture)
+      --source-server $(acr.server)
+      --source-username $(acr.userName)
+      --source-password $(BotAccount-dotnet-docker-acr-bot-password)
+      --destination-username $(dockerRegistry.userName)
+      --destination-password $(BotAccount-dotnet-dockerhub-bot-password)
+      $(imageBuilder.queueArgs)
+      $(imageBuilder.publishQueueArgs)
+      $(acr.server)/$(repo)-$(stagingRepo.suffix)
+    displayName: Copy Images
+  - template: ../steps/cleanup-docker-linux.yml

--- a/.vsts-pipelines/jobs/copy-images-linux.yml
+++ b/.vsts-pipelines/jobs/copy-images-linux.yml
@@ -4,7 +4,21 @@ parameters:
   matrix: {}
 jobs:
   - job: ${{ parameters.name }}
-    condition: or(eq(variables['singlePhase'], 'publish'), and(eq(variables['singlePhase'], ''), or(succeeded(), and(eq(variables['repo'], 'dotnet-samples'), eq(variables['singlePhase'], ''), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))))
+    condition: "
+      or(
+        eq(variables['singlePhase'], 'publish'),
+        and(
+          eq(variables['singlePhase'], ''),
+          or(
+            succeeded(),
+            and(
+              eq(variables['repo'], 'dotnet-samples'),
+              eq(variables['singlePhase'], ''),
+              succeeded('Build_Linux_amd64'),
+              succeeded('Build_Linux_arm32v7'),
+              succeeded('Build_NanoServerSac2016_amd64'),
+              succeeded('Build_NanoServer1709_amd64'),
+              succeeded('Build_NanoServer1803_amd64')))))"
     dependsOn:
       - GenerateMatrices
       - Test_Linux_amd64
@@ -23,6 +37,18 @@ jobs:
       architecture: ${{ parameters.architecture }}
     steps:
       - template: ../steps/init-docker-linux.yml
-      - script: $(runImageBuilderCmd) copyImages --manifest $(manifest) --architecture $(architecture) $(imageBuilderPaths) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: >
+          $(runImageBuilderCmd) copyImages
+          --manifest $(manifest)
+          $(imageBuilderPaths)
+          --architecture $(architecture)
+          --source-server $(acr.server)
+          --source-username $(acr.userName)
+          --source-password $(BotAccount-dotnet-docker-acr-bot-password)
+          --destination-username $(dockerRegistry.userName)
+          --destination-password $(BotAccount-dotnet-dockerhub-bot-password)
+          $(imageBuilder.queueArgs)
+          $(imageBuilder.publishQueueArgs)
+          $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/cleanup-docker-linux.yml

--- a/.vsts-pipelines/jobs/copy-images-windows.yml
+++ b/.vsts-pipelines/jobs/copy-images-windows.yml
@@ -5,7 +5,21 @@ parameters:
   matrix: {}
 jobs:
   - job: ${{ parameters.name }}
-    condition: or(eq(variables['singlePhase'], 'publish'), and(eq(variables['singlePhase'], ''), or(succeeded(), and(eq(variables['repo'], 'dotnet-samples'), eq(variables['singlePhase'], ''), succeeded('Build_Linux_amd64'), succeeded('Build_Linux_arm32v7'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))))
+    condition: "
+      or(
+        eq(variables['singlePhase'], 'publish'),
+        and(
+          eq(variables['singlePhase'], ''),
+          or(
+            succeeded(),
+            and(
+              eq(variables['repo'], 'dotnet-samples'),
+              eq(variables['singlePhase'], ''),
+              succeeded('Build_Linux_amd64'),
+              succeeded('Build_Linux_arm32v7'),
+              succeeded('Build_NanoServerSac2016_amd64'),
+              succeeded('Build_NanoServer1709_amd64'),
+              succeeded('Build_NanoServer1803_amd64')))))"
     dependsOn:
       - GenerateMatrices
       - Test_Linux_amd64
@@ -24,6 +38,18 @@ jobs:
       osVersion: ${{ parameters.osVersion }}
     steps:
       - template: ../steps/init-docker-windows.yml
-      - script: $(runImageBuilderCmd) copyImages --manifest $(manifest) --os-version $(osVersion) $(imageBuilderPaths) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: >
+          $(runImageBuilderCmd) copyImages
+          --manifest $(manifest)
+          $(imageBuilderPaths)
+          --os-version $(osVersion)
+          --source-server $(acr.server)
+          --source-username $(acr.userName)
+          --source-password $(BotAccount-dotnet-docker-acr-bot-password)
+          --destination-username $(dockerRegistry.userName)
+          --destination-password $(BotAccount-dotnet-dockerhub-bot-password)
+          $(imageBuilder.queueArgs)
+          $(imageBuilder.publishQueueArgs)
+          $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/cleanup-docker-windows.yml

--- a/.vsts-pipelines/jobs/copy-images-windows.yml
+++ b/.vsts-pipelines/jobs/copy-images-windows.yml
@@ -4,52 +4,52 @@ parameters:
   demands: []
   matrix: {}
 jobs:
-  - job: ${{ parameters.name }}
-    condition: "
-      or(
-        eq(variables['singlePhase'], 'publish'),
-        and(
-          eq(variables['singlePhase'], ''),
-          or(
-            succeeded(),
-            and(
-              eq(variables['repo'], 'dotnet-samples'),
-              eq(variables['singlePhase'], ''),
-              succeeded('Build_Linux_amd64'),
-              succeeded('Build_Linux_arm32v7'),
-              succeeded('Build_NanoServerSac2016_amd64'),
-              succeeded('Build_NanoServer1709_amd64'),
-              succeeded('Build_NanoServer1803_amd64')))))"
-    dependsOn:
-      - GenerateMatrices
-      - Test_Linux_amd64
-      - Test_Linux_arm32v7
-      - Test_NanoServerSac2016_amd64
-      - Test_NanoServer1709_amd64
-      - Test_NanoServer1803_amd64
-    pool:
-      name: DotNetCore-Infra
-      demands: ${{ parameters.demands }}
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    workspace:
-      clean: all
-    variables:
-      osVersion: ${{ parameters.osVersion }}
-    steps:
-      - template: ../steps/init-docker-windows.yml
-      - script: >
-          $(runImageBuilderCmd) copyImages
-          --manifest $(manifest)
-          $(imageBuilderPaths)
-          --os-version $(osVersion)
-          --source-server $(acr.server)
-          --source-username $(acr.userName)
-          --source-password $(BotAccount-dotnet-docker-acr-bot-password)
-          --destination-username $(dockerRegistry.userName)
-          --destination-password $(BotAccount-dotnet-dockerhub-bot-password)
-          $(imageBuilder.queueArgs)
-          $(imageBuilder.publishQueueArgs)
-          $(acr.server)/$(repo)-$(stagingRepo.suffix)
-        displayName: Copy Images
-      - template: ../steps/cleanup-docker-windows.yml
+- job: ${{ parameters.name }}
+  condition: "
+    or(
+      eq(variables['singlePhase'], 'publish'),
+      and(
+        eq(variables['singlePhase'], ''),
+        or(
+          succeeded(),
+          and(
+            eq(variables['repo'], 'dotnet-samples'),
+            eq(variables['singlePhase'], ''),
+            succeeded('Build_Linux_amd64'),
+            succeeded('Build_Linux_arm32v7'),
+            succeeded('Build_NanoServerSac2016_amd64'),
+            succeeded('Build_NanoServer1709_amd64'),
+            succeeded('Build_NanoServer1803_amd64')))))"
+  dependsOn:
+  - GenerateMatrices
+  - Test_Linux_amd64
+  - Test_Linux_arm32v7
+  - Test_NanoServerSac2016_amd64
+  - Test_NanoServer1709_amd64
+  - Test_NanoServer1803_amd64
+  pool:
+    name: DotNetCore-Infra
+    demands: ${{ parameters.demands }}
+  strategy:
+    matrix: ${{ parameters.matrix }}
+  workspace:
+    clean: all
+  variables:
+    osVersion: ${{ parameters.osVersion }}
+  steps:
+  - template: ../steps/init-docker-windows.yml
+  - script: >
+      $(runImageBuilderCmd) copyImages
+      --manifest $(manifest)
+      $(imageBuilderPaths)
+      --os-version $(osVersion)
+      --source-server $(acr.server)
+      --source-username $(acr.userName)
+      --source-password $(BotAccount-dotnet-docker-acr-bot-password)
+      --destination-username $(dockerRegistry.userName)
+      --destination-password $(BotAccount-dotnet-dockerhub-bot-password)
+      $(imageBuilder.queueArgs)
+      $(imageBuilder.publishQueueArgs)
+      $(acr.server)/$(repo)-$(stagingRepo.suffix)
+    displayName: Copy Images
+  - template: ../steps/cleanup-docker-windows.yml

--- a/.vsts-pipelines/jobs/publish-finalize.yml
+++ b/.vsts-pipelines/jobs/publish-finalize.yml
@@ -1,34 +1,34 @@
 jobs:
-  - job: Publish_Finalize
-    condition: "
-      and(
-        succeeded('Copy_Images_Linux_amd64'),
-        succeeded('Copy_Images_Linux_arm32v7'),
-        succeeded('Copy_Images_NanoServerSac2016_amd64'),
-        succeeded('Copy_Images_NanoServer1709_amd64'),
-        succeeded('Copy_Images_NanoServer1803_amd64'))"
-    dependsOn:
-      - Copy_Images_Linux_amd64
-      - Copy_Images_Linux_arm32v7
-      - Copy_Images_NanoServerSac2016_amd64
-      - Copy_Images_NanoServer1709_amd64
-      - Copy_Images_NanoServer1803_amd64
-    pool:
-      name: DotNet-Build
-      demands: agent.os -equals linux
-    workspace:
-      clean: all
-    variables:
-      imageBuilder.commonCmdArgs: >
-        --manifest $(manifest)
-        --username $(dockerRegistry.userName)
-        --password $(BotAccount-dotnet-dockerhub-bot-password)
-        $(imageBuilder.queueArgs)
-        $(imageBuilder.publishQueueArgs)
-    steps:
-      - template: ../steps/init-docker-linux.yml
-      - script: $(runImageBuilderCmd) publishManifest $(imageBuilder.commonCmdArgs)
-        displayName: Publish Manifest
-      - script: $(runImageBuilderCmd) updateReadme $(imageBuilder.commonCmdArgs)
-        displayName: Update Readme
-      - template: ../steps/cleanup-docker-linux.yml
+- job: Publish_Finalize
+  condition: "
+    and(
+      succeeded('Copy_Images_Linux_amd64'),
+      succeeded('Copy_Images_Linux_arm32v7'),
+      succeeded('Copy_Images_NanoServerSac2016_amd64'),
+      succeeded('Copy_Images_NanoServer1709_amd64'),
+      succeeded('Copy_Images_NanoServer1803_amd64'))"
+  dependsOn:
+  - Copy_Images_Linux_amd64
+  - Copy_Images_Linux_arm32v7
+  - Copy_Images_NanoServerSac2016_amd64
+  - Copy_Images_NanoServer1709_amd64
+  - Copy_Images_NanoServer1803_amd64
+  pool:
+    name: DotNet-Build
+    demands: agent.os -equals linux
+  workspace:
+    clean: all
+  variables:
+    imageBuilder.commonCmdArgs: >
+      --manifest $(manifest)
+      --username $(dockerRegistry.userName)
+      --password $(BotAccount-dotnet-dockerhub-bot-password)
+      $(imageBuilder.queueArgs)
+      $(imageBuilder.publishQueueArgs)
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - script: $(runImageBuilderCmd) publishManifest $(imageBuilder.commonCmdArgs)
+    displayName: Publish Manifest
+  - script: $(runImageBuilderCmd) updateReadme $(imageBuilder.commonCmdArgs)
+    displayName: Update Readme
+  - template: ../steps/cleanup-docker-linux.yml

--- a/.vsts-pipelines/jobs/publish-finalize.yml
+++ b/.vsts-pipelines/jobs/publish-finalize.yml
@@ -1,6 +1,12 @@
 jobs:
   - job: Publish_Finalize
-    condition: and(succeeded('Copy_Images_Linux_amd64'), succeeded('Copy_Images_Linux_arm32v7'), succeeded('Copy_Images_NanoServerSac2016_amd64'), succeeded('Copy_Images_NanoServer1709_amd64'), succeeded('Copy_Images_NanoServer1803_amd64'))
+    condition: "
+      and(
+        succeeded('Copy_Images_Linux_amd64'),
+        succeeded('Copy_Images_Linux_arm32v7'),
+        succeeded('Copy_Images_NanoServerSac2016_amd64'),
+        succeeded('Copy_Images_NanoServer1709_amd64'),
+        succeeded('Copy_Images_NanoServer1803_amd64'))"
     dependsOn:
       - Copy_Images_Linux_amd64
       - Copy_Images_Linux_arm32v7
@@ -13,7 +19,12 @@ jobs:
     workspace:
       clean: all
     variables:
-      imageBuilder.commonCmdArgs: --manifest $(manifest) --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs)
+      imageBuilder.commonCmdArgs: >
+        --manifest $(manifest)
+        --username $(dockerRegistry.userName)
+        --password $(BotAccount-dotnet-dockerhub-bot-password)
+        $(imageBuilder.queueArgs)
+        $(imageBuilder.publishQueueArgs)
     steps:
       - template: ../steps/init-docker-linux.yml
       - script: $(runImageBuilderCmd) publishManifest $(imageBuilder.commonCmdArgs)

--- a/.vsts-pipelines/jobs/test-images-linux-client.yml
+++ b/.vsts-pipelines/jobs/test-images-linux-client.yml
@@ -7,7 +7,14 @@ parameters:
   architecture: null
 jobs:
   - job: ${{ parameters.name }}
-    condition: and(ne(variables['repo'], 'dotnet-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
+    condition: "
+      and(
+        ne(variables['repo'], 'dotnet-samples'),
+        or(
+          and(
+            succeeded(),
+            eq(variables['singlePhase'], '')),
+          eq(variables['singlePhase'], 'test')))"
     dependsOn:
       - GenerateMatrices
       - ${{ parameters.buildDependencies }}
@@ -36,17 +43,36 @@ jobs:
           setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
           setupImageBuilder: false
           setupTestRunner: true
-      - script: docker run -t -d -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(dockerArmRunArgs) -e RUNNING_TESTS_IN_CONTAINER=true --name $(testRunner.container) $(testrunner.image)
+      - script: >
+          docker run -t -d
+          -v /var/run/docker.sock:/var/run/docker.sock
+          -v $(repoVolume):/repo
+          -w /repo $(dockerArmRunArgs)
+          -e RUNNING_TESTS_IN_CONTAINER=true 
+          --name $(testRunner.container)
+          $(testrunner.image)
         displayName: Start Test Runner Container
-      - script: docker exec $(testRunner.container) docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+      - script: >
+          docker exec $(testRunner.container)
+          docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-      - script: docker exec $(testRunner.container) pwsh -File ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion)* -OSFilter $(osVersion)* -ArchitectureFilter $(architecture) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix) $(optionalTestArgs)
+      - script: >
+          docker exec $(testRunner.container) pwsh
+          -File ./tests/run-tests.ps1
+          -VersionFilter $(dotnetVersion)*
+          -OSFilter $(osVersion)*
+          -ArchitectureFilter $(architecture)
+          -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+          $(optionalTestArgs)
         displayName: Test Images
       - script: docker exec $(testRunner.container) docker logout
         displayName: Docker logout
         condition: always()
         continueOnError: true
-      - script: docker cp $(testRunner.container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/ $(Common.TestResultsDirectory)/.
+      - script: >
+          docker cp
+          $(testRunner.container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/
+          $(Common.TestResultsDirectory)/.
         displayName: Copy Test Results
         condition: always()
         continueOnError: true

--- a/.vsts-pipelines/jobs/test-images-linux-client.yml
+++ b/.vsts-pipelines/jobs/test-images-linux-client.yml
@@ -6,91 +6,91 @@ parameters:
   useRemoteDockerServer: false
   architecture: null
 jobs:
-  - job: ${{ parameters.name }}
-    condition: "
-      and(
-        ne(variables['repo'], 'dotnet-samples'),
-        or(
-          and(
-            succeeded(),
-            eq(variables['singlePhase'], '')),
-          eq(variables['singlePhase'], 'test')))"
-    dependsOn:
-      - GenerateMatrices
-      - ${{ parameters.buildDependencies }}
-    pool:
-      ${{ if eq(parameters.useRemoteDockerServer, 'false') }}:
-        name: DotNet-Build
-      ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
-        name: DotNetCore-Infra
-      demands:
-        - agent.os -equals linux
-        - ${{ parameters.dockerServerDemands }}
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    workspace:
-      clean: all
-    variables:
-      testRunner.container: testrunner-$(Build.BuildId)-$(System.JobId)
-      architecture: ${{ parameters.architecture }}
-      ${{ if eq(parameters.useRemoteDockerServer, 'false') }}:
-        optionalTestArgs: ''
-      ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
-        optionalTestArgs: -DisableHttpVerification
-    steps:
-      - template: ../steps/init-docker-linux.yml
-        parameters:
-          setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
-          setupImageBuilder: false
-          setupTestRunner: true
-      - script: >
-          docker run -t -d
-          -v /var/run/docker.sock:/var/run/docker.sock
-          -v $(repoVolume):/repo
-          -w /repo $(dockerArmRunArgs)
-          -e RUNNING_TESTS_IN_CONTAINER=true 
-          --name $(testRunner.container)
-          $(testrunner.image)
-        displayName: Start Test Runner Container
-      - script: >
-          docker exec $(testRunner.container)
-          docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
-        displayName: Docker login
-      - script: >
-          docker exec $(testRunner.container) pwsh
-          -File ./tests/run-tests.ps1
-          -VersionFilter $(dotnetVersion)*
-          -OSFilter $(osVersion)*
-          -ArchitectureFilter $(architecture)
-          -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
-          $(optionalTestArgs)
-        displayName: Test Images
-      - script: docker exec $(testRunner.container) docker logout
-        displayName: Docker logout
-        condition: always()
-        continueOnError: true
-      - script: >
-          docker cp
-          $(testRunner.container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/
-          $(Common.TestResultsDirectory)/.
-        displayName: Copy Test Results
-        condition: always()
-        continueOnError: true
-      - task: PublishTestResults@2
-        displayName: Publish Test Results
-        condition: always()
-        continueOnError: true
-        inputs:
-          testRunner: vSTest
-          testResultsFiles: '**/*.trx'
-          searchFolder: $(Common.TestResultsDirectory)
-          mergeTestResults: true
-          publishRunAttachments: true
-          testRunTitle: Linux $(dotnetVersion) $(osVersion) $(architecture)
-      - script: docker stop $(testRunner.container)
-        displayName: Stop TestRunner Container
-        condition: always()
-        continueOnError: true
-      - template: ../steps/cleanup-docker-linux.yml
-        parameters:
-          cleanupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
+- job: ${{ parameters.name }}
+  condition: "
+    and(
+      ne(variables['repo'], 'dotnet-samples'),
+      or(
+        and(
+          succeeded(),
+          eq(variables['singlePhase'], '')),
+        eq(variables['singlePhase'], 'test')))"
+  dependsOn:
+  - GenerateMatrices
+  - ${{ parameters.buildDependencies }}
+  pool:
+    ${{ if eq(parameters.useRemoteDockerServer, 'false') }}:
+      name: DotNet-Build
+    ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
+      name: DotNetCore-Infra
+    demands:
+    - agent.os -equals linux
+    - ${{ parameters.dockerServerDemands }}
+  strategy:
+    matrix: ${{ parameters.matrix }}
+  workspace:
+    clean: all
+  variables:
+    testRunner.container: testrunner-$(Build.BuildId)-$(System.JobId)
+    architecture: ${{ parameters.architecture }}
+    ${{ if eq(parameters.useRemoteDockerServer, 'false') }}:
+      optionalTestArgs: ''
+    ${{ if eq(parameters.useRemoteDockerServer, 'true') }}:
+      optionalTestArgs: -DisableHttpVerification
+  steps:
+  - template: ../steps/init-docker-linux.yml
+    parameters:
+      setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
+      setupImageBuilder: false
+      setupTestRunner: true
+  - script: >
+      docker run -t -d
+      -v /var/run/docker.sock:/var/run/docker.sock
+      -v $(repoVolume):/repo
+      -w /repo $(dockerArmRunArgs)
+      -e RUNNING_TESTS_IN_CONTAINER=true 
+      --name $(testRunner.container)
+      $(testrunner.image)
+    displayName: Start Test Runner Container
+  - script: >
+      docker exec $(testRunner.container)
+      docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+    displayName: Docker login
+  - script: >
+      docker exec $(testRunner.container) pwsh
+      -File ./tests/run-tests.ps1
+      -VersionFilter $(dotnetVersion)*
+      -OSFilter $(osVersion)*
+      -ArchitectureFilter $(architecture)
+      -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      $(optionalTestArgs)
+    displayName: Test Images
+  - script: docker exec $(testRunner.container) docker logout
+    displayName: Docker logout
+    condition: always()
+    continueOnError: true
+  - script: >
+      docker cp
+      $(testRunner.container):/repo/tests/Microsoft.DotNet.Docker.Tests/TestResults/
+      $(Common.TestResultsDirectory)/.
+    displayName: Copy Test Results
+    condition: always()
+    continueOnError: true
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    condition: always()
+    continueOnError: true
+    inputs:
+      testRunner: vSTest
+      testResultsFiles: '**/*.trx'
+      searchFolder: $(Common.TestResultsDirectory)
+      mergeTestResults: true
+      publishRunAttachments: true
+      testRunTitle: Linux $(dotnetVersion) $(osVersion) $(architecture)
+  - script: docker stop $(testRunner.container)
+    displayName: Stop TestRunner Container
+    condition: always()
+    continueOnError: true
+  - template: ../steps/cleanup-docker-linux.yml
+    parameters:
+      cleanupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}

--- a/.vsts-pipelines/jobs/test-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/test-images-windows-client.yml
@@ -5,49 +5,49 @@ parameters:
   demands: []
   matrix: {}
 jobs:
-  - job: ${{ parameters.name }}
-    condition: "
-      and(
-        ne(variables['repo'], 'dotnet-samples'),
-        or(
-          and(
-            succeeded(),
-            eq(variables['singlePhase'], '')),
-          eq(variables['singlePhase'], 'test')))"
-    dependsOn:
-      - GenerateMatrices
-      - ${{ parameters.buildDependencies }}
-    pool:
-      name: DotNetCore-Infra
-      demands: ${{ parameters.demands }}
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    workspace:
-      clean: all
-    steps:
-      - template: ../steps/init-docker-windows.yml
-        parameters:
-          setupImageBuilder: false
-      - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
-        displayName: Docker login
-      - powershell: >
-          ./tests/run-tests.ps1
-          -VersionFilter $(dotnetVersion)*
-          -OSFilter $(osVersion)
-          -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
-        displayName: Test Images
-      - script: docker logout
-        displayName: Docker logout
-        condition: always()
-        continueOnError: true
-      - task: PublishTestResults@2
-        displayName: Publish Test Results
-        condition: always()
-        continueOnError: true
-        inputs:
-          testRunner: vSTest
-          testResultsFiles: 'tests/**/*.trx'
-          mergeTestResults: true
-          publishRunAttachments: true
-          testRunTitle: Windows $(dotnetVersion) $(osVersion) amd64
-      - template: ../steps/cleanup-docker-windows.yml
+- job: ${{ parameters.name }}
+  condition: "
+    and(
+      ne(variables['repo'], 'dotnet-samples'),
+      or(
+        and(
+          succeeded(),
+          eq(variables['singlePhase'], '')),
+        eq(variables['singlePhase'], 'test')))"
+  dependsOn:
+    - GenerateMatrices
+    - ${{ parameters.buildDependencies }}
+  pool:
+    name: DotNetCore-Infra
+    demands: ${{ parameters.demands }}
+  strategy:
+    matrix: ${{ parameters.matrix }}
+  workspace:
+    clean: all
+  steps:
+  - template: ../steps/init-docker-windows.yml
+    parameters:
+      setupImageBuilder: false
+  - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+    displayName: Docker login
+  - powershell: >
+      ./tests/run-tests.ps1
+      -VersionFilter $(dotnetVersion)*
+      -OSFilter $(osVersion)
+      -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+    displayName: Test Images
+  - script: docker logout
+    displayName: Docker logout
+    condition: always()
+    continueOnError: true
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    condition: always()
+    continueOnError: true
+    inputs:
+      testRunner: vSTest
+      testResultsFiles: 'tests/**/*.trx'
+      mergeTestResults: true
+      publishRunAttachments: true
+      testRunTitle: Windows $(dotnetVersion) $(osVersion) amd64
+  - template: ../steps/cleanup-docker-windows.yml

--- a/.vsts-pipelines/jobs/test-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/test-images-windows-client.yml
@@ -6,7 +6,14 @@ parameters:
   matrix: {}
 jobs:
   - job: ${{ parameters.name }}
-    condition: and(ne(variables['repo'], 'dotnet-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
+    condition: "
+      and(
+        ne(variables['repo'], 'dotnet-samples'),
+        or(
+          and(
+            succeeded(),
+            eq(variables['singlePhase'], '')),
+          eq(variables['singlePhase'], 'test')))"
     dependsOn:
       - GenerateMatrices
       - ${{ parameters.buildDependencies }}
@@ -23,7 +30,11 @@ jobs:
           setupImageBuilder: false
       - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
-      - powershell: ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion)* -OSFilter $(osVersion) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - powershell: >
+          ./tests/run-tests.ps1
+          -VersionFilter $(dotnetVersion)*
+          -OSFilter $(osVersion)
+          -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Test Images
       - script: docker logout
         displayName: Docker logout

--- a/.vsts-pipelines/steps/cleanup-docker-linux.yml
+++ b/.vsts-pipelines/steps/cleanup-docker-linux.yml
@@ -16,7 +16,7 @@ steps:
   # Cleanup local Docker server
   ################################################################################
   - ${{ if and(eq(parameters.excludeRunningContainers, 'false'), eq(parameters.cleanupRemoteDockerServer, 'false')) }}:
-    # Multiple build agents are running on a single host machine for remote Docker server scenarios.  Don't stop running containers.
+    # Multiple build agents run on a single host machine for remote Docker server scenarios.  Don't stop running containers.
     - script: docker stop $(docker ps -q) || true
       displayName: Stop Running Containers
       condition: always()

--- a/.vsts-pipelines/steps/cleanup-docker-linux.yml
+++ b/.vsts-pipelines/steps/cleanup-docker-linux.yml
@@ -6,22 +6,22 @@ steps:
   ################################################################################
   # Cleanup remote Docker server
   ################################################################################
-  - ${{ if eq(parameters.cleanupRemoteDockerServer, 'true') }}:
-    - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $(dockerClientImage) system prune -a -f --volumes
-      displayName: Cleanup Remote Docker Server
-      condition: always()
-      continueOnError: true
+- ${{ if eq(parameters.cleanupRemoteDockerServer, 'true') }}:
+  - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $(dockerClientImage) system prune -a -f --volumes
+    displayName: Cleanup Remote Docker Server
+    condition: always()
+    continueOnError: true
 
   ################################################################################
   # Cleanup local Docker server
   ################################################################################
-  - ${{ if and(eq(parameters.excludeRunningContainers, 'false'), eq(parameters.cleanupRemoteDockerServer, 'false')) }}:
-    # Multiple build agents run on a single host machine for remote Docker server scenarios.  Don't stop running containers.
-    - script: docker stop $(docker ps -q) || true
-      displayName: Stop Running Containers
-      condition: always()
-      continueOnError: true
-  - script: docker system prune -a -f --volumes
-    displayName: Cleanup Local Docker Server
+- ${{ if and(eq(parameters.excludeRunningContainers, 'false'), eq(parameters.cleanupRemoteDockerServer, 'false')) }}:
+  # Multiple build agents run on a single host machine for remote Docker server scenarios.  Don't stop running containers.
+  - script: docker stop $(docker ps -q) || true
+    displayName: Stop Running Containers
     condition: always()
     continueOnError: true
+- script: docker system prune -a -f --volumes
+  displayName: Cleanup Local Docker Server
+  condition: always()
+  continueOnError: true

--- a/.vsts-pipelines/steps/cleanup-docker-windows.yml
+++ b/.vsts-pipelines/steps/cleanup-docker-windows.yml
@@ -2,7 +2,7 @@ steps:
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
-  - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-CleanupDocker.ps1
-    displayName: Cleanup Docker Images
-    condition: always()
-    continueOnError: true
+- powershell: $(Build.Repository.LocalPath)/scripts/Invoke-CleanupDocker.ps1
+  displayName: Cleanup Docker Images
+  condition: always()
+  continueOnError: true

--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -18,7 +18,9 @@ steps:
     displayName: Define repoVolume Variable
   - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh buildpack-deps:stretch-scm
     displayName: Pull Image buildpack-deps:stretch-scm
-  - script: docker run --rm -v $(repoVolume):/repo buildpack-deps:stretch-scm git clone https://github.com/dotnet/dotnet-docker.git /repo
+  - script: >
+      docker run --rm -v $(repoVolume):/repo buildpack-deps:stretch-scm
+      git clone https://github.com/dotnet/dotnet-docker.git /repo
     displayName: Clone Repo
   - script: docker run --rm -v $(repoVolume):/repo -w /repo buildpack-deps:stretch-scm git checkout $(Build.SourceVersion)
     displayName: Checkout Source
@@ -27,18 +29,32 @@ steps:
   # Setup Remote Docker Server (Optional)
   ################################################################################
   - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
-    - script: echo "##vso[task.setvariable variable=dockerArmRunArgs] -v $(DOCKER_CERT_PATH):/docker-certs -e DOCKER_CERT_PATH=/docker-certs -e DOCKER_TLS_VERIFY=1 -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376"
+    - script: >
+        echo "##vso[task.setvariable variable=dockerArmRunArgs]
+        -v $(DOCKER_CERT_PATH):/docker-certs
+        -e DOCKER_CERT_PATH=/docker-certs
+        -e DOCKER_TLS_VERIFY=1
+        -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376"
       displayName: Define dockerArmRunArgs Variable
 
   ################################################################################
   # Setup Image Builder (Optional)
   ################################################################################
   - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
-    - script: echo "##vso[task.setvariable variable=imageBuilder.image]microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180904220918"
+    - script: >
+        echo "##vso[task.setvariable variable=imageBuilder.image]
+        microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180904220918"
       displayName: Define imageBuilder.image Variable
     - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
       displayName: Pull Image Builder
-    - script: echo "##vso[task.setvariable variable=runImageBuilderCmd]docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(dockerArmRunArgs) $(imageBuilder.image)"
+    - script: >
+        echo "##vso[task.setvariable variable=runImageBuilderCmd]
+        docker run --rm
+        -v /var/run/docker.sock:/var/run/docker.sock
+        -v $(repoVolume):/repo
+        -w /repo
+        $(dockerArmRunArgs)
+        $(imageBuilder.image)"
       displayName: Define runImageBuilderCmd Variable
     - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
       - script: echo "##vso[task.setvariable variable=dockerClientImage]$(imageBuilder.image)"
@@ -48,7 +64,9 @@ steps:
   # Setup Test Runner (Optional)
   ################################################################################
   - ${{ if eq(parameters.setupTestRunner, 'true') }}:
-    - script: echo "##vso[task.setvariable variable=testrunner.image]microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343"
+    - script: >
+        echo "##vso[task.setvariable variable=testrunner.image]
+        microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343"
       displayName: Define testrunner.image Variable
     - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(testrunner.image)
       displayName: Pull Test Runner

--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -7,69 +7,69 @@ steps:
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
-  - template: cleanup-docker-linux.yml
-    parameters:
-      excludeRunningContainers: ${{ parameters.setupRemoteDockerServer }}
+- template: cleanup-docker-linux.yml
+  parameters:
+    excludeRunningContainers: ${{ parameters.setupRemoteDockerServer }}
 
   ################################################################################
   # Setup Repo Volume
   ################################################################################
-  - script: echo "##vso[task.setvariable variable=repoVolume]repo-$(Build.BuildId)-$(System.JobId)"
-    displayName: Define repoVolume Variable
-  - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh buildpack-deps:stretch-scm
-    displayName: Pull Image buildpack-deps:stretch-scm
-  - script: >
-      docker run --rm -v $(repoVolume):/repo buildpack-deps:stretch-scm
-      git clone https://github.com/dotnet/dotnet-docker.git /repo
-    displayName: Clone Repo
-  - script: docker run --rm -v $(repoVolume):/repo -w /repo buildpack-deps:stretch-scm git checkout $(Build.SourceVersion)
-    displayName: Checkout Source
+- script: echo "##vso[task.setvariable variable=repoVolume]repo-$(Build.BuildId)-$(System.JobId)"
+  displayName: Define repoVolume Variable
+- script: $(Build.Repository.LocalPath)/scripts/pull-image.sh buildpack-deps:stretch-scm
+  displayName: Pull Image buildpack-deps:stretch-scm
+- script: >
+    docker run --rm -v $(repoVolume):/repo buildpack-deps:stretch-scm
+    git clone https://github.com/dotnet/dotnet-docker.git /repo
+  displayName: Clone Repo
+- script: docker run --rm -v $(repoVolume):/repo -w /repo buildpack-deps:stretch-scm git checkout $(Build.SourceVersion)
+  displayName: Checkout Source
 
   ################################################################################
   # Setup Remote Docker Server (Optional)
   ################################################################################
-  - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
-    - script: >
-        echo "##vso[task.setvariable variable=dockerArmRunArgs]
-        -v $(DOCKER_CERT_PATH):/docker-certs
-        -e DOCKER_CERT_PATH=/docker-certs
-        -e DOCKER_TLS_VERIFY=1
-        -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376"
-      displayName: Define dockerArmRunArgs Variable
+- ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
+  - script: >
+      echo "##vso[task.setvariable variable=dockerArmRunArgs]
+      -v $(DOCKER_CERT_PATH):/docker-certs
+      -e DOCKER_CERT_PATH=/docker-certs
+      -e DOCKER_TLS_VERIFY=1
+      -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376"
+    displayName: Define dockerArmRunArgs Variable
 
   ################################################################################
   # Setup Image Builder (Optional)
   ################################################################################
-  - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
-    - script: >
-        echo "##vso[task.setvariable variable=imageBuilder.image]
-        microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180904220918"
-      displayName: Define imageBuilder.image Variable
-    - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
-      displayName: Pull Image Builder
-    - script: >
-        echo "##vso[task.setvariable variable=runImageBuilderCmd]
-        docker run --rm
-        -v /var/run/docker.sock:/var/run/docker.sock
-        -v $(repoVolume):/repo
-        -w /repo
-        $(dockerArmRunArgs)
-        $(imageBuilder.image)"
-      displayName: Define runImageBuilderCmd Variable
-    - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
-      - script: echo "##vso[task.setvariable variable=dockerClientImage]$(imageBuilder.image)"
-        displayName: Define dockerClientImage Variable
+- ${{ if eq(parameters.setupImageBuilder, 'true') }}:
+  - script: >
+      echo "##vso[task.setvariable variable=imageBuilder.image]
+      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180904220918"
+    displayName: Define imageBuilder.image Variable
+  - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
+    displayName: Pull Image Builder
+  - script: >
+      echo "##vso[task.setvariable variable=runImageBuilderCmd]
+      docker run --rm
+      -v /var/run/docker.sock:/var/run/docker.sock
+      -v $(repoVolume):/repo
+      -w /repo
+      $(dockerArmRunArgs)
+      $(imageBuilder.image)"
+    displayName: Define runImageBuilderCmd Variable
+  - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
+    - script: echo "##vso[task.setvariable variable=dockerClientImage]$(imageBuilder.image)"
+      displayName: Define dockerClientImage Variable
 
   ################################################################################
   # Setup Test Runner (Optional)
   ################################################################################
-  - ${{ if eq(parameters.setupTestRunner, 'true') }}:
-    - script: >
-        echo "##vso[task.setvariable variable=testrunner.image]
-        microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343"
-      displayName: Define testrunner.image Variable
-    - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(testrunner.image)
-      displayName: Pull Test Runner
-    - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
-      - script: echo "##vso[task.setvariable variable=dockerClientImage]$(testrunner.image)"
-        displayName: Define dockerClientImage Variable
+- ${{ if eq(parameters.setupTestRunner, 'true') }}:
+  - script: >
+      echo "##vso[task.setvariable variable=testrunner.image]
+      microsoft/dotnet-buildtools-prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343"
+    displayName: Define testrunner.image Variable
+  - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(testrunner.image)
+    displayName: Pull Test Runner
+  - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
+    - script: echo "##vso[task.setvariable variable=dockerClientImage]$(testrunner.image)"
+      displayName: Define dockerClientImage Variable

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -5,30 +5,30 @@ steps:
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
-  - template: cleanup-docker-windows.yml
+- template: cleanup-docker-windows.yml
 
   ################################################################################
   # Setup Image Builder (Optional)
   ################################################################################
-  - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
-    - script: >
-        echo "##vso[task.setvariable variable=imageBuilder.image]
-        microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180904151412
-      displayName: Define imageBuilder.image Variable
-    - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 $(imageBuilder.image)
-      displayName: Pull Image Builder
-    - script: docker create --name setupImageBuilder-$(Build.BuildId)-$(System.JobId) $(imageBuilder.image)
-      displayName: Create Setup Container
-    - script: >
-        docker cp
-        setupImageBuilder-$(Build.BuildId)-$(System.JobId):/image-builder
-        $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
-      displayName: Copy Image Builder
-    - script: docker rm -f setupImageBuilder-$(Build.BuildId)-$(System.JobId)
-      displayName: Cleanup Setup Container
-      condition: always()
-      continueOnError: true
-    - script: >
-        echo "##vso[task.setvariable variable=runImageBuilderCmd]
-        $(Build.BinariesDirectory)\Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
-      displayName: Define runImageBuilderCmd Variable
+- ${{ if eq(parameters.setupImageBuilder, 'true') }}:
+  - script: >
+      echo "##vso[task.setvariable variable=imageBuilder.image]
+      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180904151412
+    displayName: Define imageBuilder.image Variable
+  - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 $(imageBuilder.image)
+    displayName: Pull Image Builder
+  - script: docker create --name setupImageBuilder-$(Build.BuildId)-$(System.JobId) $(imageBuilder.image)
+    displayName: Create Setup Container
+  - script: >
+      docker cp
+      setupImageBuilder-$(Build.BuildId)-$(System.JobId):/image-builder
+      $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
+    displayName: Copy Image Builder
+  - script: docker rm -f setupImageBuilder-$(Build.BuildId)-$(System.JobId)
+    displayName: Cleanup Setup Container
+    condition: always()
+    continueOnError: true
+  - script: >
+      echo "##vso[task.setvariable variable=runImageBuilderCmd]
+      $(Build.BinariesDirectory)\Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
+    displayName: Define runImageBuilderCmd Variable

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -11,17 +11,24 @@ steps:
   # Setup Image Builder (Optional)
   ################################################################################
   - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
-    - script: echo "##vso[task.setvariable variable=imageBuilder.image]microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180904151412
+    - script: >
+        echo "##vso[task.setvariable variable=imageBuilder.image]
+        microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180904151412
       displayName: Define imageBuilder.image Variable
-    - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 '$(imageBuilder.image)'
+    - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 $(imageBuilder.image)
       displayName: Pull Image Builder
     - script: docker create --name setupImageBuilder-$(Build.BuildId)-$(System.JobId) $(imageBuilder.image)
       displayName: Create Setup Container
-    - script: docker cp setupImageBuilder-$(Build.BuildId)-$(System.JobId):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
+    - script: >
+        docker cp
+        setupImageBuilder-$(Build.BuildId)-$(System.JobId):/image-builder
+        $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
       displayName: Copy Image Builder
     - script: docker rm -f setupImageBuilder-$(Build.BuildId)-$(System.JobId)
       displayName: Cleanup Setup Container
       condition: always()
       continueOnError: true
-    - script: echo "##vso[task.setvariable variable=runImageBuilderCmd]$(Build.BinariesDirectory)\Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
+    - script: >
+        echo "##vso[task.setvariable variable=runImageBuilderCmd]
+        $(Build.BinariesDirectory)\Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
       displayName: Define runImageBuilderCmd Variable


### PR DESCRIPTION
1. Broke all of the long lines down into multiple lines that are more readable.
2. Fixed the indentation of all sequence types to follow the standard yaml format.

If might be easier to view each commit separately.

@dotnet-bot skip ci please