### PR TITLE
Remove temp workaround for 3.1 nuget feed

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config.nightly
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config.nightly
@@ -4,7 +4,6 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-    <add key="3.1-rtm" value="https://dotnetfeed.blob.core.windows.net/dotnet-core-3-1-rtm-014727/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This NuGet feed was added temporarily to validate the 3.1 release in the nightly branch before the NuGet packages had been published externally.  It can be removed now.