### PR TITLE
Revert inadvertent publish stage changes

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -44,6 +44,7 @@ jobs:
     displayName: Copy Images
   - script: >
       $(runImageBuilderCmd) publishManifest
+      $(artifactsPath)/image-info.json
       --repo-prefix $(publishRepoPrefix)
       --username $(acr.userName)
       --password $(BotAccount-dotnet-docker-acr-bot-password)
@@ -68,6 +69,9 @@ jobs:
       --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(publicSourceBranch).json
       $(dryRunArg)
     displayName: Publish Image Info
+  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+    artifact: image-info-final
+    displayName: Publish Image Info File Artifact
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: Component Detection
   - template: ../steps/cleanup-docker-linux.yml


### PR DESCRIPTION
Reverts changes that were inadvertently made to the publish stage when integrate the eng/common contents from docker-tools (https://github.com/dotnet/dotnet-docker/pull/1792).