### PR TITLE
Rename launch profile

### DIFF
--- a/samples/aspnetapp/aspnetapp/Properties/launchSettings.json
+++ b/samples/aspnetapp/aspnetapp/Properties/launchSettings.json
@@ -23,7 +23,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "container": {
+    "publicdev": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "http://+:80",

--- a/samples/run-in-sdk-container.md
+++ b/samples/run-in-sdk-container.md
@@ -153,7 +153,7 @@ The examples above use environment variables to configure ASP.NET Core. You can 
 The following JSON segment shows the `container` profile that was added to enable this workflow.
 
 ```json
-"container": {
+"publicdev": {
   "commandName": "Project",
   "launchBrowser": true,
   "applicationUrl": "http://+:80",
@@ -168,7 +168,7 @@ The following instructions demonstrate this scenario in various environments:
 ### Linux or macOS
 
 ```console
-docker run --rm -it -p 8000:80 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/core/sdk:3.1 dotnet run --launch-profile container
+docker run --rm -it -p 8000:80 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/core/sdk:3.1 dotnet run --launch-profile publicdev
 ```
 
 ### Windows using Linux containers
@@ -176,7 +176,7 @@ docker run --rm -it -p 8000:80 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/c
 The following example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:80 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/core/sdk:3.1 dotnet run --launch-profile container
+docker run --rm -it -p 8000:80 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/core/sdk:3.1 dotnet run --launch-profile publicdev
 ```
 
 ### Windows using Windows containers
@@ -184,7 +184,7 @@ docker run --rm -it -p 8000:80 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/c
 The following example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:80 -v ${pwd}:C:\app -w C:\app mcr.microsoft.com/dotnet/core/sdk:3.1 dotnet run --launch-profile container
+docker run --rm -it -p 8000:80 -v ${pwd}:C:\app -w C:\app mcr.microsoft.com/dotnet/core/sdk:3.1 dotnet run --launch-profile publicdev
 ```
 
 ## More Samples


### PR DESCRIPTION
The launch profile added in the sample is not container-specific, so changing its name, to "publicdev" (a more accurate description of what the profile is accomplishing). After that, will start a conversation to get this change into the .NET 5.0 templates.

@glennc suggested that we switch to a port like `5050`, for two reasons:

* Maps more closely to the localhost:5000 that is used by default.
* Proxies and other things apparently use the 80xx range, so there could be conflicts. 

If we want to do that, we may want to do that throughout the samples. We could also wait to have that conversation as part of adding this concept to the official ASP.NET Core templates.