### PR TITLE
Publish branch-specific image info file

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -74,7 +74,7 @@ jobs:
       --git-owner dotnet
       --git-repo versions
       --git-branch master
-      --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(Build.SourceBranchName).json
+      --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(publicSourceBranch).json
     displayName: Publish Image Info
     condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -63,6 +63,18 @@ jobs:
       --git-repo versions
       --git-branch master
       --git-path build-info/docker/image-info.json
+    displayName: Publish Image Info (legacy)
+    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
+  - script: >
+      $(runImageBuilderCmd) publishImageInfo
+      $(dotnetBot-userName)
+      $(dotnetBot-email)
+      $(dotnet-bot-user-repo-adminrepohook-pat)
+      $(artifactsPath)/image-info.json
+      --git-owner dotnet
+      --git-repo versions
+      --git-branch master
+      --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(Build.SourceBranchName).json
     displayName: Publish Image Info
     condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
When the different .NET Docker repos build images and publish the results to the [image-info.json](https://github.com/dotnet/versions/blob/master/build-info/docker/image-info.json) file, it is possible they can be overwriting data if not all of the repos are using the same image info schema.  In addition, it'd also be beneficial from a readability perspective, to view the image info content for just a single GitHub repo.

For those reasons, we're going to split the existing [image-info.json](https://github.com/dotnet/versions/blob/master/build-info/docker/image-info.json) into a set of image info files, each one specific to a particular GitHub repo and branch.  Until this is completely rolled out, we're going to maintain the original image info file but also introduce each of these new repo-specific files.