### PR TITLE
Remove use of workspace clean within builds as it is not reliable

### DIFF
--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -12,8 +12,6 @@ jobs:
   pool: ${{ parameters.pool }}
   strategy:
     matrix: ${{ parameters.matrix }}
-  workspace:
-    clean: all
   variables:
     osVersion: ${{ parameters.osVersion }}
   steps:

--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -6,8 +6,6 @@ jobs:
   pool: # linuxAmd64Pool
     name: DotNet-Build
     demands: agent.os -equals linux
-  workspace:
-    clean: all
   steps:
   - template: ../steps/init-docker-linux.yml
   - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type build

--- a/.vsts-pipelines/jobs/copy-images.yml
+++ b/.vsts-pipelines/jobs/copy-images.yml
@@ -34,8 +34,6 @@ jobs:
   pool: ${{ parameters.pool }}
   strategy:
     matrix: ${{ parameters.matrix }}
-  workspace:
-    clean: all
   variables:
     osVersion: ${{ parameters.osVersion }}
     architecture: ${{ parameters.architecture }}

--- a/.vsts-pipelines/jobs/publish-finalize.yml
+++ b/.vsts-pipelines/jobs/publish-finalize.yml
@@ -18,8 +18,6 @@ jobs:
   - Copy_Images_NanoServer1709_amd64
   - Copy_Images_NanoServer1803_amd64
   pool: ${{ parameters.pool }}
-  workspace:
-    clean: all
   variables:
     imageBuilder.commonCmdArgs: >
       --manifest $(manifest)

--- a/.vsts-pipelines/jobs/test-images-linux-client.yml
+++ b/.vsts-pipelines/jobs/test-images-linux-client.yml
@@ -21,8 +21,6 @@ jobs:
   pool: ${{ parameters.pool }}
   strategy:
     matrix: ${{ parameters.matrix }}
-  workspace:
-    clean: all
   variables:
     testRunner.container: testrunner-$(Build.BuildId)-$(System.JobId)
     architecture: ${{ parameters.architecture }}

--- a/.vsts-pipelines/jobs/test-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/test-images-windows-client.yml
@@ -19,8 +19,6 @@ jobs:
   pool: ${{ parameters.pool }}
   strategy:
     matrix: ${{ parameters.matrix }}
-  workspace:
-    clean: all
   steps:
   - template: ../steps/init-docker-windows.yml
     parameters:

--- a/.vsts-pipelines/steps/cleanup-docker-windows.yml
+++ b/.vsts-pipelines/steps/cleanup-docker-windows.yml
@@ -6,3 +6,10 @@ steps:
   displayName: Cleanup Docker Images
   condition: always()
   continueOnError: true
+- powershell: |
+    if (Test-Path $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder) {
+      Remove-Item $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder -Force -Recurse;
+    }
+  displayName: Cleanup Image Builder
+  condition: always()
+  continueOnError: true

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -22,7 +22,7 @@ steps:
   - script: >
       docker cp
       setupImageBuilder-$(Build.BuildId)-$(System.JobId):/image-builder
-      $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
+      $(Build.BinariesDirectory)/.Microsoft.DotNet.ImageBuilder
     displayName: Copy Image Builder
   - script: docker rm -f setupImageBuilder-$(Build.BuildId)-$(System.JobId)
     displayName: Cleanup Setup Container
@@ -30,5 +30,5 @@ steps:
     continueOnError: true
   - script: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
-      $(Build.BinariesDirectory)\Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
+      $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
     displayName: Define runImageBuilderCmd Variable


### PR DESCRIPTION
The workspace cleanup logic is failing to cleanup consistently.  Refactored the build logic to cleanup the ImageBuilder tool which is the reason for using the built-in cleanup in the first place.