### PR TITLE
Update sdk first run comment

### DIFF
--- a/3.0/sdk/alpine3.8/amd64/Dockerfile
+++ b/3.0/sdk/alpine3.8/amd64/Dockerfile
@@ -23,5 +23,5 @@ ENV DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/bionic/amd64/Dockerfile
+++ b/3.0/sdk/bionic/amd64/Dockerfile
@@ -33,5 +33,5 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/bionic/arm32v7/Dockerfile
+++ b/3.0/sdk/bionic/arm32v7/Dockerfile
@@ -33,5 +33,5 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/bionic/arm64v8/Dockerfile
+++ b/3.0/sdk/bionic/arm64v8/Dockerfile
@@ -33,5 +33,5 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -38,5 +38,5 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1803/amd64/Dockerfile
@@ -38,5 +38,5 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -38,5 +38,5 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -28,5 +28,5 @@ ENV ASPNETCORE_URLS=http://+:80 `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/stretch/amd64/Dockerfile
+++ b/3.0/sdk/stretch/amd64/Dockerfile
@@ -33,5 +33,5 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/stretch/arm32v7/Dockerfile
+++ b/3.0/sdk/stretch/arm32v7/Dockerfile
@@ -33,5 +33,5 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/3.0/sdk/stretch/arm64v8/Dockerfile
+++ b/3.0/sdk/stretch/arm64v8/Dockerfile
@@ -33,5 +33,5 @@ ENV ASPNETCORE_URLS=http://+:80 \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
+# Trigger first run experience by running arbitrary cmd
 RUN dotnet help


### PR DESCRIPTION
The _first run_ comment in the 3.0 SDK dockerfiles is out of date with the removal of the NuGet package cache.  The comment was updated appropriately.

Related #793