### PR TITLE
Update Focal Dockerfiles to use libicu66

### DIFF
--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal
 
 # .NET Core dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/focal/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/focal/arm32v7/Dockerfile
@@ -2,7 +2,7 @@ FROM arm32v7/ubuntu:focal
 
 # .NET Core dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/focal/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/focal/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ FROM arm64v8/ubuntu:focal
 
 # .NET Core dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/sdk/focal/amd64/Dockerfile
+++ b/5.0/sdk/focal/amd64/Dockerfile
@@ -12,7 +12,7 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/sdk/focal/amd64/Dockerfile
+++ b/5.0/sdk/focal/amd64/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/arm32v7/Dockerfile
+++ b/5.0/sdk/focal/arm32v7/Dockerfile
@@ -12,7 +12,7 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/sdk/focal/arm32v7/Dockerfile
+++ b/5.0/sdk/focal/arm32v7/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/arm64v8/Dockerfile
+++ b/5.0/sdk/focal/arm64v8/Dockerfile
@@ -12,7 +12,7 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/sdk/focal/arm64v8/Dockerfile
+++ b/5.0/sdk/focal/arm64v8/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \


### PR DESCRIPTION
Focal Dockerfiles were using the `libicu65` package which is no longer available in the Focal feed.  Updating it to reference `libicu66` instead.