### PR TITLE
Updates for 3.1 release

### DIFF
--- a/3.1/aspnet/alpine3.10/amd64/Dockerfile
+++ b/3.1/aspnet/alpine3.10/amd64/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-alpine3.10
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='0611074ea3a3836e57561114548abb0f468f6fc5d6d09ffdb1ce15cfb150a28ccf644218e2610ad4c0603fcf42e57fe07e0be82db4c0ab25bd66011688c27a6c' \
+    && aspnetcore_sha512='fa5e4ae71134a8a6db4ad6a247d3e31406673e03f0a64f7faaad3d84cfb3b70d2cf69e9d9abc1f8688138907d4ddd37cd908669999d85a87892e164053c63847' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/alpine3.10/amd64/Dockerfile
+++ b/3.1/aspnet/alpine3.10/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='fa5e4ae71134a8a6db4ad6a247d3e31406673e03f0a64f7faaad3d84cfb3b70d2cf69e9d9abc1f8688138907d4ddd37cd908669999d85a87892e164053c63847' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-alpine3.10-arm64v8
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-    && aspnetcore_sha512='720369b73dbcbe6bffffc654d04b5c37886f0d0e5ab5b85615110b59c74486562693b55a7caa04e352aa902e7234203bbd540a0a1fe0b820b3f382fa45a8c127' \
+    && aspnetcore_sha512='6244dd1dd7d18f00bcc6a1faa2b6da61bc3edc9748f9513b617c84b1c2cb04d3b7328f398ce9a1e9834db56bb6246756b7c5409c179000eaab113a88a2da5b3a' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/aspnet/alpine3.10/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='6244dd1dd7d18f00bcc6a1faa2b6da61bc3edc9748f9513b617c84b1c2cb04d3b7328f398ce9a1e9834db56bb6246756b7c5409c179000eaab113a88a2da5b3a' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/amd64/Dockerfile
+++ b/3.1/aspnet/bionic/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/amd64/Dockerfile
+++ b/3.1/aspnet/bionic/amd64/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-bionic
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-    && aspnetcore_sha512='4005ceaecf160821d1f2df76c30661bd939e3a4ab0e73b5c7d557db8d1559b48f7afe4c1e7e4ca86ea47191d003865dc272a7acf761643fa060dfcbc868ba25c' \
+    && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm32v7/Dockerfile
+++ b/3.1/aspnet/bionic/arm32v7/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-bionic-arm32v7
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-    && aspnetcore_sha512='d5162decae6a916ee7a9fadf356f461eda619bab87065e1fd7c3b38f5df52e5aea4e85c84109868185831712313d99c3af5bc112c7509278f32bf03a95b7b20e' \
+    && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm32v7/Dockerfile
+++ b/3.1/aspnet/bionic/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm64v8/Dockerfile
+++ b/3.1/aspnet/bionic/arm64v8/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-bionic-arm64v8
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-    && aspnetcore_sha512='1709ca4d3edc1f5330886c24046c92746ad270acd7fd24674cba08052d3c6080396d0a13eb5535a1e33773ea3497b40fcb29dce24b506dae592d0111b6f0e0a6' \
+    && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/bionic/arm64v8/Dockerfile
+++ b/3.1/aspnet/bionic/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/amd64/Dockerfile
+++ b/3.1/aspnet/buster-slim/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/amd64/Dockerfile
+++ b/3.1/aspnet/buster-slim/amd64/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-buster-slim
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-    && aspnetcore_sha512='4005ceaecf160821d1f2df76c30661bd939e3a4ab0e73b5c7d557db8d1559b48f7afe4c1e7e4ca86ea47191d003865dc272a7acf761643fa060dfcbc868ba25c' \
+    && aspnetcore_sha512='7d14e4617413fd7939f90a4e283b7abedbd51ecfbc150938d4c52ecca8182cab8c4946408c1f6369944c68757c91b580796d9e0c62349c377c5e90b739a87d8b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm32v7/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm32v7/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-buster-slim-arm32v7
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-    && aspnetcore_sha512='d5162decae6a916ee7a9fadf356f461eda619bab87065e1fd7c3b38f5df52e5aea4e85c84109868185831712313d99c3af5bc112c7509278f32bf03a95b7b20e' \
+    && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm32v7/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='d8ac48b37b5d239e08f68c9f56c7f8d8c3ef2db3b7f55aaa123c990bf19a4b4546d71aded53ce266ea77095a0b6bcc319a9e3c1a5be418a09ece501e59538677' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm64v8/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm64v8/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-buster-slim-arm64v8
 
 # Install ASP.NET Core
-RUN aspnetcore_version=3.1.0-preview3.19555.2 \
+RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-    && aspnetcore_sha512='1709ca4d3edc1f5330886c24046c92746ad270acd7fd24674cba08052d3c6080396d0a13eb5535a1e33773ea3497b40fcb29dce24b506dae592d0111b6f0e0a6' \
+    && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/buster-slim/arm64v8/Dockerfile
+++ b/3.1/aspnet/buster-slim/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.0 \
     && curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='0a7fae3a4549b3954037adeafe0673728c7b4e765aa0a3952e58de2b6f746d3785434fe2970f6a4ff78c9228e2ffbda2e400e47917ef9da4dc938f4ef09e2643' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/3.1/aspnet/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/aspnet/nanoserver-1809/amd64/Dockerfile
@@ -8,9 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-RUN $aspnetcore_version = '3.1.0-preview3.19555.2'; `
+RUN $aspnetcore_version = '3.1.0'; `
     Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
-    $aspnetcore_sha512 = 'eaafb36636e9cee9e885075d102cb3aad50328ae02c0a9a11a1b45c4717158cd2c4fc3d1fe58e9a56dfbd4dc46521e5590441af0093b87d61aeb061e6939c46b'; `
+    $aspnetcore_sha512 = '6adb4e332cd4a4f905130bd3715351f7f3e4426692a1522d274c4aca7ab3803ce34e2e7dbf57bb96be71eb6962819a465f78fcabe9c5046257ae330b96731eb6'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/aspnet/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.1/aspnet/nanoserver-1809/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 FROM $REPO:3.1-nanoserver-1809-arm32v7
 
 # Install ASP.NET Core Runtime
-RUN set "aspnetcore_version=3.1.0-preview3.19555.2" `
+RUN set "aspnetcore_version=3.1.0" `
     && call curl -SL --output dotnet.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/%aspnetcore_version%/aspnetcore-runtime-%aspnetcore_version%-win-arm.zip `
     && tar -zxf dotnet.zip -C "%ProgramFiles%\dotnet" ./shared/Microsoft.AspNetCore.App `
     && del dotnet.zip

--- a/3.1/aspnet/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/aspnet/nanoserver-1903/amd64/Dockerfile
@@ -8,9 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:1903 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-RUN $aspnetcore_version = '3.1.0-preview3.19555.2'; `
+RUN $aspnetcore_version = '3.1.0'; `
     Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
-    $aspnetcore_sha512 = 'eaafb36636e9cee9e885075d102cb3aad50328ae02c0a9a11a1b45c4717158cd2c4fc3d1fe58e9a56dfbd4dc46521e5590441af0093b87d61aeb061e6939c46b'; `
+    $aspnetcore_sha512 = '6adb4e332cd4a4f905130bd3715351f7f3e4426692a1522d274c4aca7ab3803ce34e2e7dbf57bb96be71eb6962819a465f78fcabe9c5046257ae330b96731eb6'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/aspnet/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/aspnet/nanoserver-1909/amd64/Dockerfile
@@ -8,9 +8,9 @@ FROM mcr.microsoft.com/windows/servercore:1909 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-RUN $aspnetcore_version = '3.1.0-preview3.19555.2'; `
+RUN $aspnetcore_version = '3.1.0'; `
     Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
-    $aspnetcore_sha512 = 'eaafb36636e9cee9e885075d102cb3aad50328ae02c0a9a11a1b45c4717158cd2c4fc3d1fe58e9a56dfbd4dc46521e5590441af0093b87d61aeb061e6939c46b'; `
+    $aspnetcore_sha512 = '6adb4e332cd4a4f905130bd3715351f7f3e4426692a1522d274c4aca7ab3803ce34e2e7dbf57bb96be71eb6962819a465f78fcabe9c5046257ae330b96731eb6'; `
     if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/runtime/alpine3.10/amd64/Dockerfile
+++ b/3.1/runtime/alpine3.10/amd64/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
 FROM $REPO:3.1-alpine3.10
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-    && dotnet_sha512='b8ad662ef806d961a7fffabe495b65bdab0fd8825c758e515149b55708f421e3599d0abd8159325f46da0daf95cf1868bb6637481c0c1315e07af3d5b19be545' \
+    && dotnet_sha512='040e55c341aa15357bd7e1ee4fd421f13056aac2eaf9f327c77fd1948fbe963d23a66cc5ffdfaa232407853fd250922327107e2878bf0af9a7652fd2c4c46815' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/3.1/runtime/alpine3.10/amd64/Dockerfile
+++ b/3.1/runtime/alpine3.10/amd64/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='040e55c341aa15357bd7e1ee4fd421f13056aac2eaf9f327c77fd1948fbe963d23a66cc5ffdfaa232407853fd250922327107e2878bf0af9a7652fd2c4c46815' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz

--- a/3.1/runtime/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/runtime/alpine3.10/arm64v8/Dockerfile
@@ -2,9 +2,9 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
 FROM $REPO:3.1-alpine3.10-arm64v8
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-    && dotnet_sha512='e349a2239823e038b53436173583d03a228ca796fa31d390aaafb936af1624a6adfc1165388ad92a612fed427267041aa0be8849ee9fe541fad24b2530e1f5d7' \
+    && dotnet_sha512='417858bb24e1ec7337c7b85dd2c16ba3b16182bb0839e7c67d46b4ba38d430dd95a58e5ec533586c0cd4b69fc0f82323297eb4c5fbd8c2e8a5f9a1d36a3658f9' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/3.1/runtime/alpine3.10/arm64v8/Dockerfile
+++ b/3.1/runtime/alpine3.10/arm64v8/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='417858bb24e1ec7337c7b85dd2c16ba3b16182bb0839e7c67d46b4ba38d430dd95a58e5ec533586c0cd4b69fc0f82323297eb4c5fbd8c2e8a5f9a1d36a3658f9' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz

--- a/3.1/runtime/bionic/amd64/Dockerfile
+++ b/3.1/runtime/bionic/amd64/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-    && dotnet_sha512='e3c618fb1ed6314cc3387f84dfb89d95d807be60ab4ad0cd1712f145a1c3619c683f933ba2c39e0c683fcfc4a50f5d366c6ad9fdb584e75a326102e9da390342' \
+    && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/runtime/bionic/amd64/Dockerfile
+++ b/3.1/runtime/bionic/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/arm32v7/Dockerfile
+++ b/3.1/runtime/bionic/arm32v7/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-    && dotnet_sha512='d338db64acd721c6a903e19146c487e8182f3a466257bd45128d8f6f29ac45bd598e2c0cf641f82c0e7770ae6307fedf67c312c7ac80258b3b3c567cffa31f89' \
+    && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/runtime/bionic/arm32v7/Dockerfile
+++ b/3.1/runtime/bionic/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/arm64v8/Dockerfile
+++ b/3.1/runtime/bionic/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/bionic/arm64v8/Dockerfile
+++ b/3.1/runtime/bionic/arm64v8/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-    && dotnet_sha512='0f43f3a6601fae9d6c1f56f0024debb9b12632b77a13e8b11c41c936f71629976e5cff59cb75f2e3ed3573431af13e4f4cb9cb5d1f3a9d41dfb4e10a917dd83e' \
+    && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/runtime/buster-slim/amd64/Dockerfile
+++ b/3.1/runtime/buster-slim/amd64/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-    && dotnet_sha512='e3c618fb1ed6314cc3387f84dfb89d95d807be60ab4ad0cd1712f145a1c3619c683f933ba2c39e0c683fcfc4a50f5d366c6ad9fdb584e75a326102e9da390342' \
+    && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/runtime/buster-slim/amd64/Dockerfile
+++ b/3.1/runtime/buster-slim/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='99949807c00871d66e8ce7c25c14998e78a0ea60ba8cc42244643ed2e13aa360285df1c8d27729df3efb319f4af9163ea5626c1478a9dd4bed9d2a58e01d6343' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/arm32v7/Dockerfile
+++ b/3.1/runtime/buster-slim/arm32v7/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-    && dotnet_sha512='d338db64acd721c6a903e19146c487e8182f3a466257bd45128d8f6f29ac45bd598e2c0cf641f82c0e7770ae6307fedf67c312c7ac80258b3b3c567cffa31f89' \
+    && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/runtime/buster-slim/arm32v7/Dockerfile
+++ b/3.1/runtime/buster-slim/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='a665ed66621e557db17c4b92a8db99e1b555a2d81e6764ffd25da39c94531888759eb1af1a209d2718fe843f89ce92a884c4b51fad55cf84d8001952ad5e7eb8' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/arm64v8/Dockerfile
+++ b/3.1/runtime/buster-slim/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.0 \
     && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/3.1/runtime/buster-slim/arm64v8/Dockerfile
+++ b/3.1/runtime/buster-slim/arm64v8/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-RUN dotnet_version=3.1.0-preview3.19553.2 \
+RUN dotnet_version=3.1.0 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-    && dotnet_sha512='0f43f3a6601fae9d6c1f56f0024debb9b12632b77a13e8b11c41c936f71629976e5cff59cb75f2e3ed3573431af13e4f4cb9cb5d1f3a9d41dfb4e10a917dd83e' \
+    && dotnet_sha512='c3978544d3dec58fc522339788d743d4629ad087254231f93315935262d51cf6b3ce60747c06aa6e689ae5be9e21a8bf6d5a707b41a79f7399549756b3b6d340' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/runtime/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/runtime/nanoserver-1809/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-RUN $dotnet_version = '3.1.0-preview3.19553.2'; `
+RUN $dotnet_version = '3.1.0'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
-    $dotnet_sha512 = 'f245798a4fabc82525a6f05866cf363e9ba0c3c3ad7aca4613a80e9fb9dce9b5202ecfc6d3d37f2f00618d26c1b44f66bd821511185a6169fce1c9503a5ed934'; `
+    $dotnet_sha512 = '90a534dd82c99d659373a7549c87dad4dc1ff9d3074e355785ee0f9db6022d785913b019f42652b3a4906d2963f08d2c86cdd95fb77a7ad7ccfefd626ad51490'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/runtime/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.1/runtime/nanoserver-1809/arm32v7/Dockerfile
@@ -14,7 +14,7 @@ RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
 USER ContainerUser
 
 # Install .NET Core
-RUN set "dotnet_version=3.1.0-preview3.19553.2" `
+RUN set "dotnet_version=3.1.0" `
     && call curl -SL --output dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/%dotnet_version%/dotnet-runtime-%dotnet_version%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `
     && tar -zxf dotnet.zip -C "%ProgramFiles%\dotnet" `

--- a/3.1/runtime/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/runtime/nanoserver-1903/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/windows/servercore:1903 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-RUN $dotnet_version = '3.1.0-preview3.19553.2'; `
+RUN $dotnet_version = '3.1.0'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
-    $dotnet_sha512 = 'f245798a4fabc82525a6f05866cf363e9ba0c3c3ad7aca4613a80e9fb9dce9b5202ecfc6d3d37f2f00618d26c1b44f66bd821511185a6169fce1c9503a5ed934'; `
+    $dotnet_sha512 = '90a534dd82c99d659373a7549c87dad4dc1ff9d3074e355785ee0f9db6022d785913b019f42652b3a4906d2963f08d2c86cdd95fb77a7ad7ccfefd626ad51490'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/runtime/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/runtime/nanoserver-1909/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/windows/servercore:1909 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-RUN $dotnet_version = '3.1.0-preview3.19553.2'; `
+RUN $dotnet_version = '3.1.0'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
-    $dotnet_sha512 = 'f245798a4fabc82525a6f05866cf363e9ba0c3c3ad7aca4613a80e9fb9dce9b5202ecfc6d3d37f2f00618d26c1b44f66bd821511185a6169fce1c9503a5ed934'; `
+    $dotnet_sha512 = '90a534dd82c99d659373a7549c87dad4dc1ff9d3074e355785ee0f9db6022d785913b019f42652b3a4906d2963f08d2c86cdd95fb77a7ad7ccfefd626ad51490'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -19,9 +19,9 @@ ENV \
 RUN apk add --no-cache icu-libs
 
 # Install .NET Core SDK
-RUN dotnet_sdk_version=3.1.100-preview3-014645 \
+RUN dotnet_sdk_version=3.1.100 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-    && dotnet_sha512='47f02feb163679e96db052de0c32cc7e8a12f8ac3e4d6a60abfbc0f270489a39e420f1c2c4ead5015f0c5c1b077ecb24056f78ec61b779f6166f7db4900e2843' \
+    && dotnet_sha512='517c1dadbc9081e112f75589eb7160ef70183eb3d93fd55800e145b21f4dd6f5fbe19397ee7476aa16493e112ef95b311ff61bb08d9231b30a7ea609806d85ee' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -31,9 +31,9 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.0.0-preview.5 \
+RUN powershell_version=7.0.0-preview.6 \
     && wget -O PowerShell.Linux.Alpine.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='5d5dc58d5744a9012696058074c1e72471a7f45489564fdf3fbfb5a89a61f8832f026aa7a0742a542d7dc5c125ba6baef00b74c3e75338b9eae056bf0e9b4ee4' \
+    && powershell_sha512='7807b7be0a034e2ae36236f056bebddbc2be553cca0e02ab83babf79b0c011bd9966f135c2e285c4de9f76b874785cd93ecfe09c01a0f3868dedcdad76eb6fc4' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \

--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='517c1dadbc9081e112f75589eb7160ef70183eb3d93fd55800e145b21f4dd6f5fbe19397ee7476aa16493e112ef95b311ff61bb08d9231b30a7ea609806d85ee' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
@@ -37,6 +37,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && chmod 755 /usr/share/powershell/pwsh \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \

--- a/3.1/sdk/bionic/amd64/Dockerfile
+++ b/3.1/sdk/bionic/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.x64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/bionic/amd64/Dockerfile
+++ b/3.1/sdk/bionic/amd64/Dockerfile
@@ -35,9 +35,9 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.0.0-preview.5 \
+RUN powershell_version=7.0.0-preview.6 \
     && curl -SL --output PowerShell.Linux.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='04b1f1597b7a0eb71c789a4435d9c0547399c127d17b7e530d7cf6fe731e7e1a29189a2d58859212e34d031d04fc8ae705090cfb306c451f63578683a7ddd9fa' \
+    && powershell_sha512='41313882873e28122db266a63e6d1d508d201b77f22cd0496de2ff1c410798553ee9e4cebb2c9094574177f05738f18be79116e591a93c1abe733a96d2eb01d6' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/3.1/sdk/bionic/amd64/Dockerfile
+++ b/3.1/sdk/bionic/amd64/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-RUN dotnet_sdk_version=3.1.100-preview3-014645 \
+RUN dotnet_sdk_version=3.1.100 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-    && dotnet_sha512='df7252d0602d23152a557cbb6a6917ee48cba75a72aeeeb7647bd16405fd0747a7d9253c9bc1df6903d6d3504fbd35c87c9ce1567407070f4be06bbe04e03237' \
+    && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/sdk/bionic/arm32v7/Dockerfile
+++ b/3.1/sdk/bionic/arm32v7/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-RUN dotnet_sdk_version=3.1.100-preview3-014645 \
+RUN dotnet_sdk_version=3.1.100 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-    && dotnet_sha512='44d4b9d9daaddb32845fd946ff6cc5a2600928edfd9c1dcef602e0ed81f807ddb3e9d698f9b8fd661a195c5aa232bd92cc23ffeea8d1cf05f36bd8819d66f788' \
+    && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/sdk/bionic/arm32v7/Dockerfile
+++ b/3.1/sdk/bionic/arm32v7/Dockerfile
@@ -35,9 +35,9 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.0.0-preview.5 \
+RUN powershell_version=7.0.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='43f5f10d505fe88a9d1fe5c9b6285e4fcf8956f086feffd48c57a6052ae2ccf7f9ecdb80162181acb169eec9fb36374b62f09274b0d1f0b379b38d5571fddf29' \
+    && powershell_sha512='26fdc19e7c8317a1f7bd8f786d031437dc2ce86983b22cccdec4d3b952aff6cf0984207be9d4fd4bdeb327d1fa51eb6f11292f8e83d76f7e2658d867bafa83ae' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/3.1/sdk/bionic/arm32v7/Dockerfile
+++ b/3.1/sdk/bionic/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/bionic/arm64v8/Dockerfile
+++ b/3.1/sdk/bionic/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/bionic/arm64v8/Dockerfile
+++ b/3.1/sdk/bionic/arm64v8/Dockerfile
@@ -35,9 +35,9 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.0.0-preview.5 \
+RUN powershell_version=7.0.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='d146464dcdadf641dcbff538c950ff7edefa0fc398488c4ffac3187eb8db78a68101e461b3d9e0419773a668df693dc223c273cfb64fb5572ddaf744594942c1' \
+    && powershell_sha512='84c380e3353018452cf6a65b2e35ec2aa9cb0ac7f7b831956fd35ff4ce9f26e031fb61ab26d144e98c4e954dee463098db4bdfa1492c69088ab4cd3e1f7a31bd' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/3.1/sdk/bionic/arm64v8/Dockerfile
+++ b/3.1/sdk/bionic/arm64v8/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-RUN dotnet_sdk_version=3.1.100-preview3-014645 \
+RUN dotnet_sdk_version=3.1.100 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-    && dotnet_sha512='9bf6478d1a1b249c8af3d449bc3e9ab144035d5ec247865c7d5a164071727fd725ac1639a6a8690da5339200cfc456911e98dc4b0b83bcc63d9bfe03aba91ebc' \
+    && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/sdk/buster/amd64/Dockerfile
+++ b/3.1/sdk/buster/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.x64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/buster/amd64/Dockerfile
+++ b/3.1/sdk/buster/amd64/Dockerfile
@@ -35,9 +35,9 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.0.0-preview.5 \
+RUN powershell_version=7.0.0-preview.6 \
     && curl -SL --output PowerShell.Linux.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='04b1f1597b7a0eb71c789a4435d9c0547399c127d17b7e530d7cf6fe731e7e1a29189a2d58859212e34d031d04fc8ae705090cfb306c451f63578683a7ddd9fa' \
+    && powershell_sha512='41313882873e28122db266a63e6d1d508d201b77f22cd0496de2ff1c410798553ee9e4cebb2c9094574177f05738f18be79116e591a93c1abe733a96d2eb01d6' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/3.1/sdk/buster/amd64/Dockerfile
+++ b/3.1/sdk/buster/amd64/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-RUN dotnet_sdk_version=3.1.100-preview3-014645 \
+RUN dotnet_sdk_version=3.1.100 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-    && dotnet_sha512='df7252d0602d23152a557cbb6a6917ee48cba75a72aeeeb7647bd16405fd0747a7d9253c9bc1df6903d6d3504fbd35c87c9ce1567407070f4be06bbe04e03237' \
+    && dotnet_sha512='5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/sdk/buster/arm32v7/Dockerfile
+++ b/3.1/sdk/buster/arm32v7/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-RUN dotnet_sdk_version=3.1.100-preview3-014645 \
+RUN dotnet_sdk_version=3.1.100 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-    && dotnet_sha512='44d4b9d9daaddb32845fd946ff6cc5a2600928edfd9c1dcef602e0ed81f807ddb3e9d698f9b8fd661a195c5aa232bd92cc23ffeea8d1cf05f36bd8819d66f788' \
+    && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/sdk/buster/arm32v7/Dockerfile
+++ b/3.1/sdk/buster/arm32v7/Dockerfile
@@ -35,9 +35,9 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.0.0-preview.5 \
+RUN powershell_version=7.0.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='43f5f10d505fe88a9d1fe5c9b6285e4fcf8956f086feffd48c57a6052ae2ccf7f9ecdb80162181acb169eec9fb36374b62f09274b0d1f0b379b38d5571fddf29' \
+    && powershell_sha512='26fdc19e7c8317a1f7bd8f786d031437dc2ce86983b22cccdec4d3b952aff6cf0984207be9d4fd4bdeb327d1fa51eb6f11292f8e83d76f7e2658d867bafa83ae' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/3.1/sdk/buster/arm32v7/Dockerfile
+++ b/3.1/sdk/buster/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='9f4848b4bca649cc6131032de4b0115549a3dafb6bf90250930794aa69f7939bba82cedda67578348a83b50b7057e452846a400589bb4e9d4a2d1b33ce57c71c' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/buster/arm64v8/Dockerfile
+++ b/3.1/sdk/buster/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
@@ -41,6 +41,7 @@ RUN powershell_version=7.0.0-preview.6 \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
     && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \

--- a/3.1/sdk/buster/arm64v8/Dockerfile
+++ b/3.1/sdk/buster/arm64v8/Dockerfile
@@ -35,9 +35,9 @@ RUN dotnet_sdk_version=3.1.100 \
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.0.0-preview.5 \
+RUN powershell_version=7.0.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='d146464dcdadf641dcbff538c950ff7edefa0fc398488c4ffac3187eb8db78a68101e461b3d9e0419773a668df693dc223c273cfb64fb5572ddaf744594942c1' \
+    && powershell_sha512='84c380e3353018452cf6a65b2e35ec2aa9cb0ac7f7b831956fd35ff4ce9f26e031fb61ab26d144e98c4e954dee463098db4bdfa1492c69088ab4cd3e1f7a31bd' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/3.1/sdk/buster/arm64v8/Dockerfile
+++ b/3.1/sdk/buster/arm64v8/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-RUN dotnet_sdk_version=3.1.100-preview3-014645 \
+RUN dotnet_sdk_version=3.1.100 \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-    && dotnet_sha512='9bf6478d1a1b249c8af3d449bc3e9ab144035d5ec247865c7d5a164071727fd725ac1639a6a8690da5339200cfc456911e98dc4b0b83bcc63d9bfe03aba91ebc' \
+    && dotnet_sha512='93634c555698ca5c3392332a93551b1548fa103328401c5c25e8955f085124b887b73736b70a139fc8eb8d622e47fcfc0aa25210b73a8f851906b32eaa8a9887' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \

--- a/3.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -27,6 +27,7 @@ RUN $powershell_version = '7.0.0-preview.6'; `
     }; `
     `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+    \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 

--- a/3.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '3.1.100-preview3-014645'; `
+RUN $dotnet_sdk_version = '3.1.100'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
-    $dotnet_sha512 = 'be60b824877055a706ee3d55c41bca3c4718cb1da61d25135b5514df43e1567cb7643cf9c7c77343b306b51270afbf7436b9365d01dc83685e36cc02c56be98f'; `
+    $dotnet_sha512 = '94ee575d6104058cdd31370fc686b5d1aa23bf4a54611843c1f93afc82cad3523217b5f2eaddd4b5c136bca252d2c9047092f7054052c8683fa0f363ca28ad11'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -18,9 +18,9 @@ RUN $dotnet_sdk_version = '3.1.100'; `
     Remove-Item -Force dotnet.zip
 
 # Install PowerShell global tool
-RUN $powershell_version = '7.0.0-preview.5'; `
+RUN $powershell_version = '7.0.0-preview.6'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-    $powershell_sha512 = '1f197c2fc4c26345768dc62782e585e003b6ffe21b065ac7487e151e467e1fd8325209697b94459ed07b22b00a3e75ad7417144230b6ce6aed02b4b9ffc583dc'; `
+    $powershell_sha512 = '563a5aaa99b3f330fbfff0f99674f70f469680c8547f7dd07077bb915a6f90de21624b7a935a43efc288b58b3c23ef01ca18262e65bfdbb65014170f8868f62c'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -13,7 +13,7 @@ ENV `
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1809-arm32
 
 # Install .NET Core SDK
-RUN set "dotnet_sdk_version=3.1.100-preview3-014645" `
+RUN set "dotnet_sdk_version=3.1.100" `
     && call curl -SL --output dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/%dotnet_sdk_version%/dotnet-sdk-%dotnet_sdk_version%-win-arm.zip `
     && mkdir "%ProgramFiles%\dotnet" `
     && tar -zxf dotnet.zip -C "%ProgramFiles%\dotnet" `

--- a/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -24,6 +24,7 @@ RUN set "powershell_version=7.0.0-preview.6" `
     && call curl -SL --output PowerShell.Windows.arm32.%powershell_version%.nupkg https://pwshtool.blob.core.windows.net/tool/%powershell_version%/PowerShell.Windows.arm32.%powershell_version%.nupkg `
     && mkdir "%ProgramFiles%\powershell" `
     && call "%ProgramFiles%\dotnet\dotnet" tool install --add-source . --tool-path "%ProgramFiles%\powershell" --version %powershell_version% PowerShell.Windows.arm32 `
+    && call rmdir "%TEMP%\NuGetScratch" /S /Q `
     && call del PowerShell.Windows.arm32.%powershell_version%.nupkg `
     && call del "%ProgramFiles%\powershell\.store\powershell.windows.arm32\%powershell_version%\powershell.windows.arm32\%powershell_version%\powershell.windows.arm32.%powershell_version%.nupkg"
 

--- a/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile
@@ -20,7 +20,7 @@ RUN set "dotnet_sdk_version=3.1.100" `
     && del dotnet.zip
 
 # Install PowerShell global tool
-RUN set "powershell_version=7.0.0-preview.5" `
+RUN set "powershell_version=7.0.0-preview.6" `
     && call curl -SL --output PowerShell.Windows.arm32.%powershell_version%.nupkg https://pwshtool.blob.core.windows.net/tool/%powershell_version%/PowerShell.Windows.arm32.%powershell_version%.nupkg `
     && mkdir "%ProgramFiles%\powershell" `
     && call "%ProgramFiles%\dotnet\dotnet" tool install --add-source . --tool-path "%ProgramFiles%\powershell" --version %powershell_version% PowerShell.Windows.arm32 `

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -27,6 +27,7 @@ RUN $powershell_version = '7.0.0-preview.6'; `
     }; `
     `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+    \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/windows/servercore:1903 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '3.1.100-preview3-014645'; `
+RUN $dotnet_sdk_version = '3.1.100'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
-    $dotnet_sha512 = 'be60b824877055a706ee3d55c41bca3c4718cb1da61d25135b5514df43e1567cb7643cf9c7c77343b306b51270afbf7436b9365d01dc83685e36cc02c56be98f'; `
+    $dotnet_sha512 = '94ee575d6104058cdd31370fc686b5d1aa23bf4a54611843c1f93afc82cad3523217b5f2eaddd4b5c136bca252d2c9047092f7054052c8683fa0f363ca28ad11'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -18,9 +18,9 @@ RUN $dotnet_sdk_version = '3.1.100'; `
     Remove-Item -Force dotnet.zip
 
 # Install PowerShell global tool
-RUN $powershell_version = '7.0.0-preview.5'; `
+RUN $powershell_version = '7.0.0-preview.6'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-    $powershell_sha512 = '1f197c2fc4c26345768dc62782e585e003b6ffe21b065ac7487e151e467e1fd8325209697b94459ed07b22b00a3e75ad7417144230b6ce6aed02b4b9ffc583dc'; `
+    $powershell_sha512 = '563a5aaa99b3f330fbfff0f99674f70f469680c8547f7dd07077bb915a6f90de21624b7a935a43efc288b58b3c23ef01ca18262e65bfdbb65014170f8868f62c'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -27,6 +27,7 @@ RUN $powershell_version = '7.0.0-preview.6'; `
     }; `
     `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+    \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/windows/servercore:1909 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '3.1.100-preview3-014645'; `
+RUN $dotnet_sdk_version = '3.1.100'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
-    $dotnet_sha512 = 'be60b824877055a706ee3d55c41bca3c4718cb1da61d25135b5514df43e1567cb7643cf9c7c77343b306b51270afbf7436b9365d01dc83685e36cc02c56be98f'; `
+    $dotnet_sha512 = '94ee575d6104058cdd31370fc686b5d1aa23bf4a54611843c1f93afc82cad3523217b5f2eaddd4b5c136bca252d2c9047092f7054052c8683fa0f363ca28ad11'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -18,9 +18,9 @@ RUN $dotnet_sdk_version = '3.1.100'; `
     Remove-Item -Force dotnet.zip
 
 # Install PowerShell global tool
-RUN $powershell_version = '7.0.0-preview.5'; `
+RUN $powershell_version = '7.0.0-preview.6'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-    $powershell_sha512 = '1f197c2fc4c26345768dc62782e585e003b6ffe21b065ac7487e151e467e1fd8325209697b94459ed07b22b00a3e75ad7417144230b6ce6aed02b4b9ffc583dc'; `
+    $powershell_sha512 = '563a5aaa99b3f330fbfff0f99674f70f469680c8547f7dd07077bb915a6f90de21624b7a935a43efc288b58b3c23ef01ca18262e65bfdbb65014170f8868f62c'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -50,7 +50,10 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim, 3.0-buster-slim, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/buster-slim/amd64/Dockerfile) | Debian 10
+3.1.0-buster-slim, 3.1-buster-slim, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/buster-slim/amd64/Dockerfile) | Debian 10
+3.1.0-alpine3.10, 3.1-alpine3.10, 3.1.0-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/alpine3.10/amd64/Dockerfile) | Alpine 3.10
+3.1.0-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/bionic/amd64/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim, 3.0-buster-slim, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/buster-slim/amd64/Dockerfile) | Debian 10
 3.0.1-alpine3.10, 3.0-alpine3.10, 3.0.1-alpine, 3.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/alpine3.10/amd64/Dockerfile) | Alpine 3.10
 3.0.1-alpine3.9, 3.0-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 3.0.1-disco, 3.0-disco | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/disco/amd64/Dockerfile) | Ubuntu 19.04
@@ -64,33 +67,24 @@ Tags | Dockerfile | OS Version
 2.1.14-alpine3.9, 2.1-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnet/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 2.1.14-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnet/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim, 3.1-buster-slim, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/buster-slim/amd64/Dockerfile) | Debian 10
-3.1.0-preview3-alpine3.10, 3.1-alpine3.10, 3.1.0-preview3-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/alpine3.10/amd64/Dockerfile) | Alpine 3.10
-3.1.0-preview3-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/bionic/amd64/Dockerfile) | Ubuntu 18.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim-arm64v8, 3.0-buster-slim-arm64v8, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/buster-slim/arm64v8/Dockerfile) | Debian 10
+3.1.0-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/buster-slim/arm64v8/Dockerfile) | Debian 10
+3.1.0-alpine3.10-arm64v8, 3.1-alpine3.10-arm64v8, 3.1.0-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
+3.1.0-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim-arm64v8, 3.0-buster-slim-arm64v8, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/buster-slim/arm64v8/Dockerfile) | Debian 10
 3.0.1-alpine3.10-arm64v8, 3.0-alpine3.10-arm64v8, 3.0.1-alpine-arm64v8, 3.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
 3.0.1-alpine3.9-arm64v8, 3.0-alpine3.9-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/alpine3.9/arm64v8/Dockerfile) | Alpine 3.9
 3.0.1-disco-arm64v8, 3.0-disco-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/disco/arm64v8/Dockerfile) | Ubuntu 19.04
 3.0.1-bionic-arm64v8, 3.0-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/buster-slim/arm64v8/Dockerfile) | Debian 10
-3.1.0-preview3-alpine3.10-arm64v8, 3.1-alpine3.10-arm64v8, 3.1.0-preview3-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
-3.1.0-preview3-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
-
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim-arm32v7, 3.0-buster-slim-arm32v7, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/buster-slim/arm32v7/Dockerfile) | Debian 10
+3.1.0-buster-slim-arm32v7, 3.1-buster-slim-arm32v7, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/buster-slim/arm32v7/Dockerfile) | Debian 10
+3.1.0-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim-arm32v7, 3.0-buster-slim-arm32v7, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/buster-slim/arm32v7/Dockerfile) | Debian 10
 3.0.1-disco-arm32v7, 3.0-disco-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/disco/arm32v7/Dockerfile) | Ubuntu 19.04
 3.0.1-bionic-arm32v7, 3.0-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 2.2.8-stretch-slim-arm32v7, 2.2-stretch-slim-arm32v7, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnet/stretch-slim/arm32v7/Dockerfile) | Debian 9
@@ -98,58 +92,36 @@ Tags | Dockerfile | OS Version
 2.1.14-stretch-slim-arm32v7, 2.1-stretch-slim-arm32v7, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnet/stretch-slim/arm32v7/Dockerfile) | Debian 9
 2.1.14-bionic-arm32v7, 2.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnet/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim-arm32v7, 3.1-buster-slim-arm32v7, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/buster-slim/arm32v7/Dockerfile) | Debian 10
-3.1.0-preview3-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
-
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1909, 3.0-nanoserver-1909, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1909/amd64/Dockerfile)
+3.1.0-nanoserver-1909, 3.1-nanoserver-1909, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1909/amd64/Dockerfile)
+3.0.1-nanoserver-1909, 3.0-nanoserver-1909, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1909/amd64/Dockerfile)
 2.2.8-nanoserver-1909, 2.2-nanoserver-1909, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnet/nanoserver-1909/amd64/Dockerfile)
 2.1.14-nanoserver-1909, 2.1-nanoserver-1909, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnet/nanoserver-1909/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1909, 3.1-nanoserver-1909, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1903, 3.0-nanoserver-1903, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1903/amd64/Dockerfile)
+3.1.0-nanoserver-1903, 3.1-nanoserver-1903, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1903/amd64/Dockerfile)
+3.0.1-nanoserver-1903, 3.0-nanoserver-1903, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1903/amd64/Dockerfile)
 2.2.8-nanoserver-1903, 2.2-nanoserver-1903, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnet/nanoserver-1903/amd64/Dockerfile)
 2.1.14-nanoserver-1903, 2.1-nanoserver-1903, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnet/nanoserver-1903/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1903, 3.1-nanoserver-1903, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1809, 3.0-nanoserver-1809, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1809/amd64/Dockerfile)
+3.1.0-nanoserver-1809, 3.1-nanoserver-1809, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1809/amd64/Dockerfile)
+3.0.1-nanoserver-1809, 3.0-nanoserver-1809, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1809/amd64/Dockerfile)
 2.2.8-nanoserver-1809, 2.2-nanoserver-1809, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnet/nanoserver-1809/amd64/Dockerfile)
 2.1.14-nanoserver-1809, 2.1-nanoserver-1809, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/aspnet/nanoserver-1809/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1809, 3.1-nanoserver-1809, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1809/amd64/Dockerfile)
 
 ## Windows Server 2019 arm32 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1809-arm32v7, 3.0-nanoserver-1809-arm32v7, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile)
+3.1.0-nanoserver-1809-arm32v7, 3.1-nanoserver-1809-arm32v7, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1809/arm32v7/Dockerfile)
+3.0.1-nanoserver-1809-arm32v7, 3.0-nanoserver-1809-arm32v7, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile)
 2.2.8-nanoserver-1809-arm32v7, 2.2-nanoserver-1809-arm32v7, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1809-arm32v7, 3.1-nanoserver-1809-arm32v7, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/aspnet/nanoserver-1809/arm32v7/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/core/aspnet at https://mcr.microsoft.com/v2/dotnet/core/aspnet/tags/list.
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,9 +1,9 @@
 # Featured Tags
 
-* `3.0` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/aspnet:3.0`
-* `2.1` (LTS)
-  * `docker pull mcr.microsoft.com/dotnet/core/aspnet:2.1`
+* `3.1` (Current)
+  * `docker pull mcr.microsoft.com/dotnet/core/aspnet:3.1`
+* `3.1` (LTS)
+  * `docker pull mcr.microsoft.com/dotnet/core/aspnet:3.1`
 
 # About This Image
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,8 +1,6 @@
 # Featured Tags
 
-* `3.1` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/aspnet:3.1`
-* `3.1` (LTS)
+* `3.1` (LTS/Current)
   * `docker pull mcr.microsoft.com/dotnet/core/aspnet:3.1`
 
 # About This Image

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -1,8 +1,6 @@
 # Featured Tags
 
-* `3.1` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/runtime-deps:3.1`
-* `3.1` (LTS)
+* `3.1` (LTS/Current)
   * `docker pull mcr.microsoft.com/dotnet/core/runtime-deps:3.1`
 
 # About This Image

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -38,7 +38,10 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim, 3.0-buster-slim, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/amd64/Dockerfile) | Debian 10
+3.1.0-buster-slim, 3.1-buster-slim, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/amd64/Dockerfile) | Debian 10
+3.1.0-alpine3.10, 3.1-alpine3.10, 3.1.0-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.10/amd64/Dockerfile) | Alpine 3.10
+3.1.0-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/amd64/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim, 3.0-buster-slim, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/amd64/Dockerfile) | Debian 10
 3.0.1-alpine3.10, 3.0-alpine3.10, 3.0.1-alpine, 3.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.10/amd64/Dockerfile) | Alpine 3.10
 3.0.1-alpine3.9, 3.0-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 3.0.1-disco, 3.0-disco | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/disco/amd64/Dockerfile) | Ubuntu 19.04
@@ -52,45 +55,30 @@ Tags | Dockerfile | OS Version
 2.1.14-alpine3.9, 2.1-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 2.1.14-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim, 3.1-buster-slim, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/amd64/Dockerfile) | Debian 10
-3.1.0-preview3-alpine3.10, 3.1-alpine3.10, 3.1.0-preview3-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.10/amd64/Dockerfile) | Alpine 3.10
-3.1.0-preview3-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/amd64/Dockerfile) | Ubuntu 18.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim-arm64v8, 3.0-buster-slim-arm64v8, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm64v8/Dockerfile) | Debian 10
+3.1.0-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm64v8/Dockerfile) | Debian 10
+3.1.0-alpine3.10-arm64v8, 3.1-alpine3.10-arm64v8, 3.1.0-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
+3.1.0-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim-arm64v8, 3.0-buster-slim-arm64v8, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm64v8/Dockerfile) | Debian 10
 3.0.1-alpine3.10-arm64v8, 3.0-alpine3.10-arm64v8, 3.0.1-alpine-arm64v8, 3.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
 3.0.1-alpine3.9-arm64v8, 3.0-alpine3.9-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.9/arm64v8/Dockerfile) | Alpine 3.9
 3.0.1-disco-arm64v8, 3.0-disco-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/disco/arm64v8/Dockerfile) | Ubuntu 19.04
 3.0.1-bionic-arm64v8, 3.0-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm64v8/Dockerfile) | Debian 10
-3.1.0-preview3-alpine3.10-arm64v8, 3.1-alpine3.10-arm64v8, 3.1.0-preview3-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
-3.1.0-preview3-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
-
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim-arm32v7, 3.0-buster-slim-arm32v7, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm32v7/Dockerfile) | Debian 10
+3.1.0-buster-slim-arm32v7, 3.1-buster-slim-arm32v7, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm32v7/Dockerfile) | Debian 10
+3.1.0-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim-arm32v7, 3.0-buster-slim-arm32v7, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm32v7/Dockerfile) | Debian 10
 3.0.1-disco-arm32v7, 3.0-disco-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/disco/arm32v7/Dockerfile) | Ubuntu 19.04
 3.0.1-bionic-arm32v7, 3.0-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 2.2.8-stretch-slim-arm32v7, 2.2-stretch-slim-arm32v7, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile) | Debian 9
 2.2.8-bionic-arm32v7, 2.2-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 2.1.14-stretch-slim-arm32v7, 2.1-stretch-slim-arm32v7, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile) | Debian 9
 2.1.14-bionic-arm32v7, 2.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime-deps/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
-
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim-arm32v7, 3.1-buster-slim-arm32v7, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/buster-slim/arm32v7/Dockerfile) | Debian 10
-3.1.0-preview3-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime-deps/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 
 You can retrieve a list of all available tags for dotnet/core/runtime-deps at https://mcr.microsoft.com/v2/dotnet/core/runtime-deps/tags/list.
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -1,9 +1,9 @@
 # Featured Tags
 
-* `3.0` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/runtime-deps:3.0`
-* `2.1` (LTS)
-  * `docker pull mcr.microsoft.com/dotnet/core/runtime-deps:2.1`
+* `3.1` (Current)
+  * `docker pull mcr.microsoft.com/dotnet/core/runtime-deps:3.1`
+* `3.1` (LTS)
+  * `docker pull mcr.microsoft.com/dotnet/core/runtime-deps:3.1`
 
 # About This Image
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,9 +1,9 @@
 # Featured Tags
 
-* `3.0` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/runtime:3.0`
-* `2.1` (LTS)
-  * `docker pull mcr.microsoft.com/dotnet/core/runtime:2.1`
+* `3.1` (Current)
+  * `docker pull mcr.microsoft.com/dotnet/core/runtime:3.1`
+* `3.1` (LTS)
+  * `docker pull mcr.microsoft.com/dotnet/core/runtime:3.1`
 
 # About This Image
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,8 +1,6 @@
 # Featured Tags
 
-* `3.1` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/runtime:3.1`
-* `3.1` (LTS)
+* `3.1` (LTS/Current)
   * `docker pull mcr.microsoft.com/dotnet/core/runtime:3.1`
 
 # About This Image

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -46,7 +46,10 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim, 3.0-buster-slim, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/buster-slim/amd64/Dockerfile) | Debian 10
+3.1.0-buster-slim, 3.1-buster-slim, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/buster-slim/amd64/Dockerfile) | Debian 10
+3.1.0-alpine3.10, 3.1-alpine3.10, 3.1.0-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/alpine3.10/amd64/Dockerfile) | Alpine 3.10
+3.1.0-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/bionic/amd64/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim, 3.0-buster-slim, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/buster-slim/amd64/Dockerfile) | Debian 10
 3.0.1-alpine3.10, 3.0-alpine3.10, 3.0.1-alpine, 3.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/alpine3.10/amd64/Dockerfile) | Alpine 3.10
 3.0.1-alpine3.9, 3.0-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 3.0.1-disco, 3.0-disco | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/disco/amd64/Dockerfile) | Ubuntu 19.04
@@ -60,33 +63,24 @@ Tags | Dockerfile | OS Version
 2.1.14-alpine3.9, 2.1-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 2.1.14-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim, 3.1-buster-slim, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/buster-slim/amd64/Dockerfile) | Debian 10
-3.1.0-preview3-alpine3.10, 3.1-alpine3.10, 3.1.0-preview3-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/alpine3.10/amd64/Dockerfile) | Alpine 3.10
-3.1.0-preview3-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/bionic/amd64/Dockerfile) | Ubuntu 18.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim-arm64v8, 3.0-buster-slim-arm64v8, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/buster-slim/arm64v8/Dockerfile) | Debian 10
+3.1.0-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/buster-slim/arm64v8/Dockerfile) | Debian 10
+3.1.0-alpine3.10-arm64v8, 3.1-alpine3.10-arm64v8, 3.1.0-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
+3.1.0-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim-arm64v8, 3.0-buster-slim-arm64v8, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/buster-slim/arm64v8/Dockerfile) | Debian 10
 3.0.1-alpine3.10-arm64v8, 3.0-alpine3.10-arm64v8, 3.0.1-alpine-arm64v8, 3.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
 3.0.1-alpine3.9-arm64v8, 3.0-alpine3.9-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/alpine3.9/arm64v8/Dockerfile) | Alpine 3.9
 3.0.1-disco-arm64v8, 3.0-disco-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/disco/arm64v8/Dockerfile) | Ubuntu 19.04
 3.0.1-bionic-arm64v8, 3.0-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/buster-slim/arm64v8/Dockerfile) | Debian 10
-3.1.0-preview3-alpine3.10-arm64v8, 3.1-alpine3.10-arm64v8, 3.1.0-preview3-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/alpine3.10/arm64v8/Dockerfile) | Alpine 3.10
-3.1.0-preview3-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
-
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.1-buster-slim-arm32v7, 3.0-buster-slim-arm32v7, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/buster-slim/arm32v7/Dockerfile) | Debian 10
+3.1.0-buster-slim-arm32v7, 3.1-buster-slim-arm32v7, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/buster-slim/arm32v7/Dockerfile) | Debian 10
+3.1.0-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
+3.0.1-buster-slim-arm32v7, 3.0-buster-slim-arm32v7, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/buster-slim/arm32v7/Dockerfile) | Debian 10
 3.0.1-disco-arm32v7, 3.0-disco-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/disco/arm32v7/Dockerfile) | Ubuntu 19.04
 3.0.1-bionic-arm32v7, 3.0-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 2.2.8-stretch-slim-arm32v7, 2.2-stretch-slim-arm32v7, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/runtime/stretch-slim/arm32v7/Dockerfile) | Debian 9
@@ -94,58 +88,36 @@ Tags | Dockerfile | OS Version
 2.1.14-stretch-slim-arm32v7, 2.1-stretch-slim-arm32v7, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/stretch-slim/arm32v7/Dockerfile) | Debian 9
 2.1.14-bionic-arm32v7, 2.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.0-preview3-buster-slim-arm32v7, 3.1-buster-slim-arm32v7, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/buster-slim/arm32v7/Dockerfile) | Debian 10
-3.1.0-preview3-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
-
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1909, 3.0-nanoserver-1909, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1909/amd64/Dockerfile)
+3.1.0-nanoserver-1909, 3.1-nanoserver-1909, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1909/amd64/Dockerfile)
+3.0.1-nanoserver-1909, 3.0-nanoserver-1909, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1909/amd64/Dockerfile)
 2.2.8-nanoserver-1909, 2.2-nanoserver-1909, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/runtime/nanoserver-1909/amd64/Dockerfile)
 2.1.14-nanoserver-1909, 2.1-nanoserver-1909, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1909/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1909, 3.1-nanoserver-1909, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1903, 3.0-nanoserver-1903, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1903/amd64/Dockerfile)
+3.1.0-nanoserver-1903, 3.1-nanoserver-1903, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1903/amd64/Dockerfile)
+3.0.1-nanoserver-1903, 3.0-nanoserver-1903, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1903/amd64/Dockerfile)
 2.2.8-nanoserver-1903, 2.2-nanoserver-1903, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/runtime/nanoserver-1903/amd64/Dockerfile)
 2.1.14-nanoserver-1903, 2.1-nanoserver-1903, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1903/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1903, 3.1-nanoserver-1903, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1809, 3.0-nanoserver-1809, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1809/amd64/Dockerfile)
+3.1.0-nanoserver-1809, 3.1-nanoserver-1809, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1809/amd64/Dockerfile)
+3.0.1-nanoserver-1809, 3.0-nanoserver-1809, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1809/amd64/Dockerfile)
 2.2.8-nanoserver-1809, 2.2-nanoserver-1809, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/runtime/nanoserver-1809/amd64/Dockerfile)
 2.1.14-nanoserver-1809, 2.1-nanoserver-1809, 2.1.14, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/runtime/nanoserver-1809/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1809, 3.1-nanoserver-1809, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1809/amd64/Dockerfile)
 
 ## Windows Server 2019 arm32 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.1-nanoserver-1809-arm32v7, 3.0-nanoserver-1809-arm32v7, 3.0.1, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1809/arm32v7/Dockerfile)
+3.1.0-nanoserver-1809-arm32v7, 3.1-nanoserver-1809-arm32v7, 3.1.0, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1809/arm32v7/Dockerfile)
+3.0.1-nanoserver-1809-arm32v7, 3.0-nanoserver-1809-arm32v7, 3.0.1, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/runtime/nanoserver-1809/arm32v7/Dockerfile)
 2.2.8-nanoserver-1809-arm32v7, 2.2-nanoserver-1809-arm32v7, 2.2.8, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/runtime/nanoserver-1809/arm32v7/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.0-preview3-nanoserver-1809-arm32v7, 3.1-nanoserver-1809-arm32v7, 3.1.0-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/runtime/nanoserver-1809/arm32v7/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/core/runtime at https://mcr.microsoft.com/v2/dotnet/core/runtime/tags/list.
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -50,7 +50,10 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.101-buster, 3.0-buster, 3.0.101, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/buster/amd64/Dockerfile) | Debian 10
+3.1.100-buster, 3.1-buster, 3.1.100, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/buster/amd64/Dockerfile) | Debian 10
+3.1.100-alpine3.10, 3.1-alpine3.10, 3.1.100-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/alpine3.10/amd64/Dockerfile) | Alpine 3.10
+3.1.100-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/bionic/amd64/Dockerfile) | Ubuntu 18.04
+3.0.101-buster, 3.0-buster, 3.0.101, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/buster/amd64/Dockerfile) | Debian 10
 3.0.101-alpine3.10, 3.0-alpine3.10, 3.0.101-alpine, 3.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/alpine3.10/amd64/Dockerfile) | Alpine 3.10
 3.0.101-alpine3.9, 3.0-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 3.0.101-disco, 3.0-disco | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/disco/amd64/Dockerfile) | Ubuntu 19.04
@@ -64,30 +67,21 @@ Tags | Dockerfile | OS Version
 2.1.607-alpine3.9, 2.1-alpine3.9 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/alpine3.9/amd64/Dockerfile) | Alpine 3.9
 2.1.607-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.100-preview3-buster, 3.1-buster, 3.1.100-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/buster/amd64/Dockerfile) | Debian 10
-3.1.100-preview3-alpine3.10, 3.1-alpine3.10, 3.1.100-preview3-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/alpine3.10/amd64/Dockerfile) | Alpine 3.10
-3.1.100-preview3-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/bionic/amd64/Dockerfile) | Ubuntu 18.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.101-buster-arm64v8, 3.0-buster-arm64v8, 3.0.101, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/buster/arm64v8/Dockerfile) | Debian 10
+3.1.100-buster-arm64v8, 3.1-buster-arm64v8, 3.1.100, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/buster/arm64v8/Dockerfile) | Debian 10
+3.1.100-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
+3.0.101-buster-arm64v8, 3.0-buster-arm64v8, 3.0.101, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/buster/arm64v8/Dockerfile) | Debian 10
 3.0.101-disco-arm64v8, 3.0-disco-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/disco/arm64v8/Dockerfile) | Ubuntu 19.04
 3.0.101-bionic-arm64v8, 3.0-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
-
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.100-preview3-buster-arm64v8, 3.1-buster-arm64v8, 3.1.100-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/buster/arm64v8/Dockerfile) | Debian 10
-3.1.100-preview3-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-3.0.101-buster-arm32v7, 3.0-buster-arm32v7, 3.0.101, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/buster/arm32v7/Dockerfile) | Debian 10
+3.1.100-buster-arm32v7, 3.1-buster-arm32v7, 3.1.100, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/buster/arm32v7/Dockerfile) | Debian 10
+3.1.100-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
+3.0.101-buster-arm32v7, 3.0-buster-arm32v7, 3.0.101, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/buster/arm32v7/Dockerfile) | Debian 10
 3.0.101-disco-arm32v7, 3.0-disco-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/disco/arm32v7/Dockerfile) | Ubuntu 19.04
 3.0.101-bionic-arm32v7, 3.0-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 2.2.207-stretch-arm32v7, 2.2-stretch-arm32v7, 2.2.207, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/stretch/arm32v7/Dockerfile) | Debian 9
@@ -95,58 +89,36 @@ Tags | Dockerfile | OS Version
 2.1.607-stretch-arm32v7, 2.1-stretch-arm32v7, 2.1.607, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/stretch/arm32v7/Dockerfile) | Debian 9
 2.1.607-bionic-arm32v7, 2.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 
-##### .NET Core 3.1 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-3.1.100-preview3-buster-arm32v7, 3.1-buster-arm32v7, 3.1.100-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/buster/arm32v7/Dockerfile) | Debian 10
-3.1.100-preview3-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
-
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.101-nanoserver-1909, 3.0-nanoserver-1909, 3.0.101, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1909/amd64/Dockerfile)
+3.1.100-nanoserver-1909, 3.1-nanoserver-1909, 3.1.100, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1909/amd64/Dockerfile)
+3.0.101-nanoserver-1909, 3.0-nanoserver-1909, 3.0.101, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1909/amd64/Dockerfile)
 2.2.207-nanoserver-1909, 2.2-nanoserver-1909, 2.2.207, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1909/amd64/Dockerfile)
 2.1.607-nanoserver-1909, 2.1-nanoserver-1909, 2.1.607, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1909/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.100-preview3-nanoserver-1909, 3.1-nanoserver-1909, 3.1.100-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.101-nanoserver-1903, 3.0-nanoserver-1903, 3.0.101, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1903/amd64/Dockerfile)
+3.1.100-nanoserver-1903, 3.1-nanoserver-1903, 3.1.100, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1903/amd64/Dockerfile)
+3.0.101-nanoserver-1903, 3.0-nanoserver-1903, 3.0.101, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1903/amd64/Dockerfile)
 2.2.207-nanoserver-1903, 2.2-nanoserver-1903, 2.2.207, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1903/amd64/Dockerfile)
 2.1.607-nanoserver-1903, 2.1-nanoserver-1903, 2.1.607, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1903/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.100-preview3-nanoserver-1903, 3.1-nanoserver-1903, 3.1.100-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.101-nanoserver-1809, 3.0-nanoserver-1809, 3.0.101, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/amd64/Dockerfile)
+3.1.100-nanoserver-1809, 3.1-nanoserver-1809, 3.1.100, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1809/amd64/Dockerfile)
+3.0.101-nanoserver-1809, 3.0-nanoserver-1809, 3.0.101, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/amd64/Dockerfile)
 2.2.207-nanoserver-1809, 2.2-nanoserver-1809, 2.2.207, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1809/amd64/Dockerfile)
 2.1.607-nanoserver-1809, 2.1-nanoserver-1809, 2.1.607, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/nanoserver-1809/amd64/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.100-preview3-nanoserver-1809, 3.1-nanoserver-1809, 3.1.100-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1809/amd64/Dockerfile)
 
 ## Windows Server 2019 arm32 Tags
 Tag | Dockerfile
 ---------| ---------------
-3.0.101-nanoserver-1809-arm32v7, 3.0-nanoserver-1809-arm32v7, 3.0.101, 3.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile)
+3.1.100-nanoserver-1809-arm32v7, 3.1-nanoserver-1809-arm32v7, 3.1.100, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile)
+3.0.101-nanoserver-1809-arm32v7, 3.0-nanoserver-1809-arm32v7, 3.0.101, 3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.0/sdk/nanoserver-1809/arm32v7/Dockerfile)
 2.2.207-nanoserver-1809-arm32v7, 2.2-nanoserver-1809-arm32v7, 2.2.207, 2.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/nanoserver-1809/arm32v7/Dockerfile)
-
-##### .NET Core 3.1 Preview Tags
-Tag | Dockerfile
----------| ---------------
-3.1.100-preview3-nanoserver-1809-arm32v7, 3.1-nanoserver-1809-arm32v7, 3.1.100-preview3, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/3.1/sdk/nanoserver-1809/arm32v7/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/core/sdk at https://mcr.microsoft.com/v2/dotnet/core/sdk/tags/list.
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,8 +1,6 @@
 # Featured Tags
 
-* `3.1` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/sdk:3.1`
-* `3.1` (LTS)
+* `3.1` (LTS/Current)
   * `docker pull mcr.microsoft.com/dotnet/core/sdk:3.1`
 
 # About This Image

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,9 +1,9 @@
 # Featured Tags
 
-* `3.0` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/core/sdk:3.0`
-* `2.1` (LTS)
-  * `docker pull mcr.microsoft.com/dotnet/core/sdk:2.1`
+* `3.1` (Current)
+  * `docker pull mcr.microsoft.com/dotnet/core/sdk:3.1`
+* `3.1` (LTS)
+  * `docker pull mcr.microsoft.com/dotnet/core/sdk:3.1`
 
 # About This Image
 

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -1,4 +1,7 @@
 $(McrTagsYmlRepo:aspnet)
+$(McrTagsYmlTagGroup:3.1-buster-slim)
+$(McrTagsYmlTagGroup:3.1-alpine3.10)
+$(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:3.0-buster-slim)
 $(McrTagsYmlTagGroup:3.0-alpine3.10)
 $(McrTagsYmlTagGroup:3.0-alpine3.9)
@@ -12,12 +15,11 @@ $(McrTagsYmlTagGroup:2.1-stretch-slim)
 $(McrTagsYmlTagGroup:2.1-alpine3.10)
 $(McrTagsYmlTagGroup:2.1-alpine3.9)
 $(McrTagsYmlTagGroup:2.1-bionic)
-$(McrTagsYmlTagGroup:3.1-buster-slim)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-alpine3.10)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-buster-slim-arm64v8)
+$(McrTagsYmlTagGroup:3.1-alpine3.10-arm64v8)
+$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
+$(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
+$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:3.0-buster-slim-arm64v8)
 $(McrTagsYmlTagGroup:3.0-alpine3.10-arm64v8)
 $(McrTagsYmlTagGroup:3.0-alpine3.9-arm64v8)
@@ -30,32 +32,18 @@ $(McrTagsYmlTagGroup:2.2-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.2-bionic-arm32v7)
 $(McrTagsYmlTagGroup:2.1-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
-$(McrTagsYmlTagGroup:3.1-buster-slim-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-alpine3.10-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1909)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1909)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1903)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1903)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1903)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1903)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1903)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1809)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1809)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1809)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1809)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1809)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1809-arm32v7)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1809-arm32v7)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1809-arm32v7)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1809-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
@@ -1,4 +1,7 @@
 $(McrTagsYmlRepo:runtime-deps)
+$(McrTagsYmlTagGroup:3.1-buster-slim)
+$(McrTagsYmlTagGroup:3.1-alpine3.10)
+$(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:3.0-buster-slim)
 $(McrTagsYmlTagGroup:3.0-alpine3.10)
 $(McrTagsYmlTagGroup:3.0-alpine3.9)
@@ -12,23 +15,16 @@ $(McrTagsYmlTagGroup:2.1-stretch-slim)
 $(McrTagsYmlTagGroup:2.1-alpine3.10)
 $(McrTagsYmlTagGroup:2.1-alpine3.9)
 $(McrTagsYmlTagGroup:2.1-bionic)
-$(McrTagsYmlTagGroup:3.1-buster-slim)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-alpine3.10)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-buster-slim-arm64v8)
+$(McrTagsYmlTagGroup:3.1-alpine3.10-arm64v8)
+$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:3.0-buster-slim-arm64v8)
 $(McrTagsYmlTagGroup:3.0-alpine3.10-arm64v8)
 $(McrTagsYmlTagGroup:3.0-alpine3.9-arm64v8)
 $(McrTagsYmlTagGroup:3.0-disco-arm64v8)
 $(McrTagsYmlTagGroup:3.0-bionic-arm64v8)
-$(McrTagsYmlTagGroup:3.1-buster-slim-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-alpine3.10-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
+$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:3.0-buster-slim-arm32v7)
 $(McrTagsYmlTagGroup:3.0-disco-arm32v7)
 $(McrTagsYmlTagGroup:3.0-bionic-arm32v7)
@@ -36,7 +32,3 @@ $(McrTagsYmlTagGroup:2.2-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.2-bionic-arm32v7)
 $(McrTagsYmlTagGroup:2.1-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
-$(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -1,4 +1,7 @@
 $(McrTagsYmlRepo:runtime)
+$(McrTagsYmlTagGroup:3.1-buster-slim)
+$(McrTagsYmlTagGroup:3.1-alpine3.10)
+$(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:3.0-buster-slim)
 $(McrTagsYmlTagGroup:3.0-alpine3.10)
 $(McrTagsYmlTagGroup:3.0-alpine3.9)
@@ -12,23 +15,16 @@ $(McrTagsYmlTagGroup:2.1-stretch-slim)
 $(McrTagsYmlTagGroup:2.1-alpine3.10)
 $(McrTagsYmlTagGroup:2.1-alpine3.9)
 $(McrTagsYmlTagGroup:2.1-bionic)
-$(McrTagsYmlTagGroup:3.1-buster-slim)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-alpine3.10)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-buster-slim-arm64v8)
+$(McrTagsYmlTagGroup:3.1-alpine3.10-arm64v8)
+$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:3.0-buster-slim-arm64v8)
 $(McrTagsYmlTagGroup:3.0-alpine3.10-arm64v8)
 $(McrTagsYmlTagGroup:3.0-alpine3.9-arm64v8)
 $(McrTagsYmlTagGroup:3.0-disco-arm64v8)
 $(McrTagsYmlTagGroup:3.0-bionic-arm64v8)
-$(McrTagsYmlTagGroup:3.1-buster-slim-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-alpine3.10-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
+$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:3.0-buster-slim-arm32v7)
 $(McrTagsYmlTagGroup:3.0-disco-arm32v7)
 $(McrTagsYmlTagGroup:3.0-bionic-arm32v7)
@@ -36,26 +32,18 @@ $(McrTagsYmlTagGroup:2.2-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.2-bionic-arm32v7)
 $(McrTagsYmlTagGroup:2.1-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
-$(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1909)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1909)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1903)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1903)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1903)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1903)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1903)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1809)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1809)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1809)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1809)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1809)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1809-arm32v7)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1809-arm32v7)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1809-arm32v7)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1809-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -1,4 +1,7 @@
 $(McrTagsYmlRepo:sdk)
+$(McrTagsYmlTagGroup:3.1-buster)
+$(McrTagsYmlTagGroup:3.1-alpine3.10)
+$(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:3.0-buster)
 $(McrTagsYmlTagGroup:3.0-alpine3.10)
 $(McrTagsYmlTagGroup:3.0-alpine3.9)
@@ -12,19 +15,13 @@ $(McrTagsYmlTagGroup:2.1-stretch)
 $(McrTagsYmlTagGroup:2.1-alpine3.10)
 $(McrTagsYmlTagGroup:2.1-alpine3.9)
 $(McrTagsYmlTagGroup:2.1-bionic)
-$(McrTagsYmlTagGroup:3.1-buster)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-alpine3.10)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-buster-arm64v8)
+$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:3.0-buster-arm64v8)
 $(McrTagsYmlTagGroup:3.0-disco-arm64v8)
 $(McrTagsYmlTagGroup:3.0-bionic-arm64v8)
-$(McrTagsYmlTagGroup:3.1-buster-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-buster-arm32v7)
+$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:3.0-buster-arm32v7)
 $(McrTagsYmlTagGroup:3.0-disco-arm32v7)
 $(McrTagsYmlTagGroup:3.0-bionic-arm32v7)
@@ -32,26 +29,18 @@ $(McrTagsYmlTagGroup:2.2-stretch-arm32v7)
 $(McrTagsYmlTagGroup:2.2-bionic-arm32v7)
 $(McrTagsYmlTagGroup:2.1-stretch-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
-$(McrTagsYmlTagGroup:3.1-buster-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
-$(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1909)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1909)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1903)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1903)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1903)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1903)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1903)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1809)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1809)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1809)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1809)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1809)
-    customSubTableTitle: .NET Core 3.1 Preview Tags
+$(McrTagsYmlTagGroup:3.1-nanoserver-1809-arm32v7)
 $(McrTagsYmlTagGroup:3.0-nanoserver-1809-arm32v7)
 $(McrTagsYmlTagGroup:2.2-nanoserver-1809-arm32v7)
-$(McrTagsYmlTagGroup:3.1-nanoserver-1809-arm32v7)
-    customSubTableTitle: .NET Core 3.1 Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -197,7 +197,7 @@
               "documentationGroup": "3.1"
             },
             "latest": {
-              "documentationGroup": "3.0"
+              "documentationGroup": "3.1"
             }
           },
           "platforms": [
@@ -762,8 +762,7 @@
         {
           "sharedTags": {
             "$(3.0-RuntimeVersion)": {},
-            "3.0": {},
-            "latest": {}
+            "3.0": {}
           },
           "platforms": [
             {
@@ -1040,7 +1039,8 @@
         {
           "sharedTags": {
             "$(3.1-RuntimeVersion)": {},
-            "3.1": {}
+            "3.1": {},
+            "latest": {}
           },
           "platforms": [
             {
@@ -1502,8 +1502,7 @@
         {
           "sharedTags": {
             "$(3.0-RuntimeVersion)": {},
-            "3.0": {},
-            "latest": {}
+            "3.0": {}
           },
           "platforms": [
             {
@@ -1792,7 +1791,8 @@
         {
           "sharedTags": {
             "$(3.1-RuntimeVersion)": {},
-            "3.1": {}
+            "3.1": {},
+            "latest": {}
           },
           "platforms": [
             {
@@ -2242,8 +2242,7 @@
         {
           "sharedTags": {
             "$(3.0-SdkVersion)": {},
-            "3.0": {},
-            "latest": {}
+            "3.0": {}
           },
           "platforms": [
             {
@@ -2439,7 +2438,8 @@
         {
           "sharedTags": {
             "$(3.1-SdkVersion)": {},
-            "3.1": {}
+            "3.1": {},
+            "latest": {}
           },
           "platforms": [
             {

--- a/manifest.json
+++ b/manifest.json
@@ -8,8 +8,8 @@
     "2.2-SdkVersion": "2.2.207",
     "3.0-RuntimeVersion": "3.0.1",
     "3.0-SdkVersion": "3.0.101",
-    "3.1-RuntimeVersion": "3.1.0-preview3",
-    "3.1-SdkVersion": "3.1.100-preview3"
+    "3.1-RuntimeVersion": "3.1.0",
+    "3.1-SdkVersion": "3.1.100"
   },
   "repos": [
     {


### PR DESCRIPTION
* Updates all the Dockerfiles to use the 3.1 RTM version instead of preview 3 version.
* Update tags and READMEs to designate 3.1 as an official release instead of preview.
* Update PowerShell to 7.0.0-preview 6 (#1489)
* Fix file ownership issues (#1493)

