### PR TITLE
Update headers in readme due to markdown rendering changed in Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
-### Container sample: Run a simple application
+## Container sample: Run a simple application
 
 Type the following command to run a sample console application:
 
@@ -19,7 +19,7 @@ Type the following command to run a sample console application:
 docker run --rm microsoft/dotnet-samples
 ```
 
-### Container sample: Run a web application
+## Container sample: Run a web application
 
 Type the following command to run a sample web application:
 
@@ -31,9 +31,9 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/aspnetcore-docker-https.md) to use HTTPS with this image.
 
-## Tags
+# Tags
 
-# Linux amd64 tags
+## Linux amd64 tags
 
 - [`2.2.100-sdk-stretch`, `2.2-sdk-stretch`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/stretch/amd64/Dockerfile)
 - [`2.2.100-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.100-sdk-alpine`, `2.2-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/alpine3.8/amd64/Dockerfile)
@@ -60,17 +60,17 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 - [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
 - [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
 
-**.NET Core 1.0, 1.1 and 3.0 Preview tags**
+### .NET Core 1.0, 1.1 and 3.0 Preview tags
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
-# Linux arm64 tags
+## Linux arm64 tags
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
-# Linux arm32 tags
+## Linux arm32 tags
 
 - [`2.2.100-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/stretch/arm32v7/Dockerfile)
 - [`2.2.100-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/bionic/arm32v7/Dockerfile)
@@ -89,11 +89,11 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 - [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
-# Windows Server, version 1809 amd64 tags
+## Windows Server, version 1809 amd64 tags
 
 - [`2.2.100-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
 - [`2.2.0-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
@@ -102,17 +102,17 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 - [`2.1.6-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
-# Windows Server 2016, version 1709, and version 1803 amd64 tags
+## Windows Server 2016, version 1709, and version 1803 amd64 tags
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 
-## What is .NET Core?
+# What is .NET Core?
 
 [.NET Core](https://docs.microsoft.com/dotnet/core/) is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
 
@@ -128,35 +128,35 @@ You are invited to [contribute new features](https://github.com/dotnet/core/blob
 
 ![logo](https://avatars0.githubusercontent.com/u/9141961?v=3&amp;s=100)
 
-## .NET Core Docker Samples
+# .NET Core Docker Samples
 
 The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/samples/README.md) show various ways to use .NET Core and Docker together. See [Building Docker Images for .NET Core Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-### Building .NET Core Apps with Docker
+## Building .NET Core Apps with Docker
 
 * [.NET Core Docker Sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
 * [ASP.NET Core Docker Sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Core Web App.
 
-### Develop .NET Core Apps in a Container
+## Develop .NET Core Apps in a Container
 
 * [Develop .NET Core Applications](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/dotnet-docker-dev-in-container.md) - This sample shows how to develop, build and test .NET Core applications with Docker without the need to install the .NET Core SDK.
 * [Develop ASP.NET Core Applications](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/aspnet-docker-dev-in-container.md) - This sample shows how to develop and test ASP.NET Core applications with Docker without the need to install the .NET Core SDK.
 
-### Optimizing Container Size
+## Optimizing Container Size
 
 * [.NET Core Alpine Docker Sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile.alpine-x64) builds, tests, and runs an application using Alpine.
 * [.NET Core self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/dotnet-docker-selfcontained.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile.debian-x64-selfcontained) builds and runs an application as a self-contained application.
 
-### ARM32 / Raspberry Pi
+## ARM32 / Raspberry Pi
 
 * [.NET Core ARM32 Docker Sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/dotnet-docker-arm32.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile) builds and runs an application with Debian on ARM32 (works on Raspberry Pi).
 * [ASP.NET Core ARM32 Docker Sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile) builds and runs an ASP.NET Core application with Debian on ARM32 (works on Raspberry Pi).
 
-## Image variants
+# Image variants
 
 The `microsoft/dotnet` images come in different flavors, each designed for a specific use case.
 
-### `microsoft/dotnet:<version>-sdk`
+## `microsoft/dotnet:<version>-sdk`
 
 This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.
 
@@ -168,29 +168,29 @@ It contains the .NET Core SDK which is comprised of three parts:
 
 Use this image for your development process (developing, building and testing applications).
 
-### `microsoft/dotnet:<version>-aspnetcore-runtime`
+## `microsoft/dotnet:<version>-aspnetcore-runtime`
 
 This image contains the ASP.NET Core and .NET Core runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 
-### `microsoft/dotnet:<version>-runtime`
+## `microsoft/dotnet:<version>-runtime`
 
 This image contains the .NET Core runtimes and libraries and is optimized for running .NET Core apps in production.
 
-### `microsoft/dotnet:<version>-runtime-deps`
+## `microsoft/dotnet:<version>-runtime-deps`
 
 This image contains the native dependencies needed by .NET Core. It does not include .NET Core. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
 
-## Issues
+# Issues
 
 If you have any problems with or questions about this image, please contact us through a [GitHub issue](https://github.com/dotnet/dotnet-docker/issues).
 
-## Licenses
+# Licenses
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Windows Nano Server license](https://hub.docker.com/r/microsoft/nanoserver/) (only applies to Windows containers)
 * [Pricing and licensing for Windows Server 2016](https://www.microsoft.com/en-us/cloud-platform/windows-server-pricing)
 
-## Related Repos
+# Related Repos
 
 .NET Core Docker Hub repos:
 
@@ -202,5 +202,4 @@ If you have any problems with or questions about this image, please contact us t
 
 * [microsoft/aspnet](https://hub.docker.com/r/microsoft/aspnet/) for ASP.NET Web Forms and MVC images.
 * [microsoft/dotnet-framework](https://hub.docker.com/r/microsoft/dotnet-framework/) for .NET Framework images.
-* [microsoft/dotnet-framework-build](https://hub.docker.com/r/microsoft/dotnet-framework-build/) for building .NET Framework applications with Docker.
 * [microsoft/dotnet-framework-samples](https://hub.docker.com/r/microsoft/dotnet-framework-samples/) for .NET Framework and ASP.NET sample images.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 - [`2.1.6-runtime-deps-alpine3.7`, `2.1-runtime-deps-alpine3.7`, `2.1.6-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine3.7/amd64/Dockerfile)
 - [`2.1.6-runtime-deps-bionic`, `2.1-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile)
 
-### .NET Core 1.0, 1.1 and 3.0 Preview tags
+**.NET Core 1.0, 1.1 and 3.0 Preview tags**
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
 ## Linux arm64 tags
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
@@ -89,7 +89,7 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 - [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 
@@ -102,7 +102,7 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/mast
 - [`2.1.6-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/master/TAGS.md).
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -34,7 +34,7 @@
 - [`1.0.13-runtime-jessie`, `1.0-runtime-jessie`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/jessie/amd64/Dockerfile)
 - [`1.0.13-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.13-runtime-deps`, `1.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime-deps/jessie/amd64/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-preview-sdk-stretch`, `3.0-sdk-stretch`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/stretch/amd64/Dockerfile)
 - [`3.0.100-preview-sdk-alpine3.8`, `3.0-sdk-alpine3.8`, `3.0.100-preview-sdk-alpine`, `3.0-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/alpine3.8/amd64/Dockerfile)
@@ -51,7 +51,7 @@
 
 ## Linux arm64 tags
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-preview-sdk-stretch-arm64v8`, `3.0-sdk-stretch-arm64v8`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/stretch/arm64v8/Dockerfile)
 - [`3.0.100-preview-sdk-bionic-arm64v8`, `3.0-sdk-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/bionic/arm64v8/Dockerfile)
@@ -81,7 +81,7 @@
 - [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-preview-sdk-stretch-arm32v7`, `3.0-sdk-stretch-arm32v7`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/stretch/arm32v7/Dockerfile)
 - [`3.0.100-preview-sdk-bionic-arm32v7`, `3.0-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/bionic/arm32v7/Dockerfile)
@@ -101,7 +101,7 @@
 - [`2.1.6-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-preview-sdk-nanoserver-1809`, `3.0-sdk-nanoserver-1809`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-1809`, `3.0-aspnetcore-runtime-nanoserver-1809`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
@@ -116,7 +116,7 @@
 - [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-preview-sdk-nanoserver-1803`, `3.0-sdk-nanoserver-1803`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1803/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-1803`, `3.0-aspnetcore-runtime-nanoserver-1803`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
@@ -131,7 +131,7 @@
 - [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-preview-sdk-nanoserver-1709`, `3.0-sdk-nanoserver-1709`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1709/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-1709`, `3.0-aspnetcore-runtime-nanoserver-1709`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
@@ -149,7 +149,7 @@
 - [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 - [`3.0.100-preview-sdk-nanoserver-sac2016`, `3.0-sdk-nanoserver-sac2016`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-sac2016`, `3.0-aspnetcore-runtime-nanoserver-sac2016`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)

--- a/TAGS.md
+++ b/TAGS.md
@@ -1,6 +1,6 @@
-## Complete set of Tags
+# Complete set of Tags
 
-# Linux amd64 tags
+## Linux amd64 tags
 
 - [`2.2.100-sdk-stretch`, `2.2-sdk-stretch`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/stretch/amd64/Dockerfile)
 - [`2.2.100-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.100-sdk-alpine`, `2.2-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/alpine3.8/amd64/Dockerfile)
@@ -34,7 +34,7 @@
 - [`1.0.13-runtime-jessie`, `1.0-runtime-jessie`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/jessie/amd64/Dockerfile)
 - [`1.0.13-runtime-deps-jessie`, `1.0-runtime-deps-jessie`, `1.0.13-runtime-deps`, `1.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime-deps/jessie/amd64/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 - [`3.0.100-preview-sdk-stretch`, `3.0-sdk-stretch`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/stretch/amd64/Dockerfile)
 - [`3.0.100-preview-sdk-alpine3.8`, `3.0-sdk-alpine3.8`, `3.0.100-preview-sdk-alpine`, `3.0-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/alpine3.8/amd64/Dockerfile)
@@ -49,9 +49,9 @@
 - [`3.0.0-preview-runtime-deps-alpine3.8`, `3.0-runtime-deps-alpine3.8`, `3.0.0-preview-runtime-deps-alpine`, `3.0-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.8/amd64/Dockerfile)
 - [`3.0.0-preview-runtime-deps-bionic`, `3.0-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/amd64/Dockerfile)
 
-# Linux arm64 tags
+## Linux arm64 tags
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 - [`3.0.100-preview-sdk-stretch-arm64v8`, `3.0-sdk-stretch-arm64v8`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/stretch/arm64v8/Dockerfile)
 - [`3.0.100-preview-sdk-bionic-arm64v8`, `3.0-sdk-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/bionic/arm64v8/Dockerfile)
@@ -62,7 +62,7 @@
 - [`3.0.0-preview-runtime-deps-stretch-slim-arm64v8`, `3.0-runtime-deps-stretch-slim-arm64v8`, `3.0.0-preview-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile)
 - [`3.0.0-preview-runtime-deps-bionic-arm64v8`, `3.0-runtime-deps-bionic-arm64v8` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm64v8/Dockerfile)
 
-# Linux arm32 tags
+## Linux arm32 tags
 
 - [`2.2.100-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/stretch/arm32v7/Dockerfile)
 - [`2.2.100-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/bionic/arm32v7/Dockerfile)
@@ -81,7 +81,7 @@
 - [`2.1.6-runtime-deps-stretch-slim-arm32v7`, `2.1-runtime-deps-stretch-slim-arm32v7`, `2.1.6-runtime-deps`, `2.1-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.6-runtime-deps-bionic-arm32v7`, `2.1-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 - [`3.0.100-preview-sdk-stretch-arm32v7`, `3.0-sdk-stretch-arm32v7`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/stretch/arm32v7/Dockerfile)
 - [`3.0.100-preview-sdk-bionic-arm32v7`, `3.0-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/bionic/arm32v7/Dockerfile)
@@ -92,7 +92,7 @@
 - [`3.0.0-preview-runtime-deps-stretch-slim-arm32v7`, `3.0-runtime-deps-stretch-slim-arm32v7`, `3.0.0-preview-runtime-deps`, `3.0-runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile)
 - [`3.0.0-preview-runtime-deps-bionic-arm32v7`, `3.0-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm32v7/Dockerfile)
 
-# Windows Server, version 1809 amd64 tags
+## Windows Server, version 1809 amd64 tags
 
 - [`2.2.100-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
 - [`2.2.0-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
@@ -101,13 +101,13 @@
 - [`2.1.6-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 - [`3.0.100-preview-sdk-nanoserver-1809`, `3.0-sdk-nanoserver-1809`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-1809`, `3.0-aspnetcore-runtime-nanoserver-1809`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
 - [`3.0.0-preview-runtime-nanoserver-1809`, `3.0-runtime-nanoserver-1809`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1809/amd64/Dockerfile)
 
-# Windows Server, version 1803 amd64 tags
+## Windows Server, version 1803 amd64 tags
 
 - [`2.2.100-sdk-nanoserver-1803`, `2.2-sdk-nanoserver-1803`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1803/amd64/Dockerfile)
 - [`2.2.0-aspnetcore-runtime-nanoserver-1803`, `2.2-aspnetcore-runtime-nanoserver-1803`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
@@ -116,13 +116,13 @@
 - [`2.1.6-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 - [`3.0.100-preview-sdk-nanoserver-1803`, `3.0-sdk-nanoserver-1803`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1803/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-1803`, `3.0-aspnetcore-runtime-nanoserver-1803`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
 - [`3.0.0-preview-runtime-nanoserver-1803`, `3.0-runtime-nanoserver-1803`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1803/amd64/Dockerfile)
 
-# Windows Server, version 1709 amd64 tags
+## Windows Server, version 1709 amd64 tags
 
 - [`2.2.100-sdk-nanoserver-1709`, `2.2-sdk-nanoserver-1709`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1709/amd64/Dockerfile)
 - [`2.2.0-aspnetcore-runtime-nanoserver-1709`, `2.2-aspnetcore-runtime-nanoserver-1709`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
@@ -131,13 +131,13 @@
 - [`2.1.6-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.6-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
 - [`2.1.6-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.6-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 - [`3.0.100-preview-sdk-nanoserver-1709`, `3.0-sdk-nanoserver-1709`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1709/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-1709`, `3.0-aspnetcore-runtime-nanoserver-1709`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
 - [`3.0.0-preview-runtime-nanoserver-1709`, `3.0-runtime-nanoserver-1709`, `3.0.0-preview-runtime`, `3.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1709/amd64/Dockerfile)
 
-# Windows Server 2016 amd64 tags
+## Windows Server 2016 amd64 tags
 
 - [`2.2.100-sdk-nanoserver-sac2016`, `2.2-sdk-nanoserver-sac2016`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.2.0-aspnetcore-runtime-nanoserver-sac2016`, `2.2-aspnetcore-runtime-nanoserver-sac2016`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
@@ -149,7 +149,7 @@
 - [`1.1.10-runtime-nanoserver-sac2016`, `1.1-runtime-nanoserver-sac2016`, `1.1.10-runtime`, `1.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.0.13-runtime-nanoserver-sac2016`, `1.0-runtime-nanoserver-sac2016`, `1.0.13-runtime`, `1.0-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/1.0/runtime/nanoserver-sac2016/amd64/Dockerfile)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 - [`3.0.100-preview-sdk-nanoserver-sac2016`, `3.0-sdk-nanoserver-sac2016`, `3.0.100-preview-sdk`, `3.0-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`3.0.0-preview-aspnetcore-runtime-nanoserver-sac2016`, `3.0-aspnetcore-runtime-nanoserver-sac2016`, `3.0.0-preview-aspnetcore-runtime`, `3.0-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -4,7 +4,7 @@ param(
     [string]$Manifest='manifest.json',
     [string]$ReadMeTemplate='./scripts/ReadmeTagsDocumentationTemplate.md',
     [string]$TagsTemplate='./scripts/TagsDocumentationTemplate.md',
-    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181030184558'
+    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181221161902'
 )
 
 $ErrorActionPreference = 'Stop'

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -27,13 +27,13 @@ $(TagDoc:2.1-runtime-deps-stretch-slim)
 $(TagDoc:2.1-runtime-deps-alpine3.7)
 $(TagDoc:2.1-runtime-deps-bionic)
 
-### .NET Core 1.0, 1.1 and 3.0 Preview tags
+**.NET Core 1.0, 1.1 and 3.0 Preview tags**
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
 ## Linux arm64 tags
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
@@ -56,7 +56,7 @@ $(TagDoc:2.1-runtime-bionic-arm32v7)
 $(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
 $(TagDoc:2.1-runtime-deps-bionic-arm32v7)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
@@ -69,7 +69,7 @@ $(TagDoc:2.1-sdk-nanoserver-1809)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1809)
 $(TagDoc:2.1-runtime-nanoserver-1809)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -1,6 +1,6 @@
-## Tags
+# Tags
 
-# Linux amd64 tags
+## Linux amd64 tags
 
 $(TagDoc:2.2-sdk-stretch)
 $(TagDoc:2.2-sdk-alpine3.8)
@@ -27,17 +27,17 @@ $(TagDoc:2.1-runtime-deps-stretch-slim)
 $(TagDoc:2.1-runtime-deps-alpine3.7)
 $(TagDoc:2.1-runtime-deps-bionic)
 
-**.NET Core 1.0, 1.1 and 3.0 Preview tags**
+### .NET Core 1.0, 1.1 and 3.0 Preview tags
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
-# Linux arm64 tags
+## Linux arm64 tags
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
-# Linux arm32 tags
+## Linux arm32 tags
 
 $(TagDoc:2.2-sdk-stretch-arm32v7)
 $(TagDoc:2.2-sdk-bionic-arm32v7)
@@ -56,11 +56,11 @@ $(TagDoc:2.1-runtime-bionic-arm32v7)
 $(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
 $(TagDoc:2.1-runtime-deps-bionic-arm32v7)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
-# Windows Server, version 1809 amd64 tags
+## Windows Server, version 1809 amd64 tags
 
 $(TagDoc:2.2-sdk-nanoserver-1809)
 $(TagDoc:2.2-aspnetcore-runtime-nanoserver-1809)
@@ -69,11 +69,11 @@ $(TagDoc:2.1-sdk-nanoserver-1809)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1809)
 $(TagDoc:2.1-runtime-nanoserver-1809)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 
-# Windows Server 2016, version 1709, and version 1803 amd64 tags
+## Windows Server 2016, version 1709, and version 1803 amd64 tags
 
 See the [complete set of tags]($(System:SourceUrl)/TAGS.md).
 

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -34,7 +34,7 @@ $(TagDoc:1.1-runtime-deps-stretch)
 $(TagDoc:1.0-runtime-jessie)
 $(TagDoc:1.0-runtime-deps-jessie)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 $(TagDoc:3.0-sdk-stretch)
 $(TagDoc:3.0-sdk-alpine3.8)
@@ -51,7 +51,7 @@ $(TagDoc:3.0-runtime-deps-bionic)
 
 ## Linux arm64 tags
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 $(TagDoc:3.0-sdk-stretch-arm64v8)
 $(TagDoc:3.0-sdk-bionic-arm64v8)
@@ -81,7 +81,7 @@ $(TagDoc:2.1-runtime-bionic-arm32v7)
 $(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
 $(TagDoc:2.1-runtime-deps-bionic-arm32v7)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 $(TagDoc:3.0-sdk-stretch-arm32v7)
 $(TagDoc:3.0-sdk-bionic-arm32v7)
@@ -101,7 +101,7 @@ $(TagDoc:2.1-sdk-nanoserver-1809)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1809)
 $(TagDoc:2.1-runtime-nanoserver-1809)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 $(TagDoc:3.0-sdk-nanoserver-1809)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-1809)
@@ -116,7 +116,7 @@ $(TagDoc:2.1-sdk-nanoserver-1803)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1803)
 $(TagDoc:2.1-runtime-nanoserver-1803)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 $(TagDoc:3.0-sdk-nanoserver-1803)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-1803)
@@ -131,7 +131,7 @@ $(TagDoc:2.1-sdk-nanoserver-1709)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1709)
 $(TagDoc:2.1-runtime-nanoserver-1709)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 $(TagDoc:3.0-sdk-nanoserver-1709)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-1709)
@@ -149,7 +149,7 @@ $(TagDoc:1.1-sdk-nanoserver-sac2016)
 $(TagDoc:1.1-runtime-nanoserver-sac2016)
 $(TagDoc:1.0-runtime-nanoserver-sac2016)
 
-### .NET Core 3.0 Preview tags
+**.NET Core 3.0 Preview tags**
 
 $(TagDoc:3.0-sdk-nanoserver-sac2016)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-sac2016)

--- a/scripts/TagsDocumentationTemplate.md
+++ b/scripts/TagsDocumentationTemplate.md
@@ -1,6 +1,6 @@
-## Complete set of Tags
+# Complete set of Tags
 
-# Linux amd64 tags
+## Linux amd64 tags
 
 $(TagDoc:2.2-sdk-stretch)
 $(TagDoc:2.2-sdk-alpine3.8)
@@ -34,7 +34,7 @@ $(TagDoc:1.1-runtime-deps-stretch)
 $(TagDoc:1.0-runtime-jessie)
 $(TagDoc:1.0-runtime-deps-jessie)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 $(TagDoc:3.0-sdk-stretch)
 $(TagDoc:3.0-sdk-alpine3.8)
@@ -49,9 +49,9 @@ $(TagDoc:3.0-runtime-deps-stretch-slim)
 $(TagDoc:3.0-runtime-deps-alpine3.8)
 $(TagDoc:3.0-runtime-deps-bionic)
 
-# Linux arm64 tags
+## Linux arm64 tags
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 $(TagDoc:3.0-sdk-stretch-arm64v8)
 $(TagDoc:3.0-sdk-bionic-arm64v8)
@@ -62,7 +62,7 @@ $(TagDoc:3.0-runtime-bionic-arm64v8)
 $(TagDoc:3.0-runtime-deps-stretch-slim-arm64v8)
 $(TagDoc:3.0-runtime-deps-bionic-arm64v8)
 
-# Linux arm32 tags
+## Linux arm32 tags
 
 $(TagDoc:2.2-sdk-stretch-arm32v7)
 $(TagDoc:2.2-sdk-bionic-arm32v7)
@@ -81,7 +81,7 @@ $(TagDoc:2.1-runtime-bionic-arm32v7)
 $(TagDoc:2.1-runtime-deps-stretch-slim-arm32v7)
 $(TagDoc:2.1-runtime-deps-bionic-arm32v7)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 $(TagDoc:3.0-sdk-stretch-arm32v7)
 $(TagDoc:3.0-sdk-bionic-arm32v7)
@@ -92,7 +92,7 @@ $(TagDoc:3.0-runtime-bionic-arm32v7)
 $(TagDoc:3.0-runtime-deps-stretch-slim-arm32v7)
 $(TagDoc:3.0-runtime-deps-bionic-arm32v7)
 
-# Windows Server, version 1809 amd64 tags
+## Windows Server, version 1809 amd64 tags
 
 $(TagDoc:2.2-sdk-nanoserver-1809)
 $(TagDoc:2.2-aspnetcore-runtime-nanoserver-1809)
@@ -101,13 +101,13 @@ $(TagDoc:2.1-sdk-nanoserver-1809)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1809)
 $(TagDoc:2.1-runtime-nanoserver-1809)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 $(TagDoc:3.0-sdk-nanoserver-1809)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-1809)
 $(TagDoc:3.0-runtime-nanoserver-1809)
 
-# Windows Server, version 1803 amd64 tags
+## Windows Server, version 1803 amd64 tags
 
 $(TagDoc:2.2-sdk-nanoserver-1803)
 $(TagDoc:2.2-aspnetcore-runtime-nanoserver-1803)
@@ -116,13 +116,13 @@ $(TagDoc:2.1-sdk-nanoserver-1803)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1803)
 $(TagDoc:2.1-runtime-nanoserver-1803)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 $(TagDoc:3.0-sdk-nanoserver-1803)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-1803)
 $(TagDoc:3.0-runtime-nanoserver-1803)
 
-# Windows Server, version 1709 amd64 tags
+## Windows Server, version 1709 amd64 tags
 
 $(TagDoc:2.2-sdk-nanoserver-1709)
 $(TagDoc:2.2-aspnetcore-runtime-nanoserver-1709)
@@ -131,13 +131,13 @@ $(TagDoc:2.1-sdk-nanoserver-1709)
 $(TagDoc:2.1-aspnetcore-runtime-nanoserver-1709)
 $(TagDoc:2.1-runtime-nanoserver-1709)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 $(TagDoc:3.0-sdk-nanoserver-1709)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-1709)
 $(TagDoc:3.0-runtime-nanoserver-1709)
 
-# Windows Server 2016 amd64 tags
+## Windows Server 2016 amd64 tags
 
 $(TagDoc:2.2-sdk-nanoserver-sac2016)
 $(TagDoc:2.2-aspnetcore-runtime-nanoserver-sac2016)
@@ -149,7 +149,7 @@ $(TagDoc:1.1-sdk-nanoserver-sac2016)
 $(TagDoc:1.1-runtime-nanoserver-sac2016)
 $(TagDoc:1.0-runtime-nanoserver-sac2016)
 
-**.NET Core 3.0 Preview tags**
+### .NET Core 3.0 Preview tags
 
 $(TagDoc:3.0-sdk-nanoserver-sac2016)
 $(TagDoc:3.0-aspnetcore-runtime-nanoserver-sac2016)


### PR DESCRIPTION
Docker Hub's markdown rendering used to render '##' headers with a larger font than '#' headers therefore the readme worked around that.  This has changed recently therefore the readme was adjusted accordingly.

I uploaded the readme to my [personal Docker Hub repository](https://hub.docker.com/r/msimons/dotnet) so you can see what it looks like.

@dotnet-bot skip ci please