### PR TITLE
Fixup incorrect POWERSHELL_DISTRIBUTION_CHANNEL ENV in nanoserver-1909 image

### DIFF
--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -19,8 +19,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
     Remove-Item -Force dotnet.zip
 
 # Install PowerShell global tool
-ENV POWERSHELL_VERSION=7.0.0-preview.5 `
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1909
+ENV POWERSHELL_VERSION=7.0.0-preview.5
 
 RUN Invoke-WebRequest -OutFile PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg https://pwshtool.blob.core.windows.net/tool/$ENV:POWERSHELL_VERSION/PowerShell.Windows.x64.$ENV:POWERSHELL_VERSION.nupkg; `
     $powershell_sha512 = '1f197c2fc4c26345768dc62782e585e003b6ffe21b065ac7487e151e467e1fd8325209697b94459ed07b22b00a3e75ad7417144230b6ce6aed02b4b9ffc583dc'; `
@@ -50,7 +49,9 @@ ENV DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1909
 
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help


### PR DESCRIPTION
Looks like the fix for #1444 was missed when creating the nanoserver-1909 images.  This is causing the builds to fail with the recently added ENV utests - #1446.