### PR TITLE
Update Image Builder ref that uses new image info schema

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -44,6 +44,7 @@ jobs:
     displayName: Copy Images
   - script: >
       $(runImageBuilderCmd) publishManifest
+      $(artifactsPath)/image-info.json
       --repo-prefix $(publishRepoPrefix)
       --username $(acr.userName)
       --password $(BotAccount-dotnet-docker-acr-bot-password)
@@ -68,6 +69,9 @@ jobs:
       --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(publicSourceBranch).json
       $(dryRunArg)
     displayName: Publish Image Info
+  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+    artifact: image-info-final
+    displayName: Publish Image Info File Artifact
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: Component Detection
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200323205142
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200323205142
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200326192320
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200326192320
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200312212452
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200312212452
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20200323205142
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20200323205142
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
       "mcrTagsMetadataTemplatePath": "eng/mcr-tags-metadata-templates/runtime-deps-tags.yml",
       "images": [
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "sharedTags": {
             "$(2.1-RuntimeVersion)": {
               "documentationGroup": "2.1"
@@ -57,6 +58,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/alpine3.10/amd64",
@@ -74,6 +76,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/alpine3.11/amd64",
@@ -97,6 +100,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/bionic/amd64",
@@ -114,6 +118,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -133,6 +138,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/focal/amd64",
@@ -150,6 +156,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "sharedTags": {
             "$(3.1-RuntimeVersion)": {
               "documentationGroup": "3.1"
@@ -205,6 +212,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/alpine3.10/amd64",
@@ -222,6 +230,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -241,6 +250,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/alpine3.11/amd64",
@@ -264,6 +274,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -289,6 +300,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/bionic/amd64",
@@ -306,6 +318,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -325,6 +338,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -344,6 +358,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/focal/amd64",
@@ -357,6 +372,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -372,6 +388,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "sharedTags": {
             "$(5.0-RuntimeVersion)": {},
             "5.0": {},
@@ -412,6 +429,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/alpine3.11/amd64",
@@ -427,6 +445,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -444,6 +463,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/focal/amd64",
@@ -457,6 +477,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -480,6 +501,7 @@
       "mcrTagsMetadataTemplatePath": "eng/mcr-tags-metadata-templates/runtime-tags.yml",
       "images": [
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "sharedTags": {
             "$(2.1-RuntimeVersion)": {},
             "2.1": {}
@@ -541,6 +563,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -557,6 +580,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -575,6 +599,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -591,6 +616,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -609,6 +635,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -625,6 +652,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "sharedTags": {
             "$(3.1-RuntimeVersion)": {},
             "3.1": {}
@@ -710,6 +738,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -726,6 +755,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -752,6 +782,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -770,6 +801,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -798,6 +830,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -814,6 +847,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -832,6 +866,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -850,6 +885,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -866,6 +902,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -884,6 +921,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "sharedTags": {
             "$(5.0-RuntimeVersion)": {},
             "5.0": {},
@@ -970,6 +1008,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -988,6 +1027,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1016,6 +1056,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1032,6 +1073,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1058,6 +1100,7 @@
       "mcrTagsMetadataTemplatePath": "eng/mcr-tags-metadata-templates/aspnet-tags.yml",
       "images": [
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "sharedTags": {
             "$(2.1-RuntimeVersion)": {},
             "2.1": {}
@@ -1119,6 +1162,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1135,6 +1179,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1153,6 +1198,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1169,6 +1215,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -1187,6 +1234,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1203,6 +1251,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "sharedTags": {
             "$(3.1-RuntimeVersion)": {},
             "3.1": {}
@@ -1300,6 +1349,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1316,6 +1366,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1342,6 +1393,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1360,6 +1412,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1388,6 +1441,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1404,6 +1458,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -1422,6 +1477,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1440,6 +1496,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1456,6 +1513,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1474,6 +1532,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "sharedTags": {
             "$(5.0-RuntimeVersion)": {},
             "5.0": {},
@@ -1572,6 +1631,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1590,6 +1650,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1618,6 +1679,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1634,6 +1696,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-RuntimeVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1660,6 +1723,7 @@
       "mcrTagsMetadataTemplatePath": "eng/mcr-tags-metadata-templates/sdk-tags.yml",
       "images": [
         {
+          "productVersion": "$(2.1-SdkVersion)",
           "sharedTags": {
             "$(2.1-SdkVersion)": {},
             "2.1": {}
@@ -1715,6 +1779,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-SdkVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1731,6 +1796,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-SdkVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1749,6 +1815,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-SdkVersion)",
           "platforms": [
             {
               "dockerfile": "2.1/sdk/bionic/amd64",
@@ -1762,6 +1829,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-SdkVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -1777,6 +1845,7 @@
           ]
         },
         {
+          "productVersion": "$(2.1-SdkVersion)",
           "platforms": [
             {
               "dockerfile": "2.1/sdk/focal/amd64",
@@ -1790,6 +1859,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "sharedTags": {
             "$(3.1-SdkVersion)": {},
             "3.1": {}
@@ -1866,6 +1936,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1882,6 +1953,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -1900,6 +1972,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "platforms": [
             {
               "dockerfile": "3.1/sdk/bionic/amd64",
@@ -1913,6 +1986,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "platforms": [
             {
               "architecture": "arm",
@@ -1928,6 +2002,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1943,6 +2018,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "platforms": [
             {
               "dockerfile": "3.1/sdk/focal/amd64",
@@ -1956,6 +2032,7 @@
           ]
         },
         {
+          "productVersion": "$(3.1-SdkVersion)",
           "platforms": [
             {
               "architecture": "arm64",
@@ -1971,6 +2048,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-SdkVersion)",
           "sharedTags": {
             "$(5.0-SdkVersion)": {},
             "5.0": {},
@@ -2048,6 +2126,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-SdkVersion)",
           "platforms": [
             {
               "buildArgs": {
@@ -2066,6 +2145,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-SdkVersion)",
           "platforms": [
             {
               "dockerfile": "5.0/sdk/focal/amd64",
@@ -2079,6 +2159,7 @@
           ]
         },
         {
+          "productVersion": "$(5.0-SdkVersion)",
           "platforms": [
             {
               "architecture": "arm64",

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -1,8 +1,5 @@
 {
   "registry": "mcr.microsoft.com",
-  "variables": {
-    "SampleProductVersion": "3.1"
-  },
   "repos": [
     {
       "id": "samples",
@@ -11,7 +8,6 @@
       "mcrTagsMetadataTemplatePath": "eng/mcr-tags-metadata-templates/samples-tags.yml",
       "images": [
         {
-          "productVersion": "$(SampleProductVersion)",
           "sharedTags": {
             "dotnetapp": {},
             "latest": {}
@@ -81,7 +77,6 @@
           ]
         },
         {
-          "productVersion": "$(SampleProductVersion)",
           "sharedTags": {
             "aspnetapp": {}
           },

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -1,5 +1,8 @@
 {
   "registry": "mcr.microsoft.com",
+  "variables": {
+    "SampleProductVersion": "3.1"
+  },
   "repos": [
     {
       "id": "samples",
@@ -8,6 +11,7 @@
       "mcrTagsMetadataTemplatePath": "eng/mcr-tags-metadata-templates/samples-tags.yml",
       "images": [
         {
+          "productVersion": "$(SampleProductVersion)",
           "sharedTags": {
             "dotnetapp": {},
             "latest": {}
@@ -77,6 +81,7 @@
           ]
         },
         {
+          "productVersion": "$(SampleProductVersion)",
           "sharedTags": {
             "aspnetapp": {}
           },


### PR DESCRIPTION
References a version of Image Builder that is configured to use the new image info schema as defined by https://github.com/dotnet/docker-tools/issues/438.  