### PR TITLE
Add version monitor build pipeline

### DIFF
--- a/.vsts-pipelines/builds/version-monitor.yml
+++ b/.vsts-pipelines/builds/version-monitor.yml
@@ -1,0 +1,21 @@
+trigger: none
+pr: none
+variables:
+- template: ../variables/common.yml
+jobs:
+- job: VersionMonitor
+  pool: Hosted Ubuntu 1604
+  workspace:
+    clean: all
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - script: >
+      $(runImageBuilderCmd) updateVersions
+      $(dotnetBot-userName)
+      $(dotnetBot-email)
+      $(dotnet-bot-user-repo-adminrepohook-pat)
+      --git-branch master
+      --git-owner dotnet
+      --architecture '*'
+    displayName: Update Docker Image Version Info
+  - template: ../steps/cleanup-docker-linux.yml


### PR DESCRIPTION
This is a port of a modeled build that exists today to monitor the Docker version dependencies this repo depends on so that automatic builds will get triggered as base images are updated.