### PR TITLE
Updates for 2.1.6

### DIFF
--- a/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
@@ -1,12 +1,12 @@
 FROM microsoft/dotnet:2.1-runtime-deps-alpine3.7
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='5d87fb86e4e70bf0769d081a0b0c4388348bcefe61559242af17a9604bbdb3269e4ab47c420105ab6a2236431978adede9406d3ff0845602a398bb81f4ecf6f7' \
+    && aspnetcore_sha512='f909a6b70d105588c0d4c684e88c1eb2b83001ba55b9bfb0932807953ea9756c5539d3b9bd11666cb07cc68ed362f3786c8f6a0ff91da072e4b67cd8b5abc16a' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
-    && aspnetcore_sha512='3326963ba0a431ca430d8f1a7940487e516952ec560da563f03662b71b2ac8b5d9904b0e1422212e452b49f563349d10fea34241f4d5e4811d0aedc02c557029' \
+    && aspnetcore_sha512='4d6416c7c078047abe3493fdd7bebe0a796bdb2aaefad302fb6a64dd225c871a1183f016f0974c6dcd82f80ae893660b2aeac2abb70509435845a430e0117e29' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
-    && aspnetcore_sha512='5d503f7181c59d95ddc7d537dbc4b26fb6d5b6bea25b0a29154906fa422e7014e80e0a8ee92c6f81484d169a17b3e8284d455e3e05d85cefe736190e769b7355' \
+    && aspnetcore_sha512='2312ba29ebcb3ca2e473c90727563e04c89cd771bcb68be76ed8bcb1d196e7d5b9a886177481837ae397142497cc2947a19372fe0da23f0ada0b3c1ad4fd0218' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = '98224c8646b7eab234b97f52735905bb0219ea2290490e408ff469459ea82116068854e7b9c5869bccef780b4ceac17477f34f23e06a0a6bedca445a3866d73e'; `
+    $aspnetcore_sha512 = '333c7eadbd5e5202db706696ed682298c4fc66551ad87a9c374a28cd459aa8c6a47952434bc642e1191b0f10e09520b9a34e6be19c5387aeec1ff19c2001ec32'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = '98224c8646b7eab234b97f52735905bb0219ea2290490e408ff469459ea82116068854e7b9c5869bccef780b4ceac17477f34f23e06a0a6bedca445a3866d73e'; `
+    $aspnetcore_sha512 = '333c7eadbd5e5202db706696ed682298c4fc66551ad87a9c374a28cd459aa8c6a47952434bc642e1191b0f10e09520b9a34e6be19c5387aeec1ff19c2001ec32'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -4,10 +4,10 @@ FROM microsoft/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = '98224c8646b7eab234b97f52735905bb0219ea2290490e408ff469459ea82116068854e7b9c5869bccef780b4ceac17477f34f23e06a0a6bedca445a3866d73e'; `
+    $aspnetcore_sha512 = '333c7eadbd5e5202db706696ed682298c4fc66551ad87a9c374a28cd459aa8c6a47952434bc642e1191b0f10e09520b9a34e6be19c5387aeec1ff19c2001ec32'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
-    && aspnetcore_sha512='3326963ba0a431ca430d8f1a7940487e516952ec560da563f03662b71b2ac8b5d9904b0e1422212e452b49f563349d10fea34241f4d5e4811d0aedc02c557029' \
+    && aspnetcore_sha512='4d6416c7c078047abe3493fdd7bebe0a796bdb2aaefad302fb6a64dd225c871a1183f016f0974c6dcd82f80ae893660b2aeac2abb70509435845a430e0117e29' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.5
+ENV ASPNETCORE_VERSION 2.1.6
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
-    && aspnetcore_sha512='5d503f7181c59d95ddc7d537dbc4b26fb6d5b6bea25b0a29154906fa422e7014e80e0a8ee92c6f81484d169a17b3e8284d455e3e05d85cefe736190e769b7355' \
+    && aspnetcore_sha512='2312ba29ebcb3ca2e473c90727563e04c89cd771bcb68be76ed8bcb1d196e7d5b9a886177481837ae397142497cc2947a19372fe0da23f0ada0b3c1ad4fd0218' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/runtime/alpine3.7/amd64/Dockerfile
@@ -1,12 +1,12 @@
 FROM microsoft/dotnet:2.1-runtime-deps-alpine3.7
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='6823778d6ae0a57a9782d1fa460fcea2c7df99c719d14d4aef96e4cbc48406936090e2f727cbcb961f6e645ea960374575e37db8f59907cfc5a588bb1044d840' \
+    && dotnet_sha512='8a0900b7dc010aa2293c5926d13a05f0a2de1f13eac6a1eaa3c9997a8ec6363d83c852763b118b3ddb6586f95f34263cf27e769b4637bb4bd196bf73aa62269e' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/runtime/bionic/amd64/Dockerfile
+++ b/2.1/runtime/bionic/amd64/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='d815c79fd868d2642898ddc09c890a90c4ab26ef8999046581d7e3912bb06ec97ce6637ce8bf0ceb9deb773daab1c0cd93e336992c885a4fd7550d6686d4dbf4' \
+    && dotnet_sha512='74d99aefcbe953b30743330689e750156e68c3410bc26c40a11b60bbbf1d01887262bd6d7c0eeacca4d6b696c1a04980d9be2dc2a222226fa910b885d2fb5956' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime/bionic/arm32v7/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='89a77a07065ea24e7198c77a233b9ce5c6cf51b1deb2ef55c88f0adbb2ecd9db1ba4e7d55eec2ef7139c47f91346fed360161a5bb6e3a7ccfc4559bcde286364' \
+    && dotnet_sha512='4f44cd5f6b61d0a4b7e73b138fdf5edcaa9e148bf0473514551f4d03d97c29f297662c726d145ecdf80cb58a086f925f97b7896c796cb3d82fe927f5caf7bbcc' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = 'aa7145201f1ed0689ff6abeb53b9c64c1efa1420dee7e5cc916168fd2479e252ed56b2492221f4038edbc73056accd9d4a46ec469155f2bdf0fc71bd909bd220'; `
+    $dotnet_sha512 = 'f716c90b0a4512f3611a9d6d922ff1f7b5bf306440283798e17b893920d390df15c503f5808ee34beb3ce6355308c6bb3435f06cdafde60be31397c2633cc270'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = 'aa7145201f1ed0689ff6abeb53b9c64c1efa1420dee7e5cc916168fd2479e252ed56b2492221f4038edbc73056accd9d4a46ec469155f2bdf0fc71bd909bd220'; `
+    $dotnet_sha512 = 'f716c90b0a4512f3611a9d6d922ff1f7b5bf306440283798e17b893920d390df15c503f5808ee34beb3ce6355308c6bb3435f06cdafde60be31397c2633cc270'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM microsoft/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = 'aa7145201f1ed0689ff6abeb53b9c64c1efa1420dee7e5cc916168fd2479e252ed56b2492221f4038edbc73056accd9d4a46ec469155f2bdf0fc71bd909bd220'; `
+    $dotnet_sha512 = 'f716c90b0a4512f3611a9d6d922ff1f7b5bf306440283798e17b893920d390df15c503f5808ee34beb3ce6355308c6bb3435f06cdafde60be31397c2633cc270'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime/stretch-slim/amd64/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='d815c79fd868d2642898ddc09c890a90c4ab26ef8999046581d7e3912bb06ec97ce6637ce8bf0ceb9deb773daab1c0cd93e336992c885a4fd7550d6686d4dbf4' \
+    && dotnet_sha512='74d99aefcbe953b30743330689e750156e68c3410bc26c40a11b60bbbf1d01887262bd6d7c0eeacca4d6b696c1a04980d9be2dc2a222226fa910b885d2fb5956' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime/stretch-slim/arm32v7/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.5
+ENV DOTNET_VERSION 2.1.6
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='89a77a07065ea24e7198c77a233b9ce5c6cf51b1deb2ef55c88f0adbb2ecd9db1ba4e7d55eec2ef7139c47f91346fed360161a5bb6e3a7ccfc4559bcde286364' \
+    && dotnet_sha512='4f44cd5f6b61d0a4b7e73b138fdf5edcaa9e148bf0473514551f4d03d97c29f297662c726d145ecdf80cb58a086f925f97b7896c796cb3d82fe927f5caf7bbcc' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/alpine3.7/amd64/Dockerfile
+++ b/2.1/sdk/alpine3.7/amd64/Dockerfile
@@ -8,12 +8,12 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='620f091eba8d111b13d440c20926f60919e64dd421c6cbf2696b6f3f643a3d654b7dc394e6e84b1c4bef6ff872c754a7317e9b94977cbcb93b5d0fdfe08d8b55' \
+    && dotnet_sha512='af061f17d88e4371fe523b895b60a0259296e2cc2bd9854a04541b87038638e0a7b7053288b45bc00a89fbb04dbdb7218a76ea9dfed8919457e758c532c15e9f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='903a8a633aea9211ba36232a2decb3b34a59bb62bc145a0e7a90ca46dd37bb6c2da02bcbe2c50c17e08cdff8e48605c0f990786faf1f06be1ea4a4d373beb8a9' \
+    && dotnet_sha512='85055728e2433dfde41d15c85475f2dc6cfdd30242b4b23065b63cb12cc846acb93c09c000b02b722890ceac8ac382b40871c78660716ca2339c71052fe52f4e' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/bionic/arm32v7/Dockerfile
+++ b/2.1/sdk/bionic/arm32v7/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='144f1a8822f57d3e9286ed80b7ee0c7796cb2765632dd99d0f89a276248c3be77d8d90c8bf987af0237e67f2af26be834c138441980d2c7d35156ee1bb7e3d94' \
+    && dotnet_sha512='106d3e5b7b96ca3522e78b77f094cecaac38c348d7138c2fcae0464ff9d57ec137802603c4a5c6f81b9eae9de39b86bff8d9fc573817e033982eb576532e334c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
@@ -25,7 +25,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Add NuGet cache (ARM SDK doesn't include it)
     && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
-    && lzma_sha512='74455b7e3dca5885427b1d8131f5eb6ce9013994c7bf39401fbb304e69cbb7aebd06cfb13991fb55f01d0671315368a9880e17b5df811078501213402d24d6d5' \
+    && lzma_sha512='329b72d6576a200e2bf75297102806d33c691f38489c3b2b83fe354509cbc19bf9509a219b2b0a5e3a3a193326ef8a8f836ee11cd1df196e75b4b3738e783b15' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure Kestrel web server to bind to port 80 when present

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '52bb1117f170587eaceec1f78cdc41a41d4272154b5535bf61c86bfb75287323cac248434b05eabe4bc7716facabdb0f6475015cbb63f38d91af662618a06720'; `
+    $dotnet_sha512 = 'c8a398773a517b7d36bc29895fc1c4b6b0d47cfdbed04d115fc75e8d0a4b7542b67c9125f701ec1c53038e846848f3c77cacae2b61986e66164cfca05005ca08'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM microsoft/windowsservercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '52bb1117f170587eaceec1f78cdc41a41d4272154b5535bf61c86bfb75287323cac248434b05eabe4bc7716facabdb0f6475015cbb63f38d91af662618a06720'; `
+    $dotnet_sha512 = 'c8a398773a517b7d36bc29895fc1c4b6b0d47cfdbed04d115fc75e8d0a4b7542b67c9125f701ec1c53038e846848f3c77cacae2b61986e66164cfca05005ca08'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM microsoft/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '52bb1117f170587eaceec1f78cdc41a41d4272154b5535bf61c86bfb75287323cac248434b05eabe4bc7716facabdb0f6475015cbb63f38d91af662618a06720'; `
+    $dotnet_sha512 = 'c8a398773a517b7d36bc29895fc1c4b6b0d47cfdbed04d115fc75e8d0a4b7542b67c9125f701ec1c53038e846848f3c77cacae2b61986e66164cfca05005ca08'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/stretch/amd64/Dockerfile
+++ b/2.1/sdk/stretch/amd64/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='903a8a633aea9211ba36232a2decb3b34a59bb62bc145a0e7a90ca46dd37bb6c2da02bcbe2c50c17e08cdff8e48605c0f990786faf1f06be1ea4a4d373beb8a9' \
+    && dotnet_sha512='85055728e2433dfde41d15c85475f2dc6cfdd30242b4b23065b63cb12cc846acb93c09c000b02b722890ceac8ac382b40871c78660716ca2339c71052fe52f4e' \
     && sha512sum dotnet.tar.gz \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/2.1/sdk/stretch/arm32v7/Dockerfile
+++ b/2.1/sdk/stretch/arm32v7/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.403
+ENV DOTNET_SDK_VERSION 2.1.500
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='144f1a8822f57d3e9286ed80b7ee0c7796cb2765632dd99d0f89a276248c3be77d8d90c8bf987af0237e67f2af26be834c138441980d2c7d35156ee1bb7e3d94' \
+    && dotnet_sha512='106d3e5b7b96ca3522e78b77f094cecaac38c348d7138c2fcae0464ff9d57ec137802603c4a5c6f81b9eae9de39b86bff8d9fc573817e033982eb576532e334c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
@@ -25,7 +25,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Add NuGet cache (ARM SDK doesn't include it)
     && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
-    && lzma_sha512='74455b7e3dca5885427b1d8131f5eb6ce9013994c7bf39401fbb304e69cbb7aebd06cfb13991fb55f01d0671315368a9880e17b5df811078501213402d24d6d5' \
+    && lzma_sha512='329b72d6576a200e2bf75297102806d33c691f38489c3b2b83fe354509cbc19bf9509a219b2b0a5e3a3a193326ef8a8f836ee11cd1df196e75b4b3738e783b15' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure Kestrel web server to bind to port 80 when present

--- a/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
+++ b/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.8
 
 RUN apk add --no-cache \
     ca-certificates \

--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 # Linux amd64 tags
 
-- [`2.1.403-sdk-stretch`, `2.1-sdk-stretch`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.403-sdk-alpine3.7`, `2.1-sdk-alpine3.7`, `2.1.403-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/alpine3.7/amd64/Dockerfile)
-- [`2.1.403-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7`, `2.1.5-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.1.5-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.5-runtime-alpine3.7`, `2.1-runtime-alpine3.7`, `2.1.5-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.5-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/amd64/Dockerfile)
-- [`2.1.5-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.5-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.1.5-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7`, `2.1.5-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
-- [`2.1.5-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`2.1.500-sdk-stretch`, `2.1-sdk-stretch`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.500-sdk-alpine3.7`, `2.1-sdk-alpine3.7`, `2.1.500-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/alpine3.7/amd64/Dockerfile)
+- [`2.1.500-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7`, `2.1.6-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-alpine3.7`, `2.1-runtime-alpine3.7`, `2.1.6-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
 - [`1.1.10-sdk-1.1.11-stretch`, `1.1-sdk-stretch` (*1.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/stretch/amd64/Dockerfile)
 - [`1.1.10-sdk-1.1.11-jessie`, `1.1-sdk-jessie`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/amd64/Dockerfile)
 - [`1.1.10-runtime-stretch`, `1.1-runtime-stretch` (*1.1/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/stretch/amd64/Dockerfile)
@@ -60,9 +60,9 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 
 # Windows Server, version 1803 amd64 tags
 
-- [`2.1.403-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.5-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 
@@ -70,9 +70,9 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.1.403-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.5-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 
@@ -80,9 +80,9 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 
 # Windows Server 2016 amd64 tags
 
-- [`2.1.403-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.5-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.1.10-sdk-1.1.11-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
@@ -93,14 +93,14 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 
 # Linux arm32 tags
 
-- [`2.1.403-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.403-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/arm32v7/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.5-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.5-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.5-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.5-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.5-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.500-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.500-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 **.NET Core 2.2 Preview tags**
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -2,18 +2,18 @@
 
 # Linux amd64 tags
 
-- [`2.1.403-sdk-stretch`, `2.1-sdk-stretch`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.403-sdk-alpine3.7`, `2.1-sdk-alpine3.7`, `2.1.403-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/alpine3.7/amd64/Dockerfile)
-- [`2.1.403-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7`, `2.1.5-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.1.5-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.1.5-runtime-alpine3.7`, `2.1-runtime-alpine3.7`, `2.1.5-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/alpine3.7/amd64/Dockerfile)
-- [`2.1.5-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/amd64/Dockerfile)
-- [`2.1.5-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.5-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.1.5-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7`, `2.1.5-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
-- [`2.1.5-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`2.1.500-sdk-stretch`, `2.1-sdk-stretch`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.500-sdk-alpine3.7`, `2.1-sdk-alpine3.7`, `2.1.500-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/alpine3.7/amd64/Dockerfile)
+- [`2.1.500-sdk-bionic`, `2.1-sdk-bionic` (*2.1/sdk/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7`, `2.1.6-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic`, `2.1-aspnetcore-runtime-bionic` (*2.1/aspnetcore-runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-stretch-slim`, `2.1-runtime-stretch-slim`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-alpine3.7`, `2.1-runtime-alpine3.7`, `2.1.6-runtime-alpine`, `2.1-runtime-alpine` (*2.1/runtime/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-bionic`, `2.1-runtime-bionic` (*2.1/runtime/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim`, `2.1-runtime-deps-stretch-slim`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine3.7/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
+- [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*2.1/runtime-deps/bionic/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
 - [`1.1.10-sdk-1.1.11-stretch`, `1.1-sdk-stretch` (*1.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/stretch/amd64/Dockerfile)
 - [`1.1.10-sdk-1.1.11-jessie`, `1.1-sdk-jessie`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/jessie/amd64/Dockerfile)
 - [`1.1.10-runtime-stretch`, `1.1-runtime-stretch` (*1.1/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/stretch/amd64/Dockerfile)
@@ -39,9 +39,9 @@
 
 # Windows Server, version 1803 amd64 tags
 
-- [`2.1.403-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.5-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1803/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview 3 tags**
 
@@ -51,9 +51,9 @@
 
 # Windows Server, version 1709 amd64 tags
 
-- [`2.1.403-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.5-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-1709/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
 **.NET Core 2.2 Preview 3 tags**
 
@@ -63,9 +63,9 @@
 
 # Windows Server 2016 amd64 tags
 
-- [`2.1.403-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.5-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.500-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.6-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.1.10-sdk-1.1.11-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*1.1/sdk/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*1.1/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver-sac2016/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
@@ -78,14 +78,14 @@
 
 # Linux arm32 tags
 
-- [`2.1.403-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.403-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.403-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/arm32v7/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.5-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.5-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.5-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.5-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.5-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.5-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.5-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.5-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.500-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.500-sdk`, `2.1-sdk`, `sdk`, `latest` (*2.1/sdk/stretch/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.500-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*2.1/sdk/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime`, `aspnetcore-runtime` (*2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.6-runtime`, `2.1-runtime`, `runtime` (*2.1/runtime/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*2.1/runtime/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps`, `runtime-deps` (*2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*2.1/runtime-deps/bionic/arm32v7/Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 **.NET Core 2.2 Preview 3 tags**
 

--- a/manifest.json
+++ b/manifest.json
@@ -202,7 +202,7 @@
         },
         {
           "sharedTags": {
-            "2.1.5-runtime-deps": {},
+            "2.1.6-runtime-deps": {},
             "2.1-runtime-deps": {},
             "2.2.0-preview3-runtime-deps": {},
             "2.2-runtime-deps": {},
@@ -216,7 +216,7 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-stretch-slim": {},
+                "2.1.6-runtime-deps-stretch-slim": {},
                 "2.1-runtime-deps-stretch-slim": {},
                 "2.2.0-preview3-runtime-deps-stretch-slim": {},
                 "2.2-runtime-deps-stretch-slim": {}
@@ -227,7 +227,7 @@
               "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-stretch-slim-arm32v7": {},
+                "2.1.6-runtime-deps-stretch-slim-arm32v7": {},
                 "2.1-runtime-deps-stretch-slim-arm32v7": {},
                 "2.2.0-preview3-runtime-deps-stretch-slim-arm32v7": {},
                 "2.2-runtime-deps-stretch-slim-arm32v7": {}
@@ -238,7 +238,7 @@
         },
         {
           "sharedTags": {
-            "2.1.5-runtime": {},
+            "2.1.6-runtime": {},
             "2.1-runtime": {},
             "runtime": {},
             "2-runtime": {
@@ -250,7 +250,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-stretch-slim": {},
+                "2.1.6-runtime-stretch-slim": {},
                 "2.1-runtime-stretch-slim": {}
               }
             },
@@ -259,7 +259,7 @@
               "dockerfile": "2.1/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-stretch-slim-arm32v7": {},
+                "2.1.6-runtime-stretch-slim-arm32v7": {},
                 "2.1-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -269,7 +269,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.5-runtime-nanoserver-sac2016": {},
+                "2.1.6-runtime-nanoserver-sac2016": {},
                 "2.1-runtime-nanoserver-sac2016": {},
                 "2-runtime-nanoserver": {
                   "isUndocumented": true
@@ -281,7 +281,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.5-runtime-nanoserver-1709": {},
+                "2.1.6-runtime-nanoserver-1709": {},
                 "2.1-runtime-nanoserver-1709": {}
               }
             },
@@ -290,7 +290,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.5-runtime-nanoserver-1803": {},
+                "2.1.6-runtime-nanoserver-1803": {},
                 "2.1-runtime-nanoserver-1803": {}
               }
             }
@@ -298,7 +298,7 @@
         },
         {
           "sharedTags": {
-            "2.1.5-aspnetcore-runtime": {},
+            "2.1.6-aspnetcore-runtime": {},
             "2.1-aspnetcore-runtime": {},
             "aspnetcore-runtime": {},
             "2-aspnetcore-runtime": {
@@ -310,7 +310,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-stretch-slim": {},
+                "2.1.6-aspnetcore-runtime-stretch-slim": {},
                 "2.1-aspnetcore-runtime-stretch-slim": {}
               }
             },
@@ -319,7 +319,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-stretch-slim-arm32v7": {},
+                "2.1.6-aspnetcore-runtime-stretch-slim-arm32v7": {},
                 "2.1-aspnetcore-runtime-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -329,7 +329,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.5-aspnetcore-runtime-nanoserver-sac2016": {},
+                "2.1.6-aspnetcore-runtime-nanoserver-sac2016": {},
                 "2.1-aspnetcore-runtime-nanoserver-sac2016": {}
               }
             },
@@ -338,7 +338,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.5-aspnetcore-runtime-nanoserver-1709": {},
+                "2.1.6-aspnetcore-runtime-nanoserver-1709": {},
                 "2.1-aspnetcore-runtime-nanoserver-1709": {}
               }
             },
@@ -347,7 +347,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.5-aspnetcore-runtime-nanoserver-1803": {},
+                "2.1.6-aspnetcore-runtime-nanoserver-1803": {},
                 "2.1-aspnetcore-runtime-nanoserver-1803": {}
               }
             }
@@ -355,7 +355,7 @@
         },
         {
           "sharedTags": {
-            "2.1.403-sdk": {},
+            "2.1.500-sdk": {},
             "2.1-sdk": {},
             "sdk": {},
             "latest": {},
@@ -368,7 +368,7 @@
               "dockerfile": "2.1/sdk/stretch/amd64",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-stretch": {},
+                "2.1.500-sdk-stretch": {},
                 "2.1-sdk-stretch": {}
               }
             },
@@ -377,7 +377,7 @@
               "dockerfile": "2.1/sdk/stretch/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-stretch-arm32v7": {},
+                "2.1.500-sdk-stretch-arm32v7": {},
                 "2.1-sdk-stretch-arm32v7": {}
               },
               "variant": "v7"
@@ -387,7 +387,7 @@
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
-                "2.1.403-sdk-nanoserver-sac2016": {},
+                "2.1.500-sdk-nanoserver-sac2016": {},
                 "2.1-sdk-nanoserver-sac2016": {},
                 "2-sdk-nanoserver": {
                   "isUndocumented": true
@@ -399,7 +399,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
-                "2.1.403-sdk-nanoserver-1709": {},
+                "2.1.500-sdk-nanoserver-1709": {},
                 "2.1-sdk-nanoserver-1709": {}
               }
             },
@@ -408,7 +408,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
-                "2.1.403-sdk-nanoserver-1803": {},
+                "2.1.500-sdk-nanoserver-1803": {},
                 "2.1-sdk-nanoserver-1803": {}
               }
             }
@@ -420,9 +420,9 @@
               "dockerfile": "2.1/runtime-deps/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-alpine3.7": {},
+                "2.1.6-runtime-deps-alpine3.7": {},
                 "2.1-runtime-deps-alpine3.7": {},
-                "2.1.5-runtime-deps-alpine": {},
+                "2.1.6-runtime-deps-alpine": {},
                 "2.1-runtime-deps-alpine": {}
               }
             }
@@ -434,9 +434,9 @@
               "dockerfile": "2.1/runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-alpine3.7": {},
+                "2.1.6-runtime-alpine3.7": {},
                 "2.1-runtime-alpine3.7": {},
-                "2.1.5-runtime-alpine": {},
+                "2.1.6-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
               }
             }
@@ -448,9 +448,9 @@
               "dockerfile": "2.1/aspnetcore-runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-alpine3.7": {},
+                "2.1.6-aspnetcore-runtime-alpine3.7": {},
                 "2.1-aspnetcore-runtime-alpine3.7": {},
-                "2.1.5-aspnetcore-runtime-alpine": {},
+                "2.1.6-aspnetcore-runtime-alpine": {},
                 "2.1-aspnetcore-runtime-alpine": {}
               }
             }
@@ -462,9 +462,9 @@
               "dockerfile": "2.1/sdk/alpine3.7/amd64",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-alpine3.7": {},
+                "2.1.500-sdk-alpine3.7": {},
                 "2.1-sdk-alpine3.7": {},
-                "2.1.403-sdk-alpine": {},
+                "2.1.500-sdk-alpine": {},
                 "2.1-sdk-alpine": {}
               }
             }
@@ -476,7 +476,7 @@
               "dockerfile": "2.1/runtime-deps/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-bionic": {},
+                "2.1.6-runtime-deps-bionic": {},
                 "2.1-runtime-deps-bionic": {},
                 "2.2.0-preview3-runtime-deps-bionic": {},
                 "2.2-runtime-deps-bionic": {}
@@ -490,7 +490,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-bionic": {},
+                "2.1.6-aspnetcore-runtime-bionic": {},
                 "2.1-aspnetcore-runtime-bionic": {}
               }
             }
@@ -502,7 +502,7 @@
               "dockerfile": "2.1/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-bionic": {},
+                "2.1.6-runtime-bionic": {},
                 "2.1-runtime-bionic": {}
               }
             }
@@ -514,7 +514,7 @@
               "dockerfile": "2.1/sdk/bionic/amd64",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-bionic": {},
+                "2.1.500-sdk-bionic": {},
                 "2.1-sdk-bionic": {}
               }
             }
@@ -527,7 +527,7 @@
               "dockerfile": "2.1/runtime-deps/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-deps-bionic-arm32v7": {},
+                "2.1.6-runtime-deps-bionic-arm32v7": {},
                 "2.1-runtime-deps-bionic-arm32v7": {},
                 "2.2.0-preview3-runtime-deps-bionic-arm32v7": {},
                 "2.2-runtime-deps-bionic-arm32v7": {}
@@ -543,7 +543,7 @@
               "dockerfile": "2.1/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-aspnetcore-runtime-bionic-arm32v7": {},
+                "2.1.6-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.1-aspnetcore-runtime-bionic-arm32v7": {}
               }
             }
@@ -556,7 +556,7 @@
               "dockerfile": "2.1/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.5-runtime-bionic-arm32v7": {},
+                "2.1.6-runtime-bionic-arm32v7": {},
                 "2.1-runtime-bionic-arm32v7": {}
               },
               "variant": "v7"
@@ -570,7 +570,7 @@
               "dockerfile": "2.1/sdk/bionic/arm32v7",
               "os": "linux",
               "tags": {
-                "2.1.403-sdk-bionic-arm32v7": {},
+                "2.1.500-sdk-bionic-arm32v7": {},
                 "2.1-sdk-bionic-arm32v7": {}
               },
               "variant": "v7"

--- a/manifest.json
+++ b/manifest.json
@@ -545,7 +545,8 @@
               "tags": {
                 "2.1.6-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.1-aspnetcore-runtime-bionic-arm32v7": {}
-              }
+              },
+              "variant": "v7"
             }
           ]
         },
@@ -837,7 +838,8 @@
               "tags": {
                 "2.2.0-preview3-aspnetcore-runtime-bionic-arm32v7": {},
                 "2.2-aspnetcore-runtime-bionic-arm32v7": {}
-              }
+              },
+              "variant": "v7"
             }
           ]
         },

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -2,18 +2,18 @@
 
 # Linux amd64 tags
 
-$(TagDoc:2.1.403-sdk-stretch)
-$(TagDoc:2.1.403-sdk-alpine3.7)
-$(TagDoc:2.1.403-sdk-bionic)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.5-aspnetcore-runtime-alpine3.7)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic)
-$(TagDoc:2.1.5-runtime-stretch-slim)
-$(TagDoc:2.1.5-runtime-alpine3.7)
-$(TagDoc:2.1.5-runtime-bionic)
-$(TagDocList:2.1.5-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.5-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7|2.1.5-runtime-deps-alpine|2.1-runtime-deps-alpine)
-$(TagDocList:2.1.5-runtime-deps-bionic|2.1-runtime-deps-bionic)
+$(TagDoc:2.1.500-sdk-stretch)
+$(TagDoc:2.1.500-sdk-alpine3.7)
+$(TagDoc:2.1.500-sdk-bionic)
+$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1.6-aspnetcore-runtime-alpine3.7)
+$(TagDoc:2.1.6-aspnetcore-runtime-bionic)
+$(TagDoc:2.1.6-runtime-stretch-slim)
+$(TagDoc:2.1.6-runtime-alpine3.7)
+$(TagDoc:2.1.6-runtime-bionic)
+$(TagDocList:2.1.6-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
+$(TagDocList:2.1.6-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7|2.1.6-runtime-deps-alpine|2.1-runtime-deps-alpine)
+$(TagDocList:2.1.6-runtime-deps-bionic|2.1-runtime-deps-bionic)
 $(TagDoc:1.1.10-sdk-1.1.11-stretch)
 $(TagDoc:1.1.10-sdk-1.1.11-jessie)
 $(TagDoc:1.1.10-runtime-stretch)
@@ -28,9 +28,9 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server, version 1803 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1803)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.1.5-runtime-nanoserver-1803)
+$(TagDoc:2.1.500-sdk-nanoserver-1803)
+$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.1.6-runtime-nanoserver-1803)
 
 **.NET Core 2.2 Preview tags**
 
@@ -38,9 +38,9 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server, version 1709 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1709)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.1.5-runtime-nanoserver-1709)
+$(TagDoc:2.1.500-sdk-nanoserver-1709)
+$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.1.6-runtime-nanoserver-1709)
 
 **.NET Core 2.2 Preview tags**
 
@@ -48,9 +48,9 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Windows Server 2016 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-sac2016)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.1.5-runtime-nanoserver-sac2016)
+$(TagDoc:2.1.500-sdk-nanoserver-sac2016)
+$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.1.6-runtime-nanoserver-sac2016)
 $(TagDoc:1.1.10-sdk-1.1.11-nanoserver-sac2016)
 $(TagDoc:1.1.10-runtime-nanoserver-sac2016)
 $(TagDoc:1.0.13-runtime-nanoserver-sac2016)
@@ -61,14 +61,14 @@ See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 # Linux arm32 tags
 
-$(TagDoc:2.1.403-sdk-stretch-arm32v7)
-$(TagDoc:2.1.403-sdk-bionic-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.1.5-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-runtime-bionic-arm32v7)
-$(TagDocList:2.1.5-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.5-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
+$(TagDoc:2.1.500-sdk-stretch-arm32v7)
+$(TagDoc:2.1.500-sdk-bionic-arm32v7)
+$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1.6-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.1.6-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1.6-runtime-bionic-arm32v7)
+$(TagDocList:2.1.6-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
+$(TagDocList:2.1.6-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
 
 **.NET Core 2.2 Preview tags**
 

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -2,18 +2,18 @@
 
 # Linux amd64 tags
 
-$(TagDoc:2.1.403-sdk-stretch)
-$(TagDoc:2.1.403-sdk-alpine3.7)
-$(TagDoc:2.1.403-sdk-bionic)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim)
-$(TagDoc:2.1.5-aspnetcore-runtime-alpine3.7)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic)
-$(TagDoc:2.1.5-runtime-stretch-slim)
-$(TagDoc:2.1.5-runtime-alpine3.7)
-$(TagDoc:2.1.5-runtime-bionic)
-$(TagDocList:2.1.5-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.5-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7|2.1.5-runtime-deps-alpine|2.1-runtime-deps-alpine)
-$(TagDocList:2.1.5-runtime-deps-bionic|2.1-runtime-deps-bionic)
+$(TagDoc:2.1.500-sdk-stretch)
+$(TagDoc:2.1.500-sdk-alpine3.7)
+$(TagDoc:2.1.500-sdk-bionic)
+$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim)
+$(TagDoc:2.1.6-aspnetcore-runtime-alpine3.7)
+$(TagDoc:2.1.6-aspnetcore-runtime-bionic)
+$(TagDoc:2.1.6-runtime-stretch-slim)
+$(TagDoc:2.1.6-runtime-alpine3.7)
+$(TagDoc:2.1.6-runtime-bionic)
+$(TagDocList:2.1.6-runtime-deps-stretch-slim|2.1-runtime-deps-stretch-slim|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
+$(TagDocList:2.1.6-runtime-deps-alpine3.7|2.1-runtime-deps-alpine3.7|2.1.6-runtime-deps-alpine|2.1-runtime-deps-alpine)
+$(TagDocList:2.1.6-runtime-deps-bionic|2.1-runtime-deps-bionic)
 $(TagDoc:1.1.10-sdk-1.1.11-stretch)
 $(TagDoc:1.1.10-sdk-1.1.11-jessie)
 $(TagDoc:1.1.10-runtime-stretch)
@@ -39,9 +39,9 @@ $(TagDocList:2.2.0-preview3-runtime-deps-bionic|2.2-runtime-deps-bionic)
 
 # Windows Server, version 1803 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1803)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1803)
-$(TagDoc:2.1.5-runtime-nanoserver-1803)
+$(TagDoc:2.1.500-sdk-nanoserver-1803)
+$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1803)
+$(TagDoc:2.1.6-runtime-nanoserver-1803)
 
 **.NET Core 2.2 Preview 3 tags**
 
@@ -51,9 +51,9 @@ $(TagDoc:2.2.0-preview3-runtime-nanoserver-1803)
 
 # Windows Server, version 1709 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-1709)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-1709)
-$(TagDoc:2.1.5-runtime-nanoserver-1709)
+$(TagDoc:2.1.500-sdk-nanoserver-1709)
+$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-1709)
+$(TagDoc:2.1.6-runtime-nanoserver-1709)
 
 **.NET Core 2.2 Preview 3 tags**
 
@@ -63,9 +63,9 @@ $(TagDoc:2.2.0-preview3-runtime-nanoserver-1709)
 
 # Windows Server 2016 amd64 tags
 
-$(TagDoc:2.1.403-sdk-nanoserver-sac2016)
-$(TagDoc:2.1.5-aspnetcore-runtime-nanoserver-sac2016)
-$(TagDoc:2.1.5-runtime-nanoserver-sac2016)
+$(TagDoc:2.1.500-sdk-nanoserver-sac2016)
+$(TagDoc:2.1.6-aspnetcore-runtime-nanoserver-sac2016)
+$(TagDoc:2.1.6-runtime-nanoserver-sac2016)
 $(TagDoc:1.1.10-sdk-1.1.11-nanoserver-sac2016)
 $(TagDoc:1.1.10-runtime-nanoserver-sac2016)
 $(TagDoc:1.0.13-runtime-nanoserver-sac2016)
@@ -78,14 +78,14 @@ $(TagDoc:2.2.0-preview3-runtime-nanoserver-sac2016)
 
 # Linux arm32 tags
 
-$(TagDoc:2.1.403-sdk-stretch-arm32v7)
-$(TagDoc:2.1.403-sdk-bionic-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.1.5-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1.5-runtime-bionic-arm32v7)
-$(TagDocList:2.1.5-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.5-runtime-deps|2.1-runtime-deps|runtime-deps)
-$(TagDocList:2.1.5-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
+$(TagDoc:2.1.500-sdk-stretch-arm32v7)
+$(TagDoc:2.1.500-sdk-bionic-arm32v7)
+$(TagDoc:2.1.6-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1.6-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.1.6-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1.6-runtime-bionic-arm32v7)
+$(TagDocList:2.1.6-runtime-deps-stretch-slim-arm32v7|2.1-runtime-deps-stretch-slim-arm32v7|2.1.6-runtime-deps|2.1-runtime-deps|runtime-deps)
+$(TagDocList:2.1.6-runtime-deps-bionic-arm32v7|2.1-runtime-deps-bionic-arm32v7)
 
 **.NET Core 2.2 Preview 3 tags**
 


### PR DESCRIPTION
CI is expected to fail until 2.1.6 is released.