### PR TITLE
Enable tests on 3.0 images

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public bool HasNoSdk { get; set; }
         public bool IsWeb { get; set; }
         public bool IsAlpine { get => OsVariant.StartsWith("alpine"); }
-        public bool IsArm { get => String.Equals("arm", Architecture, StringComparison.OrdinalIgnoreCase); }
+        public bool IsArm { get => Architecture.StartsWith("arm"); }
         public string OsVariant { get; set; }
 
         public string RuntimeDepsVersion


### PR DESCRIPTION
Related #692

There are still a number of disabled tests that are blocked on product issues.