### PR TITLE
Add support for Linux Arm64

### DIFF
--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -30,6 +30,18 @@ jobs:
     dockerClientOS: linux
 - template: build-images.yml
   parameters:
+    phase: Build_Linux_arm64v8
+    pool: # linuxArm64v8Pool
+      name: DotNetCore-Infra
+      demands:
+      - agent.os -equals linux
+      - RemoteDockerServerOS -equals linux
+      - RemoteDockerServerArch -equals arm64v8
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm64v8'] ]
+    useRemoteDockerServer: true
+    dockerClientOS: linux
+- template: build-images.yml
+  parameters:
     name: Build_Linux_arm32v7
     pool: # linuxArm32v7Pool
       name: DotNetCore-Infra
@@ -86,6 +98,19 @@ jobs:
     architecture: amd64
 - template: test-images-linux-client.yml
   parameters:
+    phase: Test_Linux_arm64v8
+    buildDependencies: Build_Linux_arm64v8
+    pool: # linuxArm64v8Pool
+      name: DotNetCore-Infra
+      demands:
+      - agent.os -equals linux
+      - RemoteDockerServerOS -equals linux
+      - RemoteDockerServerArch -equals arm64v8
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.testMatrixLinuxArm64v8'] ]
+    architecture: arm64
+    useRemoteDockerServer: true
+- template: test-images-linux-client.yml
+  parameters:
     name: Test_Linux_arm32v7
     buildDependencies: Build_Linux_arm32v7
     pool: # linuxArm32v7Pool
@@ -137,6 +162,16 @@ jobs:
       - agent.os -equals linux
     matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64'] ]
     architecture: amd64
+    dockerClientOS: linux
+- template: copy-images.yml
+  parameters:
+    phase: Copy_Images_Linux_arm64v8
+    pool: # linuxAmd64Pool - arm images can be copied with amd64 machines which will be much faster.
+      name: DotNet-Build
+      demands:
+      - agent.os -equals linux
+    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm64v8'] ]
+    architecture: arm64
     dockerClientOS: linux
 - template: copy-images.yml
   parameters:

--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -30,7 +30,7 @@ jobs:
     dockerClientOS: linux
 - template: build-images.yml
   parameters:
-    phase: Build_Linux_arm64v8
+    name: Build_Linux_arm64v8
     pool: # linuxArm64v8Pool
       name: DotNetCore-Infra
       demands:
@@ -98,7 +98,7 @@ jobs:
     architecture: amd64
 - template: test-images-linux-client.yml
   parameters:
-    phase: Test_Linux_arm64v8
+    name: Test_Linux_arm64v8
     buildDependencies: Build_Linux_arm64v8
     pool: # linuxArm64v8Pool
       name: DotNetCore-Infra
@@ -106,7 +106,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals arm64v8
-    matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.testMatrixLinuxArm64v8'] ]
+    matrix: $[ dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxArm64v8'] ]
     architecture: arm64
     useRemoteDockerServer: true
 - template: test-images-linux-client.yml
@@ -165,8 +165,8 @@ jobs:
     dockerClientOS: linux
 - template: copy-images.yml
   parameters:
-    phase: Copy_Images_Linux_arm64v8
-    pool: # linuxAmd64Pool - arm images can be copied with amd64 machines which will be much faster.
+    name: Copy_Images_Linux_arm64v8
+    pool: # linuxAmd64Pool - arm images can be copied with amd64 machines which are more plentiful.
       name: DotNet-Build
       demands:
       - agent.os -equals linux

--- a/.vsts-pipelines/jobs/copy-images.yml
+++ b/.vsts-pipelines/jobs/copy-images.yml
@@ -18,6 +18,7 @@ jobs:
             eq(variables['repo'], 'dotnet-samples'),
             eq(variables['singlePhase'], ''),
             succeeded('Build_Linux_amd64'),
+            succeeded('Build_Linux_arm64v8'),
             succeeded('Build_Linux_arm32v7'),
             succeeded('Build_NanoServerSac2016_amd64'),
             succeeded('Build_NanoServer1709_amd64'),
@@ -25,6 +26,7 @@ jobs:
   dependsOn:
   - GenerateMatrices
   - Test_Linux_amd64
+  - Test_Linux_arm64v8
   - Test_Linux_arm32v7
   - Test_NanoServerSac2016_amd64
   - Test_NanoServer1709_amd64

--- a/.vsts-pipelines/jobs/publish-finalize.yml
+++ b/.vsts-pipelines/jobs/publish-finalize.yml
@@ -5,12 +5,14 @@ jobs:
   condition: "
     and(
       succeeded('Copy_Images_Linux_amd64'),
+      succeeded('Copy_Images_Linux_arm64v8'),
       succeeded('Copy_Images_Linux_arm32v7'),
       succeeded('Copy_Images_NanoServerSac2016_amd64'),
       succeeded('Copy_Images_NanoServer1709_amd64'),
       succeeded('Copy_Images_NanoServer1803_amd64'))"
   dependsOn:
   - Copy_Images_Linux_amd64
+  - Copy_Images_Linux_arm64v8
   - Copy_Images_Linux_arm32v7
   - Copy_Images_NanoServerSac2016_amd64
   - Copy_Images_NanoServer1709_amd64

--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -43,7 +43,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181016194522"
+      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181022195013"
     displayName: Define imageBuilder.image Variable
   - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
     displayName: Pull Image Builder

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -13,7 +13,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181016124511
+      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181022125001
     displayName: Define imageBuilder.image Variable
   - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 $(imageBuilder.image)
     displayName: Pull Image Builder

--- a/3.0/runtime-deps/bionic/arm64v8/Dockerfile
+++ b/3.0/runtime-deps/bionic/arm64v8/Dockerfile
@@ -1,0 +1,21 @@
+FROM arm64v8/ubuntu:bionic
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu60 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure Kestrel web server to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile
+++ b/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile
@@ -1,0 +1,21 @@
+FROM arm64v8/debian:stretch-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu57 \
+        liblttng-ust0 \
+        libssl1.0.2 \
+        libstdc++6 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure Kestrel web server to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true

--- a/3.0/runtime/bionic/arm64v8/Dockerfile
+++ b/3.0/runtime/bionic/arm64v8/Dockerfile
@@ -1,0 +1,17 @@
+FROM microsoft/dotnet-nightly:3.0-runtime-deps-bionic-arm64v8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV DOTNET_VERSION 3.0.0-preview1-27004-04
+
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz \
+    && dotnet_sha512='1f9657ea3fbfe33143578da330d6f5dd2dc37f95cac833fca1f531d6efbeb5be4e8de6e2913e68ae5712cf63c75187446b7ffa9e45a561bb8992ec5266918e14' \
+    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.0/runtime/stretch-slim/arm64v8/Dockerfile
+++ b/3.0/runtime/stretch-slim/arm64v8/Dockerfile
@@ -1,0 +1,17 @@
+FROM microsoft/dotnet-nightly:3.0-runtime-deps-stretch-slim-arm64v8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV DOTNET_VERSION 3.0.0-preview1-27004-04
+
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz \
+    && dotnet_sha512='1f9657ea3fbfe33143578da330d6f5dd2dc37f95cac833fca1f531d6efbeb5be4e8de6e2913e68ae5712cf63c75187446b7ffa9e45a561bb8992ec5266918e14' \
+    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
 
+# Linux arm64 tags
+
+**.NET Core 3.0 Preview tags**
+
+See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
+
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 
 ## What is .NET Core?

--- a/TAGS.md
+++ b/TAGS.md
@@ -113,6 +113,15 @@
 - [`3.0.0-alpha1-aspnetcore-runtime-nanoserver-sac2016`, `3.0-aspnetcore-runtime-nanoserver-sac2016`, `3.0.0-alpha1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`3.0.0-alpha1-runtime-nanoserver-sac2016`, `3.0-runtime-nanoserver-sac2016`, `3.0.0-alpha1-runtime`, `3.0-runtime` (*3.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
+# Linux arm64 tags
+
+**.NET Core 3.0 Alpha 1 tags**
+
+- [`3.0.0-alpha1-runtime-stretch-slim-arm64v8`, `3.0-runtime-stretch-slim-arm64v8`, `3.0.0-alpha1-runtime`, `3.0-runtime` (*3.0/runtime/stretch-slim/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm64v8/Dockerfile)
+- [`3.0.0-alpha1-runtime-bionic-arm64v8`, `3.0-runtime-bionic-arm64v8` (*3.0/runtime/bionic/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm64v8/Dockerfile)
+- [`3.0.0-alpha1-runtime-deps-stretch-slim-arm64v8`, `3.0-runtime-deps-stretch-slim-arm64v8`, `3.0.0-alpha1-runtime-deps`, `3.0-runtime-deps` (*3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile)
+- [`3.0.0-alpha1-runtime-deps-bionic-arm64v8`, `3.0-runtime-deps-bionic-arm64v8` (*3.0/runtime-deps/bionic/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm64v8/Dockerfile)
+
 # Linux arm32 tags
 
 - [`2.1.403-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)

--- a/manifest.json
+++ b/manifest.json
@@ -597,7 +597,8 @@
               "tags": {
                 "2.1.5-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.1-aspnetcore-runtime-bionic-arm32v7": {}
-              }
+              },
+              "variant": "v7"
             }
           ]
         },
@@ -875,7 +876,8 @@
               "tags": {
                 "2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.2-aspnetcore-runtime-bionic-arm32v7": {}
-              }
+              },
+              "variant": "v7"
             }
           ]
         },
@@ -930,6 +932,16 @@
                 "3.0-runtime-deps-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "3.0/runtime-deps/stretch-slim/arm64v8",
+              "os": "linux",
+              "tags": {
+                "3.0.0-alpha1-runtime-deps-stretch-slim-arm64v8": {},
+                "3.0-runtime-deps-stretch-slim-arm64v8": {}
+              },
+              "variant": "v8"
             }
           ]
         },
@@ -956,6 +968,16 @@
                 "3.0-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "3.0/runtime/stretch-slim/arm64v8",
+              "os": "linux",
+              "tags": {
+                "3.0.0-alpha1-runtime-stretch-slim-arm64v8": {},
+                "3.0-runtime-stretch-slim-arm64v8": {}
+              },
+              "variant": "v8"
             },
             {
               "dockerfile": "3.0/runtime/nanoserver-sac2016/amd64",
@@ -1219,7 +1241,8 @@
               "tags": {
                 "3.0.0-alpha1-aspnetcore-runtime-bionic-arm32v7": {},
                 "3.0-aspnetcore-runtime-bionic-arm32v7": {}
-              }
+              },
+              "variant": "v7"
             }
           ]
         },
@@ -1248,6 +1271,34 @@
                 "3.0-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "3.0/runtime-deps/bionic/arm64v8",
+              "os": "linux",
+              "tags": {
+                "3.0.0-alpha1-runtime-deps-bionic-arm64v8": {},
+                "3.0-runtime-deps-bionic-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "3.0/runtime/bionic/arm64v8",
+              "os": "linux",
+              "tags": {
+                "3.0.0-alpha1-runtime-bionic-arm64v8": {},
+                "3.0-runtime-bionic-arm64v8": {}
+              },
+              "variant": "v8"
             }
           ]
         }

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -78,5 +78,11 @@ $(TagDocList:2.1.5-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
+# Linux arm64 tags
+
+**.NET Core 3.0 Preview tags**
+
+See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
+
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -113,6 +113,15 @@ $(TagDoc:3.0.100-alpha1-sdk-nanoserver-sac2016)
 $(TagDoc:3.0.0-alpha1-aspnetcore-runtime-nanoserver-sac2016)
 $(TagDoc:3.0.0-alpha1-runtime-nanoserver-sac2016)
 
+# Linux arm64 tags
+
+**.NET Core 3.0 Alpha 1 tags**
+
+$(TagDoc:3.0.0-alpha1-runtime-stretch-slim-arm64v8)
+$(TagDoc:3.0.0-alpha1-runtime-bionic-arm64v8)
+$(TagDoc:3.0.0-alpha1-runtime-deps-stretch-slim-arm64v8)
+$(TagDoc:3.0.0-alpha1-runtime-deps-bionic-arm64v8)
+
 # Linux arm32 tags
 
 $(TagDoc:2.1.403-sdk-stretch-arm32v7)

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -59,11 +59,15 @@ namespace Microsoft.DotNet.Docker.Tests
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.Alpine38 },
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, Architecture = "arm" },
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.Bionic, Architecture = "arm" },
+            new ImageData { DotNetVersion = "3.0", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, Architecture = "arm64" },
+            new ImageData { DotNetVersion = "3.0", OsVariant = OS.Bionic, Architecture = "arm64" },
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, IsWeb = true },
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.Bionic, IsWeb = true },
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.Alpine38, IsWeb = true },
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, Architecture = "arm", IsWeb = true },
             new ImageData { DotNetVersion = "3.0", OsVariant = OS.Bionic, Architecture = "arm", IsWeb = true },
+            new ImageData { DotNetVersion = "3.0", OsVariant = OS.StretchSlim, SdkOsVariant = OS.Stretch, Architecture = "arm64", IsWeb = true },
+            new ImageData { DotNetVersion = "3.0", OsVariant = OS.Bionic, Architecture = "arm64", IsWeb = true },
         };
         private static readonly ImageData[] s_windowsTestData =
         {


### PR DESCRIPTION
These are the initial changes to add Linux Arm64 images (runtime and runtime-deps).  The aspnetcore-runtime and sdk images are blocked on product support.

Related to #504