### PR TITLE
Adjust timeout for Windows arm build leg

### DIFF
--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -12,4 +12,3 @@ stages:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       buildMatrixType: platformVersionedOs
       customBuildLegGrouping: pr-build
-      windowsArmBuildJobTimeout: 120


### PR DESCRIPTION
Fixes #1314 

The current Windows ARM build legs for CI are taking ~30 min which is well under the default 60 min timeout.