### PR TITLE
Rewrite Dockerfile for arm32 Linux samples

### DIFF
--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -20,12 +20,12 @@ jobs:
   variables:
     osVersion: ${{ parameters.osVersion }}
   steps:
-  - ${{ if eq(parameters.name, 'Build_Linux_arm32v7') }}:
+  - ${{ if and(contains(variables.manifest, 'samples'), eq(parameters.name, 'Build_Linux_arm32v7')) }}:
     - script: >
         job="$(Agent.JobName)" &&
         sampleFolder=$(echo "$job" | grep -o -E "aspnetapp|dotnetapp") &&
         dockerfilePath="samples/$sampleFolder/Dockerfile" &&
-        sed 's/:2.2 AS/:2.2-bionic-arm32v7 AS/g' $dockerfilePath > Dockerfile.tmp &&
+        sed 's/:2.2 AS/:2.2-stretch-slim-arm32v7 AS/g' $dockerfilePath > Dockerfile.tmp &&
         mv Dockerfile.tmp $dockerfilePath
       displayName: Update Sample Dockerfile
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -20,6 +20,14 @@ jobs:
   variables:
     osVersion: ${{ parameters.osVersion }}
   steps:
+  - ${{ if eq(parameters.name, 'Build_Linux_arm32v7') }}:
+    - script: >
+        job="$(Agent.JobName)" &&
+        sampleFolder=$(echo "$job" | grep -o -E "aspnetapp|dotnetapp") &&
+        dockerfilePath="samples/$sampleFolder/Dockerfile" &&
+        sed 's/:2.2 AS/:2.2-bionic-arm32v7 AS/g' $dockerfilePath > Dockerfile.tmp &&
+        mv Dockerfile.tmp $dockerfilePath
+      displayName: Update Sample Dockerfile
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
     parameters:
       setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -20,14 +20,18 @@ jobs:
   variables:
     osVersion: ${{ parameters.osVersion }}
   steps:
-  - ${{ if and(contains(variables.manifest, 'samples'), eq(parameters.name, 'Build_Linux_arm32v7')) }}:
-    - script: >
-        job="$(Agent.JobName)" &&
-        sampleFolder=$(echo "$job" | grep -o -E "aspnetapp|dotnetapp") &&
-        dockerfilePath="samples/$sampleFolder/Dockerfile" &&
-        sed 's/:2.2 AS/:2.2-stretch-slim-arm32v7 AS/g' $dockerfilePath > Dockerfile.tmp &&
-        mv Dockerfile.tmp $dockerfilePath
-      displayName: Update Sample Dockerfile
+  - script: >
+      job="$(Agent.JobName)" &&
+      sampleFolder=$(echo "$job" | grep -o -E "aspnetapp|dotnetapp") &&
+      dockerfilePath="samples/$sampleFolder/Dockerfile" &&
+      sed 's/:2.2 AS/:2.2-stretch-slim-arm32v7 AS/g' $dockerfilePath > Dockerfile.tmp &&
+      mv Dockerfile.tmp $dockerfilePath
+    displayName: Update Sample Dockerfile
+    condition: "
+      and(
+        succeeded(),
+        contains(variables.manifest, 'samples'),
+        eq(parameters.name, 'Build_Linux_arm32v7'))"
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
     parameters:
       setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -20,6 +20,12 @@ jobs:
   variables:
     osVersion: ${{ parameters.osVersion }}
   steps:
+  # This script is necessary to workaround there not being a matching architecture when pulling images
+  # on an aarch64 machine. By using the multi-arch tag for the images referenced in the sample
+  # Dockerfiles, the Docker CLI attempts to find a matching arch and can't find one. The workaround is
+  # to manually update the Dockerfiles to refer to the architecture-specific images. The long-term
+  # solution is to use the --platform option in Docker CLI when generally available.
+  # See https://github.com/moby/moby/pull/37350
   - script: >
       job="$(Agent.JobName)" &&
       sampleFolder=$(echo "$job" | grep -o -E "aspnetapp|dotnetapp") &&

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -24,14 +24,16 @@ jobs:
       job="$(Agent.JobName)" &&
       sampleFolder=$(echo "$job" | grep -o -E "aspnetapp|dotnetapp") &&
       dockerfilePath="samples/$sampleFolder/Dockerfile" &&
-      sed 's/:2.2 AS/:2.2-stretch-slim-arm32v7 AS/g' $dockerfilePath > Dockerfile.tmp &&
+      sed 's/:2.2 AS build/:2.2-stretch-arm32v7 AS build/g' $dockerfilePath > Dockerfile.tmp &&
+      mv Dockerfile.tmp $dockerfilePath &&
+      sed 's/:2.2 AS runtime/:2.2-stretch-slim-arm32v7 AS runtime/g' $dockerfilePath > Dockerfile.tmp &&
       mv Dockerfile.tmp $dockerfilePath
     displayName: Update Sample Dockerfile
     condition: "
       and(
         succeeded(),
-        contains(variables.manifest, 'samples'),
-        eq(parameters.name, 'Build_Linux_arm32v7'))"
+        contains(variables['manifest'], 'samples'),
+        eq('${{ parameters.name }}', 'Build_Linux_arm32v7'))"
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
     parameters:
       setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}


### PR DESCRIPTION
The samples build is failing for arm32 Linux leg because the build agents have an architecture of aarch64 and the multi-arch manifest description doesn't have a matching architecture for the 2.2 SDK and runtime images that we reference.  To fix this, we eventually want to make use of the `--platform` option on the Docker CLI to explicitly set what platform we want to get but that's only available in experimental mode.  To workaround this, we are going to modify the Dockerfile dynamically so it uses the platform-specific tag for the image instead of the 2.2 flag.