### PR TITLE
Update 3.0 perf baseline

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -81,7 +81,7 @@
     "2.2/sdk/alpine3.9/amd64": 1469237937,
     "2.2/sdk/bionic/amd64": 1708503951,
     "2.2/sdk/bionic/arm32v7": 1597309570,
-    "3.0/sdk/stretch/amd64": 615355010,
+    "3.0/sdk/stretch/amd64": 648298293,
     "3.0/sdk/stretch/arm32v7": 609617777,
     "3.0/sdk/stretch/arm64v8": 667334243,
     "3.0/sdk/alpine3.9/amd64": 382038072,

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -36,9 +36,9 @@
     "2.2/sdk/nanoserver-1803/amd64": 1771364308,
     "2.2/sdk/nanoserver-1809/amd64": 1653665204,
     "2.2/sdk/nanoserver-1809/arm32v7": 373223933,
-    "3.0/sdk/nanoserver-1709/amd64": 672018338,
-    "3.0/sdk/nanoserver-1803/amd64": 696480822,
+    "3.0/sdk/nanoserver-1709/amd64": 717998875,
+    "3.0/sdk/nanoserver-1803/amd64": 740948382,
     "3.0/sdk/nanoserver-1809/amd64": 601285113,
-    "3.0/sdk/nanoserver-1809/arm32v7": 495008825
+    "3.0/sdk/nanoserver-1809/arm32v7": 537430874
   }
 }


### PR DESCRIPTION
A few 3.0 size baseline changes after merging the latest 3.0 in last week.