### PR TITLE
Add ENTRYPOINT when container is running

### DIFF
--- a/3.0/sdk/disco/amd64/Dockerfile
+++ b/3.0/sdk/disco/amd64/Dockerfile
@@ -47,3 +47,9 @@ RUN curl -SL --output PowerShell.Linux.x64.$POWERSHELL_VERSION.nupkg https://pws
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm
+
+COPY . /app
+WORKDIR /app
+
+EXPOSE 5001
+ENTRYPOINT ["dotnet", "WebApplication.dll"]


### PR DESCRIPTION
We use dockerfile to build an image, cause we want to put a application in it. so I thing we should add a ENTRYPOINT to make it easier.