### PR TITLE
Remove LTTng Dependency from Images

### DIFF
--- a/1.0/runtime-deps/jessie/amd64/Dockerfile
+++ b/1.0/runtime-deps/jessie/amd64/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu52 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         libunwind8 \

--- a/1.1/runtime-deps/stretch/amd64/Dockerfile
+++ b/1.1/runtime-deps/stretch/amd64/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         libunwind8 \

--- a/1.1/sdk/jessie/amd64/Dockerfile
+++ b/1.1/sdk/jessie/amd64/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu52 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         libunwind8 \

--- a/1.1/sdk/stretch/amd64/Dockerfile
+++ b/1.1/sdk/stretch/amd64/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         libunwind8 \

--- a/2.1/runtime-deps/alpine3.7/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine3.7/amd64/Dockerfile
@@ -10,10 +10,7 @@ RUN apk add --no-cache \
         libssl1.0 \
         libstdc++ \
         tzdata \
-        userspace-rcu \
-        zlib \
-    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
-        lttng-ust
+        zlib
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/2.1/runtime-deps/bionic/amd64/Dockerfile
+++ b/2.1/runtime-deps/bionic/amd64/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         zlib1g \

--- a/2.1/runtime-deps/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/bionic/arm32v7/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         zlib1g \

--- a/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         zlib1g \

--- a/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         zlib1g \

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         zlib1g \

--- a/2.1/sdk/bionic/arm32v7/Dockerfile
+++ b/2.1/sdk/bionic/arm32v7/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         zlib1g \

--- a/2.1/sdk/stretch/amd64/Dockerfile
+++ b/2.1/sdk/stretch/amd64/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         zlib1g \

--- a/2.1/sdk/stretch/arm32v7/Dockerfile
+++ b/2.1/sdk/stretch/arm32v7/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         zlib1g \

--- a/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
+++ b/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
@@ -10,10 +10,7 @@ RUN apk add --no-cache \
     libssl1.0 \
     libstdc++ \
     tzdata \
-    userspace-rcu \
-    zlib \
-    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
-    lttng-ust
+    zlib
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/2.2/sdk/bionic/amd64/Dockerfile
+++ b/2.2/sdk/bionic/amd64/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         zlib1g \

--- a/2.2/sdk/bionic/arm32v7/Dockerfile
+++ b/2.2/sdk/bionic/arm32v7/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
         zlib1g \

--- a/2.2/sdk/stretch/amd64/Dockerfile
+++ b/2.2/sdk/stretch/amd64/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         zlib1g \

--- a/2.2/sdk/stretch/arm32v7/Dockerfile
+++ b/2.2/sdk/stretch/arm32v7/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.0.2 \
         libstdc++6 \
         zlib1g \

--- a/3.0/runtime-deps/alpine3.8/amd64/Dockerfile
+++ b/3.0/runtime-deps/alpine3.8/amd64/Dockerfile
@@ -10,9 +10,7 @@ RUN apk add --no-cache \
     libssl1.0 \
     libstdc++ \
     tzdata \
-    userspace-rcu \
-    zlib \
-    lttng-ust
+    zlib
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/3.0/runtime-deps/bionic/amd64/Dockerfile
+++ b/3.0/runtime-deps/bionic/amd64/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/runtime-deps/bionic/arm32v7/Dockerfile
+++ b/3.0/runtime-deps/bionic/arm32v7/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/runtime-deps/bionic/arm64v8/Dockerfile
+++ b/3.0/runtime-deps/bionic/arm64v8/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/runtime-deps/stretch-slim/amd64/Dockerfile
+++ b/3.0/runtime-deps/stretch-slim/amd64/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile
+++ b/3.0/runtime-deps/stretch-slim/arm32v7/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile
+++ b/3.0/runtime-deps/stretch-slim/arm64v8/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/sdk/bionic/amd64/Dockerfile
+++ b/3.0/sdk/bionic/amd64/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/sdk/bionic/arm32v7/Dockerfile
+++ b/3.0/sdk/bionic/arm32v7/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/sdk/bionic/arm64v8/Dockerfile
+++ b/3.0/sdk/bionic/arm64v8/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu60 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/sdk/stretch/amd64/Dockerfile
+++ b/3.0/sdk/stretch/amd64/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/sdk/stretch/arm32v7/Dockerfile
+++ b/3.0/sdk/stretch/arm32v7/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.0/sdk/stretch/arm64v8/Dockerfile
+++ b/3.0/sdk/stretch/arm64v8/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu57 \
-        liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \


### PR DESCRIPTION
Liblttng (and it's dependency userspacercu) are not actually required to build or run .NET Core applications.  They are only required when building the CoreCLR product.

Liblttng is an optional component that can be used alongside lttng-tools to collect tracing data from running .NET Core applications.  Removing liblttng saves some disk space (~1MB on alpine).  Given that it can't be used on its own without lttng-tools, there isn't a reason to have it built into the image.  We should remove it to help those who are striving for super-small images.

cc: @richlander 