### PR TITLE
Update build/test scripts to use new parameter names

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/new-distro-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/new-distro-release.md
@@ -18,7 +18,7 @@ Distro: &lt;name/version&gt;
 1. - [ ] Run the command to update the image size baseline file: `.\tests\performance\Validate-ImageSize.ps1 -UpdateBaselines`
 1. - [ ] Inspect generated changes for correctness
 1. - [ ] Consider whether sample Dockerfiles should be authored if this is a new distro and them to the [samples](https://github.com/dotnet/dotnet-docker/tree/master/samples)
-1. - [ ] Run the command to build and test your changes: `.build-and-test.ps1 -OSFilter <os>`
+1. - [ ] Run the command to build and test your changes: `.build-and-test.ps1 -OS <os>`
 1. - [ ] Commit generated changes
 1. - [ ] Create PR
 1. - [ ] Get PR signoff

--- a/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
@@ -17,7 +17,7 @@ Windows version: &lt;version&gt;
 1. - [ ] Test the images
       1. - [ ] Create a local VM of the new Windows version
       1. - [ ] Clone this repo with the above changes onto the VM
-      1. - [ ] Run `.\build-and-test.ps1 -OSFilter nanoserver-<VERSION>` to build and test your changes
+      1. - [ ] Run `.\build-and-test.ps1 -OS nanoserver-<VERSION>` to build and test your changes
 1. - [ ] Commit generated changes
 1. - [ ] Create PR
 1. - [ ] Get PR signoff

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static IEnumerable<ImageData> FilterImagesByVersion(this IEnumerable<ProductImageData> imageData)
         {
-            string versionFilterPattern = GetFilterRegexPattern("IMAGE_VERSION_FILTER");
+            string versionFilterPattern = GetFilterRegexPattern("IMAGE_VERSION");
             return imageData
                 .Where(imageData => versionFilterPattern == null
                     || Regex.IsMatch(imageData.VersionString, versionFilterPattern, RegexOptions.IgnoreCase));
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static IEnumerable<ImageData> FilterImagesByArch(this IEnumerable<ImageData> imageData)
         {
-            string archFilterPattern = GetFilterRegexPattern("IMAGE_ARCH_FILTER");
+            string archFilterPattern = GetFilterRegexPattern("IMAGE_ARCH");
             return imageData
                 .Where(imageData => archFilterPattern == null
                     || Regex.IsMatch(Enum.GetName(typeof(Arch), imageData.Arch), archFilterPattern, RegexOptions.IgnoreCase));
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static IEnumerable<ImageData> FilterImagesByOs(this IEnumerable<ImageData> imageData)
         {
-            string osFilterPattern = GetFilterRegexPattern("IMAGE_OS_FILTER");
+            string osFilterPattern = GetFilterRegexPattern("IMAGE_OS");
             return imageData
                 .Where(imageData => osFilterPattern == null
                     || Regex.IsMatch(imageData.OS, osFilterPattern, RegexOptions.IgnoreCase));

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -6,9 +6,9 @@
 
 [cmdletbinding()]
 param(
-    [string]$VersionFilter,
-    [string]$ArchitectureFilter,
-    [string]$OSFilter,
+    [string]$Version,
+    [string]$Architecture,
+    [string]$OS,
     [string]$Registry,
     [string]$RepoPrefix,
     [switch]$DisableHttpVerification,
@@ -71,8 +71,8 @@ Push-Location "$PSScriptRoot\Microsoft.DotNet.Docker.Tests"
 
 Try {
     # Run Tests
-    if ([string]::IsNullOrWhiteSpace($ArchitectureFilter)) {
-        $ArchitectureFilter = "amd64"
+    if ([string]::IsNullOrWhiteSpace($Architecture)) {
+        $Architecture = "amd64"
     }
 
     if ($DisableHttpVerification) {
@@ -89,9 +89,9 @@ Try {
         $env:PULL_IMAGES = $null
     }
 
-    $env:IMAGE_ARCH_FILTER = $ArchitectureFilter
-    $env:IMAGE_OS_FILTER = $OSFilter
-    $env:IMAGE_VERSION_FILTER = $VersionFilter
+    $env:IMAGE_ARCH = $Architecture
+    $env:IMAGE_OS = $OS
+    $env:IMAGE_VERSION = $Version
     $env:REGISTRY = $Registry
     $env:REPO_PREFIX = $RepoPrefix
     $env:IMAGE_INFO_PATH = $ImageInfoPath


### PR DESCRIPTION
Updating the build and test scripts in response to the parameter name changes in https://github.com/dotnet/docker-tools/pull/429.