### PR TITLE
Fix test logic to support new image info schema

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -27,8 +27,7 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             ImageInfoData = new Lazy<JObject>(() =>
             {
-                //string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
-                string imageInfoPath = @"C:\repos\versions\build-info\docker\image-info.dotnet-dotnet-docker-nightly.json";
+                string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
                 if (!String.IsNullOrEmpty(imageInfoPath))
                 {
                     string imageInfoContents = File.ReadAllText(imageInfoPath);

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -21,17 +21,18 @@ namespace Microsoft.DotNet.Docker.Tests
         public bool IsArm => Arch == Arch.Arm || Arch == Arch.Arm64;
         public string OS { get; set; }
 
-        private static Lazy<JArray> ImageInfoData;
+        private static readonly Lazy<JObject> ImageInfoData;
 
         static ImageData()
         {
-            ImageInfoData = new Lazy<JArray>(() =>
+            ImageInfoData = new Lazy<JObject>(() =>
             {
-                string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
+                //string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
+                string imageInfoPath = @"C:\repos\versions\build-info\docker\image-info.dotnet-dotnet-docker-nightly.json";
                 if (!String.IsNullOrEmpty(imageInfoPath))
                 {
                     string imageInfoContents = File.ReadAllText(imageInfoPath);
-                    return JsonConvert.DeserializeObject<JArray>(imageInfoContents);
+                    return JsonConvert.DeserializeObject<JObject>(imageInfoContents);
                 }
 
                 return null;
@@ -127,13 +128,15 @@ namespace Microsoft.DotNet.Docker.Tests
             if (ImageData.ImageInfoData.Value != null)
             {
                 JObject repoInfo = (JObject)ImageData.ImageInfoData.Value
+                    .Value<JArray>("repos")
                     .FirstOrDefault(imageInfoRepo => imageInfoRepo["repo"].ToString() == repo);
 
                 if (repoInfo?["images"] != null)
                 {
-                    imageExistsInStaging = repoInfo["images"]
-                        .Cast<JProperty>()
-                        .Any(imageInfo => imageInfo.Value["simpleTags"].Any(imageTag => imageTag.ToString() == tag));
+                    imageExistsInStaging = repoInfo.Value<JArray>("images")
+                        .SelectMany(imageInfo => imageInfo.Value<JArray>("platforms"))
+                        .Cast<JObject>()
+                        .Any(platformInfo => platformInfo.Value<JArray>("simpleTags").Any(imageTag => imageTag.ToString() == tag));
                 }
                 else
                 {


### PR DESCRIPTION
The test code reads from the image info file to determine whether it needs to pull any images.  Since the image info schema was changed as part of https://github.com/dotnet/docker-tools/issues/438, the code is being updated to support this new schema.