### PR TITLE
Use correct matrix type for sample builds in public

### DIFF
--- a/eng/pipelines/dotnet-core-samples.yml
+++ b/eng/pipelines/dotnet-core-samples.yml
@@ -17,3 +17,6 @@ variables:
   value: -TestCategories sample
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      buildMatrixType: platformVersionedOs


### PR DESCRIPTION
Public builds for the sample pipeline are failing because generation of the build matrix is using the wrong matrix type.