### PR TITLE
Sample: Use default bin and obj directories locally (#1033)

### DIFF
--- a/samples/aspnetapp/Directory.Build.props
+++ b/samples/aspnetapp/Directory.Build.props
@@ -10,9 +10,4 @@
     <BaseOutputPath>$(MSBuildProjectDirectory)/bin/container/</BaseOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' != 'true'">
-    <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/obj/local/</BaseIntermediateOutputPath>
-    <BaseOutputPath>$(MSBuildProjectDirectory)/bin/local/</BaseOutputPath>
-  </PropertyGroup>
-  
 </Project>

--- a/samples/dotnetapp/Directory.Build.props
+++ b/samples/dotnetapp/Directory.Build.props
@@ -10,9 +10,4 @@
     <BaseOutputPath>$(MSBuildProjectDirectory)/bin/container/</BaseOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' != 'true'">
-    <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/obj/local/</BaseIntermediateOutputPath>
-    <BaseOutputPath>$(MSBuildProjectDirectory)/bin/local/</BaseOutputPath>
-  </PropertyGroup>
-  
 </Project>

--- a/samples/dotnetapp/dotnet-docker-dev-in-container.md
+++ b/samples/dotnetapp/dotnet-docker-dev-in-container.md
@@ -20,12 +20,12 @@ You can also [download the repository as a zip](https://github.com/dotnet/dotnet
 
 This approach relies on [volume mounting](https://docs.docker.com/engine/admin/volumes/volumes/) (that's the `-v` argument in the following commands) to mount source into the container (without using a Dockerfile). You may need to [Enable shared drives (Windows)](https://docs.docker.com/docker-for-windows/#shared-drives) or [file sharing (macOS)](https://docs.docker.com/docker-for-mac/#file-sharing) first.
 
-To avoid conflicts between container usage and your local environment, you need to use a different set of `obj` and `bin` folders for each environment.
+To avoid conflicts between container usage and your local environment, you need to use a different set of `obj` and `bin` folders for your container environment.
 
  Make this change with the following steps:
 
  1. Delete your existing obj and bin folders manually or use `dotnet clean`.
- 2. Add a [Directory.Build.props](Directory.Build.props) file to your project to use a different set of `obj` and `bin` folders for your local and container environments.
+ 2. Add a [Directory.Build.props](Directory.Build.props) file to your project to use a different set of `obj` and `bin` folders for your container environment.
 
 ## Run your application in a container while you Develop
 


### PR DESCRIPTION
* Use default bin and obj directories locally

Changing BaseIntermediateOutputPath prevents "dotnet ef" from working.

Resolves aspnet/EntityFrameworkCore#12220

* Update dotnet-docker-dev-in-container.md