### PR TITLE
Update preview drop location

### DIFF
--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -7,7 +7,7 @@ set -u
 
 channel=$1
 
-curl -SLo sdk.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$channel/dotnet-sdk-latest-win-x64.zip
+curl -SLo sdk.zip https://aka.ms/dotnet/$channel/Sdk/dotnet-sdk-win-x64.zip
 unzip sdk.zip -d sdk
 rm sdk.zip
 


### PR DESCRIPTION
Updates the URL that is used to check for latest .NET Core drops.  This URL is better because it avoids cases where spurious builds are indicated as latest.