### PR TITLE
Remove 5.0 Focal ARM32 from manifest and tags

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -98,7 +98,6 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-preview-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-preview, 5.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/aspnet/buster-slim/arm32v7/Dockerfile) | Debian 10
-5.0.0-preview-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/aspnet/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -86,7 +86,6 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-preview-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-preview, 5.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile) | Debian 10
-5.0.0-preview-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/runtime-deps/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 You can retrieve a list of all available tags for dotnet/core/runtime-deps at https://mcr.microsoft.com/v2/dotnet/core/runtime-deps/tags/list.
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -94,7 +94,6 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-preview-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-preview, 5.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/runtime/buster-slim/arm32v7/Dockerfile) | Debian 10
-5.0.0-preview-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/runtime/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -95,7 +95,6 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.100-preview-buster-arm32v7, 5.0-buster-arm32v7, 5.0.100-preview, 5.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/sdk/buster/arm32v7/Dockerfile) | Debian 10
-5.0.100-preview-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/5.0/sdk/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -29,8 +29,6 @@ $(McrTagsYmlTagGroup:2.1-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET Core 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal-arm32v7)
-    customSubTableTitle: .NET Core 5.0 Preview Tags
 $(McrTagsYmlTagGroup:3.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:5.0-nanoserver-1909)

--- a/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
@@ -29,5 +29,3 @@ $(McrTagsYmlTagGroup:2.1-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET Core 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal-arm32v7)
-    customSubTableTitle: .NET Core 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -29,8 +29,6 @@ $(McrTagsYmlTagGroup:2.1-stretch-slim-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET Core 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal-arm32v7)
-    customSubTableTitle: .NET Core 5.0 Preview Tags
 $(McrTagsYmlTagGroup:3.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:5.0-nanoserver-1909)

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -25,8 +25,6 @@ $(McrTagsYmlTagGroup:2.1-stretch-arm32v7)
 $(McrTagsYmlTagGroup:2.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:5.0-buster-arm32v7)
     customSubTableTitle: .NET Core 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal-arm32v7)
-    customSubTableTitle: .NET Core 5.0 Preview Tags
 $(McrTagsYmlTagGroup:3.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:2.1-nanoserver-1909)
 $(McrTagsYmlTagGroup:5.0-nanoserver-1909)

--- a/manifest.json
+++ b/manifest.json
@@ -416,21 +416,6 @@
         {
           "platforms": [
             {
-              "architecture": "arm",
-              "dockerfile": "5.0/runtime-deps/focal/arm32v7",
-              "os": "linux",
-              "osVersion": "focal",
-              "tags": {
-                "$(5.0-RuntimeVersion)-focal-arm32v7": {},
-                "5.0-focal-arm32v7": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "arm64",
               "dockerfile": "5.0/runtime-deps/focal/arm64v8",
               "os": "linux",
@@ -950,24 +935,6 @@
                 "$(5.0-RuntimeVersion)-focal": {},
                 "5.0-focal": {}
               }
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "buildArgs": {
-                "REPO": "$(Repo:runtime-deps)"
-              },
-              "dockerfile": "5.0/runtime/focal/arm32v7",
-              "os": "linux",
-              "osVersion": "focal",
-              "tags": {
-                "$(5.0-RuntimeVersion)-focal-arm32v7": {},
-                "5.0-focal-arm32v7": {}
-              },
-              "variant": "v7"
             }
           ]
         },
@@ -1526,24 +1493,6 @@
         {
           "platforms": [
             {
-              "architecture": "arm",
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "5.0/aspnet/focal/arm32v7",
-              "os": "linux",
-              "osVersion": "focal",
-              "tags": {
-                "$(5.0-RuntimeVersion)-focal-arm32v7": {},
-                "5.0-focal-arm32v7": {}
-              },
-              "variant": "v7"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "architecture": "arm64",
               "buildArgs": {
                 "REPO": "$(Repo:runtime)"
@@ -1942,21 +1891,6 @@
                 "$(5.0-SdkVersion)-focal": {},
                 "5.0-focal": {}
               }
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "architecture": "arm",
-              "dockerfile": "5.0/sdk/focal/arm32v7",
-              "os": "linux",
-              "osVersion": "focal",
-              "tags": {
-                "$(5.0-SdkVersion)-focal-arm32v7": {},
-                "5.0-focal-arm32v7": {}
-              },
-              "variant": "v7"
             }
           ]
         },


### PR DESCRIPTION
Works around #1747 by removing 5.0 Focal ARM32 from the set of published tags.

Related to https://github.com/dotnet/dotnet-docker/issues/1745