### PR TITLE
Update Windows arm tagging to match base OS tagging

### DIFF
--- a/2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile
+++ b/2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile
@@ -1,11 +1,11 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809-arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
-# Install .NET Core
-ENV DOTNET_VERSION 3.0.0-preview3-27503-5
+# Install ASP.NET Core Runtime
+ENV ASPNETCORE_VERSION 2.2.3
 
-RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/%DOTNET_VERSION%/dotnet-runtime-%DOTNET_VERSION%-win-arm.zip `
+RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/%ASPNETCORE_VERSION%/aspnetcore-runtime-%ASPNETCORE_VERSION%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `
     && tar -zxf dotnet.zip -C "%ProgramFiles%\dotnet" `
     && del dotnet.zip

--- a/2.2/runtime/nanoserver-1809/arm32v7/Dockerfile
+++ b/2.2/runtime/nanoserver-1809/arm32v7/Dockerfile
@@ -1,11 +1,11 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809-arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
-# Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.2.3
+# Install .NET Core
+ENV DOTNET_VERSION 2.2.3
 
-RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/%ASPNETCORE_VERSION%/aspnetcore-runtime-%ASPNETCORE_VERSION%-win-arm.zip `
+RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/%DOTNET_VERSION%/dotnet-runtime-%DOTNET_VERSION%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `
     && tar -zxf dotnet.zip -C "%ProgramFiles%\dotnet" `
     && del dotnet.zip

--- a/2.2/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/2.2/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -1,9 +1,9 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809-arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 3.0.100-preview3-010431
+ENV DOTNET_SDK_VERSION 2.2.105
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/%DOTNET_SDK_VERSION%/dotnet-sdk-%DOTNET_SDK_VERSION%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `

--- a/3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
-FROM $REPO:3.0-nanoserver-1809-arm32
+FROM $REPO:3.0-nanoserver-1809-arm32v7
 
 # Install ASP.NET Core Runtime
 ENV ASPNETCORE_VERSION 3.0.0-preview3-19153-02

--- a/3.0/runtime/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/runtime/nanoserver-1809/arm32v7/Dockerfile
@@ -1,9 +1,9 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809-arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.2.3
+ENV DOTNET_VERSION 3.0.0-preview3-27503-5
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/%DOTNET_VERSION%/dotnet-runtime-%DOTNET_VERSION%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `

--- a/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -1,9 +1,9 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/nanoserver:1809-arm
+FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.105
+ENV DOTNET_SDK_VERSION 3.0.100-preview3-010431
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/%DOTNET_SDK_VERSION%/dotnet-sdk-%DOTNET_SDK_VERSION%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -113,11 +113,11 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 ## Windows Server, version 1809 arm32 tags
 
-- [`2.2.3-nanoserver-1809-arm32`, `2.2-nanoserver-1809-arm32`, `2.2.3`, `2.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnet/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.3-nanoserver-1809-arm32v7`, `2.2-nanoserver-1809-arm32v7`, `2.2.3`, `2.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.0-preview3-nanoserver-1809-arm32`, `3.0-nanoserver-1809-arm32`, `3.0.0-preview3`, `3.0` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1809/arm32/Dockerfile)
+- [`3.0.0-preview3-nanoserver-1809-arm32v7`, `3.0-nanoserver-1809-arm32v7`, `3.0.0-preview3`, `3.0` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -114,11 +114,11 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 
 ## Windows Server, version 1809 arm32 tags
 
-- [`2.2.3-nanoserver-1809-arm32`, `2.2-nanoserver-1809-arm32`, `2.2.3`, `2.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/runtime/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.3-nanoserver-1809-arm32v7`, `2.2-nanoserver-1809-arm32v7`, `2.2.3`, `2.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/runtime/nanoserver-1809/arm32v7/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.0-preview3-nanoserver-1809-arm32`, `3.0-nanoserver-1809-arm32`, `3.0.0-preview3`, `3.0` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1809/arm32/Dockerfile)
+- [`3.0.0-preview3-nanoserver-1809-arm32v7`, `3.0-nanoserver-1809-arm32v7`, `3.0.0-preview3`, `3.0` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1809/arm32v7/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -85,8 +85,8 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 ## Windows Server, version 1809 amd32 tags
 
-- [`dotnetapp-nanoserver-1809-arm32`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-nanoserver-1809-arm32`, `aspnetapp` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`dotnetapp-nanoserver-1809-arm32v7`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-nanoserver-1809-arm32v7`, `aspnetapp` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
 
 # Support
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -116,11 +116,11 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 
 ## Windows Server, version 1809 arm32 tags
 
-- [`2.2.105-nanoserver-1809-arm32`, `2.2-nanoserver-1809-arm32`, `2.2.105`, `2.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1809/arm32/Dockerfile)
+- [`2.2.105-nanoserver-1809-arm32v7`, `2.2-nanoserver-1809-arm32v7`, `2.2.105`, `2.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1809/arm32v7/Dockerfile)
 
 **.NET Core 3.0 Preview tags**
 
-- [`3.0.100-preview3-nanoserver-1809-arm32`, `3.0-nanoserver-1809-arm32`, `3.0.100-preview3`, `3.0` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/arm32/Dockerfile)
+- [`3.0.100-preview3-nanoserver-1809-arm32v7`, `3.0-nanoserver-1809-arm32v7`, `3.0.100-preview3`, `3.0` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 

--- a/manifest.json
+++ b/manifest.json
@@ -552,12 +552,18 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "2.2/runtime/nanoserver-1809/arm32",
+              "dockerfile": "2.2/runtime/nanoserver-1809/arm32v7",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(2.2-RuntimeVersion)-nanoserver-1809-arm32": {},
-                "2.2-nanoserver-1809-arm32": {}
+                "$(2.2-RuntimeVersion)-nanoserver-1809-arm32v7": {},
+                "2.2-nanoserver-1809-arm32v7": {},
+                "$(2.2-RuntimeVersion)-nanoserver-1809-arm32": {
+                  "isUndocumented": true
+                },
+                "2.2-nanoserver-1809-arm32": {
+                  "isUndocumented": true
+                }
               }
             }
           ]
@@ -698,12 +704,12 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "3.0/runtime/nanoserver-1809/arm32",
+              "dockerfile": "3.0/runtime/nanoserver-1809/arm32v7",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(3.0-RuntimeVersion)-nanoserver-1809-arm32": {},
-                "3.0-nanoserver-1809-arm32": {}
+                "$(3.0-RuntimeVersion)-nanoserver-1809-arm32v7": {},
+                "3.0-nanoserver-1809-arm32v7": {}
               }
             }
           ]
@@ -964,12 +970,18 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "2.2/aspnet/nanoserver-1809/arm32",
+              "dockerfile": "2.2/aspnet/nanoserver-1809/arm32v7",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(2.2-RuntimeVersion)-nanoserver-1809-arm32": {},
-                "2.2-nanoserver-1809-arm32": {}
+                "$(2.2-RuntimeVersion)-nanoserver-1809-arm32v7": {},
+                "2.2-nanoserver-1809-arm32v7": {},
+                "$(2.2-RuntimeVersion)-nanoserver-1809-arm32": {
+                  "isUndocumented": true
+                },
+                "2.2-nanoserver-1809-arm32": {
+                  "isUndocumented": true
+                }
               }
             }
           ]
@@ -1122,12 +1134,12 @@
               "buildArgs": {
                 "REPO": "$(Repo:runtime)"
               },
-              "dockerfile": "3.0/aspnet/nanoserver-1809/arm32",
+              "dockerfile": "3.0/aspnet/nanoserver-1809/arm32v7",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(3.0-RuntimeVersion)-nanoserver-1809-arm32": {},
-                "3.0-nanoserver-1809-arm32": {}
+                "$(3.0-RuntimeVersion)-nanoserver-1809-arm32v7": {},
+                "3.0-nanoserver-1809-arm32v7": {}
               }
             }
           ]
@@ -1407,12 +1419,18 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "2.2/sdk/nanoserver-1809/arm32",
+              "dockerfile": "2.2/sdk/nanoserver-1809/arm32v7",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(2.2-SdkVersion)-nanoserver-1809-arm32": {},
-                "2.2-nanoserver-1809-arm32": {}
+                "$(2.2-SdkVersion)-nanoserver-1809-arm32v7": {},
+                "2.2-nanoserver-1809-arm32v7": {},
+                "$(2.2-SdkVersion)-nanoserver-1809-arm32": {
+                  "isUndocumented": true
+                },
+                "2.2-nanoserver-1809-arm32": {
+                  "isUndocumented": true
+                }
               }
             }
           ]
@@ -1538,12 +1556,12 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "3.0/sdk/nanoserver-1809/arm32",
+              "dockerfile": "3.0/sdk/nanoserver-1809/arm32v7",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(3.0-SdkVersion)-nanoserver-1809-arm32": {},
-                "3.0-nanoserver-1809-arm32": {}
+                "$(3.0-SdkVersion)-nanoserver-1809-arm32v7": {},
+                "3.0-nanoserver-1809-arm32v7": {}
               }
             }
           ]

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -57,7 +57,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "dotnetapp-nanoserver-1809-arm32": {}
+                "dotnetapp-nanoserver-1809-arm32v7": {}
               }
             }
           ]
@@ -113,7 +113,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "aspnetapp-nanoserver-1809-arm32": {}
+                "aspnetapp-nanoserver-1809-arm32v7": {}
               }
             }
           ]

--- a/scripts/documentation-templates/aspnet-tags.md
+++ b/scripts/documentation-templates/aspnet-tags.md
@@ -65,11 +65,11 @@ $(TagDoc:3.0-nanoserver-1709)
 
 ## Windows Server, version 1809 arm32 tags
 
-$(TagDoc:2.2-nanoserver-1809-arm32)
+$(TagDoc:2.2-nanoserver-1809-arm32v7)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0-nanoserver-1809-arm32)
+$(TagDoc:3.0-nanoserver-1809-arm32v7)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 

--- a/scripts/documentation-templates/runtime-tags.md
+++ b/scripts/documentation-templates/runtime-tags.md
@@ -70,11 +70,11 @@ $(TagDoc:3.0-nanoserver-1709)
 
 ## Windows Server, version 1809 arm32 tags
 
-$(TagDoc:2.2-nanoserver-1809-arm32)
+$(TagDoc:2.2-nanoserver-1809-arm32v7)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0-nanoserver-1809-arm32)
+$(TagDoc:3.0-nanoserver-1809-arm32v7)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 

--- a/scripts/documentation-templates/samples-tags.md
+++ b/scripts/documentation-templates/samples-tags.md
@@ -27,6 +27,6 @@ $(TagDoc:aspnetapp-nanoserver-1709)
 
 ## Windows Server, version 1809 amd32 tags
 
-$(TagDoc:dotnetapp-nanoserver-1809-arm32)
-$(TagDoc:aspnetapp-nanoserver-1809-arm32)
+$(TagDoc:dotnetapp-nanoserver-1809-arm32v7)
+$(TagDoc:aspnetapp-nanoserver-1809-arm32v7)
 

--- a/scripts/documentation-templates/sdk-tags.md
+++ b/scripts/documentation-templates/sdk-tags.md
@@ -68,11 +68,11 @@ $(TagDoc:3.0-nanoserver-1709)
 
 ## Windows Server, version 1809 arm32 tags
 
-$(TagDoc:2.2-nanoserver-1809-arm32)
+$(TagDoc:2.2-nanoserver-1809-arm32v7)
 
 **.NET Core 3.0 Preview tags**
 
-$(TagDoc:3.0-nanoserver-1809-arm32)
+$(TagDoc:3.0-nanoserver-1809-arm32v7)
 
 For more information about these images and their history, please see [the relevant Dockerfile](https://github.com/dotnet/dotnet-docker/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker` GitHub repo](https://github.com/dotnet/dotnet-docker/pulls).
 


### PR DESCRIPTION
Fixes #983

This to be done as the Windows team are not going to be updating the old tags.  We will be preserving the old 2.2-arm32 tags as undocumented tags.  Since 3.0 is in preview, the old tags will not be preserved.