### PR TITLE
Update build to set source repo

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -35,6 +35,7 @@ jobs:
       --os-version "$(osVersion)"
       --architecture $(architecture)
       --retry
+      --source-repo $(publicGitRepoUri)
       $(imageBuilderBuildArgs)
       $(imageBuilderImageInfoArg)
     displayName: Build Images


### PR DESCRIPTION
The nightly build pipeline is out of sync with the version of Image Builder it uses.  This results in a build failure because the `source-repo` parameter is not set for the `build` command.  This change was originally made in https://github.com/dotnet/docker-tools/pull/457 but didn't get merged over.