### PR TITLE
Add pipeline for updating .NET Core dependencies from drop location

### DIFF
--- a/.vsts-pipelines/builds/update-dependencies-from-drop.yml
+++ b/.vsts-pipelines/builds/update-dependencies-from-drop.yml
@@ -1,0 +1,43 @@
+trigger: none
+pr: none
+variables:
+- group: DotNet-Maestro
+
+jobs:
+- job: UpdateDependencies
+  pool: Hosted Ubuntu 1604
+  steps:
+  - script: |
+      artifactDir=$BUILD_STAGINGDIRECTORY
+      curl -SLo $artifactDir/sdk.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/$(channel)/dotnet-sdk-latest-win-x64.zip
+      unzip $artifactDir/sdk.zip -d $artifactDir/sdk
+
+      cd $artifactDir/sdk/sdk
+      sdkVersionsPath=$(find . -name .version)
+      sdkVer=$(cat $sdkVersionsPath | head -2 | tail -1)
+      
+      cd $artifactDir/sdk/shared/Microsoft.NETCore.App
+      runtimeVersionsPath=$(find . -name .version)
+      runtimeVer=$(cat $runtimeVersionsPath | tail -1)
+
+      cd $artifactDir/sdk/shared/Microsoft.AspNetCore.App
+      aspnetVersionsPath=$(find . -name .version)
+      aspnetVer=$(cat $aspnetVersionsPath | tail -1)
+
+      echo "##vso[task.setvariable variable=sdkVer]$sdkVer"
+      echo "##vso[task.setvariable variable=runtimeVer]$runtimeVer"
+      echo "##vso[task.setvariable variable=aspnetVer]$aspnetVer"
+    displayName: Get Versions
+  - script: docker build -t update-dependencies -f ./scripts/update-dependencies/Dockerfile --pull .
+    displayName: Build Update Dependencies Tool
+  - script: >
+      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
+      --user dotnet-maestro-bot
+      --email dotnet-maestro-bot@microsoft.com
+      --password $(BotAccount-dotnet-maestro-bot-PAT)
+      --runtime-version $(runtimeVer)
+      --sdk-version $(sdkVer)
+      --aspnet-version $(aspnetVer)
+    displayName: Run Update Dependencies
+  - script: docker system prune -a -f --volumes
+    displayName: Cleanup Docker

--- a/.vsts-pipelines/builds/update-dependencies-from-drop.yml
+++ b/.vsts-pipelines/builds/update-dependencies-from-drop.yml
@@ -7,26 +7,7 @@ jobs:
 - job: UpdateDependencies
   pool: Hosted Ubuntu 1604
   steps:
-  - script: |
-      artifactDir=$BUILD_STAGINGDIRECTORY
-      curl -SLo $artifactDir/sdk.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/$(channel)/dotnet-sdk-latest-win-x64.zip
-      unzip $artifactDir/sdk.zip -d $artifactDir/sdk
-
-      cd $artifactDir/sdk/sdk
-      sdkVersionsPath=$(find . -name .version)
-      sdkVer=$(cat $sdkVersionsPath | head -2 | tail -1)
-      
-      cd $artifactDir/sdk/shared/Microsoft.NETCore.App
-      runtimeVersionsPath=$(find . -name .version)
-      runtimeVer=$(cat $runtimeVersionsPath | tail -1)
-
-      cd $artifactDir/sdk/shared/Microsoft.AspNetCore.App
-      aspnetVersionsPath=$(find . -name .version)
-      aspnetVer=$(cat $aspnetVersionsPath | tail -1)
-
-      echo "##vso[task.setvariable variable=sdkVer]$sdkVer"
-      echo "##vso[task.setvariable variable=runtimeVer]$runtimeVer"
-      echo "##vso[task.setvariable variable=aspnetVer]$aspnetVer"
+  - script: ./scripts/get-drop-versions.sh $(channel)
     displayName: Get Versions
   - script: docker build -t update-dependencies -f ./scripts/update-dependencies/Dockerfile --pull .
     displayName: Build Update Dependencies Tool
@@ -39,5 +20,3 @@ jobs:
       --sdk-version $(sdkVer)
       --aspnet-version $(aspnetVer)
     displayName: Run Update Dependencies
-  - script: docker system prune -a -f --volumes
-    displayName: Cleanup Docker

--- a/.vsts-pipelines/builds/update-dependencies-from-versions.yml
+++ b/.vsts-pipelines/builds/update-dependencies-from-versions.yml
@@ -1,7 +1,7 @@
 trigger: none
 pr: none
 variables:
-- template: ../variables/common.yml
+- group: DotNet-Maestro
 
 jobs:
 - job: UpdateDependencies

--- a/.vsts-pipelines/builds/update-dependencies-from-versions.yml
+++ b/.vsts-pipelines/builds/update-dependencies-from-versions.yml
@@ -16,5 +16,3 @@ jobs:
       --password $(BotAccount-dotnet-maestro-bot-PAT)
       --build-info $(buildInfoUrl)
     displayName: Run Update Dependencies
-  - script: docker system prune -a -f --volumes
-    displayName: Cleanup Docker

--- a/scripts/get-drop-versions.sh
+++ b/scripts/get-drop-versions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+channel=$1
+
+curl -SLo sdk.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/$channel/dotnet-sdk-latest-win-x64.zip
+unzip sdk.zip -d sdk
+rm sdk.zip
+
+sdkVersionsPath=$(find sdk/sdk -name .version)
+sdkVer=$(cat $sdkVersionsPath | head -2 | tail -1)
+
+runtimeVersionsPath=$(find sdk/shared/Microsoft.NETCore.App -name .version)
+runtimeVer=$(cat $runtimeVersionsPath | tail -1)
+
+aspnetVersionsPath=$(find sdk/shared/Microsoft.AspNetCore.App -name .version)
+aspnetVer=$(cat $aspnetVersionsPath | tail -1)
+
+rm -rf sdk
+
+echo "##vso[task.setvariable variable=sdkVer]$sdkVer"
+echo "##vso[task.setvariable variable=runtimeVer]$runtimeVer"
+echo "##vso[task.setvariable variable=aspnetVer]$aspnetVer"


### PR DESCRIPTION
Extracts the runtime, SDK, and ASP.NET versions from the SDK.zip file and passes those values to the update dependencies tool.  The channel to target is defined as a build argument.