### PR TITLE
Integrate eng/common

### DIFF
--- a/eng/common/readme.md
+++ b/eng/common/readme.md
@@ -25,4 +25,4 @@
 
 !!! Changes made in this directory are subject to being overwritten by automation !!!
 
-The files in this directory are shared by all .NET Docker repos. If you need to make changes to these files, open an issue.
+The files in this directory are shared by all .NET Docker repos. If you need to make changes to these files, open an issue or submit a pull request in https://github.com/dotnet/docker-tools.

--- a/eng/common/readme.md
+++ b/eng/common/readme.md
@@ -25,4 +25,4 @@
 
 !!! Changes made in this directory are subject to being overwritten by automation !!!
 
-The files in this directory are shared by all .NET Docker repos. If you need to make changes to these files, open an issue or submit a pull request in https://github.com/dotnet/docker-tools.
+The files in this directory are shared by all .NET Docker repos. If you need to make changes to these files, open an issue.

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -17,13 +17,7 @@ jobs:
   variables:
     osVersion: ${{ parameters.osVersion }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      imageBuilderBuildArgs: >
-        --registry-override $(acr.server)
-        --repo-prefix $(stagingRepoPrefix)
-        --push
-        --username $(acr.userName)
-        --password $(BotAccount-dotnet-docker-acr-bot-password)
-        $(imageBuilder.queueArgs)
+      imageBuilderBuildArgs: --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       imageBuilderBuildArgs: $(imageBuilder.queueArgs)
   steps:
@@ -57,15 +51,14 @@ jobs:
       --os-type $(osType)
       --os-version "$(osVersion)"
       --architecture $(architecture)
-      --image-info-output-path "$(imageBuilderArtifactsPath)/$(legName)-image-info.json"
       --retry
       $(imageBuilderBuildArgs)
+      $(imageBuilderImageInfoArg)
     displayName: Build Images
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: $(legName)-image-info
-      targetPath: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
-    displayName: Publish Image Info File Artifact
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
+      artifact: $(legName)-image-info
+      displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,0 +1,17 @@
+jobs:
+- job: Build
+  pool: # linuxAmd64Pool
+    name: Hosted Ubuntu 1604
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+  - script: >
+      $(runImageBuilderCmd) mergeImageInfo
+      $(artifactsPath)
+      $(artifactsPath)/image-info.json
+    displayName: Merge Image Info Files
+  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+    artifact: image-info
+    displayName: Publish Image Info File Artifact

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -15,6 +15,10 @@ jobs:
       publicSourceBranch: master
   steps:
   - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
   - script: >
       $(runImageBuilderCmd) copyAcrImages
       $(stagingRepoPrefix)
@@ -26,6 +30,7 @@ jobs:
       --os-type '*'
       --architecture '*'
       --repo-prefix $(publishRepoPrefix)
+      --image-info $(artifactsPath)/image-info.json
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Copy Images
@@ -47,22 +52,13 @@ jobs:
       $(publicGitRepoUri)/blob/$(publicSourceBranch)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Readme
-  - task: DownloadPipelineArtifact@1
-    inputs:
-      buildType: specific
-      project: $(System.TeamProject)
-      pipline: $(System.DefinitionId)
-      buildVersionToDownload: specific
-      buildId: $(sourceBuildId)
-      targetPath: $(Build.ArtifactStagingDirectory)
-    displayName: Download Pipline Artifacts
-    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
+    condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       $(dotnetBot-userName)
       $(dotnetBot-email)
       $(dotnet-bot-user-repo-adminrepohook-pat)
-      $(imageBuilderArtifactsPath)
+      $(artifactsPath)/image-info.json
       --git-owner dotnet
       --git-repo versions
       --git-branch master

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -164,10 +164,19 @@ stages:
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   ################################################################################
+  # Post-Build
+  ################################################################################
+  - stage: Post_Build
+    dependsOn: Build
+    condition: and(succeeded(), or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build')))
+    jobs:
+    - template: ../jobs/post-build.yml
+
+  ################################################################################
   # Test Images
   ################################################################################
   - stage: Test
-    dependsOn: Build
+    dependsOn: Post_Build
     condition: "
       and(
         not(contains(variables['manifest'], 'samples')),

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -1,0 +1,18 @@
+parameters:
+  targetPath: ""
+  artifactName: ""
+  requiresPublicRepoPrefix: false
+
+steps:
+- task: DownloadPipelineArtifact@1
+  inputs:
+    buildType: specific
+    project: $(System.TeamProject)
+    pipline: $(System.DefinitionId)
+    buildVersionToDownload: specific
+    buildId: $(sourceBuildId)
+    targetPath: ${{ parameters.targetPath }}
+    artifactName: ${{ parameters.artifactName }}
+  displayName: Download Build Artifact(s)
+  ${{ if eq(parameters.requiresPublicRepoPrefix, true) }}:
+    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -5,6 +5,16 @@ parameters:
   cleanupDocker: true
 
 steps:
+- script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
+  displayName: Define Artifacts Path Variable
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json'
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]'
+    displayName: Set Image Info Arg for Image Builder
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -38,13 +48,11 @@ steps:
       --build-arg IMAGE=$(imageNames.imageBuilder.linux)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
-  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]/artifacts"
-    displayName: Define Image Builder Artifacts Path Variable
   - script: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       docker run --rm
       -v /var/run/docker.sock:/var/run/docker.sock
-      -v $(Build.ArtifactStagingDirectory):$(imageBuilderArtifactsPath)
+      -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
       -w /repo
       $(dockerArmRunArgs)
       $(imageNames.imageBuilder.withrepo)"

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -2,6 +2,16 @@ parameters:
   setupImageBuilder:  true
 
 steps:
+- script: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)
+  displayName: Define Artifacts Path Variable
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]
+    displayName: Set Image Info Arg for Image Builder
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -28,5 +38,3 @@ steps:
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
     displayName: Define runImageBuilderCmd Variable
-  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]$(Build.ArtifactStagingDirectory)
-    displayName: Define Image Builder Artifacts Path Variable

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -70,7 +70,7 @@ steps:
     searchFolder: $(Common.TestResultsDirectory)
     mergeTestResults: true
     publishRunAttachments: true
-    testRunTitle: Linux $(dotnetVersion) $(osVariant) $(architecture)
+    testRunTitle: $(dotnetVersion) $(osVariant) $(architecture)
 - script: docker rm -f $(testRunner.container)
   displayName: Cleanup TestRunner Container
   condition: always()

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -2,6 +2,12 @@ parameters:
   useRemoteDockerServer: false
 
 steps:
+- template: init-docker-linux.yml
+  parameters:
+    setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
+    setupImageBuilder: false
+    setupTestRunner: true
+    cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
@@ -10,21 +16,16 @@ steps:
       optionalTestArgs="-DisableHttpVerification"
     fi
     if [ "${{ eq(variables['System.TeamProject'], 'public') }}" == "False" ]; then
-      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix)"
+      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
     else
       optionalTestArgs="$optionalTestArgs -IsLocalRun"
     fi
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
-- template: init-docker-linux.yml
-  parameters:
-    setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
-    setupImageBuilder: false
-    setupTestRunner: true
-    cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
 - script: >
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
+    -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
     -w /repo $(dockerArmRunArgs)
     -e RUNNING_TESTS_IN_CONTAINER=true 
     --name $(testRunner.container)
@@ -36,12 +37,15 @@ steps:
       -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
       "docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)"
     displayName: Docker login
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
 - script: >
     docker exec $(testRunner.container) pwsh
     -File ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)
-    -OSFilter $(osVariant)*
-    -ArchitectureFilter $(architecture)
+    -VersionFilter '$(dotnetVersion)'
+    -OSFilter '$(osVariant)*'
+    -ArchitectureFilter '$(architecture)'
     $(optionalTestArgs)
   displayName: Test Images
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,24 +1,28 @@
 steps:
-- powershell: |
-    if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
-      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX"
-    } else {
-      $optionalTestArgs="-IsLocalRun"
-    }
-    echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
-  displayName: Set Test Variables
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: init-docker-windows.yml
     parameters:
       setupImageBuilder: false
   - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
     displayName: Docker login
+- powershell: |
+    if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
+      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
+    } else {
+      $optionalTestArgs="-IsLocalRun"
+    }
+    echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
+  displayName: Set Test Variables
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
   displayName: Cleanup Old Test Results
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
 - powershell: >
     ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)
-    -OSFilter $(osVariant)
+    -VersionFilter '$(dotnetVersion)'
+    -OSFilter '$(osVariant)'
     $(optionalTestArgs)
   displayName: Test Images
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -11,6 +11,9 @@ steps:
     } else {
       $optionalTestArgs="-IsLocalRun"
     }
+    if ($env:REPOTESTARGS) {
+      $optionalTestArgs += " $env:REPOTESTARGS"
+    }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
@@ -39,6 +42,6 @@ steps:
     testResultsFiles: 'tests/**/*.trx'
     mergeTestResults: true
     publishRunAttachments: true
-    testRunTitle: Windows $(dotnetVersion) $(osVariant) amd64
+    testRunTitle: $(dotnetVersion) $(osVariant) amd64
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-windows.yml

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -3,6 +3,8 @@ variables:
 - template: common-paths.yml
 - name: stagingRepoPrefix
   value: build-staging/$(sourceBuildId)/
+- name: publishReadme
+  value: true
 - name: skipComponentGovernanceDetection
   value: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190806141135
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190806141135
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190807123248
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190807123248
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190606195358
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190606195358
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190806141135
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190806141135
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static string DockerOS => GetDockerOS();
         public static string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
         public static bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
+
         private ITestOutputHelper OutputHelper { get; set; }
 
         public DockerHelper(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -68,7 +68,9 @@ Try {
     $env:IMAGE_VERSION_FILTER = $VersionFilter
     $env:REGISTRY = $Registry
     $env:REPO_PREFIX = $RepoPrefix
-    $env:IMAGE_INFO_PATH = $ImageInfoPath
+    # Disable use of image info file for testing until it's ready to be rolled out to master
+    #$env:IMAGE_INFO_PATH = $ImageInfoPath
+    $env:IMAGE_INFO_PATH = ""
 
     $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
     $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -12,7 +12,8 @@ param(
     [string]$Registry,
     [string]$RepoPrefix,
     [switch]$DisableHttpVerification,
-    [switch]$IsLocalRun
+    [switch]$IsLocalRun,
+    [string]$ImageInfoPath
 )
 
 Set-StrictMode -Version Latest
@@ -67,6 +68,7 @@ Try {
     $env:IMAGE_VERSION_FILTER = $VersionFilter
     $env:REGISTRY = $Registry
     $env:REPO_PREFIX = $RepoPrefix
+    $env:IMAGE_INFO_PATH = $ImageInfoPath
 
     $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
     $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1


### PR DESCRIPTION
Integrates eng/common from the nightly branch as well as the associated test project changes (#1217).  We don't want to actually roll out test changes in #1217 to master yet though.  This has been explicitly disabled in the run-tests.ps1 file by ensuring the image info path is not set.  This will prevent the tests from attempting to pull any image that doesn't exist locally.  This is just a precaution for the master branch while we evaluate the test functionality in nightly.

I've preserved the commits in the PR so that the changes being applied can be viewed separately.