### PR TITLE
Revert .dockerignore change to exclude .git directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,4 @@
 **/.vscode
 **/.vs
 .dotnet
-.git
 .Microsoft.DotNet.ImageBuilder


### PR DESCRIPTION
The `.git` directory cannot be excluded because the update-dependencies tool has a dependency on it (https://github.com/dotnet/dotnet-docker/blob/master/eng/pipelines/update-dependencies-from-drop.yml#L12).  The long term solution for this is https://github.com/moby/moby/issues/12886 or possibly BuildKit which lazy loads only the build context items that are referenced.