### PR TITLE
Simplification of Windows Arm test Dockerfile to eliminate flakiness

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows.arm
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows.arm
@@ -3,22 +3,10 @@ ARG runtime_image
 
 FROM $sdk_image as build
 
-# Trigger registry hive creation to workaround intermittent Windows arm Docker issue
-# https://github.com/dotnet/dotnet-docker/issues/1054
-USER ContainerAdministrator
-
 EXPOSE 80
 
 WORKDIR app
-COPY NuGet.config .
-COPY *.csproj .
-RUN dotnet restore
-
 COPY . .
-RUN dotnet build
-
-
-FROM build as publish_fx_dependent
 
 # Trigger registry hive creation to workaround intermittent Windows arm Docker issue
 # https://github.com/dotnet/dotnet-docker/issues/1054
@@ -30,5 +18,5 @@ RUN dotnet publish -c Release -o out
 FROM $runtime_image AS fx_dependent_app
 EXPOSE 80
 WORKDIR /app
-COPY --from=publish_fx_dependent /app/out ./
+COPY --from=build /app/out ./
 ENTRYPOINT ["dotnet", "app.dll"]


### PR DESCRIPTION
The original Dockerfile pattern is used because it is what we recommend when building locally where you build numerous time and would benefit from restoring in a separate layer (establishing cached layer).  Because of the intermittent Docker ARM described in issue (#1054), I am simplifying the Dockerfile to help reduce the chances of encountering this failure.

@dotnet-bot skip CI please.