### PR TITLE
Fix Linux ARM32 builds of samples

### DIFF
--- a/README.samples.md
+++ b/README.samples.md
@@ -66,8 +66,8 @@ aspnetapp-buster-slim, aspnetapp | [Dockerfile](https://github.com/dotnet/dotnet
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-dotnetapp-buster-slim-arm32v7, dotnetapp, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile) | Debian 10
-aspnetapp-buster-slim-arm32v7, aspnetapp | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile) | Debian 10
+dotnetapp-buster-slim-arm32v7, dotnetapp, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile.linux-arm32) | Debian 10
+aspnetapp-buster-slim-arm32v7, aspnetapp | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile.linux-arm32) | Debian 10
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -23,7 +23,7 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/dotnetapp",
+              "dockerfile": "samples/dotnetapp/Dockerfile.linux-arm32",
               "os": "linux",
               "osVersion": "buster",
               "tags": {
@@ -91,7 +91,7 @@
             },
             {
               "architecture": "arm",
-              "dockerfile": "samples/aspnetapp",
+              "dockerfile": "samples/aspnetapp/Dockerfile.linux-arm32",
               "os": "linux",
               "osVersion": "buster",
               "tags": {

--- a/samples/aspnetapp/Dockerfile.linux-arm32
+++ b/samples/aspnetapp/Dockerfile.linux-arm32
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0-buster-arm32v7 AS build
+WORKDIR /app
+
+# copy csproj and restore as distinct layers
+COPY *.sln .
+COPY aspnetapp/*.csproj ./aspnetapp/
+RUN dotnet restore
+
+# copy everything else and build app
+COPY aspnetapp/. ./aspnetapp/
+WORKDIR /app/aspnetapp
+RUN dotnet publish -c Release -o out
+
+
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0-buster-slim-arm32v7 AS runtime
+WORKDIR /app
+COPY --from=build /app/aspnetapp/out ./
+ENTRYPOINT ["dotnet", "aspnetapp.dll"]

--- a/samples/dotnetapp/Dockerfile.linux-arm32
+++ b/samples/dotnetapp/Dockerfile.linux-arm32
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0-buster-arm32v7 AS build
+WORKDIR /app
+
+# copy csproj and restore as distinct layers
+COPY dotnetapp/*.csproj ./dotnetapp/
+COPY utils/*.csproj ./utils/
+WORKDIR /app/dotnetapp
+RUN dotnet restore
+
+# copy and publish app and libraries
+WORKDIR /app/
+COPY dotnetapp/. ./dotnetapp/
+COPY utils/. ./utils/
+WORKDIR /app/dotnetapp
+RUN dotnet publish -c Release -o out
+
+
+# test application -- see: dotnet-docker-unit-testing.md
+FROM build AS testrunner
+WORKDIR /app/tests
+COPY tests/. .
+ENTRYPOINT ["dotnet", "test", "--logger:trx"]
+
+
+FROM mcr.microsoft.com/dotnet/core/runtime:3.0-buster-slim-arm32v7 AS runtime
+WORKDIR /app
+COPY --from=build /app/dotnetapp/out ./
+ENTRYPOINT ["dotnet", "dotnetapp.dll"]


### PR DESCRIPTION
The Linux ARM32 Docker images for the sample images cause an error when trying to run them: standard_init_linux.go:211: exec user process caused "exec format error". This is because the images are actually built targeting ARM64. The Dockerfiles are authored to use the multi-arch tag of 3.0 but since the build is being run on an AArch64 machine, it's actually pulling down ARM64 base images, not ARM32. This is fixed by defining ARM32-specific versions of the Dockerfile that explicitly use the 3.0-buster-arm32v7 and 3.0-buster-slim-arm32v7 tags.

Related: #1383
Cherry-pick of 196f231 