### PR TITLE
Fix secret name for https certificate password

### DIFF
--- a/samples/run-aspnetcore-https-development.md
+++ b/samples/run-aspnetcore-https-development.md
@@ -68,7 +68,7 @@ dotnet dev-certs https --trust
 Configure application secrets, for the certificate:
 
 ```console
-dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "crypticpassword"
+dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Default:Password" "crypticpassword"
 ```
 
 > Note: The password must match the password used for the certificate.
@@ -107,7 +107,7 @@ dotnet dev-certs https --trust
 Configure application secrets, for the certificate:
 
 ```console
-dotnet user-secrets -p aspnetapp/aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "crypticpassword"
+dotnet user-secrets -p aspnetapp/aspnetapp.csproj set "Kestrel:Certificates:Default:Password" "crypticpassword"
 ```
 
 > Note: The password must match the password used for the certificate.
@@ -147,7 +147,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p crypticpasswor
 Configure application secrets, for the certificate:
 
 ```console
-dotnet user-secrets -p aspnetapp/aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "crypticpassword"
+dotnet user-secrets -p aspnetapp/aspnetapp.csproj set "Kestrel:Certificates:Default:Password" "crypticpassword"
 ```
 
 Build a container image:
@@ -159,7 +159,7 @@ docker build --pull -t aspnetapp .
 Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_ENVIRONMENT=Development -e ASPNETCORE_Kestrel__Certificates__Development__Password="crypticpassword" -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
+docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_ENVIRONMENT=Development -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
 ```
 
 After the application starts, navigate to `http://localhost:8000` in your web browser.
@@ -186,7 +186,7 @@ dotnet dev-certs https --trust
 Configure application secrets, for the certificate:
 
 ```console
-dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "crypticpassword"
+dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Default:Password" "crypticpassword"
 ```
 
 > Note: The password must match the password used for the certificate.


### PR DESCRIPTION
I couldn't get these samples to work until I changed the name of the variable for the development certificate password.

``` diff
-Kestrel:Certificates:Development:Password
+Kestrel:Certificates:Default:Password
```

I believe this is the only supported way to configure a default certificate (ie. not bound to an endpoint), see: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#listenoptionsusehttps.