### PR TITLE
Minor tweaks to speed up tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -212,17 +212,17 @@ namespace Microsoft.DotNet.Docker.Tests
             string name,
             string command = null,
             string workdir = null,
-            string publishArgs = " -p 80",
+            string optionalRunArgs = null,
             bool detach = false,
             bool runAsContainerAdministrator = false,
             bool skipAutoCleanup = false)
         {
             string cleanupArg = skipAutoCleanup ? string.Empty : " --rm";
-            string commandArg = command == null ? string.Empty : $" {command}";
             string detachArg = detach ? " -d -t" : string.Empty;
             string userArg = runAsContainerAdministrator ? " -u ContainerAdministrator" : string.Empty;
             string workdirArg = workdir == null ? string.Empty : $" -w {workdir}";
-            return ExecuteWithLogging($"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg}{publishArgs} {image}{commandArg}");
+            return ExecuteWithLogging(
+                $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg} {optionalRunArgs} {image} {command}");
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 _dockerHelper.Run(
                     image: _imageData.GetImage(DotNetImageType.SDK, _dockerHelper),
                     name: containerName,
-                    command: $"dotnet new {appType} --framework netcoreapp{_imageData.Version}",
+                    command: $"dotnet new {appType} --framework netcoreapp{_imageData.Version} --no-restore",
                     workdir: "/app",
                     skipAutoCleanup: true);
 
@@ -163,6 +163,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     image: image,
                     name: containerName,
                     detach: _isWeb,
+                    optionalRunArgs: _isWeb ? "-p 80" : string.Empty,
                     runAsContainerAdministrator: runAsAdmin,
                     command: command);
 

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
@@ -12,11 +12,11 @@ COPY *.csproj .
 RUN dotnet restore
 
 COPY . .
-RUN dotnet build
+RUN dotnet build --no-restore
 
 
 FROM build as publish_fx_dependent
-RUN dotnet publish -c Release -o out
+RUN dotnet publish --no-restore -c Release -o out
 
 
 FROM $runtime_image AS fx_dependent_app
@@ -28,7 +28,6 @@ ENTRYPOINT ["dotnet", "app.dll"]
 
 FROM build as publish_self_contained
 ARG rid
-RUN dotnet restore -r $rid
 RUN dotnet publish -r $rid -c Release -o out
 
 

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
@@ -11,11 +11,11 @@ COPY *.csproj .
 RUN dotnet restore
 
 COPY . .
-RUN dotnet build
+RUN dotnet build --no-restore
 
 
 FROM build as publish_fx_dependent
-RUN dotnet publish -c Release -o out
+RUN dotnet publish --no-restore -c Release -o out
 
 
 FROM $runtime_image AS fx_dependent_app


### PR DESCRIPTION
The primary change here is to utilize the `--no-restore` option in several places where restoring is unnecessary.

Fixes #1078