### PR TITLE
Fix regression in docker login within build test legs

### DIFF
--- a/.vsts-pipelines/jobs/test-images-linux-client.yml
+++ b/.vsts-pipelines/jobs/test-images-linux-client.yml
@@ -57,7 +57,7 @@ jobs:
       -RepoPrefix $(stagingRepoPrefix)
       $(optionalTestArgs)
     displayName: Test Images
-  - script: docker exec $(testRunner.container) docker logout
+  - script: docker exec $(testRunner.container) docker logout $(acr.server)
     displayName: Docker logout
     condition: always()
     continueOnError: true

--- a/.vsts-pipelines/jobs/test-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/test-images-windows-client.yml
@@ -24,10 +24,11 @@ jobs:
   - template: ../steps/init-docker-windows.yml
     parameters:
       setupImageBuilder: false
-  - powershell: >
-      ./scripts/Invoke-WithRetry.ps1 
-      "docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)"
+  - task: CmdLine@1
     displayName: Docker login
+    inputs:
+      filename: docker
+      arguments: login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
   - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
     displayName: Cleanup Old Test Results
   - powershell: >
@@ -37,7 +38,7 @@ jobs:
       -Registry $(acr.server)
       -RepoPrefix $(stagingRepoPrefix)
     displayName: Test Images
-  - script: docker logout
+  - script: docker logout $(acr.server)
     displayName: Docker logout
     condition: always()
     continueOnError: true

--- a/.vsts-pipelines/jobs/test-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/test-images-windows-client.yml
@@ -24,11 +24,8 @@ jobs:
   - template: ../steps/init-docker-windows.yml
     parameters:
       setupImageBuilder: false
-  - task: CmdLine@1
+  - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
     displayName: Docker login
-    inputs:
-      filename: docker
-      arguments: login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
   - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
     displayName: Cleanup Old Test Results
   - powershell: >


### PR DESCRIPTION
This is a workaround for #938.  We will need a better long term solution that preserves the retry logic.

While investigating this, I realized docker logout was not being called correctly so I corrected that issue as well.

@dotnet-bot skip ci please