### PR TITLE
Update alpine runtime-deps to get lttng-ust from main package feed

### DIFF
--- a/2.1/runtime-deps/alpine3.9/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine3.9/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
         lttng-ust \
         tzdata \
         userspace-rcu \
-        zlib \
+        zlib
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/2.1/runtime-deps/alpine3.9/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine3.9/amd64/Dockerfile
@@ -1,18 +1,18 @@
 FROM alpine:3.9
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-    # .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    tzdata \
-    userspace-rcu \
-    zlib \
-    lttng-ust
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        lttng-ust \
+        tzdata \
+        userspace-rcu \
+        zlib \
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
+++ b/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
         lttng-ust \
         tzdata \
         userspace-rcu \
-        zlib \
+        zlib
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
+++ b/2.2/runtime-deps/alpine3.8/amd64/Dockerfile
@@ -1,19 +1,18 @@
 FROM alpine:3.8
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-    # .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.0 \
-    libstdc++ \
-    tzdata \
-    userspace-rcu \
-    zlib \
-    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
-    lttng-ust
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.0 \
+        libstdc++ \
+        lttng-ust \
+        tzdata \
+        userspace-rcu \
+        zlib \
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -57,9 +57,9 @@ namespace Microsoft.DotNet.Docker.Tests
                 if (DockerHelper.IsLinuxContainerModeEnabled)
                 {
                     // Use `sdk` image to publish self contained app and run with `runtime-deps` image
-                    // string selfContainedTag = BuildTestAppImage("self_contained_app", appDir, customBuildArgs: $"rid={_imageData.Rid}");
-                    // tags.Add(selfContainedTag);
-                    // await RunTestAppImage(selfContainedTag, runAsAdmin: runAsAdmin);
+                    string selfContainedTag = BuildTestAppImage("self_contained_app", appDir, customBuildArgs: $"rid={_imageData.Rid}");
+                    tags.Add(selfContainedTag);
+                    await RunTestAppImage(selfContainedTag, runAsAdmin: runAsAdmin);
                 }
             }
             finally

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -57,9 +57,9 @@ namespace Microsoft.DotNet.Docker.Tests
                 if (DockerHelper.IsLinuxContainerModeEnabled)
                 {
                     // Use `sdk` image to publish self contained app and run with `runtime-deps` image
-                    string selfContainedTag = BuildTestAppImage("self_contained_app", appDir, customBuildArgs: $"rid={_imageData.Rid}");
-                    tags.Add(selfContainedTag);
-                    await RunTestAppImage(selfContainedTag, runAsAdmin: runAsAdmin);
+                    // string selfContainedTag = BuildTestAppImage("self_contained_app", appDir, customBuildArgs: $"rid={_imageData.Rid}");
+                    // tags.Add(selfContainedTag);
+                    // await RunTestAppImage(selfContainedTag, runAsAdmin: runAsAdmin);
                 }
             }
             finally


### PR DESCRIPTION
1. Update the 3.8 alpine runtime-deps image to pull lttng-ust from the main package feed vs edge.
2. Update the 3.8 and 3.9 alpine runtime-deps Dockerfile formatting to follow the Dockerfile best practices.