### PR TITLE
 Remove wildcards from filters in test steps

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -39,7 +39,7 @@ steps:
 - script: >
     docker exec $(testRunner.container) pwsh
     -File ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)*
+    -VersionFilter $(dotnetVersion)
     -OSFilter $(osVariant)*
     -ArchitectureFilter $(architecture)
     $(optionalTestArgs)

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -17,7 +17,7 @@ steps:
   displayName: Cleanup Old Test Results
 - powershell: >
     ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)*
+    -VersionFilter $(dotnetVersion)
     -OSFilter $(osVariant)
     $(optionalTestArgs)
   displayName: Test Images

--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -12,3 +12,4 @@ stages:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       buildMatrixType: platformVersionedOs
       customBuildLegGrouping: pr-build
+      windowsArmBuildJobTimeout: 120


### PR DESCRIPTION
Cherry-pick of 3c5f6ee 

As part of merging the common engineering infra to dotnet-framework-docker, I discovered a difference between the two repos in how filters are specified in tests. The dotnet-framework-docker repo had the wildcard character removed from the VersionFilter parameter. This ensured that you could run tests for just '4.7' and not end up including '4.7.x'. So I'm incorporating that difference here.