### PR TITLE
Update path exclusions for pipelines

### DIFF
--- a/eng/pipelines/dotnet-core-nightly.yml
+++ b/eng/pipelines/dotnet-core-nightly.yml
@@ -3,6 +3,11 @@ trigger:
   branches:
     include:
     - nightly
+  paths:
+    exclude:
+    - documentation/*
+    - README*
+    - samples/*
 pr:
   branches:
     include:

--- a/eng/pipelines/dotnet-core-nightly.yml
+++ b/eng/pipelines/dotnet-core-nightly.yml
@@ -9,6 +9,8 @@ pr:
     - nightly
   paths:
     exclude:
+    - documentation/*
+    - README*
     - samples/*
 
 variables:

--- a/eng/pipelines/dotnet-core-size-validation-pr.yml
+++ b/eng/pipelines/dotnet-core-size-validation-pr.yml
@@ -5,6 +5,8 @@ pr:
     - nightly
   paths:
     exclude:
+    - documentation/*
+    - README*
     - samples/*
 
 variables:

--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -5,6 +5,8 @@ pr:
     - master
   paths:
     exclude:
+    - documentation/*
+    - README*
     - samples/*
 
 variables:


### PR DESCRIPTION
Ensures that PR builds will not trigger for commits that only consist of README or documentation changes.

Fixes #1609 