### PR TITLE
Add tests to detect regressions in the size of the images

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -11,60 +11,15 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Log {
-    param ([string] $Message)
-
-    Write-Output $Message
-}
-
-function Exec {
-    param ([string] $Cmd)
-
-    Log "Executing: '$Cmd'"
-    Invoke-Expression $Cmd
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed: '$Cmd'"
-    }
-}
-
-$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20190128133725'
-$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190128213805'
-$imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
-
 pushd $PSScriptRoot
 try {
-    $activeOS = docker version -f "{{ .Server.Os }}"
-    if ($activeOS -eq "linux") {
-        # On Linux, ImageBuilder is run within a container.  The local repo is copied into a Docker volume
-        # in order to support running with a remote Docker server.
-        ./scripts/Invoke-WithRetry "docker pull $linuxImageBuilder"
-        $repoVolume = "repo-$(Get-Date -Format yyyyMMddhhmmss)"
-        Exec "docker create -v ${repoVolume}:/repo --name $imageBuilderContainerName $linuxImageBuilder"
-        Exec "docker cp ${PSScriptRoot}/. ${imageBuilderContainerName}:/repo"
-        Exec "docker container rm -f $imageBuilderContainerName"
-        $imageBuilderCmd = "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${repoVolume}:/repo -w /repo $linuxImageBuilder"
-    }
-    else {
-        # On Windows, ImageBuild is run locally due to limitations with running Docker client within a container.
-        $imageBuilderFolder = [System.IO.Path]::Combine($PSScriptRoot, ".Microsoft.DotNet.ImageBuilder")
-        $imageBuilderCmd = [System.IO.Path]::Combine($imageBuilderFolder, "image-builder", "Microsoft.DotNet.ImageBuilder.exe")
-        if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
-            ./scripts/Invoke-WithRetry "docker pull $windowsImageBuilder"
-            Exec "docker create --name $imageBuilderContainerName $windowsImageBuilder"
-            New-Item -Path "$imageBuilderFolder" -ItemType Directory -Force
-            Exec "docker cp ${imageBuilderContainerName}:/image-builder $imageBuilderFolder"
-            Exec "docker container rm -f $imageBuilderContainerName"
-        }
-    }
-
-    Exec "$imageBuilderCmd build --path '$VersionFilter/*/$OSFilter/$ArchitectureFilter' $ImageBuilderCustomArgs"
-
-    if ($activeOS -eq "linux") {
-        Exec "docker volume rm -f $repoVolume"
-    }
+    ./scripts/Invoke-ImageBuilder.ps1 "build --path '$VersionFilter/*/$OSFilter/$ArchitectureFilter' $ImageBuilderCustomArgs"
 
     if (-not $SkipTesting) {
-        ./tests/run-tests.ps1 -VersionFilter $VersionFilter -ArchitectureFilter $ArchitectureFilter -OSFilter $OSFilter -IsLocalRun
+        ./tests/run-tests.ps1 `
+            -VersionFilter $VersionFilter `
+            -ArchitectureFilter $ArchitectureFilter `
+            -OSFilter $OSFilter -IsLocalRun
     }
 }
 finally {

--- a/scripts/Invoke-ImageBuilder.ps1
+++ b/scripts/Invoke-ImageBuilder.ps1
@@ -1,0 +1,64 @@
+#!/usr/bin/env pwsh
+[cmdletbinding()]
+param(
+    [string]$ImageBuilderArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Log {
+    param ([string] $Message)
+
+    Write-Output $Message
+}
+
+function Exec {
+    param ([string] $Cmd)
+
+    Log "Executing: '$Cmd'"
+    Invoke-Expression $Cmd
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed: '$Cmd'"
+    }
+}
+
+$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20190128133725'
+$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190128213805'
+$imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
+
+pushd $PSScriptRoot/../
+try {
+    $activeOS = docker version -f "{{ .Server.Os }}"
+    if ($activeOS -eq "linux") {
+        # On Linux, ImageBuilder is run within a container.  The local repo is copied into a Docker volume
+        # in order to support running with a remote Docker server.
+        ./scripts/Invoke-WithRetry "docker pull $linuxImageBuilder"
+        $repoVolume = "repo-$(Get-Date -Format yyyyMMddhhmmss)"
+        Exec "docker create -v ${repoVolume}:/repo --name $imageBuilderContainerName $linuxImageBuilder"
+        Exec "docker cp . ${imageBuilderContainerName}:/repo"
+        Exec "docker container rm -f $imageBuilderContainerName"
+        $imageBuilderCmd = "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${repoVolume}:/repo -w /repo $linuxImageBuilder"
+    }
+    else {
+        # On Windows, ImageBuilder is run locally due to limitations with running Docker client within a container.
+        $imageBuilderFolder = ".Microsoft.DotNet.ImageBuilder"
+        $imageBuilderCmd = [System.IO.Path]::Combine($imageBuilderFolder, "image-builder", "Microsoft.DotNet.ImageBuilder.exe")
+        if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
+            ./scripts/Invoke-WithRetry "docker pull $windowsImageBuilder"
+            Exec "docker create --name $imageBuilderContainerName $windowsImageBuilder"
+            New-Item -Path "$imageBuilderFolder" -ItemType Directory -Force
+            Exec "docker cp ${imageBuilderContainerName}:/image-builder $imageBuilderFolder"
+            Exec "docker container rm -f $imageBuilderContainerName"
+        }
+    }
+
+    Exec "$imageBuilderCmd $ImageBuilderArgs"
+
+    if ($activeOS -eq "linux") {
+        Exec "docker volume rm -f $repoVolume"
+    }
+}
+finally {
+    popd
+}

--- a/scripts/Invoke-ImageBuilder.ps1
+++ b/scripts/Invoke-ImageBuilder.ps1
@@ -23,8 +23,8 @@ function Exec {
     }
 }
 
-$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20190128133725'
-$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190128213805'
+$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20190209204624'
+$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190210044705'
 $imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
 
 pushd $PSScriptRoot/../

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -1,0 +1,54 @@
+{
+  "dotnet/core-nightly/runtime-deps": {
+    "1.0/runtime-deps/jessie/amd64": 166698733,
+    "1.1/runtime-deps/stretch/amd64": 152979799,
+    "2.1/runtime-deps/stretch-slim/amd64": 99052362,
+    "2.1/runtime-deps/alpine3.7/amd64": 13352003,
+    "2.1/runtime-deps/alpine3.8/amd64": 13571739,
+    "2.1/runtime-deps/bionic/amd64": 132215006,
+    "3.0/runtime-deps/stretch-slim/amd64": 94261994,
+    "3.0/runtime-deps/alpine3.8/amd64": 12576448,
+    "3.0/runtime-deps/bionic/amd64": 127579194
+  },
+  "dotnet/core-nightly/runtime": {
+    "1.0/runtime/jessie/amd64": 250590653,
+    "1.1/runtime/jessie/amd64": 251448792,
+    "1.1/runtime/stretch/amd64": 239772302,
+    "2.1/runtime/stretch-slim/amd64": 180258057,
+    "2.1/runtime/alpine3.7/amd64": 87969792,
+    "2.1/runtime/alpine3.8/amd64": 87854021,
+    "2.1/runtime/bionic/amd64": 212327288,
+    "2.2/runtime/stretch-slim/amd64": 180521873,
+    "2.2/runtime/alpine3.8/amd64": 88116701,
+    "2.2/runtime/bionic/amd64": 212591104,
+    "3.0/runtime/stretch-slim/amd64": 182111132,
+    "3.0/runtime/alpine3.8/amd64": 88360781,
+    "3.0/runtime/bionic/amd64": 209256897
+  },
+  "dotnet/core-nightly/aspnet": {
+    "2.1/aspnet/stretch-slim/amd64": 253015005,
+    "2.1/aspnet/alpine3.7/amd64": 160704585,
+    "2.1/aspnet/alpine3.8/amd64": 160588814,
+    "2.1/aspnet/bionic/amd64": 285084236,
+    "2.2/aspnet/stretch-slim/amd64": 260099786,
+    "2.2/aspnet/alpine3.8/amd64": 167440367,
+    "2.2/aspnet/bionic/amd64": 292169017,
+    "3.0/aspnet/stretch-slim/amd64": 199172782,
+    "3.0/aspnet/alpine3.8/amd64": 105385528,
+    "3.0/aspnet/bionic/amd64": 226318547
+  },
+  "dotnet/core-nightly/sdk": {
+    "1.1/sdk/jessie/amd64": 969385565,
+    "1.1/sdk/stretch/amd64": 909378822,
+    "2.1/sdk/stretch/amd64": 1728622878,
+    "2.1/sdk/alpine3.7/amd64": 1467018965,
+    "2.1/sdk/alpine3.8/amd64": 1467676692,
+    "2.1/sdk/bionic/amd64": 1705835924,
+    "2.2/sdk/stretch/amd64": 1731290437,
+    "2.2/sdk/alpine3.8/amd64": 1470111357,
+    "2.2/sdk/bionic/amd64": 1708503951,
+    "3.0/sdk/stretch/amd64": 615355010,
+    "3.0/sdk/alpine3.8/amd64": 354672664,
+    "3.0/sdk/bionic/amd64": 592619900
+  }
+}

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -1,0 +1,50 @@
+{
+  "dotnet/core-nightly/runtime": {
+    "1.0/runtime/nanoserver-sac2016/amd64": 1277491612,
+    "1.1/runtime/nanoserver-sac2016/amd64": 1280098203,
+    "2.1/runtime/nanoserver-sac2016/amd64": 1271998970,
+    "2.1/runtime/nanoserver-1709/amd64": 408096304,
+    "2.1/runtime/nanoserver-1803/amd64": 432478820,
+    "2.1/runtime/nanoserver-1809/amd64": 410240036,
+    "2.2/runtime/nanoserver-sac2016/amd64": 1272098562,
+    "2.2/runtime/nanoserver-1709/amd64": 408234632,
+    "2.2/runtime/nanoserver-1803/amd64": 432583516,
+    "2.2/runtime/nanoserver-1809/amd64": 410361172,
+    "2.2/runtime/nanoserver-1809/arm32": 219678727,
+    "3.0/runtime/nanoserver-1709/amd64": 409311519,
+    "3.0/runtime/nanoserver-1803/amd64": 433660403,
+    "3.0/runtime/nanoserver-1809/amd64": 411445363,
+    "3.0/runtime/nanoserver-1809/arm32": 251208420
+  },
+  "dotnet/core-nightly/aspnet": {
+    "2.1/aspnet/nanoserver-sac2016/amd64": 1345313654,
+    "2.1/aspnet/nanoserver-1709/amd64": 481693443,
+    "2.1/aspnet/nanoserver-1803/amd64": 506001423,
+    "2.1/aspnet/nanoserver-1809/amd64": 483789727,
+    "2.2/aspnet/nanoserver-sac2016/amd64": 1352943342,
+    "2.2/aspnet/nanoserver-1709/amd64": 489040496,
+    "2.2/aspnet/nanoserver-1803/amd64": 513423468,
+    "2.2/aspnet/nanoserver-1809/amd64": 491209500,
+    "2.2/aspnet/nanoserver-1809/arm32": 304649664,
+    "3.0/aspnet/nanoserver-1709/amd64": 428016064,
+    "3.0/aspnet/nanoserver-1803/amd64": 452364948,
+    "3.0/aspnet/nanoserver-1809/amd64": 430149908,
+    "3.0/aspnet/nanoserver-1809/arm32": 273271505
+  },
+  "dotnet/core-nightly/sdk": {
+    "1.1/sdk/nanoserver-sac2016/amd64": 1879144343,
+    "2.1/sdk/nanoserver-sac2016/amd64": 2622122531,
+    "2.1/sdk/nanoserver-1709/amd64": 1744098715,
+    "2.1/sdk/nanoserver-1803/amd64": 1768406279,
+    "2.1/sdk/nanoserver-1809/amd64": 1746472592,
+    "2.2/sdk/nanoserver-sac2016/amd64": 2645884887,
+    "2.2/sdk/nanoserver-1709/amd64": 1747050471,
+    "2.2/sdk/nanoserver-1803/amd64": 1771364308,
+    "2.2/sdk/nanoserver-1809/amd64": 1749550836,
+    "2.2/sdk/nanoserver-1809/arm32": 373223933,
+    "3.0/sdk/nanoserver-1709/amd64": 672018338,
+    "3.0/sdk/nanoserver-1803/amd64": 696480822,
+    "3.0/sdk/nanoserver-1809/amd64": 673437831,
+    "3.0/sdk/nanoserver-1809/arm32": 495008825
+  }
+}

--- a/tests/performance/Validate-ImageSize.ps1
+++ b/tests/performance/Validate-ImageSize.ps1
@@ -1,0 +1,31 @@
+#!/usr/bin/env pwsh
+param(
+    [switch]$UpdateBaselines,
+    [switch]$UseLocalImages,
+    [string]$ImageBuilderCustomArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+pushd $PSScriptRoot/../../
+try {
+    $manifestJson = Get-Content ./manifest.json | ConvertFrom-Json
+    if ($manifestJson.Repos[0].Name.Contains("nightly")) {
+        $branch = ".nightly"
+    }
+    
+    $activeOS = docker version -f "{{ .Server.Os }}"
+    $validateImageSizeArgs = "./tests/performance/ImageSize$branch.$activeOS.json $ImageBuilderCustomArgs"
+    if ($UpdateBaselines) {
+        $validateImageSizeArgs += " --update"
+    }
+    if (!$UseLocalImages) {
+        $validateImageSizeArgs += " --pull"
+    }
+
+    ./scripts/Invoke-ImageBuilder.ps1 "validateImageSize $validateImageSizeArgs"
+}
+finally {
+    popd
+}


### PR DESCRIPTION
Depends on https://github.com/dotnet/docker-tools/pull/141.  Once that PR is merged, the image-builder version will need to be updated in this PR.