### PR TITLE
Allow builds to be cancelled

### DIFF
--- a/.vsts-pipelines/stages/build-test-publish-repo.yml
+++ b/.vsts-pipelines/stages/build-test-publish-repo.yml
@@ -9,7 +9,7 @@ stages:
 # Build Images
 ################################################################################
 - stage: Build
-  condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
+  condition: and(succeeded(), or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build')))
   jobs:
   - template: ../jobs/generate-matrix.yml
     parameters:


### PR DESCRIPTION
During build stage of the pipeline, the pipeline cannot be cancelled.  Things will keep right on running until all the jobs in the stage have finished.  This is due to a `succeeded()` check missing in the condition of the build stage.  Adding this to the condition fixes the issue.