### PR TITLE
Update to 2.1.7 and 2.2.1

### DIFF
--- a/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile
@@ -2,12 +2,12 @@ ARG REPO=microsoft/dotnet
 FROM $REPO:2.1-runtime-deps-alpine3.7
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='f0b809dd18b240ddc00f69f6706475f8f0107fa2020eb0bfea92bde04d80ec459e2008d88021ba7ad94751d6732b4bd952c241c5e64ee13c3ec35b389fa6cbda' \
+    && aspnetcore_sha512='08320fd139768557fe962c06c0316df8d30312d35a354f5d4dd6dc98c5093bda7b0facd694bd7406f3c6543d383296f7cba7d759367ee4cfdbc8ac98062cd289' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
@@ -2,10 +2,10 @@ ARG REPO=microsoft/dotnet
 FROM $REPO:2.1-runtime-deps-alpine3.8
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='f0b809dd18b240ddc00f69f6706475f8f0107fa2020eb0bfea92bde04d80ec459e2008d88021ba7ad94751d6732b4bd952c241c5e64ee13c3ec35b389fa6cbda' \
+    && aspnetcore_sha512='08320fd139768557fe962c06c0316df8d30312d35a354f5d4dd6dc98c5093bda7b0facd694bd7406f3c6543d383296f7cba7d759367ee4cfdbc8ac98062cd289' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
-    && aspnetcore_sha512='00091d762148bd1f148e85fe32a64a488cb1a54577f64da1be07cbd97779b9f0be53b4dcfdd373e45bfe44d9d1ca635e92e8b185e78afe98ea2b8a04d383b704' \
+    && aspnetcore_sha512='feef7cf9e296011b799b196f3f7cec93e685e5e1b981238064d934bc003eebc75a10567db3af02384c68000ce1d0a64f769928f6b91392934acdacb008c238ad' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
-    && aspnetcore_sha512='5a0cfe67cb5e30aaab780db49615147503d8f76424486bb6a449501901e109460a4ea31fd928fbe61366f25e6d1c1d83eac4a40ef1fef41d588f84f977fe41b5' \
+    && aspnetcore_sha512='af63ea3041938040ccf97da7839b6e4bd4f12d582bdf6f336f49179faa64ad32dfcb6352bc65902edd1b21fcdf703f99089c5fe118fa35f9074ca5296abd814d' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = 'cc51cf31efadac6ba2a842c0d28251d34d9eb2dd938b1a97954c076015c83ca48097bd9bff0946ef6b767396f077914eb5c551eddd08811fc5dba10a66d4f3a9'; `
+    $aspnetcore_sha512 = '89599d964f99216f990e9a23531bebbb56615553663c709bd28b85e8eaf8bf8d926e59c80868e3de55413464c874aa3ba093ce08fbef1556315e38bbeb89aaa5'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = 'cc51cf31efadac6ba2a842c0d28251d34d9eb2dd938b1a97954c076015c83ca48097bd9bff0946ef6b767396f077914eb5c551eddd08811fc5dba10a66d4f3a9'; `
+    $aspnetcore_sha512 = '89599d964f99216f990e9a23531bebbb56615553663c709bd28b85e8eaf8bf8d926e59c80868e3de55413464c874aa3ba093ce08fbef1556315e38bbeb89aaa5'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = 'cc51cf31efadac6ba2a842c0d28251d34d9eb2dd938b1a97954c076015c83ca48097bd9bff0946ef6b767396f077914eb5c551eddd08811fc5dba10a66d4f3a9'; `
+    $aspnetcore_sha512 = '89599d964f99216f990e9a23531bebbb56615553663c709bd28b85e8eaf8bf8d926e59c80868e3de55413464c874aa3ba093ce08fbef1556315e38bbeb89aaa5'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -4,10 +4,10 @@ FROM mcr.microsoft.com/windows/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = 'cc51cf31efadac6ba2a842c0d28251d34d9eb2dd938b1a97954c076015c83ca48097bd9bff0946ef6b767396f077914eb5c551eddd08811fc5dba10a66d4f3a9'; `
+    $aspnetcore_sha512 = '89599d964f99216f990e9a23531bebbb56615553663c709bd28b85e8eaf8bf8d926e59c80868e3de55413464c874aa3ba093ce08fbef1556315e38bbeb89aaa5'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
-    && aspnetcore_sha512='00091d762148bd1f148e85fe32a64a488cb1a54577f64da1be07cbd97779b9f0be53b4dcfdd373e45bfe44d9d1ca635e92e8b185e78afe98ea2b8a04d383b704' \
+    && aspnetcore_sha512='feef7cf9e296011b799b196f3f7cec93e685e5e1b981238064d934bc003eebc75a10567db3af02384c68000ce1d0a64f769928f6b91392934acdacb008c238ad' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.7-servicing-31150
+ENV ASPNETCORE_VERSION 2.1.7
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
-    && aspnetcore_sha512='5a0cfe67cb5e30aaab780db49615147503d8f76424486bb6a449501901e109460a4ea31fd928fbe61366f25e6d1c1d83eac4a40ef1fef41d588f84f977fe41b5' \
+    && aspnetcore_sha512='af63ea3041938040ccf97da7839b6e4bd4f12d582bdf6f336f49179faa64ad32dfcb6352bc65902edd1b21fcdf703f99089c5fe118fa35f9074ca5296abd814d' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/alpine3.7/amd64/Dockerfile
+++ b/2.1/runtime/alpine3.7/amd64/Dockerfile
@@ -2,12 +2,12 @@ ARG REPO=microsoft/dotnet
 FROM $REPO:2.1-runtime-deps-alpine3.7
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='761901baf5e694cbb9ad8e09c124c7d22e6f9d89a555574de1b396698915cf7e2dc26509607dd47226991e3aa451e572148611d7dfb645fbd4f20a1dd80609d8' \
+    && dotnet_sha512='e362a0497fcd524ea1d2fa512bf439e54ca487660a3f3e3e1b5b78b98efb4c5bfe0c4a092501adcc02ade2436ae656b9effcce738da5f49a8333ab3d058a5ad7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/runtime/alpine3.8/amd64/Dockerfile
+++ b/2.1/runtime/alpine3.8/amd64/Dockerfile
@@ -2,10 +2,10 @@ ARG REPO=microsoft/dotnet
 FROM $REPO:2.1-runtime-deps-alpine3.8
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='761901baf5e694cbb9ad8e09c124c7d22e6f9d89a555574de1b396698915cf7e2dc26509607dd47226991e3aa451e572148611d7dfb645fbd4f20a1dd80609d8' \
+    && dotnet_sha512='e362a0497fcd524ea1d2fa512bf439e54ca487660a3f3e3e1b5b78b98efb4c5bfe0c4a092501adcc02ade2436ae656b9effcce738da5f49a8333ab3d058a5ad7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/runtime/bionic/amd64/Dockerfile
+++ b/2.1/runtime/bionic/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='cf35f8d7ec4c0cb03f0aa0cd836bf92ca1e83022bb140b188f3faaee63b30de809b1859189f5559a0b6efd680d3cadaa519774152a2a5904c22b681593b768c5' \
+    && dotnet_sha512='2360e6ec9220b355a6d323d09cbbdc05ef6d84185570ac99cba92e933bd4d4967468ed38c06d43a5839943dee6552d6c63a0cf33c11ba1715d726fc7a2051125' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/bionic/arm32v7/Dockerfile
+++ b/2.1/runtime/bionic/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='da0b97c54af9dfa97988c1b983aeaef5f41cf0957771c55cbec7044ebd60d71f599576c038e855fffbceb0ec6fb77885e844bfe97c3268067b1901dfb92fb9e3' \
+    && dotnet_sha512='eea0d331e228b708d72c0c986bd834c61f2149fdb611d3163bee657ea4ffe3589f015ae657fcf21e33b18e9964d872be53e28ae0f75e56fef00a5dd4920cdfe0' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '9bbe5e9ec2294702ea3faad4be8535b3fdbdb87993bcff30d01ba391254fb0cff60183001a371cc29bf56d053e349eccee616ea26bb0077b7f1aef152f6b8029'; `
+    $dotnet_sha512 = '5d5b0dad9817b1b81650f86b7df0b5ff5ef14712dc78000dce1dac4fbc4ce45d1bc6cdb569fa883ce000aaea643dcf5f66a6179a298c0a16e0a69f4632a0bdb8'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '9bbe5e9ec2294702ea3faad4be8535b3fdbdb87993bcff30d01ba391254fb0cff60183001a371cc29bf56d053e349eccee616ea26bb0077b7f1aef152f6b8029'; `
+    $dotnet_sha512 = '5d5b0dad9817b1b81650f86b7df0b5ff5ef14712dc78000dce1dac4fbc4ce45d1bc6cdb569fa883ce000aaea643dcf5f66a6179a298c0a16e0a69f4632a0bdb8'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/nanoserver-1809/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1809/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '9bbe5e9ec2294702ea3faad4be8535b3fdbdb87993bcff30d01ba391254fb0cff60183001a371cc29bf56d053e349eccee616ea26bb0077b7f1aef152f6b8029'; `
+    $dotnet_sha512 = '5d5b0dad9817b1b81650f86b7df0b5ff5ef14712dc78000dce1dac4fbc4ce45d1bc6cdb569fa883ce000aaea643dcf5f66a6179a298c0a16e0a69f4632a0bdb8'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM mcr.microsoft.com/windows/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '9bbe5e9ec2294702ea3faad4be8535b3fdbdb87993bcff30d01ba391254fb0cff60183001a371cc29bf56d053e349eccee616ea26bb0077b7f1aef152f6b8029'; `
+    $dotnet_sha512 = '5d5b0dad9817b1b81650f86b7df0b5ff5ef14712dc78000dce1dac4fbc4ce45d1bc6cdb569fa883ce000aaea643dcf5f66a6179a298c0a16e0a69f4632a0bdb8'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/runtime/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime/stretch-slim/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='cf35f8d7ec4c0cb03f0aa0cd836bf92ca1e83022bb140b188f3faaee63b30de809b1859189f5559a0b6efd680d3cadaa519774152a2a5904c22b681593b768c5' \
+    && dotnet_sha512='2360e6ec9220b355a6d323d09cbbdc05ef6d84185570ac99cba92e933bd4d4967468ed38c06d43a5839943dee6552d6c63a0cf33c11ba1715d726fc7a2051125' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.1/runtime/stretch-slim/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.7-servicing-27120-02
+ENV DOTNET_VERSION 2.1.7
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='da0b97c54af9dfa97988c1b983aeaef5f41cf0957771c55cbec7044ebd60d71f599576c038e855fffbceb0ec6fb77885e844bfe97c3268067b1901dfb92fb9e3' \
+    && dotnet_sha512='eea0d331e228b708d72c0c986bd834c61f2149fdb611d3163bee657ea4ffe3589f015ae657fcf21e33b18e9964d872be53e28ae0f75e56fef00a5dd4920cdfe0' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/alpine3.7/amd64/Dockerfile
+++ b/2.1/sdk/alpine3.7/amd64/Dockerfile
@@ -9,12 +9,12 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='d78a479a3780c018c88df19e3a89aa15182f76d308775d38168c1f203871c228cddd4299af9ddd6f47ac5ea8ca1b6bbdaf08b77fc561572f690a5d02cea142ae' \
+    && dotnet_sha512='af45e870b4676a1f755f5f50524a1d2852faf418df759986f64cdaaaa31fff5a6a9cbea7f791231feb0e90b3c1a93a962d433b33de056552ed12bd9766fdf8c2' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/sdk/alpine3.8/amd64/Dockerfile
+++ b/2.1/sdk/alpine3.8/amd64/Dockerfile
@@ -9,10 +9,10 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='d78a479a3780c018c88df19e3a89aa15182f76d308775d38168c1f203871c228cddd4299af9ddd6f47ac5ea8ca1b6bbdaf08b77fc561572f690a5d02cea142ae' \
+    && dotnet_sha512='af45e870b4676a1f755f5f50524a1d2852faf418df759986f64cdaaaa31fff5a6a9cbea7f791231feb0e90b3c1a93a962d433b33de056552ed12bd9766fdf8c2' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='339008b06c302b6b5897a0d7a6f7b4939f3e1caf2b25b9b8d9689a0b5f2d28fd56718b699afc7cbdb99f8a42c022f1cca2a869cad3ce3519c43bd1b10e5e86fb' \
+    && dotnet_sha512='6accdf7a4e09b7d6b93d4df8484191df1290107cf396bfa85b3dd4a75596e50836143dd7cd10d0239244751a8704c2e4586f21d59361ecf527ef2cd4bc15225c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/bionic/arm32v7/Dockerfile
+++ b/2.1/sdk/bionic/arm32v7/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='5a49e9b3f74e8597e7b0e9c84996e995006c930fdbb72ebcf547727519c35596c0b30b4ca8421f7f49fa073acf162c1bf5438af916b13f1e91c7dae9641e7efa' \
+    && dotnet_sha512='8a97790cdae1aa43dd214e78483fd2201268eb7bc61718832de766bd41741a6a04a33c5a612f4046bb315d2adf5dafaa9d62a6a96ded5af38c002b7c4e682a15' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
@@ -25,7 +25,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Add NuGet cache (ARM SDK doesn't include it)
     && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
-    && lzma_sha512='4efddb4778a4c8736a0759c0c16c798057657f8f9b3baf78e24cb4dcd868dcafeacf8827d40756bc1c0aeb0cce5c3130b0435f3ff4ee36a22f9a9124d5f14c8e' \
+    && lzma_sha512='fe8da1ebb79ddfb2dd0532db36a378a352cfd0c64812507684009bcc8ca7a777f7c3ab4f38375bb8fadb4efa298675ad3c7fa434bfdf22370c2608d7832bec9f' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure web servers to bind to port 80 when present

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '0d1d058edb216f8aa82b134cc57bd2c8f2695a4816d3dc16ee565e0f4594131e525eca5ea52f68bd34f2aed237c1fda2bfb5a851488685f9efeebe71aac9d8ba'; `
+    $dotnet_sha512 = '29e44a4d6bd81ace5f7f5b5be946e7fc81325f4563d375d6809150bfc0552c70e07467770c8c6b44127b5b1c01d93ca14e1c98ba527313dc093db8942358760c'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '0d1d058edb216f8aa82b134cc57bd2c8f2695a4816d3dc16ee565e0f4594131e525eca5ea52f68bd34f2aed237c1fda2bfb5a851488685f9efeebe71aac9d8ba'; `
+    $dotnet_sha512 = '29e44a4d6bd81ace5f7f5b5be946e7fc81325f4563d375d6809150bfc0552c70e07467770c8c6b44127b5b1c01d93ca14e1c98ba527313dc093db8942358760c'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '0d1d058edb216f8aa82b134cc57bd2c8f2695a4816d3dc16ee565e0f4594131e525eca5ea52f68bd34f2aed237c1fda2bfb5a851488685f9efeebe71aac9d8ba'; `
+    $dotnet_sha512 = '29e44a4d6bd81ace5f7f5b5be946e7fc81325f4563d375d6809150bfc0552c70e07467770c8c6b44127b5b1c01d93ca14e1c98ba527313dc093db8942358760c'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM mcr.microsoft.com/windows/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '0d1d058edb216f8aa82b134cc57bd2c8f2695a4816d3dc16ee565e0f4594131e525eca5ea52f68bd34f2aed237c1fda2bfb5a851488685f9efeebe71aac9d8ba'; `
+    $dotnet_sha512 = '29e44a4d6bd81ace5f7f5b5be946e7fc81325f4563d375d6809150bfc0552c70e07467770c8c6b44127b5b1c01d93ca14e1c98ba527313dc093db8942358760c'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.1/sdk/stretch/amd64/Dockerfile
+++ b/2.1/sdk/stretch/amd64/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='339008b06c302b6b5897a0d7a6f7b4939f3e1caf2b25b9b8d9689a0b5f2d28fd56718b699afc7cbdb99f8a42c022f1cca2a869cad3ce3519c43bd1b10e5e86fb' \
+    && dotnet_sha512='6accdf7a4e09b7d6b93d4df8484191df1290107cf396bfa85b3dd4a75596e50836143dd7cd10d0239244751a8704c2e4586f21d59361ecf527ef2cd4bc15225c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.1/sdk/stretch/arm32v7/Dockerfile
+++ b/2.1/sdk/stretch/arm32v7/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.501-preview-009418
+ENV DOTNET_SDK_VERSION 2.1.503
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='5a49e9b3f74e8597e7b0e9c84996e995006c930fdbb72ebcf547727519c35596c0b30b4ca8421f7f49fa073acf162c1bf5438af916b13f1e91c7dae9641e7efa' \
+    && dotnet_sha512='8a97790cdae1aa43dd214e78483fd2201268eb7bc61718832de766bd41741a6a04a33c5a612f4046bb315d2adf5dafaa9d62a6a96ded5af38c002b7c4e682a15' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
@@ -25,7 +25,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Add NuGet cache (ARM SDK doesn't include it)
     && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
-    && lzma_sha512='4efddb4778a4c8736a0759c0c16c798057657f8f9b3baf78e24cb4dcd868dcafeacf8827d40756bc1c0aeb0cce5c3130b0435f3ff4ee36a22f9a9124d5f14c8e' \
+    && lzma_sha512='fe8da1ebb79ddfb2dd0532db36a378a352cfd0c64812507684009bcc8ca7a777f7c3ab4f38375bb8fadb4efa298675ad3c7fa434bfdf22370c2608d7832bec9f' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure web servers to bind to port 80 when present

--- a/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile
@@ -2,10 +2,10 @@ ARG REPO=microsoft/dotnet
 FROM $REPO:2.2-runtime-deps-alpine3.8
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='c297f7196b72e02ec41a5a0c027dcec1648ad552bf44036fa491d67d9b4f09e3ade84fd51ebffd68e8fa8077f2497ad851e13c83dac6aba89dd03f6df0adca6f' \
+    && aspnetcore_sha512='cafe7c0f369b4cdd0b9121a13b7a8d9420d5dcea3cea4d4cc2e5f63fce40e37269a90a772f125b7040bc7f425b9989aa78091bd5bda1f11e5103c7f98416f26e' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
-    && aspnetcore_sha512='26b3a52eb0b55eedaf731af1c1553653c73ed8e7c385119a421e33c8fca9691bae378904ee8f6fc13e1c621c9d64303ea5337750bb34e34d6ad0de788319f9bc' \
+    && aspnetcore_sha512='e027a5dada5d139a44675f28090f996375e49fbd72f7897aa925e48803632d5bf187d4f22dc8225505ac33e6a7a05dcdd8ed19d8b6d5e46b22e628315cf13e3e' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile
+++ b/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
-    && aspnetcore_sha512='71fe46137c2b485af8f191412155a4c3c732cb71c37fd77471daaf517b612bf3ef6e9c2300c75da88ba04981fa9b965d8709f2e1bca731236c72bcde7e26cc7d' \
+    && aspnetcore_sha512='e1824cdc5ff754baf98d372d8d1d6e7d7dfc6d486b5d0f3dc3411e0d89e8ae251610ff71cb9b1376b728a4281b5b24e2421f90eff8aebe12e4b46617cfc0c55a' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = '0159f27762a0dd1fb7f7e4f85259c145d8e6964289f7477d6e9d5c03898afb38dca010f900e3ccb28e282514835a66d5546bbc1542b9da8c92dd3d2759c507de'; `
+    $aspnetcore_sha512 = 'aa8802c8c482d2fc708e669d9e9f0de7e74700afb580f0197545f33b50d67317fea7101a4704b2c35b1362d92be814e3fd31436cabf53f2e7755f8953278cdd3'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = '0159f27762a0dd1fb7f7e4f85259c145d8e6964289f7477d6e9d5c03898afb38dca010f900e3ccb28e282514835a66d5546bbc1542b9da8c92dd3d2759c507de'; `
+    $aspnetcore_sha512 = 'aa8802c8c482d2fc708e669d9e9f0de7e74700afb580f0197545f33b50d67317fea7101a4704b2c35b1362d92be814e3fd31436cabf53f2e7755f8953278cdd3'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = '0159f27762a0dd1fb7f7e4f85259c145d8e6964289f7477d6e9d5c03898afb38dca010f900e3ccb28e282514835a66d5546bbc1542b9da8c92dd3d2759c507de'; `
+    $aspnetcore_sha512 = 'aa8802c8c482d2fc708e669d9e9f0de7e74700afb580f0197545f33b50d67317fea7101a4704b2c35b1362d92be814e3fd31436cabf53f2e7755f8953278cdd3'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809_arm
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/%ASPNETCORE_VERSION%/aspnetcore-runtime-%ASPNETCORE_VERSION%-win-arm.zip `
     && mkdir -p "%ProgramFiles%\dotnet" `

--- a/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -4,10 +4,10 @@ FROM mcr.microsoft.com/windows/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
-    $aspnetcore_sha512 = '0159f27762a0dd1fb7f7e4f85259c145d8e6964289f7477d6e9d5c03898afb38dca010f900e3ccb28e282514835a66d5546bbc1542b9da8c92dd3d2759c507de'; `
+    $aspnetcore_sha512 = 'aa8802c8c482d2fc708e669d9e9f0de7e74700afb580f0197545f33b50d67317fea7101a4704b2c35b1362d92be814e3fd31436cabf53f2e7755f8953278cdd3'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
+++ b/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
-    && aspnetcore_sha512='26b3a52eb0b55eedaf731af1c1553653c73ed8e7c385119a421e33c8fca9691bae378904ee8f6fc13e1c621c9d64303ea5337750bb34e34d6ad0de788319f9bc' \
+    && aspnetcore_sha512='e027a5dada5d139a44675f28090f996375e49fbd72f7897aa925e48803632d5bf187d4f22dc8225505ac33e6a7a05dcdd8ed19d8b6d5e46b22e628315cf13e3e' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.2.0
+ENV ASPNETCORE_VERSION 2.2.1
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
-    && aspnetcore_sha512='71fe46137c2b485af8f191412155a4c3c732cb71c37fd77471daaf517b612bf3ef6e9c2300c75da88ba04981fa9b965d8709f2e1bca731236c72bcde7e26cc7d' \
+    && aspnetcore_sha512='e1824cdc5ff754baf98d372d8d1d6e7d7dfc6d486b5d0f3dc3411e0d89e8ae251610ff71cb9b1376b728a4281b5b24e2421f90eff8aebe12e4b46617cfc0c55a' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \

--- a/2.2/runtime/alpine3.8/amd64/Dockerfile
+++ b/2.2/runtime/alpine3.8/amd64/Dockerfile
@@ -2,10 +2,10 @@ ARG REPO=microsoft/dotnet
 FROM $REPO:2.2-runtime-deps-alpine3.8
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='10665979bf77ec7cf92108372c7ff48b4f0e577def75513128d088567e5a2553ff1502fe6e4e403d0db485d629a11eab93cb5fe84752a0a8d15398e1f2aff53c' \
+    && dotnet_sha512='f76f8650aae126b2cdf55cce200d6400137288f5c0688e314575273ab9f87f364d06dcf0992524d8d6a127485ec11f8f6e9586a5b47604bf1f6396748b3e7fca' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.2/runtime/bionic/amd64/Dockerfile
+++ b/2.2/runtime/bionic/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='b1c08a7b44b50f66ac35b8049fc980fb3920e3a52d8ff8337d9fa0d163dc2f0111904ac3d79b97a750155bfb927177addbd72c7970ab0f301d52ee40544933fd' \
+    && dotnet_sha512='b79d87a986ce2f2b0b9efd08e8d8f1e283c478737cadd4389f2a9e81882c71906d5c1914b189eb47e11de27bdddcd01bd85fb5bd87082e0f7db6aa206729dea8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.2/runtime/bionic/arm32v7/Dockerfile
+++ b/2.2/runtime/bionic/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='c1e52e053ac5797a2a0cd621a0df257e882849621f5c74604f1b51fc11a7e310a418226df6b36c79ab694a7a18b2d80fbb04236e0d3442f13a02007b9365b2b2' \
+    && dotnet_sha512='47f65ab7598832f72e08d980843663d79cdeea365fc8b261f207ecd6c84bd5c1d7ebcce2a3c8bb015275ee3cd7da4c065f81128941e4a787b28873fad3a52d51' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.2/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/runtime/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '5b262c6d30ebeace5718d063363ccf778c49cfed535cc5baaff2d518ca94cfe83ffbdacb8eb0e3617d5cfcc3d07d3c1f7ceed0b26636f6971ba91054d78bc1f1'; `
+    $dotnet_sha512 = 'c5098cd5d8297ee7f4dd888c11a3c32dd7f34b911694a2c45981fdf6d9f3917619f07a2e15fcad07bd5cf03b3ddbdbb239b9cb7d58b00ed5496bc2850f2cf314'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/runtime/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '5b262c6d30ebeace5718d063363ccf778c49cfed535cc5baaff2d518ca94cfe83ffbdacb8eb0e3617d5cfcc3d07d3c1f7ceed0b26636f6971ba91054d78bc1f1'; `
+    $dotnet_sha512 = 'c5098cd5d8297ee7f4dd888c11a3c32dd7f34b911694a2c45981fdf6d9f3917619f07a2e15fcad07bd5cf03b3ddbdbb239b9cb7d58b00ed5496bc2850f2cf314'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/runtime/nanoserver-1809/amd64/Dockerfile
+++ b/2.2/runtime/nanoserver-1809/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '5b262c6d30ebeace5718d063363ccf778c49cfed535cc5baaff2d518ca94cfe83ffbdacb8eb0e3617d5cfcc3d07d3c1f7ceed0b26636f6971ba91054d78bc1f1'; `
+    $dotnet_sha512 = 'c5098cd5d8297ee7f4dd888c11a3c32dd7f34b911694a2c45981fdf6d9f3917619f07a2e15fcad07bd5cf03b3ddbdbb239b9cb7d58b00ed5496bc2850f2cf314'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/runtime/nanoserver-1809/arm32/Dockerfile
+++ b/2.2/runtime/nanoserver-1809/arm32/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809_arm
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/%DOTNET_VERSION%/dotnet-runtime-%DOTNET_VERSION%-win-arm.zip `
     && mkdir -p "%ProgramFiles%\dotnet" `

--- a/2.2/runtime/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.2/runtime/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM mcr.microsoft.com/windows/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '5b262c6d30ebeace5718d063363ccf778c49cfed535cc5baaff2d518ca94cfe83ffbdacb8eb0e3617d5cfcc3d07d3c1f7ceed0b26636f6971ba91054d78bc1f1'; `
+    $dotnet_sha512 = 'c5098cd5d8297ee7f4dd888c11a3c32dd7f34b911694a2c45981fdf6d9f3917619f07a2e15fcad07bd5cf03b3ddbdbb239b9cb7d58b00ed5496bc2850f2cf314'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/runtime/stretch-slim/amd64/Dockerfile
+++ b/2.2/runtime/stretch-slim/amd64/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='b1c08a7b44b50f66ac35b8049fc980fb3920e3a52d8ff8337d9fa0d163dc2f0111904ac3d79b97a750155bfb927177addbd72c7970ab0f301d52ee40544933fd' \
+    && dotnet_sha512='b79d87a986ce2f2b0b9efd08e8d8f1e283c478737cadd4389f2a9e81882c71906d5c1914b189eb47e11de27bdddcd01bd85fb5bd87082e0f7db6aa206729dea8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.2/runtime/stretch-slim/arm32v7/Dockerfile
+++ b/2.2/runtime/stretch-slim/arm32v7/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.0
+ENV DOTNET_VERSION 2.2.1
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='c1e52e053ac5797a2a0cd621a0df257e882849621f5c74604f1b51fc11a7e310a418226df6b36c79ab694a7a18b2d80fbb04236e0d3442f13a02007b9365b2b2' \
+    && dotnet_sha512='47f65ab7598832f72e08d980843663d79cdeea365fc8b261f207ecd6c84bd5c1d7ebcce2a3c8bb015275ee3cd7da4c065f81128941e4a787b28873fad3a52d51' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.2/sdk/alpine3.8/amd64/Dockerfile
+++ b/2.2/sdk/alpine3.8/amd64/Dockerfile
@@ -9,10 +9,10 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='668dbbfdee1b898de57ee7320b3f7f77c3bae896cb1480d64869512f26d6998edccc1163c9ca6ed62b326e2d745a81e82a35a24cf4f7e11319fec0c6904e566e' \
+    && dotnet_sha512='6a78a501c811a703399080a66b965bc554d7ee9746769d472d3af596eada30b77f58f974754faef94b2807714685da6e4442d44e4366a6c66001154c63392037' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/2.2/sdk/bionic/amd64/Dockerfile
+++ b/2.2/sdk/bionic/amd64/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='6bde1d0f186f068b1300d5a67e8aba56ff271b940bc0782c3a254dc0f67e7167d2fca12fc51eb3319d4ab4a91cbe5639e5104e9e0036adb8a27ca5711453a1c3' \
+    && dotnet_sha512='d7ed76a0efe2b07ac0bb3af611072b3b99f646200759cb5905a7944b1687f34d42b4b74a3a5c77dbe251f769c6c3878fc30a8d0f8f44e44bf4c7116699f3f948' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.2/sdk/bionic/arm32v7/Dockerfile
+++ b/2.2/sdk/bionic/arm32v7/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='9bd147c5e5b59106701d2cea2390976c4a3075ecfa3cf4e8e3a669e0a07e74898df9bef2a2928d500f1d3f2fd05fd9ab2cdd6a3ed5bfa6410ed0d24497db2182' \
+    && dotnet_sha512='298a6b75d72fed2beacae884e5dea09c4374b3e2d6c3cbd3fd54894d1c2e68ba89d63cf607dc8f64ca88c53cd0b1881fd3c3a7b199286b9ab1de3544f93da747' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
@@ -25,7 +25,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Add NuGet cache (ARM SDK doesn't include it)
     && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
-    && lzma_sha512='62ac1c65393ccf1955586ea40381aac8a538caab90c02d204b25ecfd9d7fe5399fcc71e096fac89302cc11d5853c57d40892d7f7b9b780788a7266d280434820' \
+    && lzma_sha512='e34e515897dabd4f58c6902b8d9149f1691a5e3b70f87bbd4012236873b9377e695b7c374812f2acde59e499dd5854f8fe14461845a1d3189e5e5085aec9723c' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure web servers to bind to port 80 when present

--- a/2.2/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1709/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '87776c7124cd25b487b14b3d42c784ee31a424c7c8191ed55810294423f3e59ebf799660864862fc1dbd6e6c8d68bd529399426811846e408d8b2fee4ab04fe5'; `
+    $dotnet_sha512 = '283c972e0a422f69d7a62f947a57416ffab15112b5b989a9d979685a6d9303bad2fc15ab504c9d65e90a3ee5c3fd55c7b4fa0efea07adc68aa6ae78195030996'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1803/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '87776c7124cd25b487b14b3d42c784ee31a424c7c8191ed55810294423f3e59ebf799660864862fc1dbd6e6c8d68bd529399426811846e408d8b2fee4ab04fe5'; `
+    $dotnet_sha512 = '283c972e0a422f69d7a62f947a57416ffab15112b5b989a9d979685a6d9303bad2fc15ab504c9d65e90a3ee5c3fd55c7b4fa0efea07adc68aa6ae78195030996'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1809/amd64/Dockerfile
@@ -6,10 +6,10 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '87776c7124cd25b487b14b3d42c784ee31a424c7c8191ed55810294423f3e59ebf799660864862fc1dbd6e6c8d68bd529399426811846e408d8b2fee4ab04fe5'; `
+    $dotnet_sha512 = '283c972e0a422f69d7a62f947a57416ffab15112b5b989a9d979685a6d9303bad2fc15ab504c9d65e90a3ee5c3fd55c7b4fa0efea07adc68aa6ae78195030996'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/sdk/nanoserver-1809/arm32/Dockerfile
+++ b/2.2/sdk/nanoserver-1809/arm32/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809_arm
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/%DOTNET_SDK_VERSION%/dotnet-sdk-%DOTNET_SDK_VERSION%-win-arm.zip `
     && mkdir -p "%ProgramFiles%\dotnet" `

--- a/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile
@@ -5,10 +5,10 @@ FROM mcr.microsoft.com/windows/nanoserver:sac2016
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-    $dotnet_sha512 = '87776c7124cd25b487b14b3d42c784ee31a424c7c8191ed55810294423f3e59ebf799660864862fc1dbd6e6c8d68bd529399426811846e408d8b2fee4ab04fe5'; `
+    $dotnet_sha512 = '283c972e0a422f69d7a62f947a57416ffab15112b5b989a9d979685a6d9303bad2fc15ab504c9d65e90a3ee5c3fd55c7b4fa0efea07adc68aa6ae78195030996'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/2.2/sdk/stretch/amd64/Dockerfile
+++ b/2.2/sdk/stretch/amd64/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='6bde1d0f186f068b1300d5a67e8aba56ff271b940bc0782c3a254dc0f67e7167d2fca12fc51eb3319d4ab4a91cbe5639e5104e9e0036adb8a27ca5711453a1c3' \
+    && dotnet_sha512='d7ed76a0efe2b07ac0bb3af611072b3b99f646200759cb5905a7944b1687f34d42b4b74a3a5c77dbe251f769c6c3878fc30a8d0f8f44e44bf4c7116699f3f948' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/2.2/sdk/stretch/arm32v7/Dockerfile
+++ b/2.2/sdk/stretch/arm32v7/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+ENV DOTNET_SDK_VERSION 2.2.102
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
-    && dotnet_sha512='9bd147c5e5b59106701d2cea2390976c4a3075ecfa3cf4e8e3a669e0a07e74898df9bef2a2928d500f1d3f2fd05fd9ab2cdd6a3ed5bfa6410ed0d24497db2182' \
+    && dotnet_sha512='298a6b75d72fed2beacae884e5dea09c4374b3e2d6c3cbd3fd54894d1c2e68ba89d63cf607dc8f64ca88c53cd0b1881fd3c3a7b199286b9ab1de3544f93da747' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
@@ -25,7 +25,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotn
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Add NuGet cache (ARM SDK doesn't include it)
     && curl -SL --output /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma \
-    && lzma_sha512='62ac1c65393ccf1955586ea40381aac8a538caab90c02d204b25ecfd9d7fe5399fcc71e096fac89302cc11d5853c57d40892d7f7b9b780788a7266d280434820' \
+    && lzma_sha512='e34e515897dabd4f58c6902b8d9149f1691a5e3b70f87bbd4012236873b9377e695b7c374812f2acde59e499dd5854f8fe14461845a1d3189e5e5085aec9723c' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
 # Configure web servers to bind to port 80 when present

--- a/README.md
+++ b/README.md
@@ -39,22 +39,22 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 ## Linux amd64 tags
 
-- [`2.2.100-sdk-stretch`, `2.2-sdk-stretch`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/amd64/Dockerfile)
-- [`2.2.100-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.100-sdk-alpine`, `2.2-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/alpine3.8/amd64/Dockerfile)
-- [`2.2.100-sdk-bionic`, `2.2-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-stretch-slim`, `2.2-aspnetcore-runtime-stretch-slim`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-alpine3.8`, `2.2-aspnetcore-runtime-alpine3.8`, `2.2.0-aspnetcore-runtime-alpine`, `2.2-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-bionic`, `2.2-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.2.0-runtime-stretch-slim`, `2.2-runtime-stretch-slim`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-runtime-alpine3.8`, `2.2-runtime-alpine3.8`, `2.2.0-runtime-alpine`, `2.2-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-runtime-bionic`, `2.2-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/amd64/Dockerfile)
-- [`2.2.0-runtime-deps-stretch-slim`, `2.2-runtime-deps-stretch-slim`, `2.2.0-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-runtime-deps-alpine3.8`, `2.2-runtime-deps-alpine3.8`, `2.2.0-runtime-deps-alpine`, `2.2-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-stretch`, `2.1-sdk-stretch`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.501-preview-sdk-alpine`, `2.1-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-bionic`, `2.1-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.2.102-sdk-stretch`, `2.2-sdk-stretch`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/amd64/Dockerfile)
+- [`2.2.102-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.102-sdk-alpine`, `2.2-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/alpine3.8/amd64/Dockerfile)
+- [`2.2.102-sdk-bionic`, `2.2-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-stretch-slim`, `2.2-aspnetcore-runtime-stretch-slim`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-alpine3.8`, `2.2-aspnetcore-runtime-alpine3.8`, `2.2.1-aspnetcore-runtime-alpine`, `2.2-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-bionic`, `2.2-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.2.1-runtime-stretch-slim`, `2.2-runtime-stretch-slim`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.2.1-runtime-alpine3.8`, `2.2-runtime-alpine3.8`, `2.2.1-runtime-alpine`, `2.2-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/alpine3.8/amd64/Dockerfile)
+- [`2.2.1-runtime-bionic`, `2.2-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/amd64/Dockerfile)
+- [`2.2.1-runtime-deps-stretch-slim`, `2.2-runtime-deps-stretch-slim`, `2.2.1-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.2.1-runtime-deps-alpine3.8`, `2.2-runtime-deps-alpine3.8`, `2.2.1-runtime-deps-alpine`, `2.2-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
+- [`2.2.1-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`2.1.503-sdk-stretch`, `2.1-sdk-stretch`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.503-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
+- [`2.1.503-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.503-sdk-alpine`, `2.1-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
+- [`2.1.503-sdk-bionic`, `2.1-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-alpine3.8`, `2.1-aspnetcore-runtime-alpine3.8`, `2.1.7-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
@@ -80,16 +80,16 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 ## Linux arm32 tags
 
-- [`2.2.100-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
-- [`2.2.100-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.0-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
-- [`2.1.501-preview-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.501-preview-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.2.102-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
+- [`2.2.102-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.1-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.1-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.1-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.1-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.1-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.503-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.503-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
 - [`2.1.7-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
@@ -103,10 +103,10 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 ## Windows Server, version 1809 amd64 tags
 
-- [`2.2.100-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
-- [`2.2.0-runtime-nanoserver-1809`, `2.2-runtime-nanoserver-1809`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-nanoserver-1809`, `2.1-sdk-nanoserver-1809`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.102-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.1-runtime-nanoserver-1809`, `2.2-runtime-nanoserver-1809`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/amd64/Dockerfile)
+- [`2.1.503-sdk-nanoserver-1809`, `2.1-sdk-nanoserver-1809`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.7-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
 
@@ -120,9 +120,9 @@ See the [complete set of tags](https://github.com/dotnet/dotnet-docker/blob/nigh
 
 ## Windows Server, version 1809 arm32 tags
 
-- [`2.2.0-sdk-nanoserver-1809-arm32`, `2.2-sdk-nanoserver-1809-arm32`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/arm32/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile)
-- [`2.2.0-runtime-nanoserver-1809-arm32`, `2.2-runtime-nanoserver-1809-arm32`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.1-sdk-nanoserver-1809-arm32`, `2.2-sdk-nanoserver-1809-arm32`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.1-runtime-nanoserver-1809-arm32`, `2.2-runtime-nanoserver-1809-arm32`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/arm32/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 

--- a/TAGS.md
+++ b/TAGS.md
@@ -2,22 +2,22 @@
 
 ## Linux amd64 tags
 
-- [`2.2.100-sdk-stretch`, `2.2-sdk-stretch`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/amd64/Dockerfile)
-- [`2.2.100-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.100-sdk-alpine`, `2.2-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/alpine3.8/amd64/Dockerfile)
-- [`2.2.100-sdk-bionic`, `2.2-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-stretch-slim`, `2.2-aspnetcore-runtime-stretch-slim`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-alpine3.8`, `2.2-aspnetcore-runtime-alpine3.8`, `2.2.0-aspnetcore-runtime-alpine`, `2.2-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-bionic`, `2.2-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile)
-- [`2.2.0-runtime-stretch-slim`, `2.2-runtime-stretch-slim`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-runtime-alpine3.8`, `2.2-runtime-alpine3.8`, `2.2.0-runtime-alpine`, `2.2-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-runtime-bionic`, `2.2-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/amd64/Dockerfile)
-- [`2.2.0-runtime-deps-stretch-slim`, `2.2-runtime-deps-stretch-slim`, `2.2.0-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
-- [`2.2.0-runtime-deps-alpine3.8`, `2.2-runtime-deps-alpine3.8`, `2.2.0-runtime-deps-alpine`, `2.2-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
-- [`2.2.0-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-stretch`, `2.1-sdk-stretch`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.501-preview-sdk-alpine`, `2.1-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-bionic`, `2.1-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
+- [`2.2.102-sdk-stretch`, `2.2-sdk-stretch`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/amd64/Dockerfile)
+- [`2.2.102-sdk-alpine3.8`, `2.2-sdk-alpine3.8`, `2.2.102-sdk-alpine`, `2.2-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/alpine3.8/amd64/Dockerfile)
+- [`2.2.102-sdk-bionic`, `2.2-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-stretch-slim`, `2.2-aspnetcore-runtime-stretch-slim`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-alpine3.8`, `2.2-aspnetcore-runtime-alpine3.8`, `2.2.1-aspnetcore-runtime-alpine`, `2.2-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-bionic`, `2.2-aspnetcore-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/amd64/Dockerfile)
+- [`2.2.1-runtime-stretch-slim`, `2.2-runtime-stretch-slim`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/amd64/Dockerfile)
+- [`2.2.1-runtime-alpine3.8`, `2.2-runtime-alpine3.8`, `2.2.1-runtime-alpine`, `2.2-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/alpine3.8/amd64/Dockerfile)
+- [`2.2.1-runtime-bionic`, `2.2-runtime-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/amd64/Dockerfile)
+- [`2.2.1-runtime-deps-stretch-slim`, `2.2-runtime-deps-stretch-slim`, `2.2.1-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/amd64/Dockerfile)
+- [`2.2.1-runtime-deps-alpine3.8`, `2.2-runtime-deps-alpine3.8`, `2.2.1-runtime-deps-alpine`, `2.2-runtime-deps-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/alpine3.8/amd64/Dockerfile)
+- [`2.2.1-runtime-deps-bionic`, `2.2-runtime-deps-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/amd64/Dockerfile)
+- [`2.1.503-sdk-stretch`, `2.1-sdk-stretch`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.503-sdk-alpine3.7`, `2.1-sdk-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.7/amd64/Dockerfile)
+- [`2.1.503-sdk-alpine3.8`, `2.1-sdk-alpine3.8`, `2.1.503-sdk-alpine`, `2.1-sdk-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/alpine3.8/amd64/Dockerfile)
+- [`2.1.503-sdk-bionic`, `2.1-sdk-bionic` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-stretch-slim`, `2.1-aspnetcore-runtime-stretch-slim`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-alpine3.7`, `2.1-aspnetcore-runtime-alpine3.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.7/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-alpine3.8`, `2.1-aspnetcore-runtime-alpine3.8`, `2.1.7-aspnetcore-runtime-alpine`, `2.1-aspnetcore-runtime-alpine` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/alpine3.8/amd64/Dockerfile)
@@ -68,16 +68,16 @@
 
 ## Linux arm32 tags
 
-- [`2.2.100-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
-- [`2.2.100-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
-- [`2.2.0-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.0-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
-- [`2.2.0-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
-- [`2.1.501-preview-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
-- [`2.1.501-preview-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
+- [`2.2.102-sdk-stretch-arm32v7`, `2.2-sdk-stretch-arm32v7`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/stretch/arm32v7/Dockerfile)
+- [`2.2.102-sdk-bionic-arm32v7`, `2.2-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/bionic/arm32v7/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2-aspnetcore-runtime-stretch-slim-arm32v7`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-bionic-arm32v7`, `2.2-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.1-runtime-stretch-slim-arm32v7`, `2.2-runtime-stretch-slim-arm32v7`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.1-runtime-bionic-arm32v7`, `2.2-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/bionic/arm32v7/Dockerfile)
+- [`2.2.1-runtime-deps-stretch-slim-arm32v7`, `2.2-runtime-deps-stretch-slim-arm32v7`, `2.2.1-runtime-deps`, `2.2-runtime-deps`, `runtime-deps` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile)
+- [`2.2.1-runtime-deps-bionic-arm32v7`, `2.2-runtime-deps-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime-deps/bionic/arm32v7/Dockerfile)
+- [`2.1.503-sdk-stretch-arm32v7`, `2.1-sdk-stretch-arm32v7`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/stretch/arm32v7/Dockerfile)
+- [`2.1.503-sdk-bionic-arm32v7`, `2.1-sdk-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/bionic/arm32v7/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1-aspnetcore-runtime-stretch-slim-arm32v7`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/stretch-slim/arm32v7/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-bionic-arm32v7`, `2.1-aspnetcore-runtime-bionic-arm32v7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/bionic/arm32v7/Dockerfile)
 - [`2.1.7-runtime-stretch-slim-arm32v7`, `2.1-runtime-stretch-slim-arm32v7`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/stretch-slim/arm32v7/Dockerfile)
@@ -98,10 +98,10 @@
 
 ## Windows Server, version 1809 amd64 tags
 
-- [`2.2.100-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
-- [`2.2.0-runtime-nanoserver-1809`, `2.2-runtime-nanoserver-1809`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-nanoserver-1809`, `2.1-sdk-nanoserver-1809`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.102-sdk-nanoserver-1809`, `2.2-sdk-nanoserver-1809`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-nanoserver-1809`, `2.2-aspnetcore-runtime-nanoserver-1809`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
+- [`2.2.1-runtime-nanoserver-1809`, `2.2-runtime-nanoserver-1809`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/amd64/Dockerfile)
+- [`2.1.503-sdk-nanoserver-1809`, `2.1-sdk-nanoserver-1809`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-nanoserver-1809`, `2.1-aspnetcore-runtime-nanoserver-1809`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1809/amd64/Dockerfile)
 - [`2.1.7-runtime-nanoserver-1809`, `2.1-runtime-nanoserver-1809`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
 
@@ -113,10 +113,10 @@
 
 ## Windows Server, version 1803 amd64 tags
 
-- [`2.2.100-sdk-nanoserver-1803`, `2.2-sdk-nanoserver-1803`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1803/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-1803`, `2.2-aspnetcore-runtime-nanoserver-1803`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
-- [`2.2.0-runtime-nanoserver-1803`, `2.2-runtime-nanoserver-1803`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1803/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`2.2.102-sdk-nanoserver-1803`, `2.2-sdk-nanoserver-1803`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1803/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-nanoserver-1803`, `2.2-aspnetcore-runtime-nanoserver-1803`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.2.1-runtime-nanoserver-1803`, `2.2-runtime-nanoserver-1803`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1803/amd64/Dockerfile)
+- [`2.1.503-sdk-nanoserver-1803`, `2.1-sdk-nanoserver-1803`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1803/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-nanoserver-1803`, `2.1-aspnetcore-runtime-nanoserver-1803`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1803/amd64/Dockerfile)
 - [`2.1.7-runtime-nanoserver-1803`, `2.1-runtime-nanoserver-1803`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1803/amd64/Dockerfile)
 
@@ -128,10 +128,10 @@
 
 ## Windows Server, version 1709 amd64 tags
 
-- [`2.2.100-sdk-nanoserver-1709`, `2.2-sdk-nanoserver-1709`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1709/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-1709`, `2.2-aspnetcore-runtime-nanoserver-1709`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.2.0-runtime-nanoserver-1709`, `2.2-runtime-nanoserver-1709`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1709/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.2.102-sdk-nanoserver-1709`, `2.2-sdk-nanoserver-1709`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1709/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-nanoserver-1709`, `2.2-aspnetcore-runtime-nanoserver-1709`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.2.1-runtime-nanoserver-1709`, `2.2-runtime-nanoserver-1709`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1709/amd64/Dockerfile)
+- [`2.1.503-sdk-nanoserver-1709`, `2.1-sdk-nanoserver-1709`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-1709/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-nanoserver-1709`, `2.1-aspnetcore-runtime-nanoserver-1709`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-1709/amd64/Dockerfile)
 - [`2.1.7-runtime-nanoserver-1709`, `2.1-runtime-nanoserver-1709`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-1709/amd64/Dockerfile)
 
@@ -143,10 +143,10 @@
 
 ## Windows Server 2016 amd64 tags
 
-- [`2.2.100-sdk-nanoserver-sac2016`, `2.2-sdk-nanoserver-sac2016`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-sac2016`, `2.2-aspnetcore-runtime-nanoserver-sac2016`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.2.0-runtime-nanoserver-sac2016`, `2.2-runtime-nanoserver-sac2016`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-sac2016/amd64/Dockerfile)
-- [`2.1.501-preview-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.501-preview-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.2.102-sdk-nanoserver-sac2016`, `2.2-sdk-nanoserver-sac2016`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.2-aspnetcore-runtime-nanoserver-sac2016`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.2.1-runtime-nanoserver-sac2016`, `2.2-runtime-nanoserver-sac2016`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-sac2016/amd64/Dockerfile)
+- [`2.1.503-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.503-sdk`, `2.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.1.7-aspnetcore-runtime-nanoserver-sac2016`, `2.1-aspnetcore-runtime-nanoserver-sac2016`, `2.1.7-aspnetcore-runtime`, `2.1-aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/aspnetcore-runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`2.1.7-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.7-runtime`, `2.1-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.1/runtime/nanoserver-sac2016/amd64/Dockerfile)
 - [`1.1.10-sdk-1.1.11-nanoserver-sac2016`, `1.1-sdk-nanoserver-sac2016`, `1.1.10-sdk-1.1.11`, `1.1-sdk` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/1.1/sdk/nanoserver-sac2016/amd64/Dockerfile)
@@ -161,9 +161,9 @@
 
 ## Windows Server, version 1809 arm32 tags
 
-- [`2.2.0-sdk-nanoserver-1809-arm32`, `2.2-sdk-nanoserver-1809-arm32`, `2.2.100-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/arm32/Dockerfile)
-- [`2.2.0-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2.0-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile)
-- [`2.2.0-runtime-nanoserver-1809-arm32`, `2.2-runtime-nanoserver-1809-arm32`, `2.2.0-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.1-sdk-nanoserver-1809-arm32`, `2.2-sdk-nanoserver-1809-arm32`, `2.2.102-sdk`, `2.2-sdk`, `sdk`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/sdk/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.1-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2-aspnetcore-runtime-nanoserver-1809-arm32`, `2.2.1-aspnetcore-runtime`, `2.2-aspnetcore-runtime`, `aspnetcore-runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.1-runtime-nanoserver-1809-arm32`, `2.2-runtime-nanoserver-1809-arm32`, `2.2.1-runtime`, `2.2-runtime`, `runtime` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/nightly/2.2/runtime/nanoserver-1809/arm32/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,9 @@
     "1.1-RuntimeVersion": "1.1.10",
     "1.1-SdkVersion": "1.1.11",
     "2.1-RuntimeVersion": "2.1.7",
-    "2.1-SdkVersion": "2.1.501-preview",
-    "2.2-RuntimeVersion": "2.2.0",
-    "2.2-SdkVersion": "2.2.100",
+    "2.1-SdkVersion": "2.1.503",
+    "2.2-RuntimeVersion": "2.2.1",
+    "2.2-SdkVersion": "2.2.102",
     "3.0-RuntimeVersion": "3.0.0-preview",
     "3.0-SdkVersion": "3.0.100-preview"
   },

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public async Task Execute()
         {
-            if (!DockerHelper.IsLinuxContainerModeEnabled && _imageData.IsArm)
+            if (!DockerHelper.IsLinuxContainerModeEnabled && _imageData.IsArm && _imageData.Version.Major == 3)
             {
                 _outputHelper.WriteLine("Tests are blocked on https://github.com/dotnet/corefx/issues/33563");
                 return;


### PR DESCRIPTION
CI is expected to fail until the release is available.