### PR TITLE
Refactor COPY syntax to use rooted source

### DIFF
--- a/2.1/aspnet/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/aspnet/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -23,7 +23,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1709
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/2.1/aspnet/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/aspnet/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1803
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/2.1/aspnet/nanoserver-1809/amd64/Dockerfile
+++ b/2.1/aspnet/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1709
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.1/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1803
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.1/runtime/nanoserver-1809/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1709
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.1/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1803
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.2/aspnet/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/aspnet/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -23,7 +23,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1709
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/2.2/aspnet/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/aspnet/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1803
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/2.2/aspnet/nanoserver-1809/amd64/Dockerfile
+++ b/2.2/aspnet/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/2.2/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/runtime/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1709
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.2/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/runtime/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1803
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.2/runtime/nanoserver-1809/amd64/Dockerfile
+++ b/2.2/runtime/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.2/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1709
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.2/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1803
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/2.2/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/2.2/sdk/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/3.0/aspnet/nanoserver-1709/amd64/Dockerfile
+++ b/3.0/aspnet/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -23,7 +23,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1709
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/3.0/aspnet/nanoserver-1803/amd64/Dockerfile
+++ b/3.0/aspnet/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1803
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/3.0/aspnet/nanoserver-1809/amd64/Dockerfile
+++ b/3.0/aspnet/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/windows/nanoserver:1809
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/3.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/3.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1709
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/3.0/runtime/nanoserver-1803/amd64/Dockerfile
+++ b/3.0/runtime/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1803
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/3.0/runtime/nanoserver-1809/amd64/Dockerfile
+++ b/3.0/runtime/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # Runtime image
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/3.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1709 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1709 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1709
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/3.0/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1803/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1803 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1803 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1803
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 

--- a/3.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer-env
+FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -22,7 +22,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
 # SDK image
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
-COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator 


### PR DESCRIPTION
The Windows Dockerfiles were inconsistently using rooted paths in the COPY syntax.  These changes ensure a consistent pattern is used and eliminates the need to escape the back slashes by using forward slashes.  I decided to also simplify the name of the installer phase since the multi-phase Dockerfiles are already being editted.  The dash in the name hurts the readability IMO.