### PR TITLE
Group all linux and windows platforms in the tags documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,23 +72,6 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
 
-# Windows Server, version 1809 amd64 tags
-
-- [`2.2.100-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
-- [`2.2.0-runtime-nanoserver-1809`, `2.2-runtime-nanoserver-1809`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-nanoserver-1809`, `2.1-sdk-nanoserver-1809`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1809/amd64/Dockerfile)
-- [`2.1.7-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
-- [`2.1.7-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
-
-**.NET Core 3.0 Preview tags**
-
-See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
-
-# Windows Server 2016, version 1709, and version 1803 amd64 tags
-
-See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
-
 # Linux arm64 tags
 
 **.NET Core 3.0 Preview tags**
@@ -115,6 +98,23 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 - [`2.1.7-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
+
+See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
+
+# Windows Server, version 1809 amd64 tags
+
+- [`2.2.100-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.0-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.0-runtime-nanoserver-1809`, `2.2-runtime-nanoserver-1809`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/amd64/Dockerfile)
+- [`2.1.501-preview-sdk-nanoserver-1809`, `2.1-sdk-nanoserver-1809`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1809/amd64/Dockerfile)
+- [`2.1.7-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
+- [`2.1.7-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
+
+**.NET Core 3.0 Preview tags**
+
+See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
+
+# Windows Server 2016, version 1709, and version 1803 amd64 tags
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nightly/TAGS.md).
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -53,6 +53,49 @@
 - [`3.0.0-preview-runtime-deps-alpine3.8`, `3.0-runtime-deps-alpine3.8`, `3.0.0-preview-runtime-deps-alpine`, `3.0-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/alpine3.8/amd64/Dockerfile)
 - [`3.0.0-preview-runtime-deps-bionic`, `3.0-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/amd64/Dockerfile)
 
+# Linux arm64 tags
+
+**.NET Core 3.0 Preview tags**
+
+- [`3.0.100-preview-sdk-stretch-arm64v8`, `3.0-sdk-stretch-arm64v8`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm64v8/Dockerfile)
+- [`3.0.100-preview-sdk-bionic-arm64v8`, `3.0-sdk-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm64v8/Dockerfile)
+- [`3.0.0-preview-aspnetcore-runtime-stretch-slim-arm64v8`, `3.0-aspnetcore-runtime-stretch-slim-arm64v8`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/arm64v8/Dockerfile)
+- [`3.0.0-preview-aspnetcore-runtime-bionic-arm64v8`, `3.0-aspnetcore-runtime-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/arm64v8/Dockerfile)
+- [`3.0.0-preview-runtime-stretch-slim-arm64v8`, `3.0-runtime-stretch-slim-arm64v8`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm64v8/Dockerfile)
+- [`3.0.0-preview-runtime-bionic-arm64v8`, `3.0-runtime-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm64v8/Dockerfile)
+- [`3.0.0-preview-runtime-deps-stretch-slim-arm64v8`, `3.0-runtime-deps-stretch-slim-arm64v8`, `3.0.0-preview-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile)
+- [`3.0.0-preview-runtime-deps-bionic-arm64v8`, `3.0-runtime-deps-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm64v8/Dockerfile)
+
+# Linux arm32 tags
+
+- [`2.2.100-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
+- [`2.2.100-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
+- [`2.2.0-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.0-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.0-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.0-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.0-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.0-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.0-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.501-preview-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.501-preview-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.1.7-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.7-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.7-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.7-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
+- [`2.1.7-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.7-runtime-deps`, `2.1-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.1.7-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+
+**.NET Core 3.0 Preview tags**
+
+- [`3.0.100-preview-sdk-stretch-arm32v7`, `3.0-sdk-stretch-arm32v7`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm32v7/Dockerfile)
+- [`3.0.100-preview-sdk-bionic-arm32v7`, `3.0-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm32v7/Dockerfile)
+- [`3.0.0-preview-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`3.0.0-preview-aspnetcore-runtime-bionic-arm32v7`, `3.0-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`3.0.0-preview-runtime-stretch-slim-arm32v7`, `3.0-runtime-stretch-slim-arm32v7`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`3.0.0-preview-runtime-bionic-arm32v7`, `3.0-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm32v7/Dockerfile)
+- [`3.0.0-preview-runtime-deps-stretch-slim-arm32v7`, `3.0-runtime-deps-stretch-slim-arm32v7`, `3.0.0-preview-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`3.0.0-preview-runtime-deps-bionic-arm32v7`, `3.0-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm32v7/Dockerfile)
+
 # Windows Server, version 1809 amd64 tags
 
 - [`2.2.100-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
@@ -115,49 +158,6 @@
 - [`3.0.100-preview-sdk-nanoserver-sac2016`, `3.0-sdk-nanoserver-sac2016`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-sac2016`, `3.0-aspnetcore-runtime-nanoserver-sac2016`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`3.0.0-preview-runtime-nanoserver-sac2016`, `3.0-runtime-nanoserver-sac2016`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
-
-# Linux arm64 tags
-
-**.NET Core 3.0 Preview tags**
-
-- [`3.0.100-preview-sdk-stretch-arm64v8`, `3.0-sdk-stretch-arm64v8`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm64v8/Dockerfile)
-- [`3.0.100-preview-sdk-bionic-arm64v8`, `3.0-sdk-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm64v8/Dockerfile)
-- [`3.0.0-preview-aspnetcore-runtime-stretch-slim-arm64v8`, `3.0-aspnetcore-runtime-stretch-slim-arm64v8`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/arm64v8/Dockerfile)
-- [`3.0.0-preview-aspnetcore-runtime-bionic-arm64v8`, `3.0-aspnetcore-runtime-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/arm64v8/Dockerfile)
-- [`3.0.0-preview-runtime-stretch-slim-arm64v8`, `3.0-runtime-stretch-slim-arm64v8`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm64v8/Dockerfile)
-- [`3.0.0-preview-runtime-bionic-arm64v8`, `3.0-runtime-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm64v8/Dockerfile)
-- [`3.0.0-preview-runtime-deps-stretch-slim-arm64v8`, `3.0-runtime-deps-stretch-slim-arm64v8`, `3.0.0-preview-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile)
-- [`3.0.0-preview-runtime-deps-bionic-arm64v8`, `3.0-runtime-deps-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm64v8/Dockerfile)
-
-# Linux arm32 tags
-
-- [`2.2.100-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
-- [`2.2.100-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.0-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
-- [`2.1.501-preview-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.501-preview-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
-- [`2.1.7-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.7-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.7-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.7-runtime-bionic-arm32v7`, `2.1-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/bionic/arm32v7/Dockerfile)
-- [`2.1.7-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.7-runtime-deps`, `2.1-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.1.7-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
-
-**.NET Core 3.0 Preview tags**
-
-- [`3.0.100-preview-sdk-stretch-arm32v7`, `3.0-sdk-stretch-arm32v7`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/stretch/arm32v7/Dockerfile)
-- [`3.0.100-preview-sdk-bionic-arm32v7`, `3.0-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/sdk/bionic/arm32v7/Dockerfile)
-- [`3.0.0-preview-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0-aspnetcore-runtime-stretch-slim-arm32v7`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`3.0.0-preview-aspnetcore-runtime-bionic-arm32v7`, `3.0-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`3.0.0-preview-runtime-stretch-slim-arm32v7`, `3.0-runtime-stretch-slim-arm32v7`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`3.0.0-preview-runtime-bionic-arm32v7`, `3.0-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime/bionic/arm32v7/Dockerfile)
-- [`3.0.0-preview-runtime-deps-stretch-slim-arm32v7`, `3.0-runtime-deps-stretch-slim-arm32v7`, `3.0.0-preview-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`3.0.0-preview-runtime-deps-bionic-arm32v7`, `3.0-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/3.0/runtime-deps/bionic/arm32v7/Dockerfile)
 
 # Windows Server, version 1809 arm32 tags
 

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -35,23 +35,6 @@ $(TagDoc:2.1-runtime-deps-bionic)
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
-# Windows Server, version 1809 amd64 tags
-
-$(TagDoc:2.2-sdk-nanoserver-1809)
-$(TagDoc:2.2-aspnetcore-runtime-nanoserver-1809)
-$(TagDoc:2.2-runtime-nanoserver-1809)
-$(TagDoc:2.1-sdk-nanoserver-1809)
-$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1809)
-$(TagDoc:2.1-runtime-nanoserver-1809)
-
-**.NET Core 3.0 Preview tags**
-
-See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
-
-# Windows Server 2016, version 1709, and version 1803 amd64 tags
-
-See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
-
 # Linux arm64 tags
 
 **.NET Core 3.0 Preview tags**
@@ -78,6 +61,23 @@ $(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
 $(TagDoc:2.1-runtime-deps-bionic-arm32v7)
 
 **.NET Core 3.0 Preview tags**
+
+See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
+
+# Windows Server, version 1809 amd64 tags
+
+$(TagDoc:2.2-sdk-nanoserver-1809)
+$(TagDoc:2.2-aspnetcore-runtime-nanoserver-1809)
+$(TagDoc:2.2-runtime-nanoserver-1809)
+$(TagDoc:2.1-sdk-nanoserver-1809)
+$(TagDoc:2.1-aspnetcore-runtime-nanoserver-1809)
+$(TagDoc:2.1-runtime-nanoserver-1809)
+
+**.NET Core 3.0 Preview tags**
+
+See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
+
+# Windows Server 2016, version 1709, and version 1803 amd64 tags
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -53,6 +53,49 @@ $(TagDoc:3.0-runtime-deps-stretch-slim)
 $(TagDoc:3.0-runtime-deps-alpine3.8)
 $(TagDoc:3.0-runtime-deps-bionic)
 
+# Linux arm64 tags
+
+**.NET Core 3.0 Preview tags**
+
+$(TagDoc:3.0-sdk-stretch-arm64v8)
+$(TagDoc:3.0-sdk-bionic-arm64v8)
+$(TagDoc:3.0-aspnetcore-runtime-stretch-slim-arm64v8)
+$(TagDoc:3.0-aspnetcore-runtime-bionic-arm64v8)
+$(TagDoc:3.0-runtime-stretch-slim-arm64v8)
+$(TagDoc:3.0-runtime-bionic-arm64v8)
+$(TagDoc:3.0-runtime-deps-stretch-slim-arm64v8)
+$(TagDoc:3.0-runtime-deps-bionic-arm64v8)
+
+# Linux arm32 tags
+
+$(TagDoc:2.2-sdk-stretch-arm32v7)
+$(TagDoc:2.2-sdk-bionic-arm32v7)
+$(TagDoc:2.2-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.2-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.2-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.2-runtime-bionic-arm32v7)
+$(TagDoc:2.2-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:2.2-runtime-deps-bionic-arm32v7)
+$(TagDoc:2.1-sdk-stretch-arm32v7)
+$(TagDoc:2.1-sdk-bionic-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-bionic-arm32v7)
+$(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:2.1-runtime-deps-bionic-arm32v7)
+
+**.NET Core 3.0 Preview tags**
+
+$(TagDoc:3.0-sdk-stretch-arm32v7)
+$(TagDoc:3.0-sdk-bionic-arm32v7)
+$(TagDoc:3.0-aspnetcore-runtime-stretch-slim-arm32v7)
+$(TagDoc:3.0-aspnetcore-runtime-bionic-arm32v7)
+$(TagDoc:3.0-runtime-stretch-slim-arm32v7)
+$(TagDoc:3.0-runtime-bionic-arm32v7)
+$(TagDoc:3.0-runtime-deps-stretch-slim-arm32v7)
+$(TagDoc:3.0-runtime-deps-bionic-arm32v7)
+
 # Windows Server, version 1809 amd64 tags
 
 $(TagDoc:2.2-sdk-nanoserver-1809)
@@ -115,49 +158,6 @@ $(TagDoc:1.0-runtime-nanoserver-sac2016)
 $(TagDoc:3.0-sdk-nanoserver-sac2016)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-sac2016)
 $(TagDoc:3.0-runtime-nanoserver-sac2016)
-
-# Linux arm64 tags
-
-**.NET Core 3.0 Preview tags**
-
-$(TagDoc:3.0-sdk-stretch-arm64v8)
-$(TagDoc:3.0-sdk-bionic-arm64v8)
-$(TagDoc:3.0-aspnetcore-runtime-stretch-slim-arm64v8)
-$(TagDoc:3.0-aspnetcore-runtime-bionic-arm64v8)
-$(TagDoc:3.0-runtime-stretch-slim-arm64v8)
-$(TagDoc:3.0-runtime-bionic-arm64v8)
-$(TagDoc:3.0-runtime-deps-stretch-slim-arm64v8)
-$(TagDoc:3.0-runtime-deps-bionic-arm64v8)
-
-# Linux arm32 tags
-
-$(TagDoc:2.2-sdk-stretch-arm32v7)
-$(TagDoc:2.2-sdk-bionic-arm32v7)
-$(TagDoc:2.2-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.2-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.2-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.2-runtime-bionic-arm32v7)
-$(TagDoc:2.2-runtime-deps-stretch-slim-arm32v7)
-$(TagDoc:2.2-runtime-deps-bionic-arm32v7)
-$(TagDoc:2.1-sdk-stretch-arm32v7)
-$(TagDoc:2.1-sdk-bionic-arm32v7)
-$(TagDoc:2.1-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:2.1-runtime-stretch-slim-arm32v7)
-$(TagDoc:2.1-runtime-bionic-arm32v7)
-$(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
-$(TagDoc:2.1-runtime-deps-bionic-arm32v7)
-
-**.NET Core 3.0 Preview tags**
-
-$(TagDoc:3.0-sdk-stretch-arm32v7)
-$(TagDoc:3.0-sdk-bionic-arm32v7)
-$(TagDoc:3.0-aspnetcore-runtime-stretch-slim-arm32v7)
-$(TagDoc:3.0-aspnetcore-runtime-bionic-arm32v7)
-$(TagDoc:3.0-runtime-stretch-slim-arm32v7)
-$(TagDoc:3.0-runtime-bionic-arm32v7)
-$(TagDoc:3.0-runtime-deps-stretch-slim-arm32v7)
-$(TagDoc:3.0-runtime-deps-bionic-arm32v7)
 
 # Windows Server, version 1809 arm32 tags
 


### PR DESCRIPTION
Currently we list all amd tags first since it has the most usage
- Linux amd64 tags
- Windows Server, version 1809 amd64 tags
- Windows Server 2016, version 1709, and version 1803 amd64 tags
- Linux arm64 tags
- Linux arm32 tags
- Windows Server, version 1809 arm32 tags

I believe the mixture of Linux on Windows tags may get confusing.  I conjecture it would be better to group all OS tags.  I don't recommend having an OS header (e.g. `Linux` and `Windows`) for two reasons.  First, the `Linux` section will easily fill the entire screen therefore you will lose this context.  Second, Docker Hub's poor markdown rendering only has two headers that are differentiable (e.g. # and ##).  We already have a `Tags` parent header.
- Linux amd64 tags
- Linux arm64 tags
- Linux arm32 tags
- Windows Server, version 1809 amd64 tags
- Windows Server 2016, version 1709, and version 1803 amd64 tags
- Windows Server, version 1809 arm32 tags