### PR TITLE
Update nanoserver-arm tag references to newest convention

### DIFF
--- a/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile
+++ b/2.2/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809_arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm
 
 # Install ASP.NET Core Runtime
 ENV ASPNETCORE_VERSION 2.2.2

--- a/2.2/runtime/nanoserver-1809/arm32/Dockerfile
+++ b/2.2/runtime/nanoserver-1809/arm32/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809_arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm
 
 # Install .NET Core
 ENV DOTNET_VERSION 2.2.2

--- a/2.2/sdk/nanoserver-1809/arm32/Dockerfile
+++ b/2.2/sdk/nanoserver-1809/arm32/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809_arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm
 
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 2.2.104

--- a/3.0/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile
+++ b/3.0/aspnetcore-runtime/nanoserver-1809/arm32/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809_arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm
 
 # Install ASP.NET Core Runtime
 ENV ASPNETCORE_VERSION 3.0.0-preview-19075-0444

--- a/3.0/runtime/nanoserver-1809/arm32/Dockerfile
+++ b/3.0/runtime/nanoserver-1809/arm32/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809_arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm
 
 # Install .NET Core
 ENV DOTNET_VERSION 3.0.0-preview-27324-5

--- a/3.0/sdk/nanoserver-1809/arm32/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/arm32/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809_arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm
 
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 3.0.100-preview-010184


### PR DESCRIPTION
This is needed because windows stopped servicing their old tagging schema.