### PR TITLE
Update ManifestUpdater to better handle versions

### DIFF
--- a/eng/update-dependencies/ManifestUpdater.cs
+++ b/eng/update-dependencies/ManifestUpdater.cs
@@ -27,7 +27,10 @@ namespace Dotnet.Docker
 
             // Derive the Docker tag version from the product build version.
             // This logic needs to handle multiple formats of the pre-release label until all products align on a single format.
-            // Example: Product build version 2.2.0-rtm-35586 => Docker tag version 2.2.0.
+            // Examples: Product build version  => Docker tag version 
+            // 2.2.0-rtm-35586 => 2.2.0
+            // 3.1.100-preview2-014589 => 3.1.100-preview2
+            // 3.1.0-preview3.19530.9 => 3.1.0-preview3
             int firstDashIndex = version.IndexOf('-');
             if (firstDashIndex != -1)
             {


### PR DESCRIPTION
This fixes the underlying issue for the manifest to not be updated correctly - https://github.com/dotnet/dotnet-docker/pull/1431/files#diff-4b1eb3dc48c4e16d49db5b42298fe654

This code is specific to the .NET versioning format and there is currently a variation between the runtime and sdk which makes this more complicated.  This is illustrated by the parameters generated by the auto update infra.

```
--runtime-version 3.1.0-preview3.19530.5 --sdk-version 3.1.100-preview2-014589 --aspnet-version 3.1.0-preview3.19530.9
```