### PR TITLE
Unit test refactoring

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -19,7 +19,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public async Task VerifyAppScenario(ImageData imageData)
+        [Trait("Category", "aspnet")]
+        public async Task VerifyAppScenario(ProductImageData imageData)
         {
             ImageScenarioVerifier verifier = new ImageScenarioVerifier(imageData, DockerHelper, OutputHelper, isWeb: true);
             await verifier.Execute();
@@ -27,7 +28,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyEnvironmentVariables(ImageData imageData)
+        [Trait("Category", "aspnet")]
+        public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             base.VerifyCommonEnvironmentVariables(imageData);
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -8,6 +8,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
+    [Trait("Category", "aspnet")]
     public class AspnetImageTests : CommonRuntimeImageTests
     {
         public AspnetImageTests(ITestOutputHelper outputHelper)
@@ -19,7 +20,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "aspnet")]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
             ImageScenarioVerifier verifier = new ImageScenarioVerifier(imageData, DockerHelper, OutputHelper, isWeb: true);
@@ -28,10 +28,16 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "aspnet")]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             base.VerifyCommonEnvironmentVariables(imageData);
+        }
+
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyInsecureFiles(ProductImageData imageData)
+        {
+            base.VerifyCommonInsecureFiles(imageData);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -32,12 +32,5 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             base.VerifyCommonEnvironmentVariables(imageData);
         }
-
-        [LinuxImageTheory]
-        [MemberData(nameof(GetImageData))]
-        public void VerifyInsecureFiles(ProductImageData imageData)
-        {
-            base.VerifyCommonInsecureFiles(imageData);
-        }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -4,10 +4,14 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
+    [Trait("Category", "runtime-deps")]
+    [Trait("Category", "runtime")]
+    [Trait("Category", "aspnet")]
     public abstract class CommonRuntimeImageTests : ImageTests
     {
         protected CommonRuntimeImageTests(ITestOutputHelper outputHelper)
@@ -33,6 +37,13 @@ namespace Microsoft.DotNet.Docker.Tests
             }
 
             EnvironmentVariableInfo.Validate(variables, ImageType, imageData, DockerHelper);
+        }
+
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyInsecureFiles(ProductImageData imageData)
+        {
+            base.VerifyCommonInsecureFiles(imageData);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -4,15 +4,12 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
     public abstract class CommonRuntimeImageTests : ImageTests
     {
-        protected abstract DotNetImageType ImageType { get; }
-
         protected CommonRuntimeImageTests(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
@@ -22,16 +19,6 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             return TestData.GetImageData()
                 .Select(imageData => new object[] { imageData });
-        }
-
-        [LinuxImageTheory]
-        [MemberData(nameof(GetImageData))]
-        [Trait("Category", "runtime")]
-        [Trait("Category", "runtime-deps")]
-        [Trait("Category", "aspnet")]
-        public void VerifyInsecureFiles(ProductImageData imageData)
-        {
-            base.VerifyCommonInsecureFiles(imageData, ImageType);
         }
 
         protected void VerifyCommonEnvironmentVariables(ProductImageData imageData)

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -11,6 +11,8 @@ namespace Microsoft.DotNet.Docker.Tests
 {
     public abstract class CommonRuntimeImageTests : ImageTests
     {
+        protected abstract DotNetImageType ImageType { get; }
+
         protected CommonRuntimeImageTests(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
@@ -24,12 +26,15 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyInsecureFiles(ImageData imageData)
+        [Trait("Category", "runtime")]
+        [Trait("Category", "runtime-deps")]
+        [Trait("Category", "aspnet")]
+        public void VerifyInsecureFiles(ProductImageData imageData)
         {
-            base.VerifyCommonInsecureFiles(imageData);
+            base.VerifyCommonInsecureFiles(imageData, ImageType);
         }
 
-        protected void VerifyCommonEnvironmentVariables(ImageData imageData)
+        protected void VerifyCommonEnvironmentVariables(ProductImageData imageData)
         {
             List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
             variables.AddRange(GetCommonEnvironmentVariables());

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -9,9 +9,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
-    [Trait("Category", "runtime-deps")]
-    [Trait("Category", "runtime")]
-    [Trait("Category", "aspnet")]
     public abstract class CommonRuntimeImageTests : ImageTests
     {
         protected CommonRuntimeImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static void Validate(
             IEnumerable<EnvironmentVariableInfo> variables,
             DotNetImageType imageType,
-            ImageData imageData,
+            ProductImageData imageData,
             DockerHelper dockerHelper)
         {
             const char delimiter = '|';

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
+        private static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
         {
             var retries = 30;
 

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
                 if (_isWeb && !Config.IsHttpVerificationDisabled)
                 {
-                    await VerifyHttpResponseFromContainerAsync(containerName, _dockerHelper, _outputHelper);
+                    await VerifyHttpResponseFromContainerAsync(containerName);
                 }
             }
             finally
@@ -178,14 +178,14 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        private static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
+        private async Task VerifyHttpResponseFromContainerAsync(string containerName)
         {
             var retries = 30;
 
             // Can't use localhost when running inside containers or Windows.
             var url = !Config.IsRunningInContainer && DockerHelper.IsLinuxContainerModeEnabled
-                ? $"http://localhost:{dockerHelper.GetContainerHostPort(containerName)}"
-                : $"http://{dockerHelper.GetContainerAddress(containerName)}";
+                ? $"http://localhost:{_dockerHelper.GetContainerHostPort(containerName)}"
+                : $"http://{_dockerHelper.GetContainerAddress(containerName)}";
 
             using (HttpClient client = new HttpClient())
             {
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     {
                         using (HttpResponseMessage result = await client.GetAsync(url))
                         {
-                            outputHelper.WriteLine($"HTTP {result.StatusCode}\n{(await result.Content.ReadAsStringAsync())}");
+                            _outputHelper.WriteLine($"HTTP {result.StatusCode}\n{(await result.Content.ReadAsStringAsync())}");
                             result.EnsureSuccessStatusCode();
                         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     }
                     catch (Exception ex)
                     {
-                        outputHelper.WriteLine($"Request to {url} failed - retrying: {ex.ToString()}");
+                        _outputHelper.WriteLine($"Request to {url} failed - retrying: {ex.ToString()}");
                     }
                 }
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -15,13 +15,13 @@ namespace Microsoft.DotNet.Docker.Tests
     public class ImageScenarioVerifier
     {
         private readonly DockerHelper _dockerHelper;
-        private readonly ImageData _imageData;
+        private readonly ProductImageData _imageData;
         private readonly bool _isWeb;
         private readonly ITestOutputHelper _outputHelper;
         private readonly string _testArtifactsDir = Path.Combine(Directory.GetCurrentDirectory(), "TestAppArtifacts");
 
         public ImageScenarioVerifier(
-            ImageData imageData,
+            ProductImageData imageData,
             DockerHelper dockerHelper,
             ITestOutputHelper outputHelper,
             bool isWeb = false)
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
                 if (_isWeb && !Config.IsHttpVerificationDisabled)
                 {
-                    await VerifyHttpResponseFromContainer(containerName);
+                    await VerifyHttpResponseFromContainerAsync(containerName, _dockerHelper, _outputHelper);
                 }
             }
             finally
@@ -178,14 +178,14 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        private async Task VerifyHttpResponseFromContainer(string containerName)
+        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
         {
             var retries = 30;
 
             // Can't use localhost when running inside containers or Windows.
             var url = !Config.IsRunningInContainer && DockerHelper.IsLinuxContainerModeEnabled
-                ? $"http://localhost:{_dockerHelper.GetContainerHostPort(containerName)}"
-                : $"http://{_dockerHelper.GetContainerAddress(containerName)}";
+                ? $"http://localhost:{dockerHelper.GetContainerHostPort(containerName)}"
+                : $"http://{dockerHelper.GetContainerAddress(containerName)}";
 
             using (HttpClient client = new HttpClient())
             {
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     {
                         using (HttpResponseMessage result = await client.GetAsync(url))
                         {
-                            _outputHelper.WriteLine($"HTTP {result.StatusCode}\n{(await result.Content.ReadAsStringAsync())}");
+                            outputHelper.WriteLine($"HTTP {result.StatusCode}\n{(await result.Content.ReadAsStringAsync())}");
                             result.EnsureSuccessStatusCode();
                         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     }
                     catch (Exception ex)
                     {
-                        _outputHelper.WriteLine($"Request to {url} failed - retrying: {ex.ToString()}");
+                        outputHelper.WriteLine($"Request to {url} failed - retrying: {ex.ToString()}");
                     }
                 }
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -19,8 +19,9 @@ namespace Microsoft.DotNet.Docker.Tests
         
         protected DockerHelper DockerHelper { get; }
         protected ITestOutputHelper OutputHelper { get; }
+        protected abstract DotNetImageType ImageType { get; }
 
-        protected void VerifyCommonInsecureFiles(ProductImageData imageData, DotNetImageType imageType)
+        protected void VerifyCommonInsecureFiles(ProductImageData imageData)
         {
             if (imageData.Version < new Version("3.1") ||
                 (imageData.OS.Contains("alpine") && imageData.IsArm))
@@ -44,8 +45,8 @@ namespace Microsoft.DotNet.Docker.Tests
             string command = $"/bin/sh -c \"{worldWritableDirectoriesWithoutStickyBitCmd} && {worldWritableFilesCmd} && {noUserOrGroupFilesCmd}\"";
 
             string output = DockerHelper.Run(
-                    image: imageData.GetImage(imageType, DockerHelper),
-                    name: imageData.GetIdentifier($"InsecureFiles-{imageType}"),
+                    image: imageData.GetImage(ImageType, DockerHelper),
+                    name: imageData.GetIdentifier($"InsecureFiles-{ImageType}"),
                     command: command
                 );
 

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -19,9 +19,8 @@ namespace Microsoft.DotNet.Docker.Tests
         
         protected DockerHelper DockerHelper { get; }
         protected ITestOutputHelper OutputHelper { get; }
-        protected abstract DotNetImageType ImageType { get; }
 
-        protected void VerifyCommonInsecureFiles(ImageData imageData)
+        protected void VerifyCommonInsecureFiles(ProductImageData imageData, DotNetImageType imageType)
         {
             if (imageData.Version < new Version("3.1") ||
                 (imageData.OS.Contains("alpine") && imageData.IsArm))
@@ -45,8 +44,8 @@ namespace Microsoft.DotNet.Docker.Tests
             string command = $"/bin/sh -c \"{worldWritableDirectoriesWithoutStickyBitCmd} && {worldWritableFilesCmd} && {noUserOrGroupFilesCmd}\"";
 
             string output = DockerHelper.Run(
-                    image: imageData.GetImage(ImageType, DockerHelper),
-                    name: imageData.GetIdentifier($"InsecureFiles-{ImageType}"),
+                    image: imageData.GetImage(imageType, DockerHelper),
+                    name: imageData.GetIdentifier($"InsecureFiles-{imageType}"),
                     command: command
                 );
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class ProductImageData : ImageData
+    {
+        private string _sdkOS;
+
+        public Version Version { get; set; }
+        public string VersionString => Version.ToString(2);
+        public bool HasCustomSdk => _sdkOS != null;
+
+        public string SdkOS
+        {
+            get => _sdkOS ?? OS.TrimEnd(Tests.OS.SlimSuffix);
+            set { _sdkOS = value; }
+        }
+
+        public override string GetIdentifier(string type) => $"{VersionString}-{base.GetIdentifier(type)}";
+
+        public string GetImage(DotNetImageType imageType, DockerHelper dockerHelper)
+        {
+            string variantName = Enum.GetName(typeof(DotNetImageType), imageType).ToLowerInvariant().Replace('_', '-');
+            string tag = GetTagName(imageType);
+            string imageName = GetImageName(tag, variantName);
+
+            PullImageIfNecessary(imageName, dockerHelper);
+
+            return imageName;
+        }
+
+        private string GetTagName(DotNetImageType imageType)
+        {
+            Version imageVersion;
+            string os;
+            switch (imageType)
+            {
+                case DotNetImageType.Runtime:
+                case DotNetImageType.Aspnet:
+                case DotNetImageType.Runtime_Deps:
+                    imageVersion = Version;
+                    os = OS;
+                    break;
+                case DotNetImageType.SDK:
+                    imageVersion = Version;
+                    os = SdkOS;
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported image type '{imageType}'");
+            }
+
+            return this.GetTagName(imageVersion.ToString(2), os);
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
+    [Trait("Category", "runtime-deps")]
     public class RuntimeDepsImageTests : CommonRuntimeImageTests
     {
         public RuntimeDepsImageTests(ITestOutputHelper outputHelper)
@@ -18,10 +19,16 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "runtime-deps")]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             base.VerifyCommonEnvironmentVariables(imageData);
+        }
+
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyInsecureFiles(ProductImageData imageData)
+        {
+            base.VerifyCommonInsecureFiles(imageData);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -23,12 +23,5 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             base.VerifyCommonEnvironmentVariables(imageData);
         }
-
-        [LinuxImageTheory]
-        [MemberData(nameof(GetImageData))]
-        public void VerifyInsecureFiles(ProductImageData imageData)
-        {
-            base.VerifyCommonInsecureFiles(imageData);
-        }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -18,7 +18,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyEnvironmentVariables(ImageData imageData)
+        [Trait("Category", "runtime-deps")]
+        public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             base.VerifyCommonEnvironmentVariables(imageData);
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -8,6 +8,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
+    [Trait("Category", "runtime")]
     public class RuntimeImageTests : CommonRuntimeImageTests
     {
         public RuntimeImageTests(ITestOutputHelper outputHelper)
@@ -19,7 +20,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "runtime")]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
             ImageScenarioVerifier verifier = new ImageScenarioVerifier(imageData, DockerHelper, OutputHelper);
@@ -28,10 +28,16 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "runtime")]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             base.VerifyCommonEnvironmentVariables(imageData);
+        }
+
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyInsecureFiles(ProductImageData imageData)
+        {
+            base.VerifyCommonInsecureFiles(imageData);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -19,7 +19,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public async Task VerifyAppScenario(ImageData imageData)
+        [Trait("Category", "runtime")]
+        public async Task VerifyAppScenario(ProductImageData imageData)
         {
             ImageScenarioVerifier verifier = new ImageScenarioVerifier(imageData, DockerHelper, OutputHelper);
             await verifier.Execute();
@@ -27,7 +28,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyEnvironmentVariables(ImageData imageData)
+        [Trait("Category", "runtime")]
+        public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             base.VerifyCommonEnvironmentVariables(imageData);
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -32,12 +32,5 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             base.VerifyCommonEnvironmentVariables(imageData);
         }
-
-        [LinuxImageTheory]
-        [MemberData(nameof(GetImageData))]
-        public void VerifyInsecureFiles(ProductImageData imageData)
-        {
-            base.VerifyCommonInsecureFiles(imageData);
-        }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -18,8 +18,6 @@ namespace Microsoft.DotNet.Docker.Tests
         {
         }
 
-        protected override DotNetImageType ImageType => DotNetImageType.SDK;
-
         public static IEnumerable<object[]> GetImageData()
         {
             return TestData.GetImageData()
@@ -30,14 +28,16 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyInsecureFiles(ImageData imageData)
+        [Trait("Category", "sdk")]
+        public void VerifyInsecureFiles(ProductImageData imageData)
         {
-            base.VerifyCommonInsecureFiles(imageData);
+            base.VerifyCommonInsecureFiles(imageData, DotNetImageType.SDK);
         }
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyEnvironmentVariables(ImageData imageData)
+        [Trait("Category", "sdk")]
+        public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
             variables.AddRange(GetCommonEnvironmentVariables());
@@ -65,7 +65,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyPackageCache(ImageData imageData)
+        [Trait("Category", "sdk")]
+        public void VerifyPackageCache(ProductImageData imageData)
         {
             string verifyCacheCommand = null;
             if (imageData.Version.Major == 2)
@@ -96,14 +97,16 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyPowerShellScenario_DefaultUser(ImageData imageData)
+        [Trait("Category", "sdk")]
+        public void VerifyPowerShellScenario_DefaultUser(ProductImageData imageData)
         {
             PowerShellScenario_Execute(imageData, null);
         }
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        public void VerifyPowerShellScenario_NonDefaultUser(ImageData imageData)
+        [Trait("Category", "sdk")]
+        public void VerifyPowerShellScenario_NonDefaultUser(ProductImageData imageData)
         {
             var optRunArgs = "-u 12345:12345"; // Linux containers test as non-root user
             if (imageData.OS.Contains("nanoserver", StringComparison.OrdinalIgnoreCase))
@@ -115,7 +118,7 @@ namespace Microsoft.DotNet.Docker.Tests
             PowerShellScenario_Execute(imageData, optRunArgs);
         }
 
-        private void PowerShellScenario_Execute(ImageData imageData, string optionalArgs)
+        private void PowerShellScenario_Execute(ProductImageData imageData, string optionalArgs)
         {
             if (imageData.Version.Major < 3)
             {
@@ -134,9 +137,9 @@ namespace Microsoft.DotNet.Docker.Tests
             Assert.Equal(output, bool.TrueString, ignoreCase: true);
         }
 
-        private class SdkImageDataEqualityComparer : IEqualityComparer<ImageData>
+        private class SdkImageDataEqualityComparer : IEqualityComparer<ProductImageData>
         {
-            public bool Equals([AllowNull] ImageData x, [AllowNull] ImageData y)
+            public bool Equals([AllowNull] ProductImageData x, [AllowNull] ProductImageData y)
             {
                 if (x is null && y is null)
                 {
@@ -158,7 +161,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     x.Arch == y.Arch;
             }
 
-            public int GetHashCode([DisallowNull] ImageData obj)
+            public int GetHashCode([DisallowNull] ProductImageData obj)
             {
                 return $"{obj.VersionString}-{obj.SdkOS}-{obj.Arch}".GetHashCode();
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -11,12 +11,15 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
+    [Trait("Category", "sdk")]
     public class SdkImageTests : ImageTests
     {
         public SdkImageTests(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
         }
+
+        protected override DotNetImageType ImageType => DotNetImageType.SDK;
 
         public static IEnumerable<object[]> GetImageData()
         {
@@ -28,15 +31,13 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "sdk")]
         public void VerifyInsecureFiles(ProductImageData imageData)
         {
-            base.VerifyCommonInsecureFiles(imageData, DotNetImageType.SDK);
+            base.VerifyCommonInsecureFiles(imageData);
         }
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "sdk")]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
@@ -65,7 +66,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "sdk")]
         public void VerifyPackageCache(ProductImageData imageData)
         {
             string verifyCacheCommand = null;
@@ -97,7 +97,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "sdk")]
         public void VerifyPowerShellScenario_DefaultUser(ProductImageData imageData)
         {
             PowerShellScenario_Execute(imageData, null);
@@ -105,7 +104,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
-        [Trait("Category", "sdk")]
         public void VerifyPowerShellScenario_NonDefaultUser(ProductImageData imageData)
         {
             var optRunArgs = "-u 12345:12345"; // Linux containers test as non-root user

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -12,75 +12,92 @@ namespace Microsoft.DotNet.Docker.Tests
 {
     public static class TestData
     {
-        private static readonly ImageData[] s_linuxTestData =
+        private static readonly ProductImageData[] s_linuxTestData =
         {
-            new ImageData { Version = V2_1, OS = OS.StretchSlim,  Arch = Arch.Amd64 },
-            new ImageData { Version = V2_1, OS = OS.Bionic,       Arch = Arch.Amd64 },
-            new ImageData { Version = V2_1, OS = OS.Alpine39,     Arch = Arch.Amd64 },
-            new ImageData { Version = V2_1, OS = OS.Alpine310,    Arch = Arch.Amd64 },
-            new ImageData { Version = V2_1, OS = OS.StretchSlim,  Arch = Arch.Arm },
-            new ImageData { Version = V2_1, OS = OS.Bionic,       Arch = Arch.Arm },
-            new ImageData { Version = V2_2, OS = OS.StretchSlim,  Arch = Arch.Amd64 },
-            new ImageData { Version = V2_2, OS = OS.Bionic,       Arch = Arch.Amd64 },
-            new ImageData { Version = V2_2, OS = OS.Alpine39,     Arch = Arch.Amd64 },
-            new ImageData { Version = V2_2, OS = OS.Alpine310,    Arch = Arch.Amd64 },
-            new ImageData { Version = V2_2, OS = OS.StretchSlim,  Arch = Arch.Arm },
-            new ImageData { Version = V2_2, OS = OS.Bionic,       Arch = Arch.Arm },
-            new ImageData { Version = V3_0, OS = OS.BusterSlim,   Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.Disco,        Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.Bionic,       Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.Alpine39,     Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.Alpine310,    Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.BusterSlim,   Arch = Arch.Arm },
-            new ImageData { Version = V3_0, OS = OS.Disco,        Arch = Arch.Arm },
-            new ImageData { Version = V3_0, OS = OS.Bionic,       Arch = Arch.Arm },
-            new ImageData { Version = V3_0, OS = OS.BusterSlim,   Arch = Arch.Arm64 },
-            new ImageData { Version = V3_0, OS = OS.Disco,        Arch = Arch.Arm64 },
-            new ImageData { Version = V3_0, OS = OS.Bionic,       Arch = Arch.Arm64 },
-            new ImageData { Version = V3_0, OS = OS.Alpine39,     Arch = Arch.Arm64,    SdkOS = OS.Buster },
-            new ImageData { Version = V3_0, OS = OS.Alpine310,    Arch = Arch.Arm64,    SdkOS = OS.Buster },
-            new ImageData { Version = V3_1, OS = OS.BusterSlim,   Arch = Arch.Amd64 },
-            new ImageData { Version = V3_1, OS = OS.Bionic,       Arch = Arch.Amd64 },
-            new ImageData { Version = V3_1, OS = OS.Alpine310,    Arch = Arch.Amd64 },
-            new ImageData { Version = V3_1, OS = OS.BusterSlim,   Arch = Arch.Arm },
-            new ImageData { Version = V3_1, OS = OS.Bionic,       Arch = Arch.Arm },
-            new ImageData { Version = V3_1, OS = OS.BusterSlim,   Arch = Arch.Arm64 },
-            new ImageData { Version = V3_1, OS = OS.Bionic,       Arch = Arch.Arm64 },
-            new ImageData { Version = V3_1, OS = OS.Alpine310,    Arch = Arch.Arm64,    SdkOS = OS.Buster },
+            new ProductImageData { Version = V2_1, OS = OS.StretchSlim,  Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.Bionic,       Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.Alpine39,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.Alpine310,    Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.StretchSlim,  Arch = Arch.Arm },
+            new ProductImageData { Version = V2_1, OS = OS.Bionic,       Arch = Arch.Arm },
+            new ProductImageData { Version = V2_2, OS = OS.StretchSlim,  Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_2, OS = OS.Bionic,       Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_2, OS = OS.Alpine39,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_2, OS = OS.Alpine310,    Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_2, OS = OS.StretchSlim,  Arch = Arch.Arm },
+            new ProductImageData { Version = V2_2, OS = OS.Bionic,       Arch = Arch.Arm },
+            new ProductImageData { Version = V3_0, OS = OS.BusterSlim,   Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.Disco,        Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.Bionic,       Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.Alpine39,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.Alpine310,    Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.BusterSlim,   Arch = Arch.Arm },
+            new ProductImageData { Version = V3_0, OS = OS.Disco,        Arch = Arch.Arm },
+            new ProductImageData { Version = V3_0, OS = OS.Bionic,       Arch = Arch.Arm },
+            new ProductImageData { Version = V3_0, OS = OS.BusterSlim,   Arch = Arch.Arm64 },
+            new ProductImageData { Version = V3_0, OS = OS.Disco,        Arch = Arch.Arm64 },
+            new ProductImageData { Version = V3_0, OS = OS.Bionic,       Arch = Arch.Arm64 },
+            new ProductImageData { Version = V3_0, OS = OS.Alpine39,     Arch = Arch.Arm64,    SdkOS = OS.Buster },
+            new ProductImageData { Version = V3_0, OS = OS.Alpine310,    Arch = Arch.Arm64,    SdkOS = OS.Buster },
+            new ProductImageData { Version = V3_1, OS = OS.BusterSlim,   Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.Bionic,       Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.Alpine310,    Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.BusterSlim,   Arch = Arch.Arm },
+            new ProductImageData { Version = V3_1, OS = OS.Bionic,       Arch = Arch.Arm },
+            new ProductImageData { Version = V3_1, OS = OS.BusterSlim,   Arch = Arch.Arm64 },
+            new ProductImageData { Version = V3_1, OS = OS.Bionic,       Arch = Arch.Arm64 },
+            new ProductImageData { Version = V3_1, OS = OS.Alpine310,    Arch = Arch.Arm64,    SdkOS = OS.Buster },
         };
-        private static readonly ImageData[] s_windowsTestData =
+        private static readonly ProductImageData[] s_windowsTestData =
         {
-            new ImageData { Version = V2_1, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
-            new ImageData { Version = V2_1, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
-            new ImageData { Version = V2_1, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
-            new ImageData { Version = V2_2, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
-            new ImageData { Version = V2_2, OS = OS.NanoServer1809, Arch = Arch.Arm },
-            new ImageData { Version = V2_2, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
-            new ImageData { Version = V2_2, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.NanoServer1809, Arch = Arch.Arm },
-            new ImageData { Version = V3_0, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
-            new ImageData { Version = V3_0, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
-            new ImageData { Version = V3_1, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
-            new ImageData { Version = V3_1, OS = OS.NanoServer1809, Arch = Arch.Arm },
-            new ImageData { Version = V3_1, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
-            new ImageData { Version = V3_1, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_2, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_2, OS = OS.NanoServer1809, Arch = Arch.Arm },
+            new ProductImageData { Version = V2_2, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_2, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.NanoServer1809, Arch = Arch.Arm },
+            new ProductImageData { Version = V3_0, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_0, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer1809, Arch = Arch.Arm },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
         };
 
-        public static IEnumerable<ImageData> GetImageData()
+        public static IEnumerable<ProductImageData> GetImageData()
         {
-            string archFilterPattern = GetFilterRegexPattern("IMAGE_ARCH_FILTER");
-            string osFilterPattern = GetFilterRegexPattern("IMAGE_OS_FILTER");
-            string versionFilterPattern = GetFilterRegexPattern("IMAGE_VERSION_FILTER");
-
-            // Filter out test data that does not match the active architecture, os and version filters.
             return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxTestData : s_windowsTestData)
-                .Where(imageData => archFilterPattern == null
-                    || Regex.IsMatch(Enum.GetName(typeof(Arch), imageData.Arch), archFilterPattern, RegexOptions.IgnoreCase))
-                .Where(imageData => osFilterPattern == null
-                    || Regex.IsMatch(imageData.OS, osFilterPattern, RegexOptions.IgnoreCase))
+                .FilterImagesByVersion()
+                .FilterImagesByArch()
+                .FilterImagesByOs()
+                .Cast<ProductImageData>();
+        }
+
+        private static IEnumerable<ImageData> FilterImagesByVersion(this IEnumerable<ProductImageData> imageData)
+        {
+            string versionFilterPattern = GetFilterRegexPattern("IMAGE_VERSION_FILTER");
+            return imageData
                 .Where(imageData => versionFilterPattern == null
                     || Regex.IsMatch(imageData.VersionString, versionFilterPattern, RegexOptions.IgnoreCase));
+        }
+
+        private static IEnumerable<ImageData> FilterImagesByArch(this IEnumerable<ImageData> imageData)
+        {
+            string archFilterPattern = GetFilterRegexPattern("IMAGE_ARCH_FILTER");
+            return imageData
+                .Where(imageData => archFilterPattern == null
+                    || Regex.IsMatch(Enum.GetName(typeof(Arch), imageData.Arch), archFilterPattern, RegexOptions.IgnoreCase));
+        }
+
+        private static IEnumerable<ImageData> FilterImagesByOs(this IEnumerable<ImageData> imageData)
+        {
+            string osFilterPattern = GetFilterRegexPattern("IMAGE_OS_FILTER");
+            return imageData
+                .Where(imageData => osFilterPattern == null
+                    || Regex.IsMatch(imageData.OS, osFilterPattern, RegexOptions.IgnoreCase));
         }
 
         private static string GetFilterRegexPattern(string filterEnvName)


### PR DESCRIPTION
Several unit test refactoring changes in order to support #391:
* Adds Category trait to unit tests so that specific categories of tests can be executed.
* Factors `ImageData` into an abstract class with a derived `ProductImageData` class.  `ImageData` is meant for generic images in general, providing support for sample images in the future.  `ProductImageData` provides functionality specific to the "product" images (SDK, runtime, etc).
* Upgrades the test project to .NET Core 3.1