### PR TITLE
Fix build timeout variable in pipeline yaml.

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -4,8 +4,8 @@ parameters:
   customBuildLegGrouping: ""
   linuxAmdBuildJobTimeout: 60
   linuxArmBuildJobTimeout: 60
-  windowsAmdJobTimeout: 60
-  windowsArmJobTimeout: 60
+  windowsAmdBuildJobTimeout: 60
+  windowsArmBuildJobTimeout: 60
 
 stages:
 

--- a/eng/pipelines/dotnet-core-nightly.yml
+++ b/eng/pipelines/dotnet-core-nightly.yml
@@ -10,6 +10,9 @@ variables:
 - template: variables/common.yml
 - name: manifest
   value: manifest.json
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: windowsArmBuildJobTimeout
+    value: 120
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml
   parameters:


### PR DESCRIPTION
The build pipeline was failing to parse because it was referencing parameter names that weren't defined.  Fixed the names of the build timeout variables in build-test-publish-repo.yml.  Also updated the nightly build to use longer timeout for Windows ARM legs in public build.