### PR TITLE
Update to libicu65 package for focal

### DIFF
--- a/2.1/runtime-deps/focal/amd64/Dockerfile
+++ b/2.1/runtime-deps/focal/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/2.1/runtime-deps/focal/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/focal/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/2.1/sdk/focal/amd64/Dockerfile
+++ b/2.1/sdk/focal/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \

--- a/2.1/sdk/focal/arm32v7/Dockerfile
+++ b/2.1/sdk/focal/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \

--- a/3.1/runtime-deps/focal/amd64/Dockerfile
+++ b/3.1/runtime-deps/focal/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/runtime-deps/focal/arm32v7/Dockerfile
+++ b/3.1/runtime-deps/focal/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/runtime-deps/focal/arm64v8/Dockerfile
+++ b/3.1/runtime-deps/focal/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/sdk/focal/amd64/Dockerfile
+++ b/3.1/sdk/focal/amd64/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/sdk/focal/arm32v7/Dockerfile
+++ b/3.1/sdk/focal/arm32v7/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/sdk/focal/arm64v8/Dockerfile
+++ b/3.1/sdk/focal/arm64v8/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/focal/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/focal/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/amd64/Dockerfile
+++ b/5.0/sdk/focal/amd64/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/arm32v7/Dockerfile
+++ b/5.0/sdk/focal/arm32v7/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/arm64v8/Dockerfile
+++ b/5.0/sdk/focal/arm64v8/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu63 \
+        libicu65 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \


### PR DESCRIPTION
The libicu63 package has been replaced with libicu65 in the Ubuntu Focal package feed.  Updating Dockerfiles to reflect this.