### PR TITLE
Use platform-specific base image tags

### DIFF
--- a/2.1/runtime-deps/alpine3.10/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine3.10/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM amd64/alpine:3.10
 
 RUN apk add --no-cache \
         ca-certificates \

--- a/2.1/runtime-deps/alpine3.11/amd64/Dockerfile
+++ b/2.1/runtime-deps/alpine3.11/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM amd64/alpine:3.11
 
 RUN apk add --no-cache \
         ca-certificates \

--- a/2.1/runtime-deps/bionic/amd64/Dockerfile
+++ b/2.1/runtime-deps/bionic/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM amd64/ubuntu:bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
+++ b/2.1/runtime-deps/stretch-slim/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM amd64/debian:stretch-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/2.1/sdk/bionic/amd64/Dockerfile
+++ b/2.1/sdk/bionic/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic-scm
+FROM amd64/buildpack-deps:bionic-scm
 
 # Install .NET CLI dependencies
 RUN apt-get update \

--- a/2.1/sdk/stretch/amd64/Dockerfile
+++ b/2.1/sdk/stretch/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:stretch-scm
+FROM amd64/buildpack-deps:stretch-scm
 
 # Install .NET CLI dependencies
 RUN apt-get update \

--- a/3.1/runtime-deps/alpine3.10/amd64/Dockerfile
+++ b/3.1/runtime-deps/alpine3.10/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM amd64/alpine:3.10
 
 RUN apk add --no-cache \
     ca-certificates \

--- a/3.1/runtime-deps/alpine3.11/amd64/Dockerfile
+++ b/3.1/runtime-deps/alpine3.11/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM amd64/alpine:3.11
 
 RUN apk add --no-cache \
     ca-certificates \

--- a/3.1/runtime-deps/bionic/amd64/Dockerfile
+++ b/3.1/runtime-deps/bionic/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM amd64/ubuntu:bionic
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.1/runtime-deps/buster-slim/amd64/Dockerfile
+++ b/3.1/runtime-deps/buster-slim/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM amd64/debian:buster-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/3.1/sdk/bionic/amd64/Dockerfile
+++ b/3.1/sdk/bionic/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic-scm
+FROM amd64/buildpack-deps:bionic-scm
 
 ENV \
     # Enable detection of running in a container

--- a/3.1/sdk/buster/amd64/Dockerfile
+++ b/3.1/sdk/buster/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster-scm
+FROM amd64/buildpack-deps:buster-scm
 
 ENV \
     # Enable detection of running in a container

--- a/5.0/runtime-deps/alpine3.11/amd64/Dockerfile
+++ b/5.0/runtime-deps/alpine3.11/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM amd64/alpine:3.11
 
 # .NET Core dependencies
 RUN apk add --no-cache \

--- a/5.0/runtime-deps/buster-slim/amd64/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM amd64/debian:buster-slim
 
 # .NET Core dependencies
 RUN apt-get update \

--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM amd64/ubuntu:focal
 
 # .NET Core dependencies
 RUN apt-get update \

--- a/5.0/sdk/buster/amd64/Dockerfile
+++ b/5.0/sdk/buster/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster-scm
+FROM amd64/buildpack-deps:buster-scm
 
 ENV \
     # Enable detection of running in a container

--- a/5.0/sdk/focal/amd64/Dockerfile
+++ b/5.0/sdk/focal/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:focal-scm
+FROM amd64/buildpack-deps:focal-scm
 
 ENV \
     # Enable detection of running in a container


### PR DESCRIPTION
The AMD64 Dockerfiles that reference an external base image tag are using a multi-arch tag.  This would cause those Dockerfiles to not build correctly if built on a machine with a different platform.  Since these Dockerfiles are platform-specific, they should be using platform-specific base image tags.

Fixes #1758