### PR TITLE
Publish image info

### DIFF
--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -57,9 +57,15 @@ jobs:
       --os-type $(osType)
       --os-version "$(osVersion)"
       --architecture $(architecture)
+      --image-info-output-path "$(imageBuilderArtifactsPath)/$(legName)-image-info.json"
       --retry
       $(imageBuilderBuildArgs)
     displayName: Build Images
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: $(legName)-image-info
+      targetPath: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
+    displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:

--- a/.vsts-pipelines/jobs/publish.yml
+++ b/.vsts-pipelines/jobs/publish.yml
@@ -63,7 +63,7 @@ jobs:
       $(dotnetBot-email)
       $(dotnet-bot-user-repo-adminrepohook-pat)
       $(imageBuilderArtifactsPath)
-      --git-owner mthalman
+      --git-owner dotnet
       --git-repo versions
       --git-branch master
       --git-path build-info/docker/image-info.json

--- a/.vsts-pipelines/jobs/publish.yml
+++ b/.vsts-pipelines/jobs/publish.yml
@@ -47,6 +47,28 @@ jobs:
       $(publicGitRepoUri)/blob/$(publicSourceBranch)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Readme
+  - task: DownloadPipelineArtifact@1
+    inputs:
+      buildType: specific
+      project: $(System.TeamProject)
+      pipline: $(System.DefinitionId)
+      buildVersionToDownload: specific
+      buildId: $(sourceBuildId)
+      targetPath: $(Build.ArtifactStagingDirectory)
+    displayName: Download Pipline Artifacts
+    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
+  - script: >
+      $(runImageBuilderCmd) publishImageInfo
+      $(dotnetBot-userName)
+      $(dotnetBot-email)
+      $(dotnet-bot-user-repo-adminrepohook-pat)
+      $(imageBuilderArtifactsPath)
+      --git-owner mthalman
+      --git-repo versions
+      --git-branch master
+      --git-path build-info/docker/image-info.json
+    displayName: Publish Image Info
+    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: Component Detection
   - template: ../steps/cleanup-docker-linux.yml

--- a/.vsts-pipelines/steps/init-docker-linux.yml
+++ b/.vsts-pipelines/steps/init-docker-linux.yml
@@ -38,10 +38,13 @@ steps:
       --build-arg IMAGE=$(imageNames.imageBuilder.linux)
       -f ./scripts/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
+  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]/artifacts"
+    displayName: Define Image Builder Artifacts Path Variable
   - script: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       docker run --rm
       -v /var/run/docker.sock:/var/run/docker.sock
+      -v $(Build.ArtifactStagingDirectory):$(imageBuilderArtifactsPath)
       -w /repo
       $(dockerArmRunArgs)
       $(imageNames.imageBuilder.withrepo)"

--- a/.vsts-pipelines/steps/init-docker-windows.yml
+++ b/.vsts-pipelines/steps/init-docker-windows.yml
@@ -28,3 +28,5 @@ steps:
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
     displayName: Define runImageBuilderCmd Variable
+  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]$(Build.ArtifactStagingDirectory)
+    displayName: Define Image Builder Artifacts Path Variable

--- a/.vsts-pipelines/variables/common.yml
+++ b/.vsts-pipelines/variables/common.yml
@@ -2,6 +2,8 @@ variables:
 - template: docker-images.yml
 - name: publicGitRepoUri
   value: https://github.com/dotnet/dotnet-docker
+- name: stagingRepoPrefix
+  value: build-staging/$(sourceBuildId)/
 - name: skipComponentGovernanceDetection
   value: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/.vsts-pipelines/variables/docker-images.yml
+++ b/.vsts-pipelines/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190603212604
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190603212604
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190606195358
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190606195358
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Updates the build pipeline so that the built images have their image info collected and published to the master image info file.

Here's how the flow works:
1. In the build stage, each build job writes to a file its own image info containing metadata about only the images it just built.  This file is published as a pipeline artifact with a unique name specific to that job so it doesn't conflict with the other jobs.
2. During the publish stage, all of the pipeline artifacts are downloaded and fed into the ImageBuilder command to merge all of the content from the files into the master image info file.

Notes:
* In order to get files into and out of the container that ImageBuilder runs in, a volume mount is used that maps to the $(Build.ArtifactStagingDirectory) of the build agent.
* In order to support scenarios where the build is run for a specific stage like test or publish where the build hasn't been run, we need the ability to target the pipeline artifacts from the source build (the build that produced the images).  The DownloadPipelineArtifact task is capable of referencing artifacts from other builds.  A sourceBuildId variable is being introduced as a variable that can be set at queue time to provide this value.  This variable replaces the original stagingRepoPrefix variable which is now computed from the sourceBuildId variable.