### PR TITLE
Update image-builder and tweak remote docker cleanup

### DIFF
--- a/.vsts-pipelines/steps/cleanup-docker-linux.yml
+++ b/.vsts-pipelines/steps/cleanup-docker-linux.yml
@@ -16,8 +16,14 @@ steps:
   # Cleanup remote Docker server
   ################################################################################
   - ${{ if eq(parameters.cleanupRemoteDockerServer, 'true') }}:
-    - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $(dockerClientImage) system prune -a -f --volumes
-      displayName: Cleanup Remote Docker Server
+    - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $(dockerClientImage) system prune -f --volumes
+      displayName: Cleanup Remote Docker Server (basic)
+      condition: always()
+      continueOnError: true
+    - script: >
+        docker run --rm $(dockerArmRunArgs) --entrypoint /bin/bash $(dockerClientImage) -c
+        'docker rmi -f $(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v -e ^arm32v7/ -e ^arm64v8/ -e ^mcr\\.microsoft\\.com/windows)'
+      displayName: Cleanup Remote Docker Server (images)
       condition: always()
       continueOnError: true
 

--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -43,7 +43,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181108224309"
+      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181116160343"
     displayName: Define imageBuilder.image Variable
   - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
     displayName: Pull Image Builder

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -13,7 +13,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181108144253
+      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181116081255
     displayName: Define imageBuilder.image Variable
   - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-WithRetry.ps1 "docker pull $(imageBuilder.image)"
     displayName: Pull Image Builder


### PR DESCRIPTION
- Update image-builder to pickup https://github.com/dotnet/docker-tools/pull/127
- Refactor remote Docker cleanup logic to preserve base images.  This really helps with slow arm machines.