### PR TITLE
Prevent image size validation script from failing in master

### DIFF
--- a/tests/performance/Validate-ImageSize.ps1
+++ b/tests/performance/Validate-ImageSize.ps1
@@ -24,6 +24,7 @@ $ErrorActionPreference = 'Stop'
 pushd $PSScriptRoot/../../
 try {
     $manifestJson = Get-Content ./manifest.json | ConvertFrom-Json
+    $branch = ""
     if ($manifestJson.Repos[0].Name.Contains("nightly")) {
         $branch = ".nightly"
     }
@@ -31,6 +32,11 @@ try {
     $activeOS = docker version -f "{{ .Server.Os }}"
     $baselinePath = "./tests/performance/ImageSize$branch.$activeOS.json"
     $commandArgs = "$baselinePath $ImageBuilderCustomArgs"
+
+    if (!(Test-Path $baselinePath)) {
+        Write-Warning "Baseline file '$baselinePath' does not exist. Skipping image size validation."
+        return
+    }
 
     if ($PullImages) {
         $commandArgs += " --pull"


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet-docker/pull/1554 cause the image size validation script to be executed when running the `build-and-test.ps1` script.  Attempting to run it from the master branch will cause it to fail because the master branch has no associated image size baseline files.

Fixing this by checking whether the baseline file exists and display a warning if it does not.