### PR TITLE
Update the dotnet-core feed used by tests in nightly branch

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config.nightly
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config.nightly
@@ -2,7 +2,8 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The myget NuGet feed used in the nightly tests is not longer being used.  .NET and ASP.NET now utilize separate feeds.  This is causing the CI failures in https://github.com/dotnet/dotnet-docker/pull/1126