### PR TITLE
Break Windows CI apart into smaller jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -9,14 +9,11 @@ platformList.each { platform ->
     def(hostOS, containerOS) = platform.tokenize(':')
     def machineLabel = (hostOS == 'Windows_2016') ? 'latest-docker' : 'latest-or-auto-docker'
 
-    if (containerOS == 'NanoServer-1803') {
-        versionList = ['2.1-2.2', '3.0']
-    }
-    else if (containerOS == 'NanoServer-1709') {
-        versionList = ['2.1-2.2', '3.0']
+    if (containerOS == 'NanoServer-1803' || containerOS == 'NanoServer-1709') {
+        versionList = ['2.1', '2.2', '3.0']
     }
     else if (containerOS == 'NanoServer-sac2016') {
-        versionList = ['1.', '2.1-2.2', '3.0']
+        versionList = ['1.', '2.1', '2.2', '3.0']
     }
     else {
         versionList = ['1.', '2.1-2.2', '3.0']


### PR DESCRIPTION
Windows 2.1 and 2.2 CI jobs can be run independently.  Linux 2.1 and 2.2 CI jobs must be run together because a common runtime-deps image is shared between the two versions.