### PR TITLE
Misc cleanup

### DIFF
--- a/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -15,4 +15,3 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
     && rm aspnetcore.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-

--- a/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
@@ -15,4 +15,3 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
     && rm aspnetcore.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-

--- a/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile
@@ -34,4 +34,6 @@ USER ContainerUser
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677
+    DOTNET_RUNNING_IN_CONTAINERS=true

--- a/tests/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.testapp
+++ b/tests/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.testapp
@@ -7,7 +7,7 @@ SHELL ["cmd", "/S", "/C"]
 
 ARG netcoreapp_version
 ARG optional_new_args=" "
-ARG optional_package_sources="."
+ARG optional_package_sources=" "
 ARG optional_restore_args=" "
 ARG template_name
 


### PR DESCRIPTION
- Removed extra WS from 2.1 ASP.NET Core Dockerfiles
- Added `DOTNET_RUNNING_IN_CONTAINERS` to the nanoserver-1809 2.1 ASP.NET Core Dockerfile to provide alignment with other nanoserver 2.1 Dockerfiles 
- Modified a test Dockerfile to work in master when no additional NuGet feeds are specified.