### PR TITLE
Update build to fix issues with tests not getting skipped for samples

### DIFF
--- a/.vsts-pipelines/jobs/copy-images.yml
+++ b/.vsts-pipelines/jobs/copy-images.yml
@@ -13,7 +13,7 @@ jobs:
           or(
             succeeded(),
             and(
-              eq(variables['repo'], 'dotnet-samples'),
+              contains(variables['manifest'], 'samples'),
               eq(variables['singlePhase'], ''),
               succeeded('Build_Linux_amd64'),
               succeeded('Build_Linux_arm32v7'),

--- a/.vsts-pipelines/jobs/test-images-linux-client.yml
+++ b/.vsts-pipelines/jobs/test-images-linux-client.yml
@@ -8,7 +8,7 @@ jobs:
 - job: ${{ parameters.name }}
   condition: "
     and(
-      ne(variables['repo'], 'dotnet-samples'),
+      not(contains(variables['manifest'], 'samples')),
       ${{ parameters.matrix }},
       or(
         and(

--- a/.vsts-pipelines/jobs/test-images-windows-client.yml
+++ b/.vsts-pipelines/jobs/test-images-windows-client.yml
@@ -7,7 +7,7 @@ jobs:
 - job: ${{ parameters.name }}
   condition: "
     and(
-      ne(variables['repo'], 'dotnet-samples'),
+      not(contains(variables['manifest'], 'samples')),
       ${{ parameters.matrix }},
       or(
         and(


### PR DESCRIPTION
Quick fix to unblock the samples build.  This logic is for skipping the test phase when building the samples. 
 During the MCR work (in nightly) the repo variable was removed.   This code path wasn't exercised until it was merged into master.

@dotnet-bot skip ci please.