### PR TITLE
Add URLS env var to nanoserver slim sample

### DIFF
--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -17,4 +17,8 @@ RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-rest
 FROM mcr.microsoft.com/windows/nanoserver:1909 AS runtime
 WORKDIR /app
 COPY --from=build /app ./
+
+# Configure web servers to bind to port 80 when present
+ENV ASPNETCORE_URLS=http://+:80
+
 ENTRYPOINT ["aspnetapp"]


### PR DESCRIPTION
The nanoserver slim sample produced an app that was inaccessible when run because it was missing the `ASPNETCORE_URLS` environment variable.