### PR TITLE
Update 3.0 Windows Arm32 images and Add test workaround for Docker issue

### DIFF
--- a/3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.0-nanoserver-1809-arm32v7
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 3.0.0-preview4-19172-03
+ENV ASPNETCORE_VERSION 3.0.0-preview4-19210-17
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/%ASPNETCORE_VERSION%/aspnetcore-runtime-%ASPNETCORE_VERSION%-win-arm.zip `
     && tar -zxf dotnet.zip -C "%ProgramFiles%\dotnet" ./shared/Microsoft.AspNetCore.App `

--- a/3.0/runtime/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/runtime/nanoserver-1809/arm32v7/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
 # Install .NET Core
-ENV DOTNET_VERSION 3.0.0-preview4-27525-12
+ENV DOTNET_VERSION 3.0.0-preview4-27610-12
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Runtime/%DOTNET_VERSION%/dotnet-runtime-%DOTNET_VERSION%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `

--- a/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 3.0.100-preview4-010965
+ENV DOTNET_SDK_VERSION 3.0.100-preview4-011188
 
 RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/%DOTNET_SDK_VERSION%/dotnet-sdk-%DOTNET_SDK_VERSION%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -132,6 +132,9 @@ namespace Microsoft.DotNet.Docker.Tests
                 ApplyProjectCustomizations(_imageData, Path.Combine(appDir, "app.csproj"));
 
                 string sourceDockerfileName = $"Dockerfile.{DockerHelper.DockerOS.ToLower()}";
+
+                // TODO: Remove Windows arm workaround once underlying Windows/Docker issue is resolved
+                // https://github.com/dotnet/dotnet-docker/issues/1054
                 if (!DockerHelper.IsLinuxContainerModeEnabled && _imageData.Arch == Arch.Arm)
                 {
                     sourceDockerfileName += $".{Enum.GetName(typeof(Arch), _imageData.Arch).ToLowerInvariant()}";

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -131,8 +131,14 @@ namespace Microsoft.DotNet.Docker.Tests
 
                 ApplyProjectCustomizations(_imageData, Path.Combine(appDir, "app.csproj"));
 
+                string sourceDockerfileName = $"Dockerfile.{DockerHelper.DockerOS.ToLower()}";
+                if (!DockerHelper.IsLinuxContainerModeEnabled && _imageData.Arch == Arch.Arm)
+                {
+                    sourceDockerfileName += $".{Enum.GetName(typeof(Arch), _imageData.Arch).ToLowerInvariant()}";
+                }
+
                 File.Copy(
-                    Path.Combine(_testArtifactsDir, $"Dockerfile.{DockerHelper.DockerOS.ToLower()}"),
+                    Path.Combine(_testArtifactsDir, sourceDockerfileName),
                     Path.Combine(appDir, "Dockerfile"));
 
                 string nuGetConfigFileName = "NuGet.config";

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows.arm
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows.arm
@@ -1,0 +1,34 @@
+ARG sdk_image
+ARG runtime_image
+
+FROM $sdk_image as build
+
+# Trigger registry hive creation to workaround intermittent Windows arm Docker issue
+# https://github.com/dotnet/dotnet-docker/issues/1054
+USER ContainerAdministrator
+
+EXPOSE 80
+
+WORKDIR app
+COPY NuGet.config .
+COPY *.csproj .
+RUN dotnet restore
+
+COPY . .
+RUN dotnet build
+
+
+FROM build as publish_fx_dependent
+
+# Trigger registry hive creation to workaround intermittent Windows arm Docker issue
+# https://github.com/dotnet/dotnet-docker/issues/1054
+USER ContainerAdministrator
+
+RUN dotnet publish -c Release -o out
+
+
+FROM $runtime_image AS fx_dependent_app
+EXPOSE 80
+WORKDIR /app
+COPY --from=publish_fx_dependent /app/out ./
+ENTRYPOINT ["dotnet", "app.dll"]


### PR DESCRIPTION
These changes include a test workaround for issue #1054.  Once the underlying Windows/Docker issue gets resolved, the workaround can be removed.