### PR TITLE
Remove test instructions from manifest

### DIFF
--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -26,7 +26,6 @@ jobs:
       $(imageBuilderPaths)
       --os-version $(osVersion)
       --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix)
-      --skip-test
       --push
       --server $(acr.server)
       --username $(acr.userName)

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,4 @@
 {
-  "testCommands": {
-    "linux": [
-      "docker build --rm -t testrunner -f ./tests/Dockerfile.linux.testrunner .",
-      "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner pwsh -File ./tests/run-tests.ps1 -VersionFilter $(VersionFilter) -ArchitectureFilter $(ArchitectureFilter) -RepoOwner $(System:RepoOwner)"
-    ],
-    "windows": [
-      "powershell -NoProfile -Command .\\tests\\run-tests.ps1 -VersionFilter $(VersionFilter) -OSFilter $(System:OsVersion) -RepoOwner $(System:RepoOwner)"
-    ]
-  },
   "repos": [
     {
       "name": "microsoft/dotnet-nightly",


### PR DESCRIPTION
The manifest.json currently has test instructions specified within it.  These can be invoked when using the ImageBuilder tool.  We no longer use these so they should be cleaned up.