### PR TITLE
Update dockerignore to reduce size of Docker context during official builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 **/.vscode
 **/.vs
 .dotnet
+.git
+.Microsoft.DotNet.ImageBuilder


### PR DESCRIPTION
I noticed on the official build machines the build context was ~600MB.  It was taking well over a minute to run the `Build Image for Image Builder` step.  With this change the build context is 3.24MB and the step takes ~15-17s.