### PR TITLE
Install sudo

### DIFF
--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update \
         libssl1.0.0 \
         libstdc++6 \
         zlib1g \
+# Add sudo for build agents that run as non-root users with sudo privileges
+        sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK


### PR DESCRIPTION
Without this, Azure Pipelines builds that use this container cannot possibly install any additional packages. They can't sudo to install them because sudo isn't in the image, and since Azure Pipelines runs build steps as non-root, `apt install` without `sudo` fails.