### PR TITLE
Refactor Invoke-CleanupDocker.ps1 to preserve the eng infra images to avoid re-pulls

### DIFF
--- a/eng/common/Invoke-CleanupDocker.ps1
+++ b/eng/common/Invoke-CleanupDocker.ps1
@@ -5,11 +5,17 @@ docker ps -a -q | ForEach-Object { docker rm -f $_ }
 
 docker volume prune -f
 
-# Windows base images are large, preserve them to avoid the overhead of pulling each time.
-docker images |
+# Preserve the Windows base images and the common eng infra images (e.g. ImageBuilder)
+# to avoid the expense of having to repull continuously.
+$engInfraImages = Get-Content ./eng/common/templates/variables/docker-images.yml |
+    Where-Object { $_.Trim() -notlike 'variables:' } |
+    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] }
+
+docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}"|
     Where-Object {
-        -Not ($_.StartsWith("mcr.microsoft.com/windows")`
-        -Or $_.StartsWith("REPOSITORY ")) } |
-    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2] } |
+        $localImage = $_
+        -Not ($localImage.StartsWith("mcr.microsoft.com/windows")`
+            -Or ($engInfraImages.Where({ $localImage.StartsWith($_) }, 'First').Count -gt 0)) } |
+    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] } |
     Select-Object -Unique |
     ForEach-Object { docker rmi -f $_ }


### PR DESCRIPTION
Pulling ImageBuilder in the Windows legs of official builds take about 2 minutes.  This is primarily because the base OS image isn't cached locally.  This change will avoid cleaning up the image and therefore will avoid re-pulling it in each build leg.

This optimization applies only to non-hosted agents and is really only an issue for Windows because of the large os images.