### PR TITLE
Fix repo ref in some aspnet Dockerfiles

### DIFF
--- a/3.0/aspnet/nanoserver-1903/amd64/Dockerfile
+++ b/3.0/aspnet/nanoserver-1903/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core-nightly/runtime
+ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1903 AS installer

--- a/3.0/aspnet/nanoserver-1909/amd64/Dockerfile
+++ b/3.0/aspnet/nanoserver-1909/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core-nightly/runtime
+ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1909 AS installer

--- a/3.1/aspnet/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/aspnet/nanoserver-1903/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core-nightly/runtime
+ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1903 AS installer

--- a/3.1/aspnet/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/aspnet/nanoserver-1909/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core-nightly/runtime
+ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1909 AS installer


### PR DESCRIPTION
Several ASP.NET Dockerfiles had incorrectly been set to reference `core-nightly` for the base image's repo instead of `core`.  These didn't affect the actual images that were published since the build system explicitly sets the `REPO` arg.  It would be an issue for anyone copying these Dockerfiles for their own use, however.

Fixes #1612