### PR TITLE
Updates to ease/automate on-boarding new patch versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ artifacts/
 # User-specific files
 *.suo
 *.user
+
+# ImageBuilder directory
+.Microsoft.DotNet.ImageBuilder

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -1,63 +1,72 @@
 #!/usr/bin/env pwsh
 [cmdletbinding()]
 param(
-    [switch]$UseImageCache,
-    [string]$VersionFilter,
-    [string]$ArchitectureFilter,
-    [string]$OSFilter
+    [string]$VersionFilter = "*",
+    [string]$OSFilter = "*",
+    [string]$ArchitectureFilter = "amd64",
+    [string]$ImageBuilderCustomArgs,
+    [switch]$SkipTesting = $false
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$(docker version) | % { Write-Host "$_" }
-$activeOS = docker version -f "{{ .Server.Os }}"
+function Log {
+    param ([string] $Message)
 
-if ($UseImageCache) {
-    $optionalDockerBuildArgs = ""
-}
-else {
-    $optionalDockerBuildArgs = "--no-cache"
+    Write-Output $Message
 }
 
-$manifest = Get-Content "manifest.json" | ConvertFrom-Json
-$manifestRepo = $manifest.Repos[0]
-$builtTags = @()
+function Exec {
+    param ([string] $Cmd)
 
-$buildFilter = "*"
-if (-not [string]::IsNullOrEmpty($versionFilter))
-{
-    $buildFilter = "$versionFilter/$buildFilter"
-}
-if (-not [string]::IsNullOrEmpty($OsFilter))
-{
-    $buildFilter = "$buildFilter/$OsFilter/*"
+    Log "Executing: '$Cmd'"
+    Invoke-Expression $Cmd
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed: '$Cmd'"
+    }
 }
 
+$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181022125001'
+$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181022195013'
+$imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
 
-$manifestRepo.Images |
-ForEach-Object {
-    $images = $_
-    $_.Platforms |
-        Where-Object { $_.os -eq "$activeOS" } |
-        Where-Object { [string]::IsNullOrEmpty($buildFilter) -or $_.dockerfile -like "$buildFilter" } |
-        Where-Object { ( [string]::IsNullOrEmpty($ArchitectureFilter) -and -not [bool]($_.PSobject.Properties.name -match "architecture"))`
-            -or ( [bool]($_.PSobject.Properties.name -match "architecture") -and $_.architecture -eq "$ArchitectureFilter" ) } |
-        ForEach-Object {
-            $dockerfilePath = $_.dockerfile
-            $tags = [array]($_.Tags | ForEach-Object { $_.PSobject.Properties })
-            $qualifiedTags = $tags | ForEach-Object { $manifestRepo.Name + ':' + $_.Name}
-            $formattedTags = $qualifiedTags -join ', '
-            Write-Host "--- Building $formattedTags from $dockerfilePath ---"
-            Invoke-Expression "docker build $optionalDockerBuildArgs -t $($qualifiedTags -join ' -t ') $dockerfilePath"
-            if ($LastExitCode -ne 0) {
-                throw "Failed building $formattedTags"
-            }
-
-            $builtTags += $formattedTags
+pushd $PSScriptRoot
+try {
+    $activeOS = docker version -f "{{ .Server.Os }}"
+    if ($activeOS -eq "linux") {
+        # On Linux, ImageBuilder is run within a container.  The local repo is copied into a Docker volume
+        # in order to support running with a remote Docker server.
+        ./scripts/Invoke-PullImage $linuxImageBuilder
+        $repoVolume = "repo-$(Get-Date -Format yyyyMMddhhmmss)"
+        Exec "docker create -v ${repoVolume}:/repo --name $imageBuilderContainerName $linuxImageBuilder"
+        Exec "docker cp ${PSScriptRoot}/. ${imageBuilderContainerName}:/repo"
+        Exec "docker container rm -f $imageBuilderContainerName"
+        $imageBuilderCmd = "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${repoVolume}:/repo -w /repo $linuxImageBuilder"
+    }
+    else {
+        # On Windows, ImageBuild is run locally due to limitations with running Docker client within a container.
+        $imageBuilderFolder = [System.IO.Path]::Combine($PSScriptRoot, ".Microsoft.DotNet.ImageBuilder")
+        $imageBuilderCmd = [System.IO.Path]::Combine($imageBuilderFolder, "image-builder", "Microsoft.DotNet.ImageBuilder.exe")
+        if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
+            ./scripts/Invoke-PullImage $windowsImageBuilder
+            Exec "docker create --name $imageBuilderContainerName $windowsImageBuilder"
+            New-Item -Path "$imageBuilderFolder" -ItemType Directory -Force
+            Exec "docker cp ${imageBuilderContainerName}:/image-builder $imageBuilderFolder"
+            Exec "docker container rm -f $imageBuilderContainerName"
         }
+    }
+
+    Exec "$imageBuilderCmd build --path '$VersionFilter/*/$OSFilter/$ArchitectureFilter' $ImageBuilderCustomArgs"
+
+    if ($activeOS -eq "linux") {
+        Exec "docker volume rm -f $repoVolume"
+    }
+
+    if (-not $SkipTesting) {
+        ./tests/run-tests.ps1 -VersionFilter $VersionFilter -ArchitectureFilter $ArchitectureFilter -OSFilter $OSFilter -IsLocalRun
+    }
 }
-
-./tests/run-tests.ps1 -VersionFilter $VersionFilter -ArchitectureFilter $ArchitectureFilter -OSFilter $OSFilter -IsLocalRun
-Write-Host "Tags built and tested:`n$($builtTags | Out-String)"
-
+finally {
+    popd
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,15 @@
 {
+  "variables": {
+    "1.0-RuntimeVersion": "1.0.13",
+    "1.1-RuntimeVersion": "1.1.10",
+    "1.1-SdkVersion": "1.1.11",
+    "2.1-RuntimeVersion": "2.1.6",
+    "2.1-SdkVersion": "2.1.500",
+    "2.2-RuntimeVersion": "2.2.0-preview3",
+    "2.2-SdkVersion": "2.2.100-preview3",
+    "3.0-RuntimeVersion": "3.0.0-preview1",
+    "3.0-SdkVersion": "3.0.100-preview1"
+  },
   "repos": [
     {
       "name": "microsoft/dotnet-nightly",
@@ -6,7 +17,7 @@
       "images": [
         {
           "sharedTags": {
-            "1.0.13-runtime-deps": {},
+            "$(1.0-RuntimeVersion)-runtime-deps": {},
             "1.0-runtime-deps": {},
             "1-runtime-deps": {
               "isUndocumented": true
@@ -20,7 +31,7 @@
               "dockerfile": "1.0/runtime-deps/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.0.13-runtime-deps-jessie": {},
+                "$(1.0-RuntimeVersion)-runtime-deps-jessie": {},
                 "1.0-runtime-deps-jessie": {},
                 "1.0-core-deps": {
                   "isUndocumented": true
@@ -37,7 +48,7 @@
         },
         {
           "sharedTags": {
-            "1.0.13-runtime": {},
+            "$(1.0-RuntimeVersion)-runtime": {},
             "1.0-runtime": {}
           },
           "platforms": [
@@ -45,7 +56,7 @@
               "dockerfile": "1.0/runtime/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.0.13-runtime-jessie": {},
+                "$(1.0-RuntimeVersion)-runtime-jessie": {},
                 "1.0-runtime-jessie": {},
                 "1.0-core": {
                   "isUndocumented": true
@@ -57,7 +68,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "1.0.13-runtime-nanoserver-sac2016": {},
+                "$(1.0-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "1.0-runtime-nanoserver-sac2016": {},
                 "1.0-runtime-nanoserver": {
                   "isUndocumented": true
@@ -68,7 +79,7 @@
         },
         {
           "sharedTags": {
-            "1.1.10-runtime": {},
+            "$(1.1-RuntimeVersion)-runtime": {},
             "1.1-runtime": {},
             "1-runtime": {
               "isUndocumented": true
@@ -79,7 +90,7 @@
               "dockerfile": "1.1/runtime/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.1.10-runtime-jessie": {},
+                "$(1.1-RuntimeVersion)-runtime-jessie": {},
                 "1.1-runtime-jessie": {},
                 "1-core": {
                   "isUndocumented": true
@@ -94,7 +105,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "1.1.10-runtime-nanoserver-sac2016": {},
+                "$(1.1-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "1.1-runtime-nanoserver-sac2016": {},
                 "1.1-runtime-nanoserver": {
                   "isUndocumented": true
@@ -111,7 +122,7 @@
         },
         {
           "sharedTags": {
-            "1.1.10-sdk-1.1.11": {},
+            "$(1.1-RuntimeVersion)-sdk-$(1.1-SdkVersion)": {},
             "1.1-sdk": {},
             "1-sdk": {
               "isUndocumented": true
@@ -125,7 +136,7 @@
               "dockerfile": "1.1/sdk/jessie/amd64",
               "os": "linux",
               "tags": {
-                "1.1.10-sdk-1.1.11-jessie": {},
+                "$(1.1-RuntimeVersion)-sdk-$(1.1-SdkVersion)-jessie": {},
                 "1.1-sdk-jessie": {}
               }
             },
@@ -134,7 +145,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "1.1.10-sdk-1.1.11-nanoserver-sac2016": {},
+                "$(1.1-RuntimeVersion)-sdk-$(1.1-SdkVersion)-nanoserver-sac2016": {},
                 "1.1-sdk-nanoserver-sac2016": {},
                 "1.1-sdk-nanoserver": {
                   "isUndocumented": true
@@ -161,7 +172,7 @@
               "dockerfile": "1.1/runtime-deps/stretch/amd64",
               "os": "linux",
               "tags": {
-                "1.1.10-runtime-deps-stretch": {},
+                "$(1.1-RuntimeVersion)-runtime-deps-stretch": {},
                 "1.1-runtime-deps-stretch": {}
               }
             }
@@ -173,7 +184,7 @@
               "dockerfile": "1.1/runtime/stretch/amd64",
               "os": "linux",
               "tags": {
-                "1.1.10-runtime-stretch": {},
+                "$(1.1-RuntimeVersion)-runtime-stretch": {},
                 "1.1-runtime-stretch": {}
               }
             }
@@ -185,7 +196,7 @@
               "dockerfile": "1.1/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "1.1.10-sdk-1.1.11-stretch": {},
+                "$(1.1-RuntimeVersion)-sdk-$(1.1-SdkVersion)-stretch": {},
                 "1.1-sdk-stretch": {}
               }
             }
@@ -193,13 +204,13 @@
         },
         {
           "sharedTags": {
-            "2.1.6-runtime-deps": {
+            "$(2.1-RuntimeVersion)-runtime-deps": {
               "documentationGroup": "2.1"
             },
             "2.1-runtime-deps": {
               "documentationGroup": "2.1"
             },
-            "2.2.0-preview3-runtime-deps": {
+            "$(2.2-RuntimeVersion)-runtime-deps": {
               "documentationGroup": "2.2"
             },
             "2.2-runtime-deps": {
@@ -217,13 +228,13 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-stretch-slim": {
+                "$(2.1-RuntimeVersion)-runtime-deps-stretch-slim": {
                   "documentationGroup": "2.1"
                 },
                 "2.1-runtime-deps-stretch-slim": {
                   "documentationGroup": "2.1"
                 },
-                "2.2.0-preview3-runtime-deps-stretch-slim": {
+                "$(2.2-RuntimeVersion)-runtime-deps-stretch-slim": {
                   "documentationGroup": "2.2"
                 },
                 "2.2-runtime-deps-stretch-slim": {
@@ -236,13 +247,13 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-stretch-slim-arm32v7": {
+                "$(2.1-RuntimeVersion)-runtime-deps-stretch-slim-arm32v7": {
                   "documentationGroup": "2.1"
                 },
                 "2.1-runtime-deps-stretch-slim-arm32v7": {
                   "documentationGroup": "2.1"
                 },
-                "2.2.0-preview3-runtime-deps-stretch-slim-arm32v7": {
+                "$(2.2-RuntimeVersion)-runtime-deps-stretch-slim-arm32v7": {
                   "documentationGroup": "2.2"
                 },
                 "2.2-runtime-deps-stretch-slim-arm32v7": {
@@ -255,7 +266,7 @@
         },
         {
           "sharedTags": {
-            "2.1.6-runtime": {},
+            "$(2.1-RuntimeVersion)-runtime": {},
             "2.1-runtime": {},
             "runtime": {},
             "2-runtime": {
@@ -267,7 +278,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-stretch-slim": {},
+                "$(2.1-RuntimeVersion)-runtime-stretch-slim": {},
                 "2.1-runtime-stretch-slim": {}
               }
             },
@@ -276,7 +287,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-stretch-slim-arm32v7": {},
+                "$(2.1-RuntimeVersion)-runtime-stretch-slim-arm32v7": {},
                 "2.1-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -286,7 +297,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.6-runtime-nanoserver-sac2016": {},
+                "$(2.1-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "2.1-runtime-nanoserver-sac2016": {},
                 "2-runtime-nanoserver": {
                   "isUndocumented": true
@@ -298,7 +309,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.6-runtime-nanoserver-1709": {},
+                "$(2.1-RuntimeVersion)-runtime-nanoserver-1709": {},
                 "2.1-runtime-nanoserver-1709": {}
               }
             },
@@ -307,7 +318,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.6-runtime-nanoserver-1803": {},
+                "$(2.1-RuntimeVersion)-runtime-nanoserver-1803": {},
                 "2.1-runtime-nanoserver-1803": {}
               }
             }
@@ -315,7 +326,7 @@
         },
         {
           "sharedTags": {
-            "2.1.6-aspnetcore-runtime": {},
+            "$(2.1-RuntimeVersion)-aspnetcore-runtime": {},
             "2.1-aspnetcore-runtime": {},
             "aspnetcore-runtime": {},
             "2-aspnetcore-runtime": {
@@ -327,7 +338,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-aspnetcore-runtime-stretch-slim": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-stretch-slim": {},
                 "2.1-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -336,7 +347,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-aspnetcore-runtime-stretch-slim-arm32v7": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-stretch-slim-arm32v7": {},
                 "2.1-aspnetcore-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -346,7 +357,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.6-aspnetcore-runtime-nanoserver-sac2016": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-nanoserver-sac2016": {},
                 "2.1-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -355,7 +366,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.6-aspnetcore-runtime-nanoserver-1709": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-nanoserver-1709": {},
                 "2.1-aspnetcore-runtime-nanoserver-1709": {}
               }
             },
@@ -364,7 +375,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.6-aspnetcore-runtime-nanoserver-1803": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-nanoserver-1803": {},
                 "2.1-aspnetcore-runtime-nanoserver-1803": {}
               }
             }
@@ -372,7 +383,7 @@
         },
         {
           "sharedTags": {
-            "2.1.500-sdk": {},
+            "$(2.1-SdkVersion)-sdk": {},
             "2.1-sdk": {},
             "sdk": {},
             "latest": {},
@@ -385,7 +396,7 @@
               "dockerfile": "2.1/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "2.1.500-sdk-stretch": {},
+                "$(2.1-SdkVersion)-sdk-stretch": {},
                 "2.1-sdk-stretch": {}
               }
             },
@@ -394,7 +405,7 @@
               "dockerfile": "2.1/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.500-sdk-stretch-arm32v7": {},
+                "$(2.1-SdkVersion)-sdk-stretch-arm32v7": {},
                 "2.1-sdk-stretch-arm32v7": {}
               },
               "variant": "v7"
@@ -404,7 +415,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.500-sdk-nanoserver-sac2016": {},
+                "$(2.1-SdkVersion)-sdk-nanoserver-sac2016": {},
                 "2.1-sdk-nanoserver-sac2016": {},
                 "2-sdk-nanoserver": {
                   "isUndocumented": true
@@ -416,7 +427,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.500-sdk-nanoserver-1709": {},
+                "$(2.1-SdkVersion)-sdk-nanoserver-1709": {},
                 "2.1-sdk-nanoserver-1709": {}
               }
             },
@@ -425,7 +436,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.500-sdk-nanoserver-1803": {},
+                "$(2.1-SdkVersion)-sdk-nanoserver-1803": {},
                 "2.1-sdk-nanoserver-1803": {}
               }
             }
@@ -437,7 +448,7 @@
               "dockerfile": "2.1/runtime-deps/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-alpine3.7": {},
+                "$(2.1-RuntimeVersion)-runtime-deps-alpine3.7": {},
                 "2.1-runtime-deps-alpine3.7": {}
               }
             }
@@ -449,7 +460,7 @@
               "dockerfile": "2.1/runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-alpine3.7": {},
+                "$(2.1-RuntimeVersion)-runtime-alpine3.7": {},
                 "2.1-runtime-alpine3.7": {}
               }
             }
@@ -461,7 +472,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-aspnetcore-runtime-alpine3.7": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-alpine3.7": {},
                 "2.1-aspnetcore-runtime-alpine3.7": {}
               }
             }
@@ -473,7 +484,7 @@
               "dockerfile": "2.1/sdk/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.500-sdk-alpine3.7": {},
+                "$(2.1-SdkVersion)-sdk-alpine3.7": {},
                 "2.1-sdk-alpine3.7": {}
               }
             }
@@ -485,25 +496,25 @@
               "dockerfile": "2.1/runtime-deps/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-alpine3.8": {
+                "$(2.1-RuntimeVersion)-runtime-deps-alpine3.8": {
                   "documentationGroup": "2.1"
                 },
                 "2.1-runtime-deps-alpine3.8": {
                   "documentationGroup": "2.1"
                 },
-                "2.2.0-preview3-runtime-deps-alpine3.8": {
+                "$(2.2-RuntimeVersion)-runtime-deps-alpine3.8": {
                   "documentationGroup": "2.2"
                 },
                 "2.2-runtime-deps-alpine3.8": {
                   "documentationGroup": "2.2"
                 },
-                "2.1.6-runtime-deps-alpine": {
+                "$(2.1-RuntimeVersion)-runtime-deps-alpine": {
                   "documentationGroup": "2.1"
                 },
                 "2.1-runtime-deps-alpine": {
                   "documentationGroup": "2.1"
                 },
-                "2.2.0-preview3-runtime-deps-alpine": {
+                "$(2.2-RuntimeVersion)-runtime-deps-alpine": {
                   "documentationGroup": "2.2"
                 },
                 "2.2-runtime-deps-alpine": {
@@ -519,9 +530,9 @@
               "dockerfile": "2.1/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-alpine3.8": {},
+                "$(2.1-RuntimeVersion)-runtime-alpine3.8": {},
                 "2.1-runtime-alpine3.8": {},
-                "2.1.6-runtime-alpine": {},
+                "$(2.1-RuntimeVersion)-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
               }
             }
@@ -533,9 +544,9 @@
               "dockerfile": "2.1/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-aspnetcore-runtime-alpine3.8": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-alpine3.8": {},
                 "2.1-aspnetcore-runtime-alpine3.8": {},
-                "2.1.6-aspnetcore-runtime-alpine": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-alpine": {},
                 "2.1-aspnetcore-runtime-alpine": {}
               }
             }
@@ -547,9 +558,9 @@
               "dockerfile": "2.1/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.1.500-sdk-alpine3.8": {},
+                "$(2.1-SdkVersion)-sdk-alpine3.8": {},
                 "2.1-sdk-alpine3.8": {},
-                "2.1.500-sdk-alpine": {},
+                "$(2.1-SdkVersion)-sdk-alpine": {},
                 "2.1-sdk-alpine": {}
               }
             }
@@ -561,13 +572,13 @@
               "dockerfile": "2.1/runtime-deps/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-bionic": {
+                "$(2.1-RuntimeVersion)-runtime-deps-bionic": {
                   "documentationGroup": "2.1"
                 },
                 "2.1-runtime-deps-bionic": {
                   "documentationGroup": "2.1"
                 },
-                "2.2.0-preview3-runtime-deps-bionic": {
+                "$(2.2-RuntimeVersion)-runtime-deps-bionic": {
                   "documentationGroup": "2.2"
                 },
                 "2.2-runtime-deps-bionic": {
@@ -583,7 +594,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-aspnetcore-runtime-bionic": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-bionic": {},
                 "2.1-aspnetcore-runtime-bionic": {}
               }
             }
@@ -595,7 +606,7 @@
               "dockerfile": "2.1/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-bionic": {},
+                "$(2.1-RuntimeVersion)-runtime-bionic": {},
                 "2.1-runtime-bionic": {}
               }
             }
@@ -607,7 +618,7 @@
               "dockerfile": "2.1/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.500-sdk-bionic": {},
+                "$(2.1-SdkVersion)-sdk-bionic": {},
                 "2.1-sdk-bionic": {}
               }
             }
@@ -620,13 +631,13 @@
               "dockerfile": "2.1/runtime-deps/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-deps-bionic-arm32v7": {
+                "$(2.1-RuntimeVersion)-runtime-deps-bionic-arm32v7": {
                   "documentationGroup": "2.1"
                 },
                 "2.1-runtime-deps-bionic-arm32v7": {
                   "documentationGroup": "2.1"
                 },
-                "2.2.0-preview3-runtime-deps-bionic-arm32v7": {
+                "$(2.2-RuntimeVersion)-runtime-deps-bionic-arm32v7": {
                   "documentationGroup": "2.2"
                 },
                 "2.2-runtime-deps-bionic-arm32v7": {
@@ -644,7 +655,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-aspnetcore-runtime-bionic-arm32v7": {},
+                "$(2.1-RuntimeVersion)-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.1-aspnetcore-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -658,7 +669,7 @@
               "dockerfile": "2.1/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.6-runtime-bionic-arm32v7": {},
+                "$(2.1-RuntimeVersion)-runtime-bionic-arm32v7": {},
                 "2.1-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -672,7 +683,7 @@
               "dockerfile": "2.1/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.500-sdk-bionic-arm32v7": {},
+                "$(2.1-SdkVersion)-sdk-bionic-arm32v7": {},
                 "2.1-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -681,7 +692,7 @@
         },
         {
           "sharedTags": {
-            "2.2.0-preview3-runtime": {},
+            "$(2.2-RuntimeVersion)-runtime": {},
             "2.2-runtime": {}
           },
           "platforms": [
@@ -689,7 +700,7 @@
               "dockerfile": "2.2/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-stretch-slim": {},
+                "$(2.2-RuntimeVersion)-runtime-stretch-slim": {},
                 "2.2-runtime-stretch-slim": {}
               }
             },
@@ -698,7 +709,7 @@
               "dockerfile": "2.2/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-stretch-slim-arm32v7": {},
+                "$(2.2-RuntimeVersion)-runtime-stretch-slim-arm32v7": {},
                 "2.2-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -708,7 +719,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.2.0-preview3-runtime-nanoserver-sac2016": {},
+                "$(2.2-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "2.2-runtime-nanoserver-sac2016": {}
               }
             },
@@ -717,7 +728,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.2.0-preview3-runtime-nanoserver-1709": {},
+                "$(2.2-RuntimeVersion)-runtime-nanoserver-1709": {},
                 "2.2-runtime-nanoserver-1709": {}
               }
             },
@@ -726,7 +737,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.2.0-preview3-runtime-nanoserver-1803": {},
+                "$(2.2-RuntimeVersion)-runtime-nanoserver-1803": {},
                 "2.2-runtime-nanoserver-1803": {}
               }
             }
@@ -734,7 +745,7 @@
         },
         {
           "sharedTags": {
-            "2.2.0-preview3-aspnetcore-runtime": {},
+            "$(2.2-RuntimeVersion)-aspnetcore-runtime": {},
             "2.2-aspnetcore-runtime": {}
           },
           "platforms": [
@@ -742,7 +753,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-stretch-slim": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-stretch-slim": {},
                 "2.2-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -751,7 +762,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-stretch-slim-arm32v7": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-stretch-slim-arm32v7": {},
                 "2.2-aspnetcore-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -761,7 +772,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-nanoserver-sac2016": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-nanoserver-sac2016": {},
                 "2.2-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -770,7 +781,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-nanoserver-1709": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-nanoserver-1709": {},
                 "2.2-aspnetcore-runtime-nanoserver-1709": {}
               }
             },
@@ -779,7 +790,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-nanoserver-1803": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-nanoserver-1803": {},
                 "2.2-aspnetcore-runtime-nanoserver-1803": {}
               }
             }
@@ -787,7 +798,7 @@
         },
         {
           "sharedTags": {
-            "2.2.100-preview3-sdk": {},
+            "$(2.2-SdkVersion)-sdk": {},
             "2.2-sdk": {}
           },
           "platforms": [
@@ -795,7 +806,7 @@
               "dockerfile": "2.2/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-stretch": {},
+                "$(2.2-SdkVersion)-sdk-stretch": {},
                 "2.2-sdk-stretch": {}
               }
             },
@@ -804,7 +815,7 @@
               "dockerfile": "2.2/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-stretch-arm32v7": {},
+                "$(2.2-SdkVersion)-sdk-stretch-arm32v7": {},
                 "2.2-sdk-stretch-arm32v7": {}
               },
               "variant": "v7"
@@ -814,7 +825,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.2.100-preview3-sdk-nanoserver-sac2016": {},
+                "$(2.2-SdkVersion)-sdk-nanoserver-sac2016": {},
                 "2.2-sdk-nanoserver-sac2016": {}
               }
             },
@@ -823,7 +834,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.2.100-preview3-sdk-nanoserver-1709": {},
+                "$(2.2-SdkVersion)-sdk-nanoserver-1709": {},
                 "2.2-sdk-nanoserver-1709": {}
               }
             },
@@ -832,7 +843,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.2.100-preview3-sdk-nanoserver-1803": {},
+                "$(2.2-SdkVersion)-sdk-nanoserver-1803": {},
                 "2.2-sdk-nanoserver-1803": {}
               }
             }
@@ -844,9 +855,9 @@
               "dockerfile": "2.2/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-alpine3.8": {},
+                "$(2.2-RuntimeVersion)-runtime-alpine3.8": {},
                 "2.2-runtime-alpine3.8": {},
-                "2.2.0-preview3-runtime-alpine": {},
+                "$(2.2-RuntimeVersion)-runtime-alpine": {},
                 "2.2-runtime-alpine": {}
               }
             }
@@ -858,9 +869,9 @@
               "dockerfile": "2.2/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-alpine3.8": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-alpine3.8": {},
                 "2.2-aspnetcore-runtime-alpine3.8": {},
-                "2.2.0-preview3-aspnetcore-runtime-alpine": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-alpine": {},
                 "2.2-aspnetcore-runtime-alpine": {}
               }
             }
@@ -872,9 +883,9 @@
               "dockerfile": "2.2/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-alpine3.8": {},
+                "$(2.2-SdkVersion)-sdk-alpine3.8": {},
                 "2.2-sdk-alpine3.8": {},
-                "2.2.100-preview3-sdk-alpine": {},
+                "$(2.2-SdkVersion)-sdk-alpine": {},
                 "2.2-sdk-alpine": {}
               }
             }
@@ -886,7 +897,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-bionic": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-bionic": {},
                 "2.2-aspnetcore-runtime-bionic": {}
               }
             }
@@ -898,7 +909,7 @@
               "dockerfile": "2.2/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-bionic": {},
+                "$(2.2-RuntimeVersion)-runtime-bionic": {},
                 "2.2-runtime-bionic": {}
               }
             }
@@ -910,7 +921,7 @@
               "dockerfile": "2.2/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-bionic": {},
+                "$(2.2-SdkVersion)-sdk-bionic": {},
                 "2.2-sdk-bionic": {}
               }
             }
@@ -923,7 +934,7 @@
               "dockerfile": "2.2/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7": {},
+                "$(2.2-RuntimeVersion)-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.2-aspnetcore-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -937,7 +948,7 @@
               "dockerfile": "2.2/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.0-preview3-runtime-bionic-arm32v7": {},
+                "$(2.2-RuntimeVersion)-runtime-bionic-arm32v7": {},
                 "2.2-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -951,7 +962,7 @@
               "dockerfile": "2.2/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.2.100-preview3-sdk-bionic-arm32v7": {},
+                "$(2.2-SdkVersion)-sdk-bionic-arm32v7": {},
                 "2.2-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -960,7 +971,7 @@
         },
         {
           "sharedTags": {
-            "3.0.0-preview1-runtime-deps": {},
+            "$(3.0-RuntimeVersion)-runtime-deps": {},
             "3.0-runtime-deps": {}
           },
           "platforms": [
@@ -968,7 +979,7 @@
               "dockerfile": "3.0/runtime-deps/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-deps-stretch-slim": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-stretch-slim": {},
                 "3.0-runtime-deps-stretch-slim": {}
               }
             },
@@ -977,7 +988,7 @@
               "dockerfile": "3.0/runtime-deps/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-deps-stretch-slim-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-stretch-slim-arm32v7": {},
                 "3.0-runtime-deps-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -987,7 +998,7 @@
               "dockerfile": "3.0/runtime-deps/stretch-slim/arm64v8",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-deps-stretch-slim-arm64v8": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-stretch-slim-arm64v8": {},
                 "3.0-runtime-deps-stretch-slim-arm64v8": {}
               },
               "variant": "v8"
@@ -996,7 +1007,7 @@
         },
         {
           "sharedTags": {
-            "3.0.0-preview1-runtime": {},
+            "$(3.0-RuntimeVersion)-runtime": {},
             "3.0-runtime": {}
           },
           "platforms": [
@@ -1004,7 +1015,7 @@
               "dockerfile": "3.0/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-stretch-slim": {},
+                "$(3.0-RuntimeVersion)-runtime-stretch-slim": {},
                 "3.0-runtime-stretch-slim": {}
               }
             },
@@ -1013,7 +1024,7 @@
               "dockerfile": "3.0/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-stretch-slim-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-stretch-slim-arm32v7": {},
                 "3.0-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -1023,7 +1034,7 @@
               "dockerfile": "3.0/runtime/stretch-slim/arm64v8",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-stretch-slim-arm64v8": {},
+                "$(3.0-RuntimeVersion)-runtime-stretch-slim-arm64v8": {},
                 "3.0-runtime-stretch-slim-arm64v8": {}
               },
               "variant": "v8"
@@ -1033,7 +1044,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "3.0.0-preview1-runtime-nanoserver-sac2016": {},
+                "$(3.0-RuntimeVersion)-runtime-nanoserver-sac2016": {},
                 "3.0-runtime-nanoserver-sac2016": {}
               }
             },
@@ -1042,7 +1053,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "3.0.0-preview1-runtime-nanoserver-1709": {},
+                "$(3.0-RuntimeVersion)-runtime-nanoserver-1709": {},
                 "3.0-runtime-nanoserver-1709": {}
               }
             },
@@ -1051,7 +1062,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "3.0.0-preview1-runtime-nanoserver-1803": {},
+                "$(3.0-RuntimeVersion)-runtime-nanoserver-1803": {},
                 "3.0-runtime-nanoserver-1803": {}
               }
             }
@@ -1059,7 +1070,7 @@
         },
         {
           "sharedTags": {
-            "3.0.0-preview1-aspnetcore-runtime": {},
+            "$(3.0-RuntimeVersion)-aspnetcore-runtime": {},
             "3.0-aspnetcore-runtime": {}
           },
           "platforms": [
@@ -1067,7 +1078,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-stretch-slim": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-stretch-slim": {},
                 "3.0-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -1076,7 +1087,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-stretch-slim-arm32v7": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-stretch-slim-arm32v7": {},
                 "3.0-aspnetcore-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -1086,7 +1097,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-nanoserver-sac2016": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-nanoserver-sac2016": {},
                 "3.0-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -1095,7 +1106,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-nanoserver-1709": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-nanoserver-1709": {},
                 "3.0-aspnetcore-runtime-nanoserver-1709": {}
               }
             },
@@ -1104,7 +1115,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-nanoserver-1803": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-nanoserver-1803": {},
                 "3.0-aspnetcore-runtime-nanoserver-1803": {}
               }
             }
@@ -1112,7 +1123,7 @@
         },
         {
           "sharedTags": {
-            "3.0.100-preview1-sdk": {},
+            "$(3.0-SdkVersion)-sdk": {},
             "3.0-sdk": {}
           },
           "platforms": [
@@ -1120,7 +1131,7 @@
               "dockerfile": "3.0/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "3.0.100-preview1-sdk-stretch": {},
+                "$(3.0-SdkVersion)-sdk-stretch": {},
                 "3.0-sdk-stretch": {}
               }
             },
@@ -1129,7 +1140,7 @@
               "dockerfile": "3.0/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.100-preview1-sdk-stretch-arm32v7": {},
+                "$(3.0-SdkVersion)-sdk-stretch-arm32v7": {},
                 "3.0-sdk-stretch-arm32v7": {}
               },
               "variant": "v7"
@@ -1139,7 +1150,7 @@
               "dockerfile": "3.0/sdk/stretch/arm64v8",
               "os": "linux",
               "tags": {
-                "3.0.100-preview1-sdk-stretch-arm64v8": {},
+                "$(3.0-SdkVersion)-sdk-stretch-arm64v8": {},
                 "3.0-sdk-stretch-arm64v8": {}
               },
               "variant": "v8"
@@ -1149,7 +1160,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "3.0.100-preview1-sdk-nanoserver-sac2016": {},
+                "$(3.0-SdkVersion)-sdk-nanoserver-sac2016": {},
                 "3.0-sdk-nanoserver-sac2016": {}
               }
             },
@@ -1158,7 +1169,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "3.0.100-preview1-sdk-nanoserver-1709": {},
+                "$(3.0-SdkVersion)-sdk-nanoserver-1709": {},
                 "3.0-sdk-nanoserver-1709": {}
               }
             },
@@ -1167,7 +1178,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "3.0.100-preview1-sdk-nanoserver-1803": {},
+                "$(3.0-SdkVersion)-sdk-nanoserver-1803": {},
                 "3.0-sdk-nanoserver-1803": {}
               }
             }
@@ -1179,9 +1190,9 @@
               "dockerfile": "3.0/runtime-deps/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-deps-alpine3.8": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-alpine3.8": {},
                 "3.0-runtime-deps-alpine3.8": {},
-                "3.0.0-preview1-runtime-deps-alpine": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-alpine": {},
                 "3.0-runtime-deps-alpine": {}
               }
             }
@@ -1193,9 +1204,9 @@
               "dockerfile": "3.0/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-alpine3.8": {},
+                "$(3.0-RuntimeVersion)-runtime-alpine3.8": {},
                 "3.0-runtime-alpine3.8": {},
-                "3.0.0-preview1-runtime-alpine": {},
+                "$(3.0-RuntimeVersion)-runtime-alpine": {},
                 "3.0-runtime-alpine": {}
               }
             }
@@ -1207,9 +1218,9 @@
               "dockerfile": "3.0/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-alpine3.8": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-alpine3.8": {},
                 "3.0-aspnetcore-runtime-alpine3.8": {},
-                "3.0.0-preview1-aspnetcore-runtime-alpine": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-alpine": {},
                 "3.0-aspnetcore-runtime-alpine": {}
               }
             }
@@ -1221,9 +1232,9 @@
               "dockerfile": "3.0/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
-                "3.0.100-preview1-sdk-alpine3.8": {},
+                "$(3.0-SdkVersion)-sdk-alpine3.8": {},
                 "3.0-sdk-alpine3.8": {},
-                "3.0.100-preview1-sdk-alpine": {},
+                "$(3.0-SdkVersion)-sdk-alpine": {},
                 "3.0-sdk-alpine": {}
               }
             }
@@ -1235,7 +1246,7 @@
               "dockerfile": "3.0/runtime-deps/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-deps-bionic": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-bionic": {},
                 "3.0-runtime-deps-bionic": {}
               }
             }
@@ -1247,7 +1258,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-bionic": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-bionic": {},
                 "3.0-aspnetcore-runtime-bionic": {}
               }
             }
@@ -1259,7 +1270,7 @@
               "dockerfile": "3.0/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-bionic": {},
+                "$(3.0-RuntimeVersion)-runtime-bionic": {},
                 "3.0-runtime-bionic": {}
               }
             }
@@ -1271,7 +1282,7 @@
               "dockerfile": "3.0/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "3.0.100-preview1-sdk-bionic": {},
+                "$(3.0-SdkVersion)-sdk-bionic": {},
                 "3.0-sdk-bionic": {}
               }
             }
@@ -1284,7 +1295,7 @@
               "dockerfile": "3.0/runtime-deps/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-deps-bionic-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-bionic-arm32v7": {},
                 "3.0-runtime-deps-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -1298,7 +1309,7 @@
               "dockerfile": "3.0/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-aspnetcore-runtime-bionic-arm32v7": {},
+                "$(3.0-RuntimeVersion)-aspnetcore-runtime-bionic-arm32v7": {},
                 "3.0-aspnetcore-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -1312,7 +1323,7 @@
               "dockerfile": "3.0/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-bionic-arm32v7": {},
+                "$(3.0-RuntimeVersion)-runtime-bionic-arm32v7": {},
                 "3.0-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -1326,7 +1337,7 @@
               "dockerfile": "3.0/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "3.0.100-preview1-sdk-bionic-arm32v7": {},
+                "$(3.0-SdkVersion)-sdk-bionic-arm32v7": {},
                 "3.0-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -1340,7 +1351,7 @@
               "dockerfile": "3.0/runtime-deps/bionic/arm64v8",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-deps-bionic-arm64v8": {},
+                "$(3.0-RuntimeVersion)-runtime-deps-bionic-arm64v8": {},
                 "3.0-runtime-deps-bionic-arm64v8": {}
               },
               "variant": "v8"
@@ -1354,7 +1365,7 @@
               "dockerfile": "3.0/runtime/bionic/arm64v8",
               "os": "linux",
               "tags": {
-                "3.0.0-preview1-runtime-bionic-arm64v8": {},
+                "$(3.0-RuntimeVersion)-runtime-bionic-arm64v8": {},
                 "3.0-runtime-bionic-arm64v8": {}
               },
               "variant": "v8"
@@ -1368,7 +1379,7 @@
               "dockerfile": "3.0/sdk/bionic/arm64v8",
               "os": "linux",
               "tags": {
-                "3.0.100-preview1-sdk-bionic-arm64v8": {},
+                "$(3.0-SdkVersion)-sdk-bionic-arm64v8": {},
                 "3.0-sdk-bionic-arm64v8": {}
               },
               "variant": "v8"

--- a/scripts/update-dependencies/ManifestUpdater.cs
+++ b/scripts/update-dependencies/ManifestUpdater.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.VersionTools.Dependencies;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Dotnet.Docker
+{
+    /// <summary>
+    /// An IDependencyUpdater that will update the full versioned tags within the manifest to align with the
+    /// current product version.
+    /// </summary>
+    public class ManifestUpdater : FileRegexUpdater
+    {
+        private const string TagVersionValueGroupName = "tagVersionValue";
+        private readonly static string[] ExcludedMonikers = { "servicing", "rtm" };
+
+        private string _tagVersion;
+
+        public ManifestUpdater(string imageVariantName, string version, string repoRoot) : base()
+        {
+            _tagVersion = version;
+
+            int firstDashIndex = version.IndexOf('-');
+            if (firstDashIndex != -1)
+            {
+                int secondDashIndex = version.IndexOf('-', firstDashIndex + 1);
+                if (secondDashIndex != -1)
+                {
+                    _tagVersion = version.Substring(0, secondDashIndex);
+                }
+
+                foreach (string excludedMoniker in ExcludedMonikers)
+                {
+                    if (_tagVersion.EndsWith($"-{excludedMoniker}", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _tagVersion = _tagVersion.Substring(0, _tagVersion.Length - (excludedMoniker.Length + 1));
+                    }
+                }
+            }
+
+            string versionVariableName = $"{version.Substring(0, version.LastIndexOf('.'))}-{imageVariantName}Version";
+            Trace.TraceInformation($"Updating {versionVariableName} to {_tagVersion}");
+
+            Path = System.IO.Path.Combine(repoRoot, "Manifest.json");
+            Regex = new Regex($"\"{versionVariableName}\": \"(?<{TagVersionValueGroupName}>[\\d]+.[\\d]+.[\\d]+(-[\\S]+)?)\"");
+            VersionGroupName = TagVersionValueGroupName;
+        }
+
+        protected override string TryGetDesiredValue(
+            IEnumerable<IDependencyInfo> dependencyBuildInfos, out IEnumerable<IDependencyInfo> usedBuildInfos)
+        {
+            usedBuildInfos = Enumerable.Empty<IDependencyInfo>();
+
+            return _tagVersion;
+        }
+    }
+}

--- a/scripts/update-dependencies/ManifestUpdater.cs
+++ b/scripts/update-dependencies/ManifestUpdater.cs
@@ -25,6 +25,8 @@ namespace Dotnet.Docker
         {
             _tagVersion = version;
 
+            // Derive the Docker tag version from the product build version.
+            // Example: Product build version 2.2.0-rtm-35586 => Docker tag version 2.2.0.
             int firstDashIndex = version.IndexOf('-');
             if (firstDashIndex != -1)
             {

--- a/scripts/update-dependencies/ReadmeUpdator.cs
+++ b/scripts/update-dependencies/ReadmeUpdator.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.VersionTools.Dependencies;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Dotnet.Docker
+{
+    /// <summary>
+    /// An IDependencyUpdater that will update the tags section of the readme with the latest tags for the repo.
+    /// </summary>
+    public class ReadMeUpdater : IDependencyUpdater
+    {
+        private string _repoRoot;
+
+        public ReadMeUpdater(string repoRoot)
+        {
+            _repoRoot = repoRoot;
+        }
+
+        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos)
+        {
+            return new DependencyUpdateTask[] {
+                new DependencyUpdateTask(
+                    () => InvokeGetTagsDocumentationScript(),
+                    Enumerable.Empty<IDependencyInfo>(),
+                    Enumerable.Empty<string>()
+                )
+            };
+        }
+
+        private void InvokeGetTagsDocumentationScript()
+        {
+            Trace.TraceInformation($"InvokeGetTagsDocumentationScript");
+
+            Process process = Process.Start("powershell", Path.Combine(_repoRoot, "scripts", "Get-TagsDocumentation.ps1"));
+            process.WaitForExit();
+        }
+    }
+}


### PR DESCRIPTION
There are three parts to these changes:

1. Update the manifest to use variables to encapsulate the full version part of the tag.  This makes it easier to on-board new patches as only one place within the manifest needs to be updated.
2. In order to support variable usage within the manifest tag names, the build-and-test script needs to be updated to use the ImageBuilder tool which supports variable substitution.
3. By using manifest variables to encapsulate the full version, the update-dependencies tool can easily update the versions and regenerate the tags readme.

The end result of these changes is that Maestro will now automatically update everything needed when a new `patch` version is created.