### PR TITLE
Update tests to support dynamically pulling missing images

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -44,12 +44,6 @@ jobs:
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
     parameters:
       setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - script: echo "##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
-      displayName: Set Image Info Arg for Image Builder
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - script: echo "##vso[task.setvariable variable=imageBuilderImageInfoArg]"
-      displayName: Set Image Info Arg for Image Builder
   - script: >
       $(runImageBuilderCmd) build
       --manifest $(manifest)

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -17,13 +17,7 @@ jobs:
   variables:
     osVersion: ${{ parameters.osVersion }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      imageBuilderBuildArgs: >
-        --registry-override $(acr.server)
-        --repo-prefix $(stagingRepoPrefix)
-        --push
-        --username $(acr.userName)
-        --password $(BotAccount-dotnet-docker-acr-bot-password)
-        $(imageBuilder.queueArgs)
+      imageBuilderBuildArgs: --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       imageBuilderBuildArgs: $(imageBuilder.queueArgs)
   steps:
@@ -51,11 +45,11 @@ jobs:
     parameters:
       setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - script: >
-        echo "##vso[task.setvariable variable=imageBuilderBuildArgs]
-        --image-info-output-path $(artifactsPath)/$(legName)-image-info.json
-        $(imageBuilderBuildArgs)"
-      displayName: Set Image Builder Args
+    - script: echo "##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
+      displayName: Set Image Info Arg for Image Builder
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - script: echo "##vso[task.setvariable variable=imageBuilderImageInfoArg]"
+      displayName: Set Image Info Arg for Image Builder
   - script: >
       $(runImageBuilderCmd) build
       --manifest $(manifest)
@@ -65,6 +59,7 @@ jobs:
       --architecture $(architecture)
       --retry
       $(imageBuilderBuildArgs)
+      $(imageBuilderImageInfoArg)
     displayName: Build Images
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -8,6 +8,13 @@ steps:
 - script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
   displayName: Define Artifacts Path Variable
 
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json'
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]'
+    displayName: Set Image Info Arg for Image Builder
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -69,10 +76,3 @@ steps:
   - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
     - script: echo "##vso[task.setvariable variable=dockerClientImage]$(imageNames.testRunner.withrepo)"
       displayName: Define dockerClientImage Variable
-
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json'
-    displayName: Set Image Info Arg for Image Builder
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]'
-    displayName: Set Image Info Arg for Image Builder

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -69,3 +69,10 @@ steps:
   - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
     - script: echo "##vso[task.setvariable variable=dockerClientImage]$(imageNames.testRunner.withrepo)"
       displayName: Define dockerClientImage Variable
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json'
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]'
+    displayName: Set Image Info Arg for Image Builder

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -5,6 +5,13 @@ steps:
 - script: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)
   displayName: Define Artifacts Path Variable
 
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]
+    displayName: Set Image Info Arg for Image Builder
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -31,10 +38,3 @@ steps:
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
     displayName: Define runImageBuilderCmd Variable
-
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json
-    displayName: Set Image Info Arg for Image Builder
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]
-    displayName: Set Image Info Arg for Image Builder

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -31,3 +31,10 @@ steps:
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
     displayName: Define runImageBuilderCmd Variable
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]
+    displayName: Set Image Info Arg for Image Builder

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -4,11 +4,8 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Text;
 using System.Threading;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
@@ -19,20 +16,11 @@ namespace Microsoft.DotNet.Docker.Tests
         public static string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
         public static bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
 
-        public JArray ImageInfoRepos { get; }
-
         private ITestOutputHelper OutputHelper { get; set; }
 
         public DockerHelper(ITestOutputHelper outputHelper)
         {
             OutputHelper = outputHelper;
-
-            string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
-            if (!String.IsNullOrEmpty(imageInfoPath))
-            {
-                string imageInfoContents = File.ReadAllText(imageInfoPath);
-                ImageInfoRepos = JsonConvert.DeserializeObject<JArray>(imageInfoContents);
-            }
         }
 
         public void Build(

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -4,8 +4,11 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
@@ -15,11 +18,21 @@ namespace Microsoft.DotNet.Docker.Tests
         public static string DockerOS => GetDockerOS();
         public static string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
         public static bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
+
+        public JArray ImageInfoRepos { get; }
+
         private ITestOutputHelper OutputHelper { get; set; }
 
         public DockerHelper(ITestOutputHelper outputHelper)
         {
             OutputHelper = outputHelper;
+
+            string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
+            if (!String.IsNullOrEmpty(imageInfoPath))
+            {
+                string imageInfoContents = File.ReadAllText(imageInfoPath);
+                ImageInfoRepos = JsonConvert.DeserializeObject<JArray>(imageInfoContents);
+            }
         }
 
         public void Build(

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -12,7 +12,8 @@ param(
     [string]$Registry,
     [string]$RepoPrefix,
     [switch]$DisableHttpVerification,
-    [switch]$IsLocalRun
+    [switch]$IsLocalRun,
+    [string]$ImageInfoPath
 )
 
 Set-StrictMode -Version Latest
@@ -67,6 +68,7 @@ Try {
     $env:IMAGE_VERSION_FILTER = $VersionFilter
     $env:REGISTRY = $Registry
     $env:REPO_PREFIX = $RepoPrefix
+    $env:IMAGE_INFO_PATH = $ImageInfoPath
 
     $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
     $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1


### PR DESCRIPTION
In order to support https://github.com/dotnet/docker-tools/issues/218, these changes update the test code to account for not having all images required by the test available in the staging ACR location.  In that case, the test will pull them directly from MCR.

Also needed to make some changes to the pipeline.  These are ugly but necessary due to issues dealing with multi-line variables in the pipeline YAML stuff.