### PR TITLE
Fixup build to work with Samples repo and misc build cleanup

### DIFF
--- a/.vsts-pipelines/builds/dotnet-nightly-size-validation.yml
+++ b/.vsts-pipelines/builds/dotnet-nightly-size-validation.yml
@@ -11,8 +11,7 @@ jobs:
 - job: WindowsPerfTests
   pool: # windows1809Amd64
     name: DotNetCore-Infra
-    demands:
-    - VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+    demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
   steps:
   - template: ../steps/cleanup-docker-windows.yml
   - powershell: ./tests/performance/Validate-ImageSize.ps1

--- a/.vsts-pipelines/builds/dotnet-nightly.yml
+++ b/.vsts-pipelines/builds/dotnet-nightly.yml
@@ -5,6 +5,9 @@ trigger:
     - nightly
 pr: none
 variables:
-  manifest: manifest.json
+- group: DotNet-Docker-Common
+- group: DotNet-Docker-Secrets
+- name: manifest
+  value: manifest.json
 jobs:
 - template: ../jobs/build-test-publish-repo.yml

--- a/.vsts-pipelines/builds/dotnet-samples.yml
+++ b/.vsts-pipelines/builds/dotnet-samples.yml
@@ -1,6 +1,9 @@
 trigger: none
 pr: none
 variables:
-  manifest: manifest.samples.json
+- group: DotNet-Docker-Common
+- group: DotNet-Docker-Secrets
+- name: manifest
+  value: manifest.samples.json
 jobs:
 - template: ../jobs/build-test-publish-repo.yml

--- a/.vsts-pipelines/builds/dotnet.yml
+++ b/.vsts-pipelines/builds/dotnet.yml
@@ -1,6 +1,9 @@
 trigger: none
 pr: none
 variables:
-  manifest: manifest.json
+- group: DotNet-Docker-Common
+- group: DotNet-Docker-Secrets
+- name: manifest
+  value: manifest.json
 jobs:
 - template: ../jobs/build-test-publish-repo.yml

--- a/.vsts-pipelines/builds/update-dependencies.yml
+++ b/.vsts-pipelines/builds/update-dependencies.yml
@@ -1,5 +1,9 @@
 trigger: none
 pr: none
+variables:
+- group: DotNet-Docker-Common
+- group: DotNet-Docker-Secrets
+
 jobs:
 - job: UpdateDependencies
   pool: Hosted Ubuntu 1604
@@ -11,7 +15,7 @@ jobs:
       --user dotnet-maestro-bot
       --email dotnet-maestro-bot@microsoft.com
       --password $(BotAccount-dotnet-maestro-bot-PAT)
-      $(buildInfoUrl)
+      --build-info $(buildInfoUrl)
     displayName: Run Update Dependencies
   - script: docker system prune -a -f --volumes
     displayName: Cleanup Docker

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -2,7 +2,6 @@ parameters:
   name: null
   pool: {}
   matrix: {}
-  osVersion: "'*'"
   dockerClientOS: null
   useRemoteDockerServer: false
 jobs:
@@ -28,7 +27,9 @@ jobs:
       $(runImageBuilderCmd) build
       --manifest $(manifest)
       $(imageBuilderPaths)
-      --os-version $(osVersion)
+      --os-type $(osType)
+      --os-version "$(osVersion)"
+      --architecture $(architecture)
       --registry-override $(acr.server)
       --repo-prefix $(stagingRepoPrefix)
       --retry

--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -24,8 +24,7 @@ jobs:
     name: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: DotNet-Build
-      demands:
-      - agent.os -equals linux
+      demands: agent.os -equals linux
     matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64']
     dockerClientOS: linux
 - template: build-images.yml
@@ -57,40 +56,32 @@ jobs:
     name: Build_NanoServerSac2016_amd64
     pool: # windowsLtsc2016Amd64Pool
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
     matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserverSac2016Amd64']
-    osVersion: nanoserver-sac2016
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
     name: Build_NanoServer1709_amd64
     pool: # windows1709Amd64Pool
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
+      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
     matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64']
-    osVersion: nanoserver-1709
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
     name: Build_NanoServer1803_amd64
     pool: # windows1803Amd64Pool
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
+      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
     matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64']
-    osVersion: nanoserver-1803
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
     name: Build_NanoServer1809_amd64
     pool: # windows1809Amd64
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+      demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
     matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1809Amd64']
-    osVersion: nanoserver-1809
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -114,8 +105,7 @@ jobs:
     buildDependencies: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: DotNet-Build
-      demands:
-      - agent.os -equals linux
+      demands: agent.os -equals linux
     matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxAmd64']
 - template: test-images-linux-client.yml
   parameters:
@@ -147,8 +137,7 @@ jobs:
     buildDependencies: Build_NanoServerSac2016_amd64
     pool: # windowsLtsc2016Amd64Pool
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
     matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserverSac2016Amd64']
 - template: test-images-windows-client.yml
   parameters:
@@ -156,8 +145,7 @@ jobs:
     buildDependencies: Build_NanoServer1709_amd64
     pool: # windows1709Amd64Pool
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
+      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
     matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1709Amd64']
 - template: test-images-windows-client.yml
   parameters:
@@ -165,8 +153,7 @@ jobs:
     buildDependencies: Build_NanoServer1803_amd64
     pool: # windows1803Amd64Pool
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
+      demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
     matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1803Amd64']
 - template: test-images-windows-client.yml
   parameters:
@@ -174,8 +161,7 @@ jobs:
     buildDependencies: Build_NanoServer1809_amd64
     pool: # windows1809Amd64
       name: DotNetCore-Infra
-      demands:
-      - VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+      demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
     matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1809Amd64']
 - template: test-images-linux-client.yml
   parameters:
@@ -197,13 +183,11 @@ jobs:
   parameters:
     pool: # linuxAmd64Pool
       name: DotNet-Build
-      demands:
-      - agent.os -equals linux
+      demands: agent.os -equals linux
     matrix: dependencies.GenerateMatrices.outputs['publishMatrix.publishMatrix']
 
 - template: publish-finalize.yml
   parameters:
     pool: # linuxAmd64Pool
       name: DotNet-Build
-      demands:
-      - agent.os -equals linux
+      demands: agent.os -equals linux

--- a/.vsts-pipelines/jobs/copy-images.yml
+++ b/.vsts-pipelines/jobs/copy-images.yml
@@ -40,9 +40,9 @@ jobs:
   - script: >
       $(runImageBuilderCmd) copyAcrImages
       --manifest $(manifest)
-      --path '$(dotnetVersion)/*/$(osVariant)*/*'
+      $(imageBuilderPaths)
       --os-type $(osType)
-      --os-version '$(osVersion)'
+      --os-version "$(osVersion)"
       --architecture $(architecture)
       --registry-override $(acr.server)
       --repo-prefix $(publishRepoPrefix)

--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -47,7 +47,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190301193659"
+      mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190305214722"
     displayName: Define imageBuilder.image Variable
   - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $(imageBuilder.image)
     displayName: Pull Image Builder

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -13,7 +13,7 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: >
       echo "##vso[task.setvariable variable=imageBuilder.image]
-      mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190301113613
+      mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190305134632
     displayName: Define imageBuilder.image Variable
   - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-WithRetry.ps1 "docker pull $(imageBuilder.image)"
     displayName: Pull Image Builder

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -12,7 +12,7 @@
           },
           "platforms": [
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp",
               "os": "linux",
               "tags": {
                 "dotnetapp-stretch": {}
@@ -20,7 +20,7 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp",
               "os": "linux",
               "tags": {
                 "dotnetapp-stretch-arm32v7": {}
@@ -28,7 +28,7 @@
               "variant": "v7"
             },
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp",
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
@@ -36,7 +36,7 @@
               }
             },
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
@@ -44,7 +44,7 @@
               }
             },
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
@@ -52,7 +52,7 @@
               }
             },
             {
-              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
@@ -61,7 +61,7 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
@@ -76,7 +76,7 @@
           },
           "platforms": [
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/aspnetapp",
               "os": "linux",
               "tags": {
                 "aspnetapp-stretch": {}
@@ -84,7 +84,7 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/aspnetapp",
               "os": "linux",
               "tags": {
                 "aspnetapp-stretch-arm32v7": {}
@@ -92,7 +92,7 @@
               "variant": "v7"
             },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/aspnetapp",
               "os": "windows",
               "osVersion": "nanoserver-sac2016",
               "tags": {
@@ -100,7 +100,7 @@
               }
             },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/aspnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1709",
               "tags": {
@@ -108,7 +108,7 @@
               }
             },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/aspnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1803",
               "tags": {
@@ -116,7 +116,7 @@
               }
             },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/aspnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
@@ -125,7 +125,7 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/aspnetapp",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {

--- a/scripts/Invoke-ImageBuilder.ps1
+++ b/scripts/Invoke-ImageBuilder.ps1
@@ -52,8 +52,8 @@ function Exec {
     }
 }
 
-$windowsImageBuilder = 'mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190301113613'
-$linuxImageBuilder = 'mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190301193659'
+$windowsImageBuilder = 'mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190305134632'
+$linuxImageBuilder = 'mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190305214722'
 
 $imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
 $containerCreated = $false


### PR DESCRIPTION
- Pull in newest image builder with fix for building samples - see https://github.com/dotnet/docker-tools/pull/155
- Add dependent variable groups into pipeline yaml
- Simplify multi-line demands
- Simplify dockerfile paths in samples manifest and make them consistent with the main manifest.  Just like with the docker cli, 'dockerfile' is optional if your Dockerfile is named 'dockerfile'
- Fix issue with update-dependencies build definition caused by https://github.com/dotnet/dotnet-docker/pull/961.  build-info is now a named optional arg.