### PR TITLE
Update PowerShell to v7.0.0-preview.1

### DIFF
--- a/3.0/sdk/alpine3.9/amd64/Dockerfile
+++ b/3.0/sdk/alpine3.9/amd64/Dockerfile
@@ -28,10 +28,10 @@ ENV DOTNET_USE_POLLING_FILE_WATCHER=true \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN wget -O PowerShell.Linux.Alpine.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.Alpine.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='0cbed2f335a5b3fee907c4c4c67521bf96b753a61bb842975793644ed9f69f2b82d459fd3778086e980aa681a0d44d2523ee429c288e7cc0c0623cb200c3fa3a' \
+    && powershell_sha512='bbf589c98a330435b011412c7296fc63d4ecc7a6f65bc0c1b7c7bef71480189b70539d3159f48abe0ceb597752ad9786cef95f7fe4831d224c7bf907159a5080' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.Alpine \

--- a/3.0/sdk/bionic/amd64/Dockerfile
+++ b/3.0/sdk/bionic/amd64/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='306a481559a027f85d875f5be8eecb8459dfda6c4672a5d8ea8c3f8c124569ddc9f2bde71cc5d55ef61de40c1a4fe30eddf39345b3dba32923f2a3441002df37' \
+    && powershell_sha512='5f11bd5fb48082f100f646c2aa4f9341bbf0ecb63b5979b95b1cd77755e659be0bfc9d90c0cfceb838830f391224c0db850d353960ad35b30d081d76279ce819' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.x64 \

--- a/3.0/sdk/bionic/arm32v7/Dockerfile
+++ b/3.0/sdk/bionic/arm32v7/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='aa6bac0e709ab404881ca04860492273c76f1745f5b94570d89786d6c6937123e426aa1e1a8faeef216098a53f1384e5cc37a804173726e1b0f9bb50e12b5000' \
+    && powershell_sha512='25752c5ccea6b20fe847cab41a8b0587e4779d2c2ef7f184a5132cf00c43675cccbd493326b2515877eff48006817e00434e9923d1454d2bafc3d84eb248d48c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.arm32 \

--- a/3.0/sdk/bionic/arm64v8/Dockerfile
+++ b/3.0/sdk/bionic/arm64v8/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='339c118f49d0699113b471f12ca62ca3a1bf511ab27ad6fd4dd6c9df4d9f8403c9a38da11c79310fa257be7cfcf76e7e291668460bf70199a0fe77ef54e62b3a' \
+    && powershell_sha512='106daec4304104e572750c9ede0f47c9355eb61fcb089b7dba5d02cb1207c0989876349caf241232847f4be09155eb3336774c67107f5ee209aff9a9f8d1c16d' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.arm64 \

--- a/3.0/sdk/buster/amd64/Dockerfile
+++ b/3.0/sdk/buster/amd64/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='306a481559a027f85d875f5be8eecb8459dfda6c4672a5d8ea8c3f8c124569ddc9f2bde71cc5d55ef61de40c1a4fe30eddf39345b3dba32923f2a3441002df37' \
+    && powershell_sha512='5f11bd5fb48082f100f646c2aa4f9341bbf0ecb63b5979b95b1cd77755e659be0bfc9d90c0cfceb838830f391224c0db850d353960ad35b30d081d76279ce819' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.x64 \

--- a/3.0/sdk/buster/arm32v7/Dockerfile
+++ b/3.0/sdk/buster/arm32v7/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='aa6bac0e709ab404881ca04860492273c76f1745f5b94570d89786d6c6937123e426aa1e1a8faeef216098a53f1384e5cc37a804173726e1b0f9bb50e12b5000' \
+    && powershell_sha512='25752c5ccea6b20fe847cab41a8b0587e4779d2c2ef7f184a5132cf00c43675cccbd493326b2515877eff48006817e00434e9923d1454d2bafc3d84eb248d48c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.arm32 \

--- a/3.0/sdk/buster/arm64v8/Dockerfile
+++ b/3.0/sdk/buster/arm64v8/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='339c118f49d0699113b471f12ca62ca3a1bf511ab27ad6fd4dd6c9df4d9f8403c9a38da11c79310fa257be7cfcf76e7e291668460bf70199a0fe77ef54e62b3a' \
+    && powershell_sha512='106daec4304104e572750c9ede0f47c9355eb61fcb089b7dba5d02cb1207c0989876349caf241232847f4be09155eb3336774c67107f5ee209aff9a9f8d1c16d' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.arm64 \

--- a/3.0/sdk/disco/amd64/Dockerfile
+++ b/3.0/sdk/disco/amd64/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='306a481559a027f85d875f5be8eecb8459dfda6c4672a5d8ea8c3f8c124569ddc9f2bde71cc5d55ef61de40c1a4fe30eddf39345b3dba32923f2a3441002df37' \
+    && powershell_sha512='5f11bd5fb48082f100f646c2aa4f9341bbf0ecb63b5979b95b1cd77755e659be0bfc9d90c0cfceb838830f391224c0db850d353960ad35b30d081d76279ce819' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.x64 \

--- a/3.0/sdk/disco/arm32v7/Dockerfile
+++ b/3.0/sdk/disco/arm32v7/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='aa6bac0e709ab404881ca04860492273c76f1745f5b94570d89786d6c6937123e426aa1e1a8faeef216098a53f1384e5cc37a804173726e1b0f9bb50e12b5000' \
+    && powershell_sha512='25752c5ccea6b20fe847cab41a8b0587e4779d2c2ef7f184a5132cf00c43675cccbd493326b2515877eff48006817e00434e9923d1454d2bafc3d84eb248d48c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.arm32 \

--- a/3.0/sdk/disco/arm64v8/Dockerfile
+++ b/3.0/sdk/disco/arm64v8/Dockerfile
@@ -36,10 +36,10 @@ ENV ASPNETCORE_URLS=http://+:80 \
 RUN dotnet help
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$POWERSHELL_VERSION/PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg \
-    && powershell_sha512='339c118f49d0699113b471f12ca62ca3a1bf511ab27ad6fd4dd6c9df4d9f8403c9a38da11c79310fa257be7cfcf76e7e291668460bf70199a0fe77ef54e62b3a' \
+    && powershell_sha512='106daec4304104e572750c9ede0f47c9355eb61fcb089b7dba5d02cb1207c0989876349caf241232847f4be09155eb3336774c67107f5ee209aff9a9f8d1c16d' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$POWERSHELL_VERSION.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $POWERSHELL_VERSION PowerShell.Linux.arm64 \

--- a/3.0/sdk/nanoserver-1803/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1803/amd64/Dockerfile
@@ -19,10 +19,10 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
     Remove-Item -Force dotnet.zip
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN Invoke-WebRequest -OutFile PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$ENV:POWERSHELL_VERSION/PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg; `
-    $powershell_sha512 = '418ab0d438d1a96afcd2502576530d7fbdedea9076871f72f225d8af6c8b124c8106bc94dbc8c56cf74e10cad89144ba525b6c09b3b700182ac9c5df9190eb33'; `
+    $powershell_sha512 = '01e1fc6a7403033650ceedd49622988903973b07b0d3cb24012d4a19260d4a2022fdb47f4ebc95b2f5191f5fbbb8c755c995b44fd60e8b1b37253ecafbb77dc3'; `
     if ((Get-FileHash PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -19,10 +19,10 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
     Remove-Item -Force dotnet.zip
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN Invoke-WebRequest -OutFile PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$ENV:POWERSHELL_VERSION/PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg; `
-    $powershell_sha512 = '418ab0d438d1a96afcd2502576530d7fbdedea9076871f72f225d8af6c8b124c8106bc94dbc8c56cf74e10cad89144ba525b6c09b3b700182ac9c5df9190eb33'; `
+    $powershell_sha512 = '01e1fc6a7403033650ceedd49622988903973b07b0d3cb24012d4a19260d4a2022fdb47f4ebc95b2f5191f5fbbb8c755c995b44fd60e8b1b37253ecafbb77dc3'; `
     if ((Get-FileHash PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/
     && del dotnet.zip
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN curl -SL --output PowerShell.Windows.arm32.%POWERSHELL_VERSION%.nupkg https://pwshtool.blob.core.windows.net/tool/%POWERSHELL_VERSION%/PowerShell.Windows.arm32.%POWERSHELL_VERSION%.nupkg `
     && mkdir "%ProgramFiles%\powershell" `

--- a/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -SL --output dotnet.zip https://dotnetcli.blob.core.windows.net/dotnet/
     && del dotnet.zip
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 7.0.0-preview.1
+ENV POWERSHELL_VERSION 6.2.1
 
 RUN curl -SL --output PowerShell.Windows.arm32.%POWERSHELL_VERSION%.nupkg https://pwshtool.blob.core.windows.net/tool/%POWERSHELL_VERSION%/PowerShell.Windows.arm32.%POWERSHELL_VERSION%.nupkg `
     && mkdir "%ProgramFiles%\powershell" `

--- a/3.0/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.0/sdk/nanoserver-1903/amd64/Dockerfile
@@ -19,10 +19,10 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.blob.core.windows.ne
     Remove-Item -Force dotnet.zip
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION 6.2.1
+ENV POWERSHELL_VERSION 7.0.0-preview.1
 
 RUN Invoke-WebRequest -OutFile PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$ENV:POWERSHELL_VERSION/PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg; `
-    $powershell_sha512 = '418ab0d438d1a96afcd2502576530d7fbdedea9076871f72f225d8af6c8b124c8106bc94dbc8c56cf74e10cad89144ba525b6c09b3b700182ac9c5df9190eb33'; `
+    $powershell_sha512 = '01e1fc6a7403033650ceedd49622988903973b07b0d3cb24012d4a19260d4a2022fdb47f4ebc95b2f5191f5fbbb8c755c995b44fd60e8b1b37253ecafbb77dc3'; `
     if ((Get-FileHash PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `


### PR DESCRIPTION
The release uses netcore 3.0 and has the fix for https://github.com/OneGet/oneget/pull/443 and resolves: https://github.com/dotnet/dotnet-docker/issues/1069#issuecomment-489744320