### PR TITLE
Fix PT template to specify appropriate build params

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/patch-tuesday-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/patch-tuesday-release.md
@@ -1,14 +1,19 @@
 # Patch Tuesday Release
 
 ## Tasks
+
 1. - [ ] Wait for the following Windows images to have been updated as part of the Windows Patch Tuesday release process:
 
       - [ ] `mcr.microsoft.com/windows/nanoserver:1809`
       - [ ] `mcr.microsoft.com/windows/nanoserver:1809-arm32v7`
       - [ ] `mcr.microsoft.com/windows/nanoserver:1903`
       - [ ] `mcr.microsoft.com/windows/nanoserver:1909`
-1. - [ ] Queue build of [dotnet-docker pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=373) (internal MSFT link)
-1. - [ ] Queue build of [dotnet-docker-nightly pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=359) (internal MSFT link)
+1. - [ ] Queue build of [dotnet-docker pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=373) (internal MSFT link) with the following parameters:
+
+          imageBuilder.pathArgs: --path '*nanoserver*'
+1. - [ ] Queue build of [dotnet-docker-nightly pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=359) (internal MSFT link) with the following parameters:
+
+          imageBuilder.pathArgs: --path '*nanoserver*'
 1. - [ ] Confirm images have been ingested by MCR
 1. - [ ] Confirm `Last Modified` field has been updated in Docker Hub for [microsoft-dotnet-core](https://hub.docker.com/_/microsoft-dotnet-core)
 1. - [ ] Confirm `Last Modified` field has been updated in Docker Hub for [microsoft-dotnet-core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly)


### PR DESCRIPTION
When queueing builds for PT, only the Windows images should be built.  Updated the issue template to set the appropriate parameters to target only the Windows images.