### PR TITLE
Remove invalid condition from download-build-artifact template ref

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -51,7 +51,7 @@ jobs:
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: image-info
-    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
+      requiresPublicRepoPrefix: true
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       $(dotnetBot-userName)

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -1,6 +1,7 @@
 parameters:
   targetPath: ""
   artifactName: ""
+  requiresPublicRepoPrefix: false
 
 steps:
 - task: DownloadPipelineArtifact@1
@@ -13,3 +14,5 @@ steps:
     targetPath: ${{ parameters.targetPath }}
     artifactName: ${{ parameters.artifactName }}
   displayName: Download Build Artifact(s)
+  ${{ if eq(parameters.requiresPublicRepoPrefix, true) }}:
+    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))


### PR DESCRIPTION
It is invalid for Azure Pipeline YAML files to use condition attributes for a reference to a template.  This was being done in publish.yml and causing a parsing failure.  Unfortunately, we need to know the value of a variable and YAML pipelines don't allow you to pass custom variables as parameter values.  Instead, I've introduced a requiresPublicRepoPrefix to the download-build-artifact template that works around this problem.  It's not pretty but I can't think of a better option due to the limitations with YAML pipelines.