### PR TITLE
Update Focal Dockerfiles to use libicu66

### DIFF
--- a/2.1/runtime-deps/focal/amd64/Dockerfile
+++ b/2.1/runtime-deps/focal/amd64/Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:focal
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
 # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/2.1/runtime-deps/focal/arm32v7/Dockerfile
+++ b/2.1/runtime-deps/focal/arm32v7/Dockerfile
@@ -1,14 +1,14 @@
 FROM arm32v7/ubuntu:focal
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
 # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/2.1/sdk/focal/amd64/Dockerfile
+++ b/2.1/sdk/focal/amd64/Dockerfile
@@ -2,11 +2,11 @@ FROM buildpack-deps:focal-scm
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \

--- a/2.1/sdk/focal/arm32v7/Dockerfile
+++ b/2.1/sdk/focal/arm32v7/Dockerfile
@@ -2,11 +2,11 @@ FROM arm32v7/buildpack-deps:focal-scm
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         liblttng-ust0 \
         libssl1.1 \
         libstdc++6 \

--- a/3.1/runtime-deps/focal/amd64/Dockerfile
+++ b/3.1/runtime-deps/focal/amd64/Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:focal
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
 # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/runtime-deps/focal/arm32v7/Dockerfile
+++ b/3.1/runtime-deps/focal/arm32v7/Dockerfile
@@ -1,14 +1,14 @@
 FROM arm32v7/ubuntu:focal
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
 # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/runtime-deps/focal/arm64v8/Dockerfile
+++ b/3.1/runtime-deps/focal/arm64v8/Dockerfile
@@ -1,14 +1,14 @@
 FROM arm64v8/ubuntu:focal
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
 # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/sdk/focal/amd64/Dockerfile
+++ b/3.1/sdk/focal/amd64/Dockerfile
@@ -12,11 +12,11 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/sdk/focal/arm32v7/Dockerfile
+++ b/3.1/sdk/focal/arm32v7/Dockerfile
@@ -12,11 +12,11 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/3.1/sdk/focal/arm64v8/Dockerfile
+++ b/3.1/sdk/focal/arm64v8/Dockerfile
@@ -12,11 +12,11 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:focal
 
 # .NET Core dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/focal/arm32v7/Dockerfile
@@ -2,11 +2,11 @@ FROM arm32v7/ubuntu:focal
 
 # .NET Core dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/focal/arm64v8/Dockerfile
@@ -2,11 +2,11 @@ FROM arm64v8/ubuntu:focal
 
 # .NET Core dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/amd64/Dockerfile
+++ b/5.0/sdk/focal/amd64/Dockerfile
@@ -12,11 +12,11 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/arm32v7/Dockerfile
+++ b/5.0/sdk/focal/arm32v7/Dockerfile
@@ -12,11 +12,11 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/sdk/focal/arm64v8/Dockerfile
+++ b/5.0/sdk/focal/arm64v8/Dockerfile
@@ -12,11 +12,11 @@ ENV \
 
 # Install .NET CLI dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu65 \
+        libicu66 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \


### PR DESCRIPTION
Focal Dockerfiles were using the `libicu65` package which is no longer available in the Focal feed.  Updating it to reference `libicu66` instead.

Merges similar changes from master branch.