### PR TITLE
Added 'Image Update Policy' section to the READMEs

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -117,6 +117,11 @@ You can retrieve a list of all available tags for dotnet/core/aspnet at https://
 
 See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Core Docker issue](https://github.com/dotnet/dotnet-docker/issues)
@@ -127,11 +132,6 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [File a Microsoft Container Registry (MCR) issue](https://github.com/microsoft/containerregistry/issues)
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# Image Update Policy
-
-* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
-* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
 
 # License
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -128,9 +128,14 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # License
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
-* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/en-us/cloud-platform/windows-server-pricing)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.md
+++ b/README.md
@@ -76,9 +76,14 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # License
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
-* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/en-us/cloud-platform/windows-server-pricing)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Core Docker issue](https://github.com/dotnet/dotnet-docker/issues)
@@ -75,11 +80,6 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [File a Microsoft Container Registry (MCR) issue](https://github.com/microsoft/containerregistry/issues)
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# Image Update Policy
-
-* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
-* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
 
 # License
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -78,6 +78,11 @@ You can retrieve a list of all available tags for dotnet/core/runtime-deps at ht
 
 See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Core Docker issue](https://github.com/dotnet/dotnet-docker/issues)
@@ -88,11 +93,6 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [File a Microsoft Container Registry (MCR) issue](https://github.com/microsoft/containerregistry/issues)
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# Image Update Policy
-
-* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
-* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
 
 # License
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -89,9 +89,14 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # License
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
-* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/en-us/cloud-platform/windows-server-pricing)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -113,6 +113,11 @@ You can retrieve a list of all available tags for dotnet/core/runtime at https:/
 
 See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Core Docker issue](https://github.com/dotnet/dotnet-docker/issues)
@@ -123,11 +128,6 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [File a Microsoft Container Registry (MCR) issue](https://github.com/microsoft/containerregistry/issues)
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# Image Update Policy
-
-* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
-* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
 
 # License
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -124,9 +124,14 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # License
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
-* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/en-us/cloud-platform/windows-server-pricing)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.samples.md
+++ b/README.samples.md
@@ -116,9 +116,14 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # License
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
-* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/en-us/cloud-platform/windows-server-pricing)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.samples.md
+++ b/README.samples.md
@@ -105,6 +105,11 @@ You can retrieve a list of all available tags for dotnet/core/samples at https:/
 
 See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Core Docker issue](https://github.com/dotnet/dotnet-docker/issues)
@@ -115,11 +120,6 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [File a Microsoft Container Registry (MCR) issue](https://github.com/microsoft/containerregistry/issues)
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# Image Update Policy
-
-* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
-* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
 
 # License
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -114,6 +114,11 @@ You can retrieve a list of all available tags for dotnet/core/sdk at https://mcr
 
 See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Core Docker issue](https://github.com/dotnet/dotnet-docker/issues)
@@ -124,11 +129,6 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [File a Microsoft Container Registry (MCR) issue](https://github.com/microsoft/containerregistry/issues)
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# Image Update Policy
-
-* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
-* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
 
 # License
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -125,8 +125,13 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Ask on Stack Overflow](https://stackoverflow.com/questions/tagged/.net-core)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
+# Image Update Policy
+
+* We update the supported .NET Core images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:1909, buildpack-deps:bionic-scm, etc.).
+* We publish .NET Core images as part of releasing new versions of .NET Core including major/minor and servicing.
+
 # License
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
-* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/en-us/cloud-platform/windows-server-pricing)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)


### PR DESCRIPTION
Added an 'Image Update Policy' section to the READMEs to call out when .NET Core images will be updated.  The purpose is to communicate our policy so that customers can know what to expect.  The desired outcome is that more customers feel compelled to take a dependency on our images.

I also tweaked one of the licensing URLs which was language specific to be neutral.

/cc @rotata - this is related to the question I asked in regards to changing the MCR readme template to make it more obvious that the full tag listing is the complete list of supported tags.