### PR TITLE
Use blob hostname for accessing SHAs

### DIFF
--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.VersionTools.Dependencies;
+using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Diagnostics;
@@ -22,11 +23,12 @@ namespace Dotnet.Docker
     {
         private const string EnvNameGroupName = "envName";
         private const string ValueGroupName = "value";
+        private const string ChecksumsHostName = "dotnetclichecksums.blob.core.windows.net";
 
         private static readonly string s_versionPattern =
             $"ENV (?<{EnvNameGroupName}>(DOTNET|ASPNETCORE)_[\\S]*VERSION) (?<{ValueGroupName}>[\\S]*)";
         private static readonly string s_urlPatternFormat =
-            $"(?<{ValueGroupName}>https://dotnetcli.blob.core.net/[^;\\s]*{{0}})";
+            $"(?<{ValueGroupName}>https://dotnetcli.azureedge.net/[^;\\s]*{{0}})";
         private static readonly string s_productUrlPattern = string.Format(s_urlPatternFormat, string.Empty);
         private static readonly string s_lzmaUrlPattern = string.Format(s_urlPatternFormat, "lzma");
         private static readonly string s_shaPatternFormat = $"[ \\$]({{0}})sha512( )*=( )*'(?<{ValueGroupName}>[^'\\s]*)'";
@@ -139,7 +141,10 @@ namespace Dotnet.Docker
         {
             string sha = null;
             string shaExt = envName.Contains("SDK") ? ".sha" : ".sha512";
-            string shaUrl = productDownloadUrl.Replace("dotnetcli", "dotnetclichecksums") + shaExt;
+
+            UriBuilder uriBuilder = new UriBuilder(productDownloadUrl);
+            uriBuilder.Host = ChecksumsHostName;
+            string shaUrl = uriBuilder.ToString() + shaExt;
 
             Trace.TraceInformation($"Downloading '{shaUrl}'.");
             using (HttpClient client = new HttpClient())
@@ -163,7 +168,7 @@ namespace Dotnet.Docker
         {
             string sha = null;
             string product = envName == "DOTNET_SDK_VERSION" ? "sdk" : "runtime";
-            string uri = $"https://dotnetcli.blob.core.net/dotnet/checksums/{productVersion}-{product}-sha.txt";
+            string uri = $"https://dotnetcli.blob.core.windows.net/dotnet/checksums/{productVersion}-{product}-sha.txt";
 
             Trace.TraceInformation($"Downloading '{uri}'.");
             using (HttpClient client = new HttpClient())

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -26,7 +26,7 @@ namespace Dotnet.Docker
         private static readonly string s_versionPattern =
             $"ENV (?<{EnvNameGroupName}>(DOTNET|ASPNETCORE)_[\\S]*VERSION) (?<{ValueGroupName}>[\\S]*)";
         private static readonly string s_urlPatternFormat =
-            $"(?<{ValueGroupName}>https://dotnetcli.azureedge.net/[^;\\s]*{{0}})";
+            $"(?<{ValueGroupName}>https://dotnetcli.blob.core.net/[^;\\s]*{{0}})";
         private static readonly string s_productUrlPattern = string.Format(s_urlPatternFormat, string.Empty);
         private static readonly string s_lzmaUrlPattern = string.Format(s_urlPatternFormat, "lzma");
         private static readonly string s_shaPatternFormat = $"[ \\$]({{0}})sha512( )*=( )*'(?<{ValueGroupName}>[^'\\s]*)'";
@@ -163,7 +163,7 @@ namespace Dotnet.Docker
         {
             string sha = null;
             string product = envName == "DOTNET_SDK_VERSION" ? "sdk" : "runtime";
-            string uri = $"https://dotnetcli.azureedge.net/dotnet/checksums/{productVersion}-{product}-sha.txt";
+            string uri = $"https://dotnetcli.blob.core.net/dotnet/checksums/{productVersion}-{product}-sha.txt";
 
             Trace.TraceInformation($"Downloading '{uri}'.");
             using (HttpClient client = new HttpClient())


### PR DESCRIPTION
The changes from #1450 caused the update-dependencies tool to fail when attempting to calculate the checksums.  It constructs a URL based off of `dotnetcli.blob.core.net` and ends up trying to access `dotnetclichecksums.azureedge.net` which doesn't exist.  To keep the logic simple, I've just reverted the change in that file back to using `dotnetcli.blob.core.net`.