### PR TITLE
 Remove wildcards from filters in test steps

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -40,7 +40,7 @@ steps:
     docker exec $(testRunner.container) pwsh
     -File ./tests/run-tests.ps1
     -VersionFilter $(dotnetVersion)
-    -OSFilter $(osVariant)
+    -OSFilter $(osVariant)*
     -ArchitectureFilter $(architecture)
     $(optionalTestArgs)
   displayName: Test Images

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -39,8 +39,8 @@ steps:
 - script: >
     docker exec $(testRunner.container) pwsh
     -File ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)*
-    -OSFilter $(osVariant)*
+    -VersionFilter $(dotnetVersion)
+    -OSFilter $(osVariant)
     -ArchitectureFilter $(architecture)
     $(optionalTestArgs)
   displayName: Test Images

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -17,7 +17,7 @@ steps:
   displayName: Cleanup Old Test Results
 - powershell: >
     ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)*
+    -VersionFilter $(dotnetVersion)
     -OSFilter $(osVariant)
     $(optionalTestArgs)
   displayName: Test Images


### PR DESCRIPTION
As part of merging the common engineering infra to dotnet-framework-docker, I discovered a difference between the two repos in how filters are specified in tests.  The dotnet-framework-docker repo had the wildcard character removed from the VersionFilter parameter.  This ensured that you could run tests for just '4.7' and not end up including '4.7.x'.  So I'm incorporating that difference here.