### PR TITLE
Disable PR validation in build definitions

### DIFF
--- a/.vsts-pipelines/builds/dotnet-nightly-size-validation.yml
+++ b/.vsts-pipelines/builds/dotnet-nightly-size-validation.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 jobs:
 - job: LinuxPerfTests
   pool: Hosted Ubuntu 1604

--- a/.vsts-pipelines/builds/dotnet-nightly.yml
+++ b/.vsts-pipelines/builds/dotnet-nightly.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - nightly
+pr: none
 variables:
   manifest: manifest.json
 jobs:

--- a/.vsts-pipelines/builds/dotnet-samples.yml
+++ b/.vsts-pipelines/builds/dotnet-samples.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 variables:
   manifest: manifest.samples.json
 jobs:

--- a/.vsts-pipelines/builds/dotnet.yml
+++ b/.vsts-pipelines/builds/dotnet.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 variables:
   manifest: manifest.json
 jobs:

--- a/.vsts-pipelines/builds/update-dependencies.yml
+++ b/.vsts-pipelines/builds/update-dependencies.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 jobs:
 - job: UpdateDependencies
   pool: Hosted Ubuntu 1604


### PR DESCRIPTION
This eliminates the need for any settings in the build definitions which I forgot in the build size validation build def.