### PR TITLE
Reference new version of image builder

### DIFF
--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -15,12 +15,15 @@ jobs:
   - template: ../steps/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
+      name: buildMatrix
   - template: ../steps/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.testMatrixType }}
+      name: testMatrix
   - template: ../steps/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.publishMatrixType }}
+      name: publishMatrix
   - template: ../steps/cleanup-docker-linux.yml
 
   ################################################################################
@@ -31,7 +34,7 @@ jobs:
     name: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxAmd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxAmd64', parameters.buildMatrixType) }}']
     dockerClientOS: linux
 - template: build-images.yml
   parameters:
@@ -42,7 +45,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm64v8', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxArm64v8', parameters.buildMatrixType) }}']
     useRemoteDockerServer: true
     dockerClientOS: linux
 - template: build-images.yml
@@ -54,7 +57,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm32v7', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxArm32v7', parameters.buildMatrixType) }}']
     dockerClientOS: linux
     useRemoteDockerServer: true
 - template: build-images.yml
@@ -63,7 +66,7 @@ jobs:
     pool: # windows1709Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1709Amd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1709Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -71,7 +74,7 @@ jobs:
     pool: # windows1803Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1803Amd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1803Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -79,7 +82,7 @@ jobs:
     pool: # windows1809Amd64
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Amd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1809Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -90,7 +93,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals nanoserver-1809
       - RemoteDockerServerArch -equals arm32
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Arm32', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1809Arm32', parameters.buildMatrixType) }}']
     dockerClientOS: linux
     useRemoteDockerServer: true
 
@@ -103,7 +106,7 @@ jobs:
     buildDependencies: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxAmd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxAmd64', parameters.testMatrixType) }}']
 - template: test-images-linux-client.yml
   parameters:
     name: Test_Linux_arm64v8
@@ -114,7 +117,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm64v8', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxArm64v8', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 - template: test-images-linux-client.yml
   parameters:
@@ -126,7 +129,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm32v7', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxArm32v7', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 - template: test-images-windows-client.yml
   parameters:
@@ -135,7 +138,7 @@ jobs:
     pool: # windows1709Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1709Amd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1709Amd64', parameters.testMatrixType) }}']
 - template: test-images-windows-client.yml
   parameters:
     name: Test_NanoServer1803_amd64
@@ -143,7 +146,7 @@ jobs:
     pool: # windows1803Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1803Amd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1803Amd64', parameters.testMatrixType) }}']
 - template: test-images-windows-client.yml
   parameters:
     name: Test_NanoServer1809_amd64
@@ -151,7 +154,7 @@ jobs:
     pool: # windows1809Amd64
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Amd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1809Amd64', parameters.testMatrixType) }}']
 - template: test-images-linux-client.yml
   parameters:
     name: Test_NanoServer1809_arm32
@@ -162,7 +165,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals nanoserver-1809
       - RemoteDockerServerArch -equals arm32
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Arm32', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1809Arm32', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 
   ################################################################################
@@ -172,7 +175,7 @@ jobs:
   parameters:
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}', parameters.publishMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('publishMatrix.{0}', parameters.publishMatrixType) }}']
 
 - template: publish-finalize.yml
   parameters:

--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -1,3 +1,8 @@
+parameters:
+  buildMatrixType: platformDependencyGraph
+  testMatrixType: platformVersionedOs
+  publishMatrixType: dependencyGraph
+
 jobs:
   ################################################################################
   # Initialization - Generate the VSTS build matrix
@@ -7,11 +12,29 @@ jobs:
     name: Hosted Ubuntu 1604
   steps:
   - template: ../steps/init-docker-linux.yml
-  - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type build --os-type '*' --architecture '*' $(imageBuilder.generateMatrixQueueArgs)
+  - script: >
+      $(runImageBuilderCmd) generateBuildMatrix
+      --manifest $(manifest)
+      --type ${{ parameters.buildMatrixType }}
+      --os-type '*'
+      --architecture '*'
+      $(imageBuilder.generateMatrixQueueArgs)
     name: buildMatrix
-  - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type test --os-type '*' --architecture '*' $(imageBuilder.generateMatrixQueueArgs)
+  - script: >
+      $(runImageBuilderCmd) generateBuildMatrix
+      --manifest $(manifest)
+      --type ${{ parameters.testMatrixType }}
+      --os-type '*'
+      --architecture '*'
+      $(imageBuilder.generateMatrixQueueArgs)
     name: testMatrix
-  - script: $(runImageBuilderCmd) generateBuildMatrix --manifest $(manifest) --type publish --os-type '*' --architecture '*' $(imageBuilder.generateMatrixQueueArgs)
+  - script: >
+      $(runImageBuilderCmd) generateBuildMatrix
+      --manifest $(manifest)
+      --type ${{ parameters.publishMatrixType }}
+      --os-type '*'
+      --architecture '*'
+      $(imageBuilder.generateMatrixQueueArgs)
     name: publishMatrix
   - template: ../steps/cleanup-docker-linux.yml
 
@@ -23,7 +46,7 @@ jobs:
     name: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxAmd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxAmd64', parameters.buildMatrixType) }}']
     dockerClientOS: linux
 - template: build-images.yml
   parameters:
@@ -34,7 +57,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm64v8']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxArm64v8', parameters.buildMatrixType) }}']
     useRemoteDockerServer: true
     dockerClientOS: linux
 - template: build-images.yml
@@ -46,7 +69,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixLinuxArm32v7']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxArm32v7', parameters.buildMatrixType) }}']
     dockerClientOS: linux
     useRemoteDockerServer: true
 - template: build-images.yml
@@ -55,7 +78,7 @@ jobs:
     pool: # windows1709Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-    matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1709Amd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1709Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -63,7 +86,7 @@ jobs:
     pool: # windows1803Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-    matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1803Amd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1803Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -71,7 +94,7 @@ jobs:
     pool: # windows1809Amd64
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-    matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1809Amd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1809Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -82,7 +105,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals nanoserver-1809
       - RemoteDockerServerArch -equals arm32
-    matrix: dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixNanoserver1809Arm32']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1809Arm32', parameters.buildMatrixType) }}']
     dockerClientOS: linux
     useRemoteDockerServer: true
 
@@ -95,7 +118,7 @@ jobs:
     buildDependencies: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxAmd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxAmd64', parameters.testMatrixType) }}']
 - template: test-images-linux-client.yml
   parameters:
     name: Test_Linux_arm64v8
@@ -106,7 +129,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxArm64v8']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxArm64v8', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 - template: test-images-linux-client.yml
   parameters:
@@ -118,7 +141,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixLinuxArm32v7']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxArm32v7', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 - template: test-images-windows-client.yml
   parameters:
@@ -127,7 +150,7 @@ jobs:
     pool: # windows1709Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-    matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1709Amd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1709Amd64', parameters.testMatrixType) }}']
 - template: test-images-windows-client.yml
   parameters:
     name: Test_NanoServer1803_amd64
@@ -135,7 +158,7 @@ jobs:
     pool: # windows1803Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-    matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1803Amd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1803Amd64', parameters.testMatrixType) }}']
 - template: test-images-windows-client.yml
   parameters:
     name: Test_NanoServer1809_amd64
@@ -143,7 +166,7 @@ jobs:
     pool: # windows1809Amd64
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-    matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1809Amd64']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1809Amd64', parameters.testMatrixType) }}']
 - template: test-images-linux-client.yml
   parameters:
     name: Test_NanoServer1809_arm32
@@ -154,7 +177,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals nanoserver-1809
       - RemoteDockerServerArch -equals arm32
-    matrix: dependencies.GenerateMatrices.outputs['testMatrix.testMatrixNanoserver1809Arm32']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1809Arm32', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 
   ################################################################################
@@ -164,7 +187,7 @@ jobs:
   parameters:
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['publishMatrix.publishMatrix']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('publishMatrix.{0}', parameters.publishMatrixType) }}']
 
 - template: publish-finalize.yml
   parameters:

--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -15,15 +15,12 @@ jobs:
   - template: ../steps/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
-    name: buildMatrix
   - template: ../steps/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.testMatrixType }}
-    name: testMatrix
   - template: ../steps/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.publishMatrixType }}
-    name: publishMatrix
   - template: ../steps/cleanup-docker-linux.yml
 
   ################################################################################
@@ -34,7 +31,7 @@ jobs:
     name: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxAmd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxAmd64', parameters.buildMatrixType) }}']
     dockerClientOS: linux
 - template: build-images.yml
   parameters:
@@ -45,7 +42,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxArm64v8', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm64v8', parameters.buildMatrixType) }}']
     useRemoteDockerServer: true
     dockerClientOS: linux
 - template: build-images.yml
@@ -57,7 +54,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixLinuxArm32v7', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm32v7', parameters.buildMatrixType) }}']
     dockerClientOS: linux
     useRemoteDockerServer: true
 - template: build-images.yml
@@ -66,7 +63,7 @@ jobs:
     pool: # windows1709Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1709Amd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1709Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -74,7 +71,7 @@ jobs:
     pool: # windows1803Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1803Amd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1803Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -82,7 +79,7 @@ jobs:
     pool: # windows1809Amd64
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1809Amd64', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Amd64', parameters.buildMatrixType) }}']
     dockerClientOS: windows
 - template: build-images.yml
   parameters:
@@ -93,7 +90,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals nanoserver-1809
       - RemoteDockerServerArch -equals arm32
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('buildMatrix.{0}MatrixNanoserver1809Arm32', parameters.buildMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Arm32', parameters.buildMatrixType) }}']
     dockerClientOS: linux
     useRemoteDockerServer: true
 
@@ -106,7 +103,7 @@ jobs:
     buildDependencies: Build_Linux_amd64
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxAmd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxAmd64', parameters.testMatrixType) }}']
 - template: test-images-linux-client.yml
   parameters:
     name: Test_Linux_arm64v8
@@ -117,7 +114,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxArm64v8', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm64v8', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 - template: test-images-linux-client.yml
   parameters:
@@ -129,7 +126,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals linux
       - RemoteDockerServerArch -equals aarch64
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixLinuxArm32v7', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixLinuxArm32v7', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 - template: test-images-windows-client.yml
   parameters:
@@ -138,7 +135,7 @@ jobs:
     pool: # windows1709Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1709Amd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1709Amd64', parameters.testMatrixType) }}']
 - template: test-images-windows-client.yml
   parameters:
     name: Test_NanoServer1803_amd64
@@ -146,7 +143,7 @@ jobs:
     pool: # windows1803Amd64Pool
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1803Amd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1803Amd64', parameters.testMatrixType) }}']
 - template: test-images-windows-client.yml
   parameters:
     name: Test_NanoServer1809_amd64
@@ -154,7 +151,7 @@ jobs:
     pool: # windows1809Amd64
       name: DotNetCore-Docker
       demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1809Amd64', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Amd64', parameters.testMatrixType) }}']
 - template: test-images-linux-client.yml
   parameters:
     name: Test_NanoServer1809_arm32
@@ -165,7 +162,7 @@ jobs:
       - agent.os -equals linux
       - RemoteDockerServerOS -equals nanoserver-1809
       - RemoteDockerServerArch -equals arm32
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('testMatrix.{0}MatrixNanoserver1809Arm32', parameters.testMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}MatrixNanoserver1809Arm32', parameters.testMatrixType) }}']
     useRemoteDockerServer: true
 
   ################################################################################
@@ -175,7 +172,7 @@ jobs:
   parameters:
     pool: # linuxAmd64Pool
       name: Hosted Ubuntu 1604
-    matrix: dependencies.GenerateMatrices.outputs['${{ format('publishMatrix.{0}', parameters.publishMatrixType) }}']
+    matrix: dependencies.GenerateMatrices.outputs['${{ format('{0}.{0}', parameters.publishMatrixType) }}']
 
 - template: publish-finalize.yml
   parameters:

--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -12,29 +12,17 @@ jobs:
     name: Hosted Ubuntu 1604
   steps:
   - template: ../steps/init-docker-linux.yml
-  - script: >
-      $(runImageBuilderCmd) generateBuildMatrix
-      --manifest $(manifest)
-      --type ${{ parameters.buildMatrixType }}
-      --os-type '*'
-      --architecture '*'
-      $(imageBuilder.generateMatrixQueueArgs)
+  - template: ../steps/generate-matrix.yml
+    parameters:
+      matrixType: ${{ parameters.buildMatrixType }}
     name: buildMatrix
-  - script: >
-      $(runImageBuilderCmd) generateBuildMatrix
-      --manifest $(manifest)
-      --type ${{ parameters.testMatrixType }}
-      --os-type '*'
-      --architecture '*'
-      $(imageBuilder.generateMatrixQueueArgs)
+  - template: ../steps/generate-matrix.yml
+    parameters:
+      matrixType: ${{ parameters.testMatrixType }}
     name: testMatrix
-  - script: >
-      $(runImageBuilderCmd) generateBuildMatrix
-      --manifest $(manifest)
-      --type ${{ parameters.publishMatrixType }}
-      --os-type '*'
-      --architecture '*'
-      $(imageBuilder.generateMatrixQueueArgs)
+  - template: ../steps/generate-matrix.yml
+    parameters:
+      matrixType: ${{ parameters.publishMatrixType }}
     name: publishMatrix
   - template: ../steps/cleanup-docker-linux.yml
 

--- a/.vsts-pipelines/steps/generate-matrix.yml
+++ b/.vsts-pipelines/steps/generate-matrix.yml
@@ -9,4 +9,5 @@ steps:
       --os-type '*'
       --architecture '*'
       $(imageBuilder.generateMatrixQueueArgs)
-    name: Generate ${{ parameters.matrixType }} Matrix
+    displayName: Generate ${{ parameters.matrixType }} Matrix
+    name: ${{ parameters.matrixType }}

--- a/.vsts-pipelines/steps/generate-matrix.yml
+++ b/.vsts-pipelines/steps/generate-matrix.yml
@@ -1,0 +1,12 @@
+parameters:
+  matrixType: null
+
+steps:
+  - script: >
+      $(runImageBuilderCmd) generateBuildMatrix
+      --manifest $(manifest)
+      --type ${{ parameters.matrixType }}
+      --os-type '*'
+      --architecture '*'
+      $(imageBuilder.generateMatrixQueueArgs)
+    name: Generate ${{ parameters.matrixType }} Matrix

--- a/.vsts-pipelines/steps/generate-matrix.yml
+++ b/.vsts-pipelines/steps/generate-matrix.yml
@@ -1,5 +1,6 @@
 parameters:
   matrixType: null
+  name: null
 
 steps:
   - script: >
@@ -10,4 +11,4 @@ steps:
       --architecture '*'
       $(imageBuilder.generateMatrixQueueArgs)
     displayName: Generate ${{ parameters.matrixType }} Matrix
-    name: ${{ parameters.matrixType }}
+    name: ${{ parameters.name }}

--- a/.vsts-pipelines/variables/docker-images.yml
+++ b/.vsts-pipelines/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190321152901
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190321152843
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190326143958
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190326143958
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Reference the newest version of ImageBuilder which has renamed the matrix types when generating a matrix.  As part of these changes, I've factored out the identifiers for those matrix types into parameters such that they map to the particular jobs that are being execute (i.e. build, test, publish).  The matrix values are then referenced dynamically by referencing the appropriate parameter.  This was done in order to better position things for better support for the PR build refactoring that will require the ability to dynamically select which matrix type will be used for the build jobs.  I would have preferred using variables defined in common.yml for defining these matrix type mappings instead of parameters but it wasn't possible due to limitations in AzDO with being able to use expressions on variables.