### PR TITLE
Refactor update-dependencies to support passing version #s on cmd line

### DIFF
--- a/scripts/update-dependencies/Options.cs
+++ b/scripts/update-dependencies/Options.cs
@@ -8,6 +8,7 @@ namespace Dotnet.Docker
 {
     public class Options
     {
+        public string AspnetVersion { get; private set; }
         public Uri BuildInfoUrl { get; private set; }
         public string GitHubEmail { get; private set; }
         public string GitHubPassword { get; private set; }
@@ -15,12 +16,43 @@ namespace Dotnet.Docker
         public string GitHubUpstreamBranch => "nightly";
         public string GitHubUpstreamOwner => "dotnet";
         public string GitHubUser { get; private set; }
+        public string RuntimeVersion { get; private set; }
+        public string SdkVersion { get; private set; }
         public bool UpdateOnly => GitHubEmail == null || GitHubPassword == null || GitHubUser == null;
 
         public void Parse(string[] args)
         {
             ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, syntax =>
             {
+                Uri buildInfoUrl = null;
+                Argument<Uri> buildInfoArg = syntax.DefineOption(
+                    "build-info",
+                    ref buildInfoUrl,
+                    (value) => new Uri(value),
+                    "URL of the build info to update the Dockerfiles with (http(s):// or file://) (alternative to *-version)");
+                BuildInfoUrl = buildInfoUrl;
+
+                string aspnetVersion = null;
+                Argument<string> aspnetVersionArg = syntax.DefineOption(
+                    "aspnet-version",
+                    ref aspnetVersion,
+                    "ASP.NET version to update the Dockerfiles with (alternative to build-info)");
+                AspnetVersion = aspnetVersion;
+
+                string runtimeVersion = null;
+                Argument<string> runtimeVersionArg = syntax.DefineOption(
+                    "runtime-version",
+                    ref runtimeVersion,
+                    ".NET runtime version to update the Dockerfiles with (alternative to build-info)");
+                RuntimeVersion = runtimeVersion;
+
+                string sdkVersion = null;
+                Argument<string> sdkVersionArg = syntax.DefineOption(
+                    "sdk-version",
+                    ref sdkVersion,
+                    "SDK version to update the Dockerfiles with (alternative to build-info)");
+                SdkVersion = sdkVersion;
+
                 string gitHubEmail = null;
                 syntax.DefineOption(
                     "email",
@@ -41,25 +73,7 @@ namespace Dotnet.Docker
                     ref gitHubUser,
                     "GitHub user used to make PR (if not specified, a PR will not be created)");
                 GitHubUser = gitHubUser;
-
-                Uri buildInfoUrl = null;
-                syntax.DefineParameter(
-                    "build-info",
-                    ref buildInfoUrl,
-                    (value) => new Uri(value),
-                    "URL of the build info to update the Dockerfiles with (http(s):// or file://)");
-                BuildInfoUrl = buildInfoUrl;
             });
-
-            // Workaround for https://github.com/dotnet/corefxlab/issues/1689
-            foreach (Argument arg in argSyntax.GetActiveArguments())
-            {
-                if (arg.IsParameter && !arg.IsSpecified)
-                {
-                    Console.Error.WriteLine($"error: `{arg.Name}` must be specified.");
-                    Environment.Exit(1);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
This change makes the update-dependencies tool easy to use for devs outside of Maestro.  Without this change you have to construct a custom build-info.xml file.  This allows you to do something like the following instead: 

`dotnet update-dependencies.dll --sdk-version 3.01`

@dotnet-bot skip ci please.