### PR TITLE
Fix Invoke-ImageBuilder for Windows scenario

### DIFF
--- a/scripts/Invoke-ImageBuilder.ps1
+++ b/scripts/Invoke-ImageBuilder.ps1
@@ -79,7 +79,7 @@ try {
         if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
             ./scripts/Invoke-WithRetry "docker pull $windowsImageBuilder"
             Exec "docker create --name $imageBuilderContainerName $windowsImageBuilder"
-            containerCreated = $true
+            $containerCreated = $true
             if (Test-Path -Path $imageBuilderFolder)
             {
                 Remove-Item -Recurse -Force -Path $imageBuilderFolder

--- a/scripts/Invoke-ImageBuilder.ps1
+++ b/scripts/Invoke-ImageBuilder.ps1
@@ -56,6 +56,7 @@ $windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanose
 $linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190216044810'
 
 $imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
+$containerCreated = $false
 
 pushd $PSScriptRoot/../
 try {
@@ -69,6 +70,7 @@ try {
         }
         
         $imageBuilderCmd = "docker run --name $imageBuilderContainerName -v /var/run/docker.sock:/var/run/docker.sock $imageBuilderImageName"
+        $containerCreated = $true
     }
     else {
         # On Windows, ImageBuilder is run locally due to limitations with running Docker client within a container.
@@ -77,7 +79,7 @@ try {
         if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
             ./scripts/Invoke-WithRetry "docker pull $windowsImageBuilder"
             Exec "docker create --name $imageBuilderContainerName $windowsImageBuilder"
-
+            containerCreated = $true
             if (Test-Path -Path $imageBuilderFolder)
             {
                 Remove-Item -Recurse -Force -Path $imageBuilderFolder
@@ -94,7 +96,9 @@ try {
     }
 }
 finally {
-    Exec "docker container rm -f $imageBuilderContainerName"
+    if ($containerCreated) {
+        Exec "docker container rm -f $imageBuilderContainerName"
+    }
     
     popd
 }


### PR DESCRIPTION
In the Windows scenario, a container may not be created when Invoke-ImageBuilder.ps1 is invoked.  So it should not attempt to remove a container in the `finally` block.  Fixed this by adding a flag which is set when the script has created the container and checking the flag before removing the container.