### PR TITLE
Update to use latest ImageBuilder

### DIFF
--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -47,7 +47,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190216044810"
+      mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190301193659"
     displayName: Define imageBuilder.image Variable
   - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
     displayName: Pull Image Builder

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -13,7 +13,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20190215204829
+      mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190301113613
     displayName: Define imageBuilder.image Variable
   - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-WithRetry.ps1 "docker pull $(imageBuilder.image)"
     displayName: Pull Image Builder

--- a/scripts/Invoke-ImageBuilder.ps1
+++ b/scripts/Invoke-ImageBuilder.ps1
@@ -52,8 +52,8 @@ function Exec {
     }
 }
 
-$windowsImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20190215204829'
-$linuxImageBuilder = 'microsoft/dotnet-buildtools-prereqs:image-builder-debian-20190216044810'
+$windowsImageBuilder = 'mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190301113613'
+$linuxImageBuilder = 'mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190301193659'
 
 $imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
 $containerCreated = $false


### PR DESCRIPTION
This is so that we can take advantage of the changes in dotnet/docker-tools#152.