### PR TITLE
Improve maintainablity of readme templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,29 +38,29 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 # Linux amd64 tags
 
-- [`2.1.500-sdk-stretch`, `2.1-sdk-stretch`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.500-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*2.1/sdk/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
-- [`2.1.500-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.500-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
-- [`2.1.500-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7` (*2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-alpine3.8`, `2.1-aspnetcore-runtime-alpine3.8`, `2.1.6-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.1.6-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.6-runtime-alpine3.7`, `2.1-runtime-alpine3.7` (*2.1/runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.6-runtime-alpine3.8`, `2.1-runtime-alpine3.8`, `2.1.6-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.8/amd64/Dockerfile)
-- [`2.1.6-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7` (*2.1/runtime-deps/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-alpine3.8`, `2.1-runtime-deps-alpine3.8`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
-- [`1.1.10-sdk-1.1.11-stretch`, `1.1-sdk-stretch` (*1.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/stretch/amd64/Dockerfile)
-- [`1.1.10-sdk-1.1.11-jessie`, `1.1-sdk-jessie`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/jessie/amd64/Dockerfile)
-- [`1.1.10-runtime-stretch`, `1.1-runtime-stretch` (*1.1/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/stretch/amd64/Dockerfile)
-- [`1.1.10-runtime-jessie`, `1.1-runtime-jessie`, `1.1.10-runtime`, `1.1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/jessie/amd64/Dockerfile)
-- [`1.1.10-runtime-deps-stretch`, `1.1-runtime-deps-stretch` (*1.1/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime-deps/stretch/amd64/Dockerfile)
-- [`1.0.13-runtime-jessie`, `1.0-runtime-jessie`, `1.0.13-runtime`, `1.0-runtime` (*1.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/jessie/amd64/Dockerfile)
-- [`1.0.13-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.13-runtime-deps`, `1.0-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
+- [`2.1.500-sdk-stretch`, `2.1-sdk-stretch`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.500-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
+- [`2.1.500-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.500-sdk-alpine`, `2.1-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
+- [`2.1.500-sdk-bionic`, `2.1-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-alpine3.8`, `2.1-aspnetcore-runtime-alpine3.8`, `2.1.6-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-alpine3.7`, `2.1-runtime-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-alpine3.8`, `2.1-runtime-alpine3.8`, `2.1.6-runtime-alpine`, `2.1-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.8/amd64/Dockerfile)
+- [`2.1.6-runtime-bionic`, `2.1-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-alpine3.8`, `2.1-runtime-deps-alpine3.8`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`1.1.10-sdk-1.1.11-stretch`, `1.1-sdk-stretch` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/stretch/amd64/Dockerfile)
+- [`1.1.10-sdk-1.1.11-jessie`, `1.1-sdk-jessie`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/jessie/amd64/Dockerfile)
+- [`1.1.10-runtime-stretch`, `1.1-runtime-stretch` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/stretch/amd64/Dockerfile)
+- [`1.1.10-runtime-jessie`, `1.1-runtime-jessie`, `1.1.10-runtime`, `1.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/jessie/amd64/Dockerfile)
+- [`1.1.10-runtime-deps-stretch`, `1.1-runtime-deps-stretch` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime-deps/stretch/amd64/Dockerfile)
+- [`1.0.13-runtime-jessie`, `1.0-runtime-jessie`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/jessie/amd64/Dockerfile)
+- [`1.0.13-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.13-runtime-deps`, `1.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -68,9 +68,9 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 # Windows Server, version 1803 amd64 tags
 
-- [`2.1.500-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -78,9 +78,9 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.1.500-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -88,12 +88,12 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 # Windows Server 2016 amd64 tags
 
-- [`2.1.500-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.6-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.10-sdk-1.1.11-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.10-sdk-1.1.11-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -101,14 +101,14 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 # Linux arm32 tags
 
-- [`2.1.500-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.500-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.6-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.6-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.500-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.500-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -2,159 +2,159 @@
 
 # Linux amd64 tags
 
-- [`2.1.500-sdk-stretch`, `2.1-sdk-stretch`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.500-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*2.1/sdk/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
-- [`2.1.500-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.500-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
-- [`2.1.500-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7` (*2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-alpine3.8`, `2.1-aspnetcore-runtime-alpine3.8`, `2.1.6-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.1.6-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.6-runtime-alpine3.7`, `2.1-runtime-alpine3.7` (*2.1/runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.6-runtime-alpine3.8`, `2.1-runtime-alpine3.8`, `2.1.6-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.8/amd64/Dockerfile)
-- [`2.1.6-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7` (*2.1/runtime-deps/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-alpine3.8`, `2.1-runtime-deps-alpine3.8`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
-- [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
-- [`1.1.10-sdk-1.1.11-stretch`, `1.1-sdk-stretch` (*1.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/stretch/amd64/Dockerfile)
-- [`1.1.10-sdk-1.1.11-jessie`, `1.1-sdk-jessie`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/jessie/amd64/Dockerfile)
-- [`1.1.10-runtime-stretch`, `1.1-runtime-stretch` (*1.1/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/stretch/amd64/Dockerfile)
-- [`1.1.10-runtime-jessie`, `1.1-runtime-jessie`, `1.1.10-runtime`, `1.1-runtime` (*1.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/jessie/amd64/Dockerfile)
-- [`1.1.10-runtime-deps-stretch`, `1.1-runtime-deps-stretch` (*1.1/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime-deps/stretch/amd64/Dockerfile)
-- [`1.0.13-runtime-jessie`, `1.0-runtime-jessie`, `1.0.13-runtime`, `1.0-runtime` (*1.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/jessie/amd64/Dockerfile)
-- [`1.0.13-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.13-runtime-deps`, `1.0-runtime-deps` (*1.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
+- [`2.1.500-sdk-stretch`, `2.1-sdk-stretch`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.500-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
+- [`2.1.500-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.500-sdk-alpine`, `2.1-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
+- [`2.1.500-sdk-bionic`, `2.1-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-alpine3.8`, `2.1-aspnetcore-runtime-alpine3.8`, `2.1.6-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-alpine3.7`, `2.1-runtime-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-alpine3.8`, `2.1-runtime-alpine3.8`, `2.1.6-runtime-alpine`, `2.1-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/alpine3.8/amd64/Dockerfile)
+- [`2.1.6-runtime-bionic`, `2.1-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-alpine3.8`, `2.1-runtime-deps-alpine3.8`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`1.1.10-sdk-1.1.11-stretch`, `1.1-sdk-stretch` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/stretch/amd64/Dockerfile)
+- [`1.1.10-sdk-1.1.11-jessie`, `1.1-sdk-jessie`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/jessie/amd64/Dockerfile)
+- [`1.1.10-runtime-stretch`, `1.1-runtime-stretch` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/stretch/amd64/Dockerfile)
+- [`1.1.10-runtime-jessie`, `1.1-runtime-jessie`, `1.1.10-runtime`, `1.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/jessie/amd64/Dockerfile)
+- [`1.1.10-runtime-deps-stretch`, `1.1-runtime-deps-stretch` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime-deps/stretch/amd64/Dockerfile)
+- [`1.0.13-runtime-jessie`, `1.0-runtime-jessie`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/jessie/amd64/Dockerfile)
+- [`1.0.13-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.13-runtime-deps`, `1.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime-deps/jessie/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 
-- [`2.2.100-preview3-sdk-stretch`, `2.2-sdk-stretch`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/amd64/Dockerfile)
-- [`2.2.100-preview3-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.100-preview3-sdk-alpine`, `2.2-sdk-alpine` (*2.2/sdk/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/alpine3.8/amd64/Dockerfile)
-- [`2.2.100-preview3-sdk-bionic`, `2.2-sdk-bionic` (*2.2/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/amd64/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-stretch-slim`, `2.2-aspnetcore-runtime-stretch-slim`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-alpine3.8`, `2.2-aspnetcore-runtime-alpine3.8`, `2.2.0-preview3-aspnetcore-runtime-alpine`, `2.2-aspnetcore-runtime-alpine` (*2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-bionic`, `2.2-aspnetcore-runtime-bionic` (*2.2/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-stretch-slim`, `2.2-runtime-stretch-slim`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-alpine3.8`, `2.2-runtime-alpine3.8`, `2.2.0-preview3-runtime-alpine`, `2.2-runtime-alpine` (*2.2/runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-bionic`, `2.2-runtime-bionic` (*2.2/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-deps-stretch-slim`, `2.2-runtime-deps-stretch-slim`, `2.2.0-preview3-runtime-deps`, `2.2-runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-deps-alpine3.8`, `2.2-runtime-deps-alpine3.8`, `2.2.0-preview3-runtime-deps-alpine`, `2.2-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`2.2.100-preview3-sdk-stretch`, `2.2-sdk-stretch`, `2.2.100-preview3-sdk`, `2.2-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/amd64/Dockerfile)
+- [`2.2.100-preview3-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.100-preview3-sdk-alpine`, `2.2-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/alpine3.8/amd64/Dockerfile)
+- [`2.2.100-preview3-sdk-bionic`, `2.2-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/amd64/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-stretch-slim`, `2.2-aspnetcore-runtime-stretch-slim`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-alpine3.8`, `2.2-aspnetcore-runtime-alpine3.8`, `2.2.0-preview3-aspnetcore-runtime-alpine`, `2.2-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-bionic`, `2.2-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-stretch-slim`, `2.2-runtime-stretch-slim`, `2.2.0-preview3-runtime`, `2.2-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-alpine3.8`, `2.2-runtime-alpine3.8`, `2.2.0-preview3-runtime-alpine`, `2.2-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/alpine3.8/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-bionic`, `2.2-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-deps-stretch-slim`, `2.2-runtime-deps-stretch-slim`, `2.2.0-preview3-runtime-deps`, `2.2-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-deps-alpine3.8`, `2.2-runtime-deps-alpine3.8`, `2.2.0-preview3-runtime-deps-alpine`, `2.2-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.100-preview1-sdk-stretch`, `3.0-sdk-stretch`, `3.0.100-preview1-sdk`, `3.0-sdk` (*3.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/amd64/Dockerfile)
-- [`3.0.100-preview1-sdk-alpine3.8`, `3.0-sdk-alpine3.8`, `3.0.100-preview1-sdk-alpine`, `3.0-sdk-alpine` (*3.0/sdk/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/alpine3.8/amd64/Dockerfile)
-- [`3.0.100-preview1-sdk-bionic`, `3.0-sdk-bionic` (*3.0/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/amd64/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-stretch-slim`, `3.0-aspnetcore-runtime-stretch-slim`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-alpine3.8`, `3.0-aspnetcore-runtime-alpine3.8`, `3.0.0-preview1-aspnetcore-runtime-alpine`, `3.0-aspnetcore-runtime-alpine` (*3.0/aspnetcore-runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-bionic`, `3.0-aspnetcore-runtime-bionic` (*3.0/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-stretch-slim`, `3.0-runtime-stretch-slim`, `3.0.0-preview1-runtime`, `3.0-runtime` (*3.0/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-alpine3.8`, `3.0-runtime-alpine3.8`, `3.0.0-preview1-runtime-alpine`, `3.0-runtime-alpine` (*3.0/runtime/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/alpine3.8/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-bionic`, `3.0-runtime-bionic` (*3.0/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-deps-stretch-slim`, `3.0-runtime-deps-stretch-slim`, `3.0.0-preview1-runtime-deps`, `3.0-runtime-deps` (*3.0/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-deps-alpine3.8`, `3.0-runtime-deps-alpine3.8`, `3.0.0-preview1-runtime-deps-alpine`, `3.0-runtime-deps-alpine` (*3.0/runtime-deps/alpine3.8/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/alpine3.8/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-deps-bionic`, `3.0-runtime-deps-bionic` (*3.0/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/amd64/Dockerfile)
+- [`3.0.100-preview1-sdk-stretch`, `3.0-sdk-stretch`, `3.0.100-preview1-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/amd64/Dockerfile)
+- [`3.0.100-preview1-sdk-alpine3.8`, `3.0-sdk-alpine3.8`, `3.0.100-preview1-sdk-alpine`, `3.0-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/alpine3.8/amd64/Dockerfile)
+- [`3.0.100-preview1-sdk-bionic`, `3.0-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/amd64/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-stretch-slim`, `3.0-aspnetcore-runtime-stretch-slim`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-alpine3.8`, `3.0-aspnetcore-runtime-alpine3.8`, `3.0.0-preview1-aspnetcore-runtime-alpine`, `3.0-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-bionic`, `3.0-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-stretch-slim`, `3.0-runtime-stretch-slim`, `3.0.0-preview1-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-alpine3.8`, `3.0-runtime-alpine3.8`, `3.0.0-preview1-runtime-alpine`, `3.0-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/alpine3.8/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-bionic`, `3.0-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-deps-stretch-slim`, `3.0-runtime-deps-stretch-slim`, `3.0.0-preview1-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-deps-alpine3.8`, `3.0-runtime-deps-alpine3.8`, `3.0.0-preview1-runtime-deps-alpine`, `3.0-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/alpine3.8/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-deps-bionic`, `3.0-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/amd64/Dockerfile)
 
 # Windows Server, version 1803 amd64 tags
 
-- [`2.1.500-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 
-- [`2.2.100-preview3-sdk-nanoserver-1803`, `2.2-sdk-nanoserver-1803`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1803/amd64/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-nanoserver-1803`, `2.2-aspnetcore-runtime-nanoserver-1803`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-nanoserver-1803`, `2.2-runtime-nanoserver-1803`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.2.100-preview3-sdk-nanoserver-1803`, `2.2-sdk-nanoserver-1803`, `2.2.100-preview3-sdk`, `2.2-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-nanoserver-1803`, `2.2-aspnetcore-runtime-nanoserver-1803`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-nanoserver-1803`, `2.2-runtime-nanoserver-1803`, `2.2.0-preview3-runtime`, `2.2-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1803/amd64/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.100-preview1-sdk-nanoserver-1803`, `3.0-sdk-nanoserver-1803`, `3.0.100-preview1-sdk`, `3.0-sdk` (*3.0/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-1803/amd64/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-nanoserver-1803`, `3.0-aspnetcore-runtime-nanoserver-1803`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-nanoserver-1803`, `3.0-runtime-nanoserver-1803`, `3.0.0-preview1-runtime`, `3.0-runtime` (*3.0/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-1803/amd64/Dockerfile)
+- [`3.0.100-preview1-sdk-nanoserver-1803`, `3.0-sdk-nanoserver-1803`, `3.0.100-preview1-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-nanoserver-1803`, `3.0-aspnetcore-runtime-nanoserver-1803`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-nanoserver-1803`, `3.0-runtime-nanoserver-1803`, `3.0.0-preview1-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-1803/amd64/Dockerfile)
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.1.500-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 
-- [`2.2.100-preview3-sdk-nanoserver-1709`, `2.2-sdk-nanoserver-1709`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-nanoserver-1709`, `2.2-aspnetcore-runtime-nanoserver-1709`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-nanoserver-1709`, `2.2-runtime-nanoserver-1709`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.2.100-preview3-sdk-nanoserver-1709`, `2.2-sdk-nanoserver-1709`, `2.2.100-preview3-sdk`, `2.2-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-nanoserver-1709`, `2.2-aspnetcore-runtime-nanoserver-1709`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-nanoserver-1709`, `2.2-runtime-nanoserver-1709`, `2.2.0-preview3-runtime`, `2.2-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1709/amd64/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.100-preview1-sdk-nanoserver-1709`, `3.0-sdk-nanoserver-1709`, `3.0.100-preview1-sdk`, `3.0-sdk` (*3.0/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-nanoserver-1709`, `3.0-aspnetcore-runtime-nanoserver-1709`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-nanoserver-1709`, `3.0-runtime-nanoserver-1709`, `3.0.0-preview1-runtime`, `3.0-runtime` (*3.0/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`3.0.100-preview1-sdk-nanoserver-1709`, `3.0-sdk-nanoserver-1709`, `3.0.100-preview1-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-nanoserver-1709`, `3.0-aspnetcore-runtime-nanoserver-1709`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-nanoserver-1709`, `3.0-runtime-nanoserver-1709`, `3.0.0-preview1-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-1709/amd64/Dockerfile)
 
 # Windows Server 2016 amd64 tags
 
-- [`2.1.500-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.6-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.10-sdk-1.1.11-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.10-sdk-1.1.11-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 
-- [`2.2.100-preview3-sdk-nanoserver-sac2016`, `2.2-sdk-nanoserver-sac2016`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-nanoserver-sac2016`, `2.2-aspnetcore-runtime-nanoserver-sac2016`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.2.0-preview3-runtime-nanoserver-sac2016`, `2.2-runtime-nanoserver-sac2016`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.2.100-preview3-sdk-nanoserver-sac2016`, `2.2-sdk-nanoserver-sac2016`, `2.2.100-preview3-sdk`, `2.2-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-nanoserver-sac2016`, `2.2-aspnetcore-runtime-nanoserver-sac2016`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.2.0-preview3-runtime-nanoserver-sac2016`, `2.2-runtime-nanoserver-sac2016`, `2.2.0-preview3-runtime`, `2.2-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.100-preview1-sdk-nanoserver-sac2016`, `3.0-sdk-nanoserver-sac2016`, `3.0.100-preview1-sdk`, `3.0-sdk` (*3.0/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-nanoserver-sac2016`, `3.0-aspnetcore-runtime-nanoserver-sac2016`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`3.0.0-preview1-runtime-nanoserver-sac2016`, `3.0-runtime-nanoserver-sac2016`, `3.0.0-preview1-runtime`, `3.0-runtime` (*3.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`3.0.100-preview1-sdk-nanoserver-sac2016`, `3.0-sdk-nanoserver-sac2016`, `3.0.100-preview1-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-nanoserver-sac2016`, `3.0-aspnetcore-runtime-nanoserver-sac2016`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`3.0.0-preview1-runtime-nanoserver-sac2016`, `3.0-runtime-nanoserver-sac2016`, `3.0.0-preview1-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
 # Linux arm64 tags
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.100-preview1-sdk-stretch-arm64v8`, `3.0-sdk-stretch-arm64v8`, `3.0.100-preview1-sdk`, `3.0-sdk` (*3.0/sdk/stretch/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm64v8/Dockerfile)
-- [`3.0.100-preview1-sdk-bionic-arm64v8`, `3.0-sdk-bionic-arm64v8` (*3.0/sdk/bionic/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm64v8/Dockerfile)
-- [`3.0.0-preview1-runtime-stretch-slim-arm64v8`, `3.0-runtime-stretch-slim-arm64v8`, `3.0.0-preview1-runtime`, `3.0-runtime` (*3.0/runtime/stretch-slim/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm64v8/Dockerfile)
-- [`3.0.0-preview1-runtime-bionic-arm64v8`, `3.0-runtime-bionic-arm64v8` (*3.0/runtime/bionic/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm64v8/Dockerfile)
-- [`3.0.0-preview1-runtime-deps-stretch-slim-arm64v8`, `3.0-runtime-deps-stretch-slim-arm64v8`, `3.0.0-preview1-runtime-deps`, `3.0-runtime-deps` (*3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile)
-- [`3.0.0-preview1-runtime-deps-bionic-arm64v8`, `3.0-runtime-deps-bionic-arm64v8` (*3.0/runtime-deps/bionic/arm64v8/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm64v8/Dockerfile)
+- [`3.0.100-preview1-sdk-stretch-arm64v8`, `3.0-sdk-stretch-arm64v8`, `3.0.100-preview1-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm64v8/Dockerfile)
+- [`3.0.100-preview1-sdk-bionic-arm64v8`, `3.0-sdk-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm64v8/Dockerfile)
+- [`3.0.0-preview1-runtime-stretch-slim-arm64v8`, `3.0-runtime-stretch-slim-arm64v8`, `3.0.0-preview1-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm64v8/Dockerfile)
+- [`3.0.0-preview1-runtime-bionic-arm64v8`, `3.0-runtime-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm64v8/Dockerfile)
+- [`3.0.0-preview1-runtime-deps-stretch-slim-arm64v8`, `3.0-runtime-deps-stretch-slim-arm64v8`, `3.0.0-preview1-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile)
+- [`3.0.0-preview1-runtime-deps-bionic-arm64v8`, `3.0-runtime-deps-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm64v8/Dockerfile)
 
 # Linux arm32 tags
 
-- [`2.1.500-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.500-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.6-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.6-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.6-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.500-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.500-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 
-- [`2.2.100-preview3-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-preview3-sdk`, `2.2-sdk` (*2.2/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
-- [`2.2.100-preview3-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*2.2/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-preview3-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.0-preview3-runtime`, `2.2-runtime` (*2.2/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-preview3-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*2.2/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-preview3-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.0-preview3-runtime-deps`, `2.2-runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-preview3-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.2.100-preview3-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-preview3-sdk`, `2.2-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
+- [`2.2.100-preview3-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.0-preview3-aspnetcore-runtime`, `2.2-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.0-preview3-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.0-preview3-runtime`, `2.2-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.0-preview3-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.0-preview3-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.0-preview3-runtime-deps`, `2.2-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.0-preview3-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.100-preview1-sdk-stretch-arm32v7`, `3.0-sdk-stretch-arm32v7`, `3.0.100-preview1-sdk`, `3.0-sdk` (*3.0/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm32v7/Dockerfile)
-- [`3.0.100-preview1-sdk-bionic-arm32v7`, `3.0-sdk-bionic-arm32v7` (*3.0/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm32v7/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`3.0.0-preview1-aspnetcore-runtime-bionic-arm32v7`, `3.0-aspnetcore-runtime-bionic-arm32v7` (*3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`3.0.0-preview1-runtime-stretch-slim-arm32v7`, `3.0-runtime-stretch-slim-arm32v7`, `3.0.0-preview1-runtime`, `3.0-runtime` (*3.0/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`3.0.0-preview1-runtime-bionic-arm32v7`, `3.0-runtime-bionic-arm32v7` (*3.0/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm32v7/Dockerfile)
-- [`3.0.0-preview1-runtime-deps-stretch-slim-arm32v7`, `3.0-runtime-deps-stretch-slim-arm32v7`, `3.0.0-preview1-runtime-deps`, `3.0-runtime-deps` (*3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`3.0.0-preview1-runtime-deps-bionic-arm32v7`, `3.0-runtime-deps-bionic-arm32v7` (*3.0/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`3.0.100-preview1-sdk-stretch-arm32v7`, `3.0-sdk-stretch-arm32v7`, `3.0.100-preview1-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm32v7/Dockerfile)
+- [`3.0.100-preview1-sdk-bionic-arm32v7`, `3.0-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm32v7/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0.0-preview1-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`3.0.0-preview1-aspnetcore-runtime-bionic-arm32v7`, `3.0-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`3.0.0-preview1-runtime-stretch-slim-arm32v7`, `3.0-runtime-stretch-slim-arm32v7`, `3.0.0-preview1-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`3.0.0-preview1-runtime-bionic-arm32v7`, `3.0-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm32v7/Dockerfile)
+- [`3.0.0-preview1-runtime-deps-stretch-slim-arm32v7`, `3.0-runtime-deps-stretch-slim-arm32v7`, `3.0.0-preview1-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`3.0.0-preview1-runtime-deps-bionic-arm32v7`, `3.0-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm32v7/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).

--- a/manifest.json
+++ b/manifest.json
@@ -202,11 +202,21 @@
         },
         {
           "sharedTags": {
-            "2.1.6-runtime-deps": {},
-            "2.1-runtime-deps": {},
-            "2.2.0-preview3-runtime-deps": {},
-            "2.2-runtime-deps": {},
-            "runtime-deps": {},
+            "2.1.6-runtime-deps": {
+              "documentationGroup": "2.1"
+            },
+            "2.1-runtime-deps": {
+              "documentationGroup": "2.1"
+            },
+            "2.2.0-preview3-runtime-deps": {
+              "documentationGroup": "2.2"
+            },
+            "2.2-runtime-deps": {
+              "documentationGroup": "2.2"
+            },
+            "runtime-deps": {
+              "documentationGroup": "2.1"
+            },
             "2-runtime-deps": {
               "isUndocumented": true
             }
@@ -216,10 +226,18 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-stretch-slim": {},
-                "2.1-runtime-deps-stretch-slim": {},
-                "2.2.0-preview3-runtime-deps-stretch-slim": {},
-                "2.2-runtime-deps-stretch-slim": {}
+                "2.1.6-runtime-deps-stretch-slim": {
+                  "documentationGroup": "2.1"
+                },
+                "2.1-runtime-deps-stretch-slim": {
+                  "documentationGroup": "2.1"
+                },
+                "2.2.0-preview3-runtime-deps-stretch-slim": {
+                  "documentationGroup": "2.2"
+                },
+                "2.2-runtime-deps-stretch-slim": {
+                  "documentationGroup": "2.2"
+                }
               }
             },
             {
@@ -227,10 +245,18 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-stretch-slim-arm32v7": {},
-                "2.1-runtime-deps-stretch-slim-arm32v7": {},
-                "2.2.0-preview3-runtime-deps-stretch-slim-arm32v7": {},
-                "2.2-runtime-deps-stretch-slim-arm32v7": {}
+                "2.1.6-runtime-deps-stretch-slim-arm32v7": {
+                  "documentationGroup": "2.1"
+                },
+                "2.1-runtime-deps-stretch-slim-arm32v7": {
+                  "documentationGroup": "2.1"
+                },
+                "2.2.0-preview3-runtime-deps-stretch-slim-arm32v7": {
+                  "documentationGroup": "2.2"
+                },
+                "2.2-runtime-deps-stretch-slim-arm32v7": {
+                  "documentationGroup": "2.2"
+                }
               },
               "variant": "v7"
             }
@@ -468,14 +494,30 @@
               "dockerfile": "2.1/runtime-deps/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-alpine3.8": {},
-                "2.1-runtime-deps-alpine3.8": {},
-                "2.2.0-preview3-runtime-deps-alpine3.8": {},
-                "2.2-runtime-deps-alpine3.8": {},
-                "2.1.6-runtime-deps-alpine": {},
-                "2.1-runtime-deps-alpine": {},
-                "2.2.0-preview3-runtime-deps-alpine": {},
-                "2.2-runtime-deps-alpine": {}
+                "2.1.6-runtime-deps-alpine3.8": {
+                  "documentationGroup": "2.1"
+                },
+                "2.1-runtime-deps-alpine3.8": {
+                  "documentationGroup": "2.1"
+                },
+                "2.2.0-preview3-runtime-deps-alpine3.8": {
+                  "documentationGroup": "2.2"
+                },
+                "2.2-runtime-deps-alpine3.8": {
+                  "documentationGroup": "2.2"
+                },
+                "2.1.6-runtime-deps-alpine": {
+                  "documentationGroup": "2.1"
+                },
+                "2.1-runtime-deps-alpine": {
+                  "documentationGroup": "2.1"
+                },
+                "2.2.0-preview3-runtime-deps-alpine": {
+                  "documentationGroup": "2.2"
+                },
+                "2.2-runtime-deps-alpine": {
+                  "documentationGroup": "2.2"
+                }
               }
             }
           ]
@@ -528,10 +570,18 @@
               "dockerfile": "2.1/runtime-deps/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-bionic": {},
-                "2.1-runtime-deps-bionic": {},
-                "2.2.0-preview3-runtime-deps-bionic": {},
-                "2.2-runtime-deps-bionic": {}
+                "2.1.6-runtime-deps-bionic": {
+                  "documentationGroup": "2.1"
+                },
+                "2.1-runtime-deps-bionic": {
+                  "documentationGroup": "2.1"
+                },
+                "2.2.0-preview3-runtime-deps-bionic": {
+                  "documentationGroup": "2.2"
+                },
+                "2.2-runtime-deps-bionic": {
+                  "documentationGroup": "2.2"
+                }
               }
             }
           ]
@@ -579,10 +629,18 @@
               "dockerfile": "2.1/runtime-deps/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-bionic-arm32v7": {},
-                "2.1-runtime-deps-bionic-arm32v7": {},
-                "2.2.0-preview3-runtime-deps-bionic-arm32v7": {},
-                "2.2-runtime-deps-bionic-arm32v7": {}
+                "2.1.6-runtime-deps-bionic-arm32v7": {
+                  "documentationGroup": "2.1"
+                },
+                "2.1-runtime-deps-bionic-arm32v7": {
+                  "documentationGroup": "2.1"
+                },
+                "2.2.0-preview3-runtime-deps-bionic-arm32v7": {
+                  "documentationGroup": "2.2"
+                },
+                "2.2-runtime-deps-bionic-arm32v7": {
+                  "documentationGroup": "2.2"
+                }
               },
               "variant": "v7"
             }

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -4,7 +4,7 @@ param(
     [string]$Manifest='manifest.json',
     [string]$ReadMeTemplate='./scripts/ReadmeTagsDocumentationTemplate.md',
     [string]$TagsTemplate='./scripts/TagsDocumentationTemplate.md',
-    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181022195013'
+    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181029193952'
 )
 
 $ErrorActionPreference = 'Stop'

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -2,29 +2,29 @@
 
 # Linux amd64 tags
 
-$(TagDoc:2.1.500-sdk-stretch)
-$(TagDoc:2.1.500-sdk-alpine3.7)
-$(TagDoc:2.1.500-sdk-alpine3.8)
-$(TagDoc:2.1.500-sdk-bionic)
-$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.6-aspnetcore-runtime-alpine3.7)
-$(TagDoc:2.1.6-aspnetcore-runtime-alpine3.8)
-$(TagDoc:2.1.6-aspnetcore-runtime-bionic)
-$(TagDoc:2.1.6-runtime-stretch-slim)
-$(TagDoc:2.1.6-runtime-alpine3.7)
-$(TagDoc:2.1.6-runtime-alpine3.8)
-$(TagDoc:2.1.6-runtime-bionic)
-$(TagDocList:2.1.6-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.6-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7)
-$(TagDocList:2.1.6-runtime-deps-alpine3.8|2.1-runtime-deps-alpine3.8|2.1.6-runtime-deps-alpine|2.1-runtime-deps-alpine)
-$(TagDocList:2.1.6-runtime-deps-bionic|2.1-runtime-deps-bionic)
-$(TagDoc:1.1.10-sdk-1.1.11-stretch)
-$(TagDoc:1.1.10-sdk-1.1.11-jessie)
-$(TagDoc:1.1.10-runtime-stretch)
-$(TagDoc:1.1.10-runtime-jessie)
-$(TagDoc:1.1.10-runtime-deps-stretch)
-$(TagDoc:1.0.13-runtime-jessie)
-$(TagDoc:1.0.13-runtime-deps-jessie)
+$(TagDoc:2.1-sdk-stretch)
+$(TagDoc:2.1-sdk-alpine3.7)
+$(TagDoc:2.1-sdk-alpine3.8)
+$(TagDoc:2.1-sdk-bionic)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.7)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.8)
+$(TagDoc:2.1-aspnetcore-runtime-bionic)
+$(TagDoc:2.1-runtime-stretch-slim)
+$(TagDoc:2.1-runtime-alpine3.7)
+$(TagDoc:2.1-runtime-alpine3.8)
+$(TagDoc:2.1-runtime-bionic)
+$(TagDoc:2.1-runtime-deps-stretch-slim)
+$(TagDoc:2.1-runtime-deps-alpine3.7)
+$(TagDoc:2.1-runtime-deps-alpine3.8)
+$(TagDoc:2.1-runtime-deps-bionic)
+$(TagDoc:1.1-sdk-stretch)
+$(TagDoc:1.1-sdk-jessie)
+$(TagDoc:1.1-runtime-stretch)
+$(TagDoc:1.1-runtime-jessie)
+$(TagDoc:1.1-runtime-deps-stretch)
+$(TagDoc:1.0-runtime-jessie)
+$(TagDoc:1.0-runtime-deps-jessie)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -32,9 +32,9 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server, version 1803 amd64 tags
 
-$(TagDoc:2.1.500-sdk-nanoserver-1803)
-$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.1.6-runtime-nanoserver-1803)
+$(TagDoc:2.1-sdk-nanoserver-1803)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.1-runtime-nanoserver-1803)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -42,9 +42,9 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server, version 1709 amd64 tags
 
-$(TagDoc:2.1.500-sdk-nanoserver-1709)
-$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.1.6-runtime-nanoserver-1709)
+$(TagDoc:2.1-sdk-nanoserver-1709)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.1-runtime-nanoserver-1709)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -52,12 +52,12 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server 2016 amd64 tags
 
-$(TagDoc:2.1.500-sdk-nanoserver-sac2016)
-$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.1.6-runtime-nanoserver-sac2016)
-$(TagDoc:1.1.10-sdk-1.1.11-nanoserver-sac2016)
-$(TagDoc:1.1.10-runtime-nanoserver-sac2016)
-$(TagDoc:1.0.13-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-sdk-nanoserver-sac2016)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.1-sdk-nanoserver-sac2016)
+$(TagDoc:1.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.0-runtime-nanoserver-sac2016)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 
@@ -65,14 +65,14 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Linux arm32 tags
 
-$(TagDoc:2.1.500-sdk-stretch-arm32v7)
-$(TagDoc:2.1.500-sdk-bionic-arm32v7)
-$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.6-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.1.6-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.6-runtime-bionic-arm32v7)
-$(TagDocList:2.1.6-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.6-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
+$(TagDoc:2.1-sdk-stretch-arm32v7)
+$(TagDoc:2.1-sdk-bionic-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-deps-bionic-arm32v7)
 
 **.NET Core 2.2 & 3.0 Preview tags**
 

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -2,159 +2,159 @@
 
 # Linux amd64 tags
 
-$(TagDoc:2.1.500-sdk-stretch)
-$(TagDoc:2.1.500-sdk-alpine3.7)
-$(TagDoc:2.1.500-sdk-alpine3.8)
-$(TagDoc:2.1.500-sdk-bionic)
-$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.6-aspnetcore-runtime-alpine3.7)
-$(TagDoc:2.1.6-aspnetcore-runtime-alpine3.8)
-$(TagDoc:2.1.6-aspnetcore-runtime-bionic)
-$(TagDoc:2.1.6-runtime-stretch-slim)
-$(TagDoc:2.1.6-runtime-alpine3.7)
-$(TagDoc:2.1.6-runtime-alpine3.8)
-$(TagDoc:2.1.6-runtime-bionic)
-$(TagDocList:2.1.6-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.6-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7)
-$(TagDocList:2.1.6-runtime-deps-alpine3.8|2.1-runtime-deps-alpine3.8|2.1.6-runtime-deps-alpine|2.1-runtime-deps-alpine)
-$(TagDocList:2.1.6-runtime-deps-bionic|2.1-runtime-deps-bionic)
-$(TagDoc:1.1.10-sdk-1.1.11-stretch)
-$(TagDoc:1.1.10-sdk-1.1.11-jessie)
-$(TagDoc:1.1.10-runtime-stretch)
-$(TagDoc:1.1.10-runtime-jessie)
-$(TagDoc:1.1.10-runtime-deps-stretch)
-$(TagDoc:1.0.13-runtime-jessie)
-$(TagDoc:1.0.13-runtime-deps-jessie)
+$(TagDoc:2.1-sdk-stretch)
+$(TagDoc:2.1-sdk-alpine3.7)
+$(TagDoc:2.1-sdk-alpine3.8)
+$(TagDoc:2.1-sdk-bionic)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.7)
+$(TagDoc:2.1-aspnetcore-runtime-alpine3.8)
+$(TagDoc:2.1-aspnetcore-runtime-bionic)
+$(TagDoc:2.1-runtime-stretch-slim)
+$(TagDoc:2.1-runtime-alpine3.7)
+$(TagDoc:2.1-runtime-alpine3.8)
+$(TagDoc:2.1-runtime-bionic)
+$(TagDoc:2.1-runtime-deps-stretch-slim)
+$(TagDoc:2.1-runtime-deps-alpine3.7)
+$(TagDoc:2.1-runtime-deps-alpine3.8)
+$(TagDoc:2.1-runtime-deps-bionic)
+$(TagDoc:1.1-sdk-stretch)
+$(TagDoc:1.1-sdk-jessie)
+$(TagDoc:1.1-runtime-stretch)
+$(TagDoc:1.1-runtime-jessie)
+$(TagDoc:1.1-runtime-deps-stretch)
+$(TagDoc:1.0-runtime-jessie)
+$(TagDoc:1.0-runtime-deps-jessie)
 
 **.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-stretch)
-$(TagDoc:2.2.100-preview3-sdk-alpine3.8)
-$(TagDoc:2.2.100-preview3-sdk-bionic)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-alpine3.8)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-bionic)
-$(TagDoc:2.2.0-preview3-runtime-stretch-slim)
-$(TagDoc:2.2.0-preview3-runtime-alpine3.8)
-$(TagDoc:2.2.0-preview3-runtime-bionic)
-$(TagDocList:2.2.0-preview3-runtime-deps-stretch-slim|2.2-runtime-deps-stretch-slim|2.2.0-preview3-runtime-deps|2.2-runtime-deps)
-$(TagDocList:2.2.0-preview3-runtime-deps-alpine3.8|2.2-runtime-deps-alpine3.8|2.2.0-preview3-runtime-deps-alpine|2.2-runtime-deps-alpine)
-$(TagDocList:2.2.0-preview3-runtime-deps-bionic|2.2-runtime-deps-bionic)
+$(TagDoc:2.2-sdk-stretch)
+$(TagDoc:2.2-sdk-alpine3.8)
+$(TagDoc:2.2-sdk-bionic)
+$(TagDoc:2.2-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.2-aspnetcore-runtime-alpine3.8)
+$(TagDoc:2.2-aspnetcore-runtime-bionic)
+$(TagDoc:2.2-runtime-stretch-slim)
+$(TagDoc:2.2-runtime-alpine3.8)
+$(TagDoc:2.2-runtime-bionic)
+$(TagDoc:2.2-runtime-deps-stretch-slim)
+$(TagDoc:2.2-runtime-deps-alpine3.8)
+$(TagDoc:2.2-runtime-deps-bionic)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-preview1-sdk-stretch)
-$(TagDoc:3.0.100-preview1-sdk-alpine3.8)
-$(TagDoc:3.0.100-preview1-sdk-bionic)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-stretch-slim)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-alpine3.8)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-bionic)
-$(TagDoc:3.0.0-preview1-runtime-stretch-slim)
-$(TagDoc:3.0.0-preview1-runtime-alpine3.8)
-$(TagDoc:3.0.0-preview1-runtime-bionic)
-$(TagDoc:3.0.0-preview1-runtime-deps-stretch-slim)
-$(TagDoc:3.0.0-preview1-runtime-deps-alpine3.8)
-$(TagDoc:3.0.0-preview1-runtime-deps-bionic)
+$(TagDoc:3.0-sdk-stretch)
+$(TagDoc:3.0-sdk-alpine3.8)
+$(TagDoc:3.0-sdk-bionic)
+$(TagDoc:3.0-aspnetcore-runtime-stretch-slim)
+$(TagDoc:3.0-aspnetcore-runtime-alpine3.8)
+$(TagDoc:3.0-aspnetcore-runtime-bionic)
+$(TagDoc:3.0-runtime-stretch-slim)
+$(TagDoc:3.0-runtime-alpine3.8)
+$(TagDoc:3.0-runtime-bionic)
+$(TagDoc:3.0-runtime-deps-stretch-slim)
+$(TagDoc:3.0-runtime-deps-alpine3.8)
+$(TagDoc:3.0-runtime-deps-bionic)
 
 # Windows Server, version 1803 amd64 tags
 
-$(TagDoc:2.1.500-sdk-nanoserver-1803)
-$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.1.6-runtime-nanoserver-1803)
+$(TagDoc:2.1-sdk-nanoserver-1803)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.1-runtime-nanoserver-1803)
 
 **.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-nanoserver-1803)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.2.0-preview3-runtime-nanoserver-1803)
+$(TagDoc:2.2-sdk-nanoserver-1803)
+$(TagDoc:2.2-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.2-runtime-nanoserver-1803)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-preview1-sdk-nanoserver-1803)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:3.0.0-preview1-runtime-nanoserver-1803)
+$(TagDoc:3.0-sdk-nanoserver-1803)
+$(TagDoc:3.0-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:3.0-runtime-nanoserver-1803)
 
 # Windows Server, version 1709 amd64 tags
 
-$(TagDoc:2.1.500-sdk-nanoserver-1709)
-$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.1.6-runtime-nanoserver-1709)
+$(TagDoc:2.1-sdk-nanoserver-1709)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.1-runtime-nanoserver-1709)
 
 **.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-nanoserver-1709)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.2.0-preview3-runtime-nanoserver-1709)
+$(TagDoc:2.2-sdk-nanoserver-1709)
+$(TagDoc:2.2-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.2-runtime-nanoserver-1709)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-preview1-sdk-nanoserver-1709)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:3.0.0-preview1-runtime-nanoserver-1709)
+$(TagDoc:3.0-sdk-nanoserver-1709)
+$(TagDoc:3.0-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:3.0-runtime-nanoserver-1709)
 
 # Windows Server 2016 amd64 tags
 
-$(TagDoc:2.1.500-sdk-nanoserver-sac2016)
-$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.1.6-runtime-nanoserver-sac2016)
-$(TagDoc:1.1.10-sdk-1.1.11-nanoserver-sac2016)
-$(TagDoc:1.1.10-runtime-nanoserver-sac2016)
-$(TagDoc:1.0.13-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-sdk-nanoserver-sac2016)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.1-sdk-nanoserver-sac2016)
+$(TagDoc:1.1-runtime-nanoserver-sac2016)
+$(TagDoc:1.0-runtime-nanoserver-sac2016)
 
 **.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-nanoserver-sac2016)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.2.0-preview3-runtime-nanoserver-sac2016)
+$(TagDoc:2.2-sdk-nanoserver-sac2016)
+$(TagDoc:2.2-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.2-runtime-nanoserver-sac2016)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-preview1-sdk-nanoserver-sac2016)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:3.0.0-preview1-runtime-nanoserver-sac2016)
+$(TagDoc:3.0-sdk-nanoserver-sac2016)
+$(TagDoc:3.0-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:3.0-runtime-nanoserver-sac2016)
 
 # Linux arm64 tags
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-preview1-sdk-stretch-arm64v8)
-$(TagDoc:3.0.100-preview1-sdk-bionic-arm64v8)
-$(TagDoc:3.0.0-preview1-runtime-stretch-slim-arm64v8)
-$(TagDoc:3.0.0-preview1-runtime-bionic-arm64v8)
-$(TagDoc:3.0.0-preview1-runtime-deps-stretch-slim-arm64v8)
-$(TagDoc:3.0.0-preview1-runtime-deps-bionic-arm64v8)
+$(TagDoc:3.0-sdk-stretch-arm64v8)
+$(TagDoc:3.0-sdk-bionic-arm64v8)
+$(TagDoc:3.0-runtime-stretch-slim-arm64v8)
+$(TagDoc:3.0-runtime-bionic-arm64v8)
+$(TagDoc:3.0-runtime-deps-stretch-slim-arm64v8)
+$(TagDoc:3.0-runtime-deps-bionic-arm64v8)
 
 # Linux arm32 tags
 
-$(TagDoc:2.1.500-sdk-stretch-arm32v7)
-$(TagDoc:2.1.500-sdk-bionic-arm32v7)
-$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.6-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.1.6-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.6-runtime-bionic-arm32v7)
-$(TagDocList:2.1.6-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.6-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
+$(TagDoc:2.1-sdk-stretch-arm32v7)
+$(TagDoc:2.1-sdk-bionic-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-deps-bionic-arm32v7)
 
 **.NET Core 2.2 Preview tags**
 
-$(TagDoc:2.2.100-preview3-sdk-stretch-arm32v7)
-$(TagDoc:2.2.100-preview3-sdk-bionic-arm32v7)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.2.0-preview3-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.2.0-preview3-runtime-bionic-arm32v7)
-$(TagDocList:2.2.0-preview3-runtime-deps-stretch-slim-arm32v7|2.2-runtime-deps-stretch-slim-arm32v7|2.2.0-preview3-runtime-deps|2.2-runtime-deps)
-$(TagDocList:2.2.0-preview3-runtime-deps-bionic-arm32v7|2.2-runtime-deps-bionic-arm32v7)
+$(TagDoc:2.2-sdk-stretch-arm32v7)
+$(TagDoc:2.2-sdk-bionic-arm32v7)
+$(TagDoc:2.2-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.2-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.2-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.2-runtime-bionic-arm32v7)
+$(TagDoc:2.2-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:2.2-runtime-deps-bionic-arm32v7)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0.100-preview1-sdk-stretch-arm32v7)
-$(TagDoc:3.0.100-preview1-sdk-bionic-arm32v7)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:3.0.0-preview1-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:3.0.0-preview1-runtime-stretch-slim-arm32v7)
-$(TagDoc:3.0.0-preview1-runtime-bionic-arm32v7)
-$(TagDoc:3.0.0-preview1-runtime-deps-stretch-slim-arm32v7)
-$(TagDoc:3.0.0-preview1-runtime-deps-bionic-arm32v7)
+$(TagDoc:3.0-sdk-stretch-arm32v7)
+$(TagDoc:3.0-sdk-bionic-arm32v7)
+$(TagDoc:3.0-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:3.0-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:3.0-runtime-stretch-slim-arm32v7)
+$(TagDoc:3.0-runtime-bionic-arm32v7)
+$(TagDoc:3.0-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:3.0-runtime-deps-bionic-arm32v7)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).


### PR DESCRIPTION
Updated the readme templates to reference the <major>.<minor> tags versus the <major>.<minor>.<patch> tags.  This eases the maintenance as the templates don't have to be updated when picking up new patch versions.  

In order to support this, a new version of the image-builder is used which has dotnet/docker-tools#119.  Along with getting this change comes the new change to not include the Dockerfile path in the readme.  This is to reduce this size of the readme to fit into Docker Hub which has a 25 K limit.