### PR TITLE
Clean up file ownership issues

### DIFF
--- a/3.1/aspnet/alpine3.10/amd64/Dockerfile
+++ b/3.1/aspnet/alpine3.10/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='fa5e4ae71134a8a6db4ad6a247d3e31406673e03f0a64f7faaad3d84cfb3b70d2cf69e9d9abc1f8688138907d4ddd37cd908669999d85a87892e164053c63847' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/alpine3.10/amd64/Dockerfile
+++ b/3.1/aspnet/alpine3.10/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='fa5e4ae71134a8a6db4ad6a247d3e31406673e03f0a64f7faaad3d84cfb3b70d2cf69e9d9abc1f8688138907d4ddd37cd908669999d85a87892e164053c63847' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='6244dd1dd7d18f00bcc6a1faa2b6da61bc3edc9748f9513b617c84b1c2cb04d3b7328f398ce9a1e9834db56bb6246756b7c5409c179000eaab113a88a2da5b3a' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='6244dd1dd7d18f00bcc6a1faa2b6da61bc3edc9748f9513b617c84b1c2cb04d3b7328f398ce9a1e9834db56bb6246756b7c5409c179000eaab113a88a2da5b3a' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/amd64/Dockerfile
+++ b/3.1/aspnet/bionic/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/amd64/Dockerfile
+++ b/3.1/aspnet/bionic/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm32v7/Dockerfile
+++ b/3.1/aspnet/bionic/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm32v7/Dockerfile
+++ b/3.1/aspnet/bionic/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm64v8/Dockerfile
+++ b/3.1/aspnet/bionic/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm64v8/Dockerfile
+++ b/3.1/aspnet/bionic/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/amd64/Dockerfile
+++ b/3.1/aspnet/buster-slim/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/amd64/Dockerfile
+++ b/3.1/aspnet/buster-slim/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm32v7/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm32v7/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm64v8/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm64v8/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/focal/amd64/Dockerfile
+++ b/3.1/aspnet/focal/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/focal/amd64/Dockerfile
+++ b/3.1/aspnet/focal/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/focal/arm32v7/Dockerfile
+++ b/3.1/aspnet/focal/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/focal/arm32v7/Dockerfile
+++ b/3.1/aspnet/focal/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/focal/arm64v8/Dockerfile
+++ b/3.1/aspnet/focal/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/focal/arm64v8/Dockerfile
+++ b/3.1/aspnet/focal/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar --no-same-owner -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/runtime/alpine3.10/amd64/Dockerfile
+++ b/3.1/runtime/alpine3.10/amd64/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='040e55c341aa15357bd7e1ee4fd421f13056aac2eaf9f327c77fd1948fbe963d23a66cc5ffdfaa232407853fd250922327107e2878bf0af9a7652fd2c4c46815' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz

--- a/3.1/runtime/alpine3.10/amd64/Dockerfile
+++ b/3.1/runtime/alpine3.10/amd64/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='040e55c341aa15357bd7e1ee4fd421f13056aac2eaf9f327c77fd1948fbe963d23a66cc5ffdfaa232407853fd250922327107e2878bf0af9a7652fd2c4c46815' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar --no-same-owner -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz

--- a/3.1/runtime/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/runtime/alpine3.10/arm64v8/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='417858bb24e1ec7337c7b85dd2c16ba3b16182bb0839e7c67d46b4ba38d430dd95a58e5ec533586c0cd4b69fc0f82323297eb4c5fbd8c2e8a5f9a1d36a3658f9' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar --no-same-owner -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz

--- a/3.1/runtime/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/runtime/alpine3.10/arm64v8/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='417858bb24e1ec7337c7b85dd2c16ba3b16182bb0839e7c67d46b4ba38d430dd95a58e5ec533586c0cd4b69fc0f82323297eb4c5fbd8c2e8a5f9a1d36a3658f9' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -C /usr/share/dotnet -oxzf dotnet.tar.gz \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz

--- a/3.1/runtime/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/runtime/alpine3.10/arm64v8/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='417858bb24e1ec7337c7b85dd2c16ba3b16182bb0839e7c67d46b4ba38d430dd95a58e5ec533586c0cd4b69fc0f82323297eb4c5fbd8c2e8a5f9a1d36a3658f9' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar --no-same-owner -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz

--- a/3.1/runtime/bionic/amd64/Dockerfile
+++ b/3.1/runtime/bionic/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/amd64/Dockerfile
+++ b/3.1/runtime/bionic/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/arm32v7/Dockerfile
+++ b/3.1/runtime/bionic/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/arm32v7/Dockerfile
+++ b/3.1/runtime/bionic/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/arm64v8/Dockerfile
+++ b/3.1/runtime/bionic/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/arm64v8/Dockerfile
+++ b/3.1/runtime/bionic/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/amd64/Dockerfile
+++ b/3.1/runtime/buster-slim/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/amd64/Dockerfile
+++ b/3.1/runtime/buster-slim/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/arm32v7/Dockerfile
+++ b/3.1/runtime/buster-slim/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/arm32v7/Dockerfile
+++ b/3.1/runtime/buster-slim/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/arm64v8/Dockerfile
+++ b/3.1/runtime/buster-slim/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/arm64v8/Dockerfile
+++ b/3.1/runtime/buster-slim/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/focal/amd64/Dockerfile
+++ b/3.1/runtime/focal/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/focal/amd64/Dockerfile
+++ b/3.1/runtime/focal/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/focal/arm32v7/Dockerfile
+++ b/3.1/runtime/focal/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/focal/arm32v7/Dockerfile
+++ b/3.1/runtime/focal/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/focal/arm64v8/Dockerfile
+++ b/3.1/runtime/focal/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/focal/arm64v8/Dockerfile
+++ b/3.1/runtime/focal/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -37,6 +37,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && chmod 755 /usr/share/powershell/pwsh \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \

--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='517c1dadbc9081e112f75589eb7160ef70183eb3d93fd55800e145b21f4dd6f5fbe19397ee7476aa16493e112ef95b311ff61bb08d9231b30a7ea609806d85ee' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='517c1dadbc9081e112f75589eb7160ef70183eb3d93fd55800e145b21f4dd6f5fbe19397ee7476aa16493e112ef95b311ff61bb08d9231b30a7ea609806d85ee' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar --no-same-owner -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/bionic/amd64/Dockerfile
+++ b/3.1/sdk/bionic/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/bionic/amd64/Dockerfile
+++ b/3.1/sdk/bionic/amd64/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.x64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/bionic/amd64/Dockerfile
+++ b/3.1/sdk/bionic/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/bionic/arm32v7/Dockerfile
+++ b/3.1/sdk/bionic/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/bionic/arm32v7/Dockerfile
+++ b/3.1/sdk/bionic/arm32v7/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/bionic/arm32v7/Dockerfile
+++ b/3.1/sdk/bionic/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/bionic/arm64v8/Dockerfile
+++ b/3.1/sdk/bionic/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/bionic/arm64v8/Dockerfile
+++ b/3.1/sdk/bionic/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/bionic/arm64v8/Dockerfile
+++ b/3.1/sdk/bionic/arm64v8/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/buster/amd64/Dockerfile
+++ b/3.1/sdk/buster/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/buster/amd64/Dockerfile
+++ b/3.1/sdk/buster/amd64/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.x64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/buster/amd64/Dockerfile
+++ b/3.1/sdk/buster/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/buster/arm32v7/Dockerfile
+++ b/3.1/sdk/buster/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/buster/arm32v7/Dockerfile
+++ b/3.1/sdk/buster/arm32v7/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/buster/arm32v7/Dockerfile
+++ b/3.1/sdk/buster/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/buster/arm64v8/Dockerfile
+++ b/3.1/sdk/buster/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/buster/arm64v8/Dockerfile
+++ b/3.1/sdk/buster/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/buster/arm64v8/Dockerfile
+++ b/3.1/sdk/buster/arm64v8/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/focal/amd64/Dockerfile
+++ b/3.1/sdk/focal/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/focal/amd64/Dockerfile
+++ b/3.1/sdk/focal/amd64/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.x64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/focal/amd64/Dockerfile
+++ b/3.1/sdk/focal/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/focal/arm32v7/Dockerfile
+++ b/3.1/sdk/focal/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/focal/arm32v7/Dockerfile
+++ b/3.1/sdk/focal/arm32v7/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/focal/arm32v7/Dockerfile
+++ b/3.1/sdk/focal/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/focal/arm64v8/Dockerfile
+++ b/3.1/sdk/focal/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/focal/arm64v8/Dockerfile
+++ b/3.1/sdk/focal/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar --no-same-owner -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/3.1/sdk/focal/arm64v8/Dockerfile
+++ b/3.1/sdk/focal/arm64v8/Dockerfile
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -27,6 +27,7 @@ RUN $powershell_version = '7.0.0-preview.6'; `
     }; `
     `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+    \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 

--- a/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -24,7 +24,7 @@ RUN set "powershell_version=7.0.0-preview.6" `
     && call curl -SL --output PowerShell.Windows.arm32.%powershell_version%.nupkg https://pwshtool.blob.core.windows.net/tool/%powershell_version%/PowerShell.Windows.arm32.%powershell_version%.nupkg `
     && mkdir "%ProgramFiles%\powershell" `
     && call "%ProgramFiles%\dotnet\dotnet" tool install --add-source . --tool-path "%ProgramFiles%\powershell" --version %powershell_version% PowerShell.Windows.arm32 `
-    && call "%ProgramFiles%\dotnet\dotnet" nuget locals all --clear `
+    && call rmdir "%TEMP%\NuGetScratch" /S /Q `
     && call del PowerShell.Windows.arm32.%powershell_version%.nupkg `
     && call del "%ProgramFiles%\powershell\.store\powershell.windows.arm32\%powershell_version%\powershell.windows.arm32\%powershell_version%\powershell.windows.arm32.%powershell_version%.nupkg"
 

--- a/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -24,6 +24,7 @@ RUN set "powershell_version=7.0.0-preview.6" `
     && call curl -SL --output PowerShell.Windows.arm32.%powershell_version%.nupkg https://pwshtool.blob.core.windows.net/tool/%powershell_version%/PowerShell.Windows.arm32.%powershell_version%.nupkg `
     && mkdir "%ProgramFiles%\powershell" `
     && call "%ProgramFiles%\dotnet\dotnet" tool install --add-source . --tool-path "%ProgramFiles%\powershell" --version %powershell_version% PowerShell.Windows.arm32 `
+    && call "%ProgramFiles%\dotnet\dotnet" nuget locals all --clear `
     && call del PowerShell.Windows.arm32.%powershell_version%.nupkg `
     && call del "%ProgramFiles%\powershell\.store\powershell.windows.arm32\%powershell_version%\powershell.windows.arm32\%powershell_version%\powershell.windows.arm32.%powershell_version%.nupkg"
 

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -27,6 +27,7 @@ RUN $powershell_version = '7.0.0-preview.6'; `
     }; `
     `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+    \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -27,6 +27,7 @@ RUN $powershell_version = '7.0.0-preview.6'; `
     }; `
     `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+    \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -109,7 +109,8 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyImage_InsecureFilesCheck(ImageData imageData)
         {
-            if (imageData.Version < new Version("3.1") || !DockerHelper.IsLinuxContainerModeEnabled)
+            if (imageData.Version < new Version("3.1") || !DockerHelper.IsLinuxContainerModeEnabled ||
+                (imageData.OS.Contains("alpine") && imageData.IsArm))
             {
                 return;
             }
@@ -120,7 +121,7 @@ namespace Microsoft.DotNet.Docker.Tests
             if (imageData.OS.Contains("alpine"))
             {
                 // BusyBox in Alpine doesn't support the more convenient -nouser and -nogroup options for the find command
-                noUserOrGroupFilesCmd = @"find / -xdev -exec stat -c %U-%n {} \+ | grep ^UNKNOWN";
+                noUserOrGroupFilesCmd = @"find / -xdev -exec stat -c %U-%n {} \+ | { grep ^UNKNOWN || true; }";
             }
             else
             {

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Docker.Tests
             if (imageData.OS.Contains("alpine"))
             {
                 // BusyBox in Alpine doesn't support the more convenient -nouser and -nogroup options for the find command
-                noUserOrGroupFilesCmd = @"find / -xdev -exec stat -c '%U %n' {} \+ | grep ^UNKNOWN";
+                noUserOrGroupFilesCmd = @"find / -xdev -exec stat -c %U-%n {} \+ | grep ^UNKNOWN";
             }
             else
             {

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -116,7 +116,17 @@ namespace Microsoft.DotNet.Docker.Tests
 
             string worldWritableDirectoriesWithoutStickyBitCmd = @"find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \)";
             string worldWritableFilesCmd = "find / -xdev -type f -perm -o+w";
-            string noUserOrGroupFilesCmd = @"find / -xdev \( -nouser -o -nogroup \)";
+            string noUserOrGroupFilesCmd;
+            if (imageData.OS.Contains("alpine"))
+            {
+                // BusyBox in Alpine doesn't support the more convenient -nouser and -nogroup options for the find command
+                noUserOrGroupFilesCmd = @"find / -xdev -exec stat -c '%U %n' {} \+ | grep ^UNKNOWN";
+            }
+            else
+            {
+                noUserOrGroupFilesCmd = @"find / -xdev \( -nouser -o -nogroup \)";
+            }
+
             string command = $"/bin/sh -c \"{worldWritableDirectoriesWithoutStickyBitCmd} && {worldWritableFilesCmd} && {noUserOrGroupFilesCmd}\"";
 
             foreach (DotNetImageType imageType in Enum.GetValues(typeof(DotNetImageType)))

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -107,6 +107,28 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
+        public void VerifySDKImage_WorldWritableFilesCheck(ImageData imageData)
+        {
+            if (imageData.Version < new Version("3.1") || !DockerHelper.IsLinuxContainerModeEnabled)
+            {
+                return;
+            }
+
+            string worldWritableDirectoriesWithoutStickyBitCmd = @"find / -xdev -type d \( -perm -0002 -a ! -perm -1000 \)";
+            string worldWritableFilesCmd = "find / -xdev -type f -perm -o+w";
+            string command = $"/bin/sh -c \"{worldWritableDirectoriesWithoutStickyBitCmd} && {worldWritableFilesCmd}\"";
+
+            string output = _dockerHelper.Run(
+                image: imageData.GetImage(DotNetImageType.SDK, _dockerHelper),
+                name: imageData.GetIdentifier($"WorldWritableFiles"),
+                command: command
+            );
+            
+            Assert.Empty(output);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetImageData))]
         public void VerifySdkImage_EnvironmentVariables(ImageData imageData)
         {
             List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();


### PR DESCRIPTION
Installing PowerShell in SDK image leaves behind world-writable directories without sticky bit set, namely `/tmp/NuGetScratch`.  These changes fix this in the 3.1 SDK images by clearing the local NuGet resources.

In addition, the files extracted from the .NET tar files end up not having ownership by the user.

Adding a unit test to verify these issues in the 3.1 SDK images.

Related: #1454