### PR TITLE
Ensure update-dependencies fails if sha not found

### DIFF
--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -49,6 +49,10 @@ namespace Dotnet.Docker
             Path = dockerfilePath;
             Regex = regex;
             VersionGroupName = ValueGroupName;
+
+            // Don't allow the base class to log errors when there's no replacement value.
+            // This class will handle that itself. This avoids errors being logged for no-ops.
+            SkipIfNoReplacementFound = true;
         }
 
         public static DockerfileShaUpdater CreateProductShaUpdater(string dockerfilePath) =>
@@ -87,6 +91,10 @@ namespace Dotnet.Docker
                             sha = sha.ToLowerInvariant();
                             s_shaCache.Add(downloadUrl, sha);
                             Trace.TraceInformation($"Retrieved sha '{sha}' for '{downloadUrl}'.");
+                        }
+                        else
+                        {
+                            Trace.TraceError($"Unable to retrieve sha for '{downloadUrl}'.");
                         }
                     }
                 }

--- a/eng/update-dependencies/ErrorTraceListener.cs
+++ b/eng/update-dependencies/ErrorTraceListener.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Dotnet.Docker
+{
+    public class ErrorTraceListener : TraceListener
+    {
+        private List<string> errors = new List<string>();
+
+        public IEnumerable<string> Errors => errors;
+
+        public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string message)
+        {
+            if (eventType == TraceEventType.Error)
+            {
+                this.errors.Add(message);
+            }
+            
+            base.TraceEvent(eventCache, source, eventType, id, message);
+        }
+
+        public override void Write(string message)
+        {
+        }
+
+        public override void WriteLine(string message)
+        {
+        }
+    }
+}

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -30,6 +30,8 @@ namespace Dotnet.Docker
         {
             try
             {
+                ErrorTraceListener errorTraceListener = new ErrorTraceListener();
+                Trace.Listeners.Add(errorTraceListener);
                 Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
 
                 Options.Parse(args);
@@ -46,6 +48,14 @@ namespace Dotnet.Docker
                     {
                         await CreatePullRequestAsync();
                     }
+                }
+
+                if (errorTraceListener.Errors.Any())
+                {
+                    string errors = String.Join(Environment.NewLine, errorTraceListener.Errors);
+                    Console.Error.WriteLine(
+                        $"Failed to update dependencies due to the following errors:{Environment.NewLine}{errors}");
+                    Environment.Exit(1);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
The `update-dependencies` tool will succeed (return a zero exit code) even if there was a SHA value that could not be retrieved when updating the files.

Fixed this by adding a trace listener that checks for any errors. If a SHA value wasn't found, it logs it as an error. At the end of the processing, it checks whether any errors occurred and then outputs the results accordingly.

Fixes #1579 