### PR TITLE
Sample for dotnet core 2.2 build dependencies + dotnet core compile o…

### DIFF
--- a/samples/dotnetapp/Dockerfile.python.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.python.alpine-x64
@@ -1,0 +1,66 @@
+FROM microsoft/dotnet:2.2-sdk-alpine AS build
+WORKDIR /app
+
+# copy csproj and restore as distinct layers
+COPY dotnetapp/*.csproj ./dotnetapp/
+COPY utils/*.csproj ./utils/
+WORKDIR /app/dotnetapp
+RUN dotnet restore
+
+# copy and publish app and libraries
+WORKDIR /app/
+COPY dotnetapp/. ./dotnetapp/
+COPY utils/. ./utils/
+WORKDIR /app/dotnetapp
+RUN dotnet publish -c Release -o out
+
+
+# test application -- see: dotnet-docker-unit-testing.md
+FROM build AS testrunner
+WORKDIR /app/tests
+COPY tests/. .
+ENTRYPOINT ["dotnet", "test", "--logger:trx"]
+
+#FROM microsoft/dotnet:2.2-runtime-alpine AS runtime
+#WORKDIR /app
+#COPY --from=build /app/dotnetapp/out ./
+#ENTRYPOINT ["dotnet", "dotnetapp.dll"]
+
+FROM python:3.6-alpine
+RUN apk add --no-cache \
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.0 \
+        libstdc++ \
+        tzdata \
+        userspace-rcu \
+        zlib \
+    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+        lttng-ust
+
+ARG REPO=microsoft/dotnet
+# Configure web servers to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.2.1
+RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
+    && dotnet_sha512='f76f8650aae126b2cdf55cce200d6400137288f5c0688e314575273ab9f87f364d06dcf0992524d8d6a127485ec11f8f6e9586a5b47604bf1f6396748b3e7fca' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet.tar.gz
+
+WORKDIR /app
+COPY --from=build /app/dotnetapp/out ./
+COPY testpython3.py ./
+ENTRYPOINT ["python","testpython3.py"]

--- a/samples/dotnetapp/testpython3.py
+++ b/samples/dotnetapp/testpython3.py
@@ -1,0 +1,11 @@
+import sys
+import this
+import subprocess
+import os
+if sys.version_info[0] < 3:
+    raise Exception("Must be using Python 3")
+else:
+    s = "".join([this.d.get(c, c) for c in this.s])
+    print("*" * 5,"Zen of Alpine Python 3","*" * 5,"\n")
+    print(s)
+    print(subprocess.call(["dotnet", "dotnetapp.dll"]))


### PR DESCRIPTION
This is a sample dockerfile that pulls in a Python 3.6  alpine image and builds dotnet dependencies + dotnet core and tests running dotnet + Python3 from a Python file as entrypoint.

A sample Dockerfile that is based off a non dotnet alpine image is required to demonstrate:

1. Building dotnet core + deps from a Python alpine image (since apk is not supported)

This is required by folks who base off their work on open source alpine images but at some point need a dotnet runtime installed and preferably alpine for smaller sizes. This will help external customers looking for such small sized samples.
