### PR TITLE
[WIP] Use repo ARG to reference runtime-deps images

### DIFF
--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -47,7 +47,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181126190316"
+      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181211175458"
     displayName: Define imageBuilder.image Variable
   - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
     displayName: Pull Image Builder

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -13,7 +13,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181126110323
+      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181211095443
     displayName: Define imageBuilder.image Variable
   - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-WithRetry.ps1 "docker pull $(imageBuilder.image)"
     displayName: Pull Image Builder

--- a/1.0/runtime/jessie/amd64/Dockerfile
+++ b/1.0/runtime/jessie/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:1.0-runtime-deps-jessie
+ARG REPO=microsoft/dotnet
+FROM $REPO:1.0-runtime-deps-jessie
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/1.1/runtime/jessie/amd64/Dockerfile
+++ b/1.1/runtime/jessie/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:1.0-runtime-deps-jessie
+ARG REPO=microsoft/dotnet
+FROM $REPO:1.0-runtime-deps-jessie
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/1.1/runtime/stretch/amd64/Dockerfile
+++ b/1.1/runtime/stretch/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:1.1-runtime-deps-stretch
+ARG REPO=microsoft/dotnet
+FROM $REPO:1.1-runtime-deps-stretch
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-alpine3.7
 
 # Install ASP.NET Core
 ENV ASPNETCORE_VERSION 2.1.7-servicing-31150

--- a/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-alpine3.8
 
 # Install ASP.NET Core
 ENV ASPNETCORE_VERSION 2.1.7-servicing-31150

--- a/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-bionic
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-bionic-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-bionic-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-stretch-slim
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-stretch-slim-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-stretch-slim-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/runtime/alpine3.7/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-alpine3.7
 
 # Install .NET Core
 ENV DOTNET_VERSION 2.1.7-servicing-27120-02

--- a/2.1/runtime/alpine3.8/amd64/Dockerfile
+++ b/2.1/runtime/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-alpine3.8
 
 # Install .NET Core
 ENV DOTNET_VERSION 2.1.7-servicing-27120-02

--- a/2.1/runtime/bionic/amd64/Dockerfile
+++ b/2.1/runtime/bionic/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-bionic
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime/bionic/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-bionic-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-bionic-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-stretch-slim
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime/stretch-slim/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-stretch-slim-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-stretch-slim-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/sdk/alpine3.7/amd64/Dockerfile
+++ b/2.1/sdk/alpine3.7/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-alpine3.7
 
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache icu-libs

--- a/2.1/sdk/alpine3.8/amd64/Dockerfile
+++ b/2.1/sdk/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.1-runtime-deps-alpine3.8
 
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache icu-libs

--- a/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-alpine3.8
 
 # Install ASP.NET Core
 ENV ASPNETCORE_VERSION 2.2.0

--- a/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-bionic
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile
+++ b/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-bionic-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-bionic-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-stretch-slim
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-stretch-slim-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-stretch-slim-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/runtime/alpine3.8/amd64/Dockerfile
+++ b/2.2/runtime/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-alpine3.8
 
 # Install .NET Core
 ENV DOTNET_VERSION 2.2.0

--- a/2.2/runtime/bionic/amd64/Dockerfile
+++ b/2.2/runtime/bionic/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-bionic
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/runtime/bionic/arm32v7/Dockerfile
+++ b/2.2/runtime/bionic/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-bionic-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-bionic-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/runtime/stretch-slim/amd64/Dockerfile
+++ b/2.2/runtime/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-stretch-slim
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.2/runtime/stretch-slim/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-stretch-slim-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-stretch-slim-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.2/sdk/alpine3.8/amd64/Dockerfile
+++ b/2.2/sdk/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:2.2-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:2.2-runtime-deps-alpine3.8
 
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache icu-libs

--- a/3.0/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
+++ b/3.0/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-alpine3.8
 
 # Install ASP.NET Core
 ENV ASPNETCORE_VERSION 3.0.0-preview-18579-0056

--- a/3.0/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/3.0/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-bionic
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile
+++ b/3.0/aspnetcore-runtime/bionic/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-bionic-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-bionic-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/aspnetcore-runtime/bionic/arm64v8/Dockerfile
+++ b/3.0/aspnetcore-runtime/bionic/arm64v8/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-bionic-arm64v8
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-bionic-arm64v8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
+++ b/3.0/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-stretch-slim
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
+++ b/3.0/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-stretch-slim-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-stretch-slim-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/aspnetcore-runtime/stretch-slim/arm64v8/Dockerfile
+++ b/3.0/aspnetcore-runtime/stretch-slim/arm64v8/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-stretch-slim-arm64v8
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-stretch-slim-arm64v8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/runtime/alpine3.8/amd64/Dockerfile
+++ b/3.0/runtime/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-alpine3.8
 
 # Install .NET Core
 ENV DOTNET_VERSION 3.0.0-preview-27122-01

--- a/3.0/runtime/bionic/amd64/Dockerfile
+++ b/3.0/runtime/bionic/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-bionic
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/runtime/bionic/arm32v7/Dockerfile
+++ b/3.0/runtime/bionic/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-bionic-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-bionic-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/runtime/bionic/arm64v8/Dockerfile
+++ b/3.0/runtime/bionic/arm64v8/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-bionic-arm64v8
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-bionic-arm64v8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/runtime/stretch-slim/amd64/Dockerfile
+++ b/3.0/runtime/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-stretch-slim
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/3.0/runtime/stretch-slim/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-stretch-slim-arm32v7
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-stretch-slim-arm32v7
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/runtime/stretch-slim/arm64v8/Dockerfile
+++ b/3.0/runtime/stretch-slim/arm64v8/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-stretch-slim-arm64v8
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-stretch-slim-arm64v8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.0/sdk/alpine3.8/amd64/Dockerfile
+++ b/3.0/sdk/alpine3.8/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet-nightly:3.0-runtime-deps-alpine3.8
+ARG REPO=microsoft/dotnet
+FROM $REPO:3.0-runtime-deps-alpine3.8
 
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache icu-libs

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -27,8 +27,8 @@ function Exec {
     }
 }
 
-$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181022125001'
-$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181022195013'
+$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20181211095443'
+$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181211175458'
 $imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
 
 pushd $PSScriptRoot

--- a/manifest.json
+++ b/manifest.json
@@ -53,6 +53,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "1.0/runtime/jessie/amd64",
               "os": "linux",
               "tags": {
@@ -87,6 +90,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "1.1/runtime/jessie/amd64",
               "os": "linux",
               "tags": {
@@ -181,6 +187,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "1.1/runtime/stretch/amd64",
               "os": "linux",
               "tags": {
@@ -271,6 +280,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
@@ -280,6 +292,9 @@
             },
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
@@ -336,6 +351,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
@@ -345,6 +363,9 @@
             },
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
@@ -471,6 +492,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
@@ -483,6 +507,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/aspnetcore-runtime/alpine3.7/amd64",
               "os": "linux",
               "tags": {
@@ -495,6 +522,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/sdk/alpine3.7/amd64",
               "os": "linux",
               "tags": {
@@ -541,6 +571,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -555,6 +588,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -569,6 +605,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -605,6 +644,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
@@ -617,6 +659,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
@@ -666,6 +711,9 @@
           "platforms": [
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
@@ -680,6 +728,9 @@
           "platforms": [
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.1/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
@@ -715,6 +766,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
@@ -724,6 +778,9 @@
             },
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
@@ -791,6 +848,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
@@ -800,6 +860,9 @@
             },
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
@@ -936,6 +999,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -950,6 +1016,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -964,6 +1033,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -978,6 +1050,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
@@ -990,6 +1065,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
@@ -1015,6 +1093,9 @@
           "platforms": [
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
@@ -1029,6 +1110,9 @@
           "platforms": [
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "2.2/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
@@ -1096,6 +1180,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
@@ -1105,6 +1192,9 @@
             },
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
@@ -1115,6 +1205,9 @@
             },
             {
               "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/runtime/stretch-slim/arm64v8",
               "os": "linux",
               "tags": {
@@ -1178,6 +1271,9 @@
           },
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/aspnetcore-runtime/stretch-slim/amd64",
               "os": "linux",
               "tags": {
@@ -1187,6 +1283,9 @@
             },
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/aspnetcore-runtime/stretch-slim/arm32v7",
               "os": "linux",
               "tags": {
@@ -1197,6 +1296,9 @@
             },
             {
               "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/aspnetcore-runtime/stretch-slim/arm64v8",
               "os": "linux",
               "tags": {
@@ -1332,6 +1434,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -1346,6 +1451,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/aspnetcore-runtime/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -1360,6 +1468,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/sdk/alpine3.8/amd64",
               "os": "linux",
               "tags": {
@@ -1386,6 +1497,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/aspnetcore-runtime/bionic/amd64",
               "os": "linux",
               "tags": {
@@ -1398,6 +1512,9 @@
         {
           "platforms": [
             {
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/runtime/bionic/amd64",
               "os": "linux",
               "tags": {
@@ -1437,6 +1554,9 @@
           "platforms": [
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/aspnetcore-runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
@@ -1451,6 +1571,9 @@
           "platforms": [
             {
               "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/runtime/bionic/arm32v7",
               "os": "linux",
               "tags": {
@@ -1493,6 +1616,9 @@
           "platforms": [
             {
               "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/runtime/bionic/arm64v8",
               "os": "linux",
               "tags": {
@@ -1507,6 +1633,9 @@
           "platforms": [
             {
               "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(System:Repo)"
+              },
               "dockerfile": "3.0/aspnetcore-runtime/bionic/arm64v8",
               "os": "linux",
               "tags": {


### PR DESCRIPTION
It is becoming increasingly difficult to ensure the correct set of changes get merged from nightly to master when we release.  One thing that makes this prone to human error is that the two branches cannot be easily diffed/merged.  One of the primary reasons for this is the Dockerfiles that are based on the runtime-deps images - `FROM microsoft/dotnet-nightly:1.1-runtime-deps-stretch` vs `FROM microsoft/dotnet:1.1-runtime-deps-stretch`.  To eliminate this friction, we are introducing a `ARG` for the `REPO` to pull the base images from.  The default value would be overridden while building the nightly branch. 