### PR TITLE
Change URL path for get-drops-version script

### DIFF
--- a/scripts/get-drop-versions.sh
+++ b/scripts/get-drop-versions.sh
@@ -7,7 +7,7 @@ set -u
 
 channel=$1
 
-curl -SLo sdk.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/$channel/dotnet-sdk-latest-win-x64.zip
+curl -SLo sdk.zip https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$channel/dotnet-sdk-latest-win-x64.zip
 unzip sdk.zip -d sdk
 rm sdk.zip
 


### PR DESCRIPTION
In order to allow us to target releases for the master branch of .NET Core SDK for the update-dependencies-from-drop pipeline, we need to update the URL that is called by the script. The master branch doesn't use "release" in the path. So we'll baseline it to support master and then for other branches, we'll prepend "release/" in the pipeline variable.