### PR TITLE
Prevent force-pushes on PR in update-dependencies

### DIFF
--- a/eng/update-dependencies/NuGet.config
+++ b/eng/update-dependencies/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.VersionTools;
-using Microsoft.DotNet.VersionTools.Automation;
-using Microsoft.DotNet.VersionTools.BuildManifest.Model;
-using Microsoft.DotNet.VersionTools.Dependencies;
-using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using LibGit2Sharp;
+using Microsoft.DotNet.VersionTools;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using Microsoft.DotNet.VersionTools.Dependencies;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 
 namespace Dotnet.Docker
 {
@@ -45,9 +46,10 @@ namespace Dotnet.Docker
                     }
                     else
                     {
-                        await CreatePullRequestAsync(buildInfos);
+                        await CreatePullRequestAsync();
                     }
                 }
+                await CreatePullRequestAsync();
             }
             catch (Exception e)
             {
@@ -147,7 +149,7 @@ namespace Dotnet.Docker
                 Enumerable.Empty<string>());
         }
 
-        private static async Task CreatePullRequestAsync(IEnumerable<IDependencyInfo> buildInfos)
+        private static async Task CreatePullRequestAsync()
         {
             GitHubAuth gitHubAuth = new GitHubAuth(Options.GitHubPassword, Options.GitHubUser, Options.GitHubEmail);
             PullRequestCreator prCreator = new PullRequestCreator(gitHubAuth, Options.GitHubUser);
@@ -157,14 +159,149 @@ namespace Dotnet.Docker
             };
 
             string commitMessage = $"[{Options.GitHubUpstreamBranch}] Update dependencies from dotnet/core-sdk";
+            GitHubProject upstreamProject = new GitHubProject(Options.GitHubProject, Options.GitHubUpstreamOwner);
+            GitHubBranch upstreamBranch = new GitHubBranch(Options.GitHubUpstreamBranch, upstreamProject);
 
-            await prCreator.CreateOrUpdateAsync(
-                commitMessage,
-                commitMessage,
-                string.Empty,
-                new GitHubBranch(Options.GitHubUpstreamBranch, new GitHubProject(Options.GitHubProject, Options.GitHubUpstreamOwner)),
-                new GitHubProject(Options.GitHubProject, gitHubAuth.User),
-                prOptions);
+            using (GitHubClient client = new GitHubClient(gitHubAuth))
+            {
+                GitHubPullRequest pullRequestToUpdate = await client.SearchPullRequestsAsync(
+                    upstreamProject,
+                    upstreamBranch.Name,
+                    await client.GetMyAuthorIdAsync());
+
+                if (pullRequestToUpdate == null)
+                {
+                    await prCreator.CreateOrUpdateAsync(
+                        commitMessage,
+                        commitMessage,
+                        string.Empty,
+                        upstreamBranch,
+                        new GitHubProject(Options.GitHubProject, gitHubAuth.User),
+                        prOptions);
+                }
+                else
+                {
+                    UpdateExistingPullRequest(gitHubAuth, prOptions, commitMessage, upstreamBranch);
+                }
+            }
+        }
+
+        private static void UpdateExistingPullRequest(
+            GitHubAuth gitHubAuth, PullRequestOptions prOptions, string commitMessage, GitHubBranch upstreamBranch)
+        {
+            // PullRequestCreator ends up force-pushing updates to an existing PR which is not great when the logic
+            // gets called on a schedule (see https://github.com/dotnet/dotnet-docker/issues/1114). To avoid this,
+            // it needs the ability to only update files that have changed from the existing PR.  Because the
+            // PullRequestCreator class doesn't rely on there being a locally cloned repo, it doesn't have an
+            // efficient way to determine whether files have changed or not. Update-dependencies would have to
+            // implement logic which pulls down each file individually from the API and compare it to what exists
+            // in the local repo.  Since that's not an efficient process, this method works by cloning the PR's
+            // branch to a temporary repo location, grabbing the whole repo where the original updates from
+            // update-dependencies were made and copying it into the temp repo, and committing and pushing 
+            // those changes in the temp repo back to the PR's branch.
+
+            string tempRepoPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                string branchName = prOptions.BranchNamingStrategy.Prefix(upstreamBranch.Name);
+                CloneOptions cloneOptions = new CloneOptions
+                {
+                    BranchName = branchName
+                };
+
+                // Clone the PR's repo/branch to a temp location
+                Repository.Clone($"https://github.com/{gitHubAuth.User}/{Options.GitHubProject}", tempRepoPath, cloneOptions);
+
+                // Remove all existing directories and files from the temp repo
+                foreach (string file in Directory.GetFiles(tempRepoPath))
+                {
+                    File.Delete(file);
+                }
+                foreach (DirectoryInfo dir in new DirectoryInfo(tempRepoPath).GetDirectories().Where(dir => dir.Name != ".git"))
+                {
+                    Directory.Delete(dir.FullName, true);
+                }
+
+                // Copy contents of local repo changes to temp repo
+                DirectoryCopy(".", tempRepoPath);
+
+                using Repository repo = new Repository(tempRepoPath);
+                RepositoryStatus status = repo.RetrieveStatus(new StatusOptions());
+
+                // If there are any changes from what exists in the PR
+                if (status.IsDirty)
+                {
+                    Commands.Stage(repo, "*");
+
+                    Signature signature = new Signature(Options.GitHubUser, Options.GitHubEmail, DateTimeOffset.Now);
+                    repo.Commit(commitMessage, signature, signature);
+
+                    Branch branch = repo.Branches[$"origin/{branchName}"];
+
+                    PushOptions pushOptions = new PushOptions
+                    {
+                        CredentialsProvider = (url, user, credTypes) => new UsernamePasswordCredentials
+                        {
+                            Username = Options.GitHubPassword,
+                            Password = String.Empty
+                        }
+                    };
+
+                    Remote remote = repo.Network.Remotes["origin"];
+                    string pushRefSpec = $@"refs/heads/{branchName}";
+
+                    repo.Network.Push(remote, pushRefSpec, pushOptions);
+                }
+            }
+            finally
+            {
+                // Cleanup temp repo
+                if (Directory.Exists(tempRepoPath))
+                {
+                    IEnumerable<string> gitFiles = Directory.GetFiles(
+                        Path.Combine(tempRepoPath, ".git"), "*", SearchOption.AllDirectories);
+
+                    // Ensure all files in .git folder are writable
+                    foreach (string file in gitFiles)
+                    {
+                        File.SetAttributes(file, FileAttributes.Normal);
+                    }
+
+                    Directory.Delete(tempRepoPath, true);
+                }
+            }
+        }
+
+        private static void DirectoryCopy(string sourceDirName, string destDirName)
+        {
+            // Get the subdirectories for the specified directory.
+            DirectoryInfo dir = new DirectoryInfo(sourceDirName);
+
+            DirectoryInfo[] dirs = dir.GetDirectories()
+                .Where(dir => !dir.Name.StartsWith("."))
+                .ToArray();
+
+            // If the destination directory doesn't exist, create it.
+            if (!Directory.Exists(destDirName))
+            {
+                Directory.CreateDirectory(destDirName);
+            }
+
+            // Get the files in the directory and copy them to the new location.
+            FileInfo[] files = dir.GetFiles();
+            foreach (FileInfo file in files)
+            {
+                string temppath = Path.Combine(destDirName, file.Name);
+                file.CopyTo(temppath, false);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+            foreach (DirectoryInfo subdir in dirs)
+            {
+                string temppath = Path.Combine(destDirName, subdir.Name);
+                DirectoryCopy(subdir.FullName, temppath);
+            }
         }
 
         private static string GetBuildVersion(this IEnumerable<IDependencyInfo> buildInfos, string name)

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.0-beta.19426.12" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="5.0.0-beta.19617.1" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2"/>
   </ItemGroup>

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="2.2.0-prerelease-02431-01" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.0-beta.19426.12" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2"/>
   </ItemGroup>


### PR DESCRIPTION
The current behavior of update-dependencies is that it will update an existing PR by force-pushing.  The consequence of this is that it triggers another build.  This happens even when there were no changes that were made from the previous state of the PR's branch.  That's because there's no logic to compare what the state of the PR's branch is.  All it does is detect what files have changed in the _local_ repo and produced a commit that contains those files and force-pushes them blindly into the PR.

Making use of `PullRequestCreator` isn't a good option in this case.  It has to do a force push because it doesn't know about or require a local repo to compare files against.  It's up to the caller to produce a correct commit.  In theory, we could implement logic in update-dependencies that requests the file content for every file in the PR's branch and compares that against the contents of the local repo.  But that would be incredibly inefficient and use up REST API quotas.

A better way is to simply clone the PR's repo/branch to the computer and let git do the comparison for us.  After cloning the repo to a temp location, update-dependencies clears out the contents to get it into a clean state.  Then it copies the contents of the repo where the changes were made into the temp repo.  Now we can use git to easily determine the diffs.  Just stage the files that changed and commit/push them back to the PR's branch.

Fixes #1114