### PR TITLE
Update base image of 5.0 SDK for Alpine and Nano

### DIFF
--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet_sdk_version=3.1.201 \
     && dotnet_sha512='9a8f14be881cacb29452300f39ee66f24e253e2df947f388ad2157114cd3f44eeeb88fae4e3dd1f9687ce47f27d43f2805f9f54694b8523dc9f998b59ae79996' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./*.txt \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/3.1/sdk/alpine3.10/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.10/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 FROM $REPO:3.1-alpine3.10
 
 ENV \
@@ -24,8 +24,7 @@ RUN dotnet_sdk_version=3.1.201 \
     && dotnet_sha512='9a8f14be881cacb29452300f39ee66f24e253e2df947f388ad2157114cd3f44eeeb88fae4e3dd1f9687ce47f27d43f2805f9f54694b8523dc9f998b59ae79996' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./*.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/3.1/sdk/alpine3.11/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.11/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet_sdk_version=3.1.201 \
     && dotnet_sha512='9a8f14be881cacb29452300f39ee66f24e253e2df947f388ad2157114cd3f44eeeb88fae4e3dd1f9687ce47f27d43f2805f9f54694b8523dc9f998b59ae79996' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./*.txt \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/3.1/sdk/alpine3.11/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.11/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 FROM $REPO:3.1-alpine3.11
 
 ENV \
@@ -24,8 +24,7 @@ RUN dotnet_sdk_version=3.1.201 \
     && dotnet_sha512='9a8f14be881cacb29452300f39ee66f24e253e2df947f388ad2157114cd3f44eeeb88fae4e3dd1f9687ce47f27d43f2805f9f54694b8523dc9f998b59ae79996' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./*.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/3.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -1,5 +1,7 @@
 # escape=`
 
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
@@ -31,10 +33,16 @@ RUN $powershell_version = '7.0.0'; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
+# Delete everything in the dotnet folder that's not needed in the SDK layer
+RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
+
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM $REPO:3.1-nanoserver-1809
 
 ENV `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS= `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)
@@ -46,7 +54,7 @@ ENV `
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/3.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -33,8 +33,8 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
-    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
-    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `
+        | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/3.1/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1809/amd64/Dockerfile
@@ -7,34 +7,34 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '3.1.201'; `
+RUN `
+    # Retrieve .NET Core SDK
+    $dotnet_sdk_version = '3.1.201'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
     $dotnet_sha512 = '89936531faf24686fb5add6f6771b78df92fab6786398a692ae5930d812322b545199e3c9eec11994233887734a61943c74943f9ba4e491106a0ff794a0ce2a5'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     Expand-Archive dotnet.zip -DestinationPath dotnet; `
-    Remove-Item -Force dotnet.zip
-
-# Install PowerShell global tool
-RUN $powershell_version = '7.0.0'; `
+    Remove-Item -Force dotnet.zip; `
+    `
+    # Install PowerShell global tool
+    $powershell_version = '7.0.0'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
     $powershell_sha512 = '1980da63a4f6017235e7af810bfda66be8fa53d0475d147a8219a36c76a903af99adb6cd5309e3dadc610389ae3525bca1ca2d30e7a991640e924334fd4e4638'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
     \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
-    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
-
-# Delete everything in the dotnet folder that's not needed in the SDK layer
-RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+    `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
+    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -7,34 +7,34 @@ FROM mcr.microsoft.com/windows/servercore:1903 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '3.1.201'; `
+RUN `
+    # Retrieve .NET Core SDK
+    $dotnet_sdk_version = '3.1.201'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
     $dotnet_sha512 = '89936531faf24686fb5add6f6771b78df92fab6786398a692ae5930d812322b545199e3c9eec11994233887734a61943c74943f9ba4e491106a0ff794a0ce2a5'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     Expand-Archive dotnet.zip -DestinationPath dotnet; `
-    Remove-Item -Force dotnet.zip
-
-# Install PowerShell global tool
-RUN $powershell_version = '7.0.0'; `
+    Remove-Item -Force dotnet.zip; `
+    `
+    # Install PowerShell global tool
+    $powershell_version = '7.0.0'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
     $powershell_sha512 = '1980da63a4f6017235e7af810bfda66be8fa53d0475d147a8219a36c76a903af99adb6cd5309e3dadc610389ae3525bca1ca2d30e7a991640e924334fd4e4638'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
     \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
-    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
-
-# Delete everything in the dotnet folder that's not needed in the SDK layer
-RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+    `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer
+    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -32,8 +32,8 @@ RUN `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
-    # Delete everything in the dotnet folder that's not needed in the SDK layer
-    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
     Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -33,8 +33,8 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
-    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
-    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `
+        | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/3.1/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1903/amd64/Dockerfile
@@ -1,5 +1,7 @@
 # escape=`
 
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1903 AS installer
 
@@ -31,10 +33,16 @@ RUN $powershell_version = '7.0.0'; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
+# Delete everything in the dotnet folder that's not needed in the SDK layer
+RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
+
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM $REPO:3.1-nanoserver-1903
 
 ENV `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS= `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)
@@ -46,7 +54,7 @@ ENV `
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -32,8 +32,8 @@ RUN `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
-    # Delete everything in the dotnet folder that's not needed in the SDK layer
-    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
     Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -1,5 +1,7 @@
 # escape=`
 
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1909 AS installer
 
@@ -31,10 +33,16 @@ RUN $powershell_version = '7.0.0'; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
+# Delete everything in the dotnet folder that's not needed in the SDK layer
+RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
+
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1909
+FROM $REPO:3.1-nanoserver-1909
 
 ENV `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS= `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)
@@ -46,7 +54,7 @@ ENV `
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -7,34 +7,34 @@ FROM mcr.microsoft.com/windows/servercore:1909 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '3.1.201'; `
+RUN `
+    # Retrieve .NET Core SDK
+    $dotnet_sdk_version = '3.1.201'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
     $dotnet_sha512 = '89936531faf24686fb5add6f6771b78df92fab6786398a692ae5930d812322b545199e3c9eec11994233887734a61943c74943f9ba4e491106a0ff794a0ce2a5'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     Expand-Archive dotnet.zip -DestinationPath dotnet; `
-    Remove-Item -Force dotnet.zip
-
-# Install PowerShell global tool
-RUN $powershell_version = '7.0.0'; `
+    Remove-Item -Force dotnet.zip; `
+    `
+    # Install PowerShell global tool
+    $powershell_version = '7.0.0'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
     $powershell_sha512 = '1980da63a4f6017235e7af810bfda66be8fa53d0475d147a8219a36c76a903af99adb6cd5309e3dadc610389ae3525bca1ca2d30e7a991640e924334fd4e4638'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
     \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
-    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
-
-# Delete everything in the dotnet folder that's not needed in the SDK layer
-RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+    `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer
+    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/3.1/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/3.1/sdk/nanoserver-1909/amd64/Dockerfile
@@ -33,8 +33,8 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
-    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
-    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `
+        | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/5.0/sdk/alpine3.11/amd64/Dockerfile
+++ b/5.0/sdk/alpine3.11/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet_sdk_version=5.0.100-preview.3.20208.17 \
     && dotnet_sha512='0a0173a9cbae0ff5afec431a7918cb53da88ab11a916d6399bd5b7f8c0d2dd4ff1653571dfad36143674f5d252281c3e97fa3421d786212e0acb6b5272e89dd6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./*.txt \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/5.0/sdk/alpine3.11/amd64/Dockerfile
+++ b/5.0/sdk/alpine3.11/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 FROM $REPO:5.0-alpine3.11
 
 ENV \
@@ -24,8 +24,7 @@ RUN dotnet_sdk_version=5.0.100-preview.3.20208.17 \
     && dotnet_sha512='0a0173a9cbae0ff5afec431a7918cb53da88ab11a916d6399bd5b7f8c0d2dd4ff1653571dfad36143674f5d252281c3e97fa3421d786212e0acb6b5272e89dd6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/5.0/sdk/alpine3.11/amd64/Dockerfile
+++ b/5.0/sdk/alpine3.11/amd64/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet_sdk_version=5.0.100-preview.3.20208.17 \
     && dotnet_sha512='0a0173a9cbae0ff5afec431a7918cb53da88ab11a916d6399bd5b7f8c0d2dd4ff1653571dfad36143674f5d252281c3e97fa3421d786212e0acb6b5272e89dd6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./*.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/5.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -30,7 +30,7 @@ RUN `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
     \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
-    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
     Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `

--- a/5.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -33,8 +33,8 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
-    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
-    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `
+        | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/5.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -1,5 +1,7 @@
 # escape=`
 
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
@@ -32,7 +34,7 @@ RUN $powershell_version = '7.1.0-preview.1'; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM $REPO:5.0-nanoserver-1809
 
 ENV `
     # Enable detection of running in a container
@@ -42,14 +44,19 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1809
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1809 `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS=
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
 USER ContainerUser
 
-COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/dotnet/packs", "/Program Files/dotnet/packs"]
+COPY --from=installer ["/dotnet/sdk", "/Program Files/dotnet/sdk"]
+COPY --from=installer ["/dotnet/shared/Microsoft.WindowsDesktop.App", "/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App"]
+COPY --from=installer ["/dotnet/templates", "/Program Files/dotnet/templates"]
 
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 

--- a/5.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -7,34 +7,34 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '5.0.100-preview.3.20208.17'; `
+RUN `
+    # Retrieve .NET Core SDK
+    $dotnet_sdk_version = '5.0.100-preview.3.20208.17'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
     $dotnet_sha512 = 'f224da928244b23cab3695cff68d183e3a68b31d5be994be15609e2351dae93140beb82677addfb950bfe3f46efe5bfefa315071c7a447ebce472e096a5064f7'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     Expand-Archive dotnet.zip -DestinationPath dotnet; `
-    Remove-Item -Force dotnet.zip
-
-# Install PowerShell global tool
-RUN $powershell_version = '7.1.0-preview.1'; `
+    Remove-Item -Force dotnet.zip; `
+    `
+    # Install PowerShell global tool
+    $powershell_version = '7.1.0-preview.1'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
     $powershell_sha512 = '8ba8c4226ffc5120782335c46a747c862141b86c3e8ef8833936d2d3fafd544bcc6f4590723caae3e631a23d16748455ceb526799aba50e090a73750363792ba'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
     \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
-    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
-
-# Delete everything in the dotnet folder that's not needed in the SDK layer
-RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force `
+    `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer
+    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/5.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -32,8 +32,8 @@ RUN `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force `
     `
-    # Delete everything in the dotnet folder that's not needed in the SDK layer
-    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
     Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 

--- a/5.0/sdk/nanoserver-1809/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1809/amd64/Dockerfile
@@ -33,10 +33,16 @@ RUN $powershell_version = '7.1.0-preview.1'; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
+# Delete everything in the dotnet folder that's not needed in the SDK layer
+RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
+
 # SDK image
 FROM $REPO:5.0-nanoserver-1809
 
 ENV `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS= `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)
@@ -44,19 +50,14 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1809 `
-    # Unset ASPNETCORE_URLS derived from aspnet base image
-    ASPNETCORE_URLS=
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1809
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
-COPY --from=installer ["/dotnet/packs", "/Program Files/dotnet/packs"]
-COPY --from=installer ["/dotnet/sdk", "/Program Files/dotnet/sdk"]
-COPY --from=installer ["/dotnet/shared/Microsoft.WindowsDesktop.App", "/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App"]
-COPY --from=installer ["/dotnet/templates", "/Program Files/dotnet/templates"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 

--- a/5.0/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1903/amd64/Dockerfile
@@ -33,11 +33,17 @@ RUN $powershell_version = '7.1.0-preview.1'; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
+# Delete everything in the dotnet folder that's not needed in the SDK layer
+RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
+
 # SDK image
 
 FROM $REPO:5.0-nanoserver-1903
 
 ENV `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS= `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)
@@ -45,19 +51,14 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1903 `
-    # Unset ASPNETCORE_URLS derived from aspnet base image
-    ASPNETCORE_URLS=
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1903
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
-COPY --from=installer ["/dotnet/packs", "/Program Files/dotnet/packs"]
-COPY --from=installer ["/dotnet/sdk", "/Program Files/dotnet/sdk"]
-COPY --from=installer ["/dotnet/shared/Microsoft.WindowsDesktop.App", "/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App"]
-COPY --from=installer ["/dotnet/templates", "/Program Files/dotnet/templates"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 

--- a/5.0/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1903/amd64/Dockerfile
@@ -32,8 +32,8 @@ RUN `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
-    # Delete everything in the dotnet folder that's not needed in the SDK layer
-    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
     Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 

--- a/5.0/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1903/amd64/Dockerfile
@@ -7,34 +7,34 @@ FROM mcr.microsoft.com/windows/servercore:1903 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '5.0.100-preview.3.20208.17'; `
+RUN `
+    # Retrieve .NET Core SDK
+    $dotnet_sdk_version = '5.0.100-preview.3.20208.17'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
     $dotnet_sha512 = 'f224da928244b23cab3695cff68d183e3a68b31d5be994be15609e2351dae93140beb82677addfb950bfe3f46efe5bfefa315071c7a447ebce472e096a5064f7'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     Expand-Archive dotnet.zip -DestinationPath dotnet; `
-    Remove-Item -Force dotnet.zip
-
-# Install PowerShell global tool
-RUN $powershell_version = '7.1.0-preview.1'; `
+    Remove-Item -Force dotnet.zip; `
+    `
+    # Install PowerShell global tool
+    $powershell_version = '7.1.0-preview.1'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
     $powershell_sha512 = '8ba8c4226ffc5120782335c46a747c862141b86c3e8ef8833936d2d3fafd544bcc6f4590723caae3e631a23d16748455ceb526799aba50e090a73750363792ba'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
     \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
-    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
-
-# Delete everything in the dotnet folder that's not needed in the SDK layer
-RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+    `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer
+    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/5.0/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1903/amd64/Dockerfile
@@ -1,5 +1,7 @@
 # escape=`
 
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1903 AS installer
 
@@ -32,7 +34,8 @@ RUN $powershell_version = '7.1.0-preview.1'; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1903
+
+FROM $REPO:5.0-nanoserver-1903
 
 ENV `
     # Enable detection of running in a container
@@ -42,14 +45,19 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1903
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1903 `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS=
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
 USER ContainerUser
 
-COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/dotnet/packs", "/Program Files/dotnet/packs"]
+COPY --from=installer ["/dotnet/sdk", "/Program Files/dotnet/sdk"]
+COPY --from=installer ["/dotnet/shared/Microsoft.WindowsDesktop.App", "/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App"]
+COPY --from=installer ["/dotnet/templates", "/Program Files/dotnet/templates"]
 
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 

--- a/5.0/sdk/nanoserver-1903/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1903/amd64/Dockerfile
@@ -33,8 +33,8 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
-    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
-    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `
+        | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/5.0/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1909/amd64/Dockerfile
@@ -1,5 +1,7 @@
 # escape=`
 
+ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1909 AS installer
 
@@ -32,7 +34,7 @@ RUN $powershell_version = '7.1.0-preview.1'; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1909
+FROM $REPO:5.0-nanoserver-1909
 
 ENV `
     # Enable detection of running in a container
@@ -42,14 +44,19 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1909
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1909 `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS=
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
 USER ContainerUser
 
-COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/dotnet/packs", "/Program Files/dotnet/packs"]
+COPY --from=installer ["/dotnet/sdk", "/Program Files/dotnet/sdk"]
+COPY --from=installer ["/dotnet/shared/Microsoft.WindowsDesktop.App", "/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App"]
+COPY --from=installer ["/dotnet/templates", "/Program Files/dotnet/templates"]
 
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 

--- a/5.0/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1909/amd64/Dockerfile
@@ -33,10 +33,16 @@ RUN $powershell_version = '7.1.0-preview.1'; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
 
+# Delete everything in the dotnet folder that's not needed in the SDK layer
+RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
+
 # SDK image
 FROM $REPO:5.0-nanoserver-1909
 
 ENV `
+    # Unset ASPNETCORE_URLS derived from aspnet base image
+    ASPNETCORE_URLS= `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)
@@ -44,19 +50,14 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1909 `
-    # Unset ASPNETCORE_URLS derived from aspnet base image
-    ASPNETCORE_URLS=
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1909
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\dotnet;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
-COPY --from=installer ["/dotnet/packs", "/Program Files/dotnet/packs"]
-COPY --from=installer ["/dotnet/sdk", "/Program Files/dotnet/sdk"]
-COPY --from=installer ["/dotnet/shared/Microsoft.WindowsDesktop.App", "/Program Files/dotnet/shared/Microsoft.WindowsDesktop.App"]
-COPY --from=installer ["/dotnet/templates", "/Program Files/dotnet/templates"]
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 

--- a/5.0/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1909/amd64/Dockerfile
@@ -7,34 +7,34 @@ FROM mcr.microsoft.com/windows/servercore:1909 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '5.0.100-preview.3.20208.17'; `
+RUN `
+    # Retrieve .NET Core SDK
+    $dotnet_sdk_version = '5.0.100-preview.3.20208.17'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
     $dotnet_sha512 = 'f224da928244b23cab3695cff68d183e3a68b31d5be994be15609e2351dae93140beb82677addfb950bfe3f46efe5bfefa315071c7a447ebce472e096a5064f7'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     Expand-Archive dotnet.zip -DestinationPath dotnet; `
-    Remove-Item -Force dotnet.zip
-
-# Install PowerShell global tool
-RUN $powershell_version = '7.1.0-preview.1'; `
+    Remove-Item -Force dotnet.zip; `
+    `
+    # Install PowerShell global tool
+    $powershell_version = '7.1.0-preview.1'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
     $powershell_sha512 = '8ba8c4226ffc5120782335c46a747c862141b86c3e8ef8833936d2d3fafd544bcc6f4590723caae3e631a23d16748455ceb526799aba50e090a73750363792ba'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    `
     \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
     \dotnet\dotnet nuget locals all --clear; `
     Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
-    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force
-
-# Delete everything in the dotnet folder that's not needed in the SDK layer
-RUN Get-ChildItem -Exclude "*.txt","packs","sdk","templates","shared" -Path dotnet | Remove-Item -Force -Recurse; `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+    `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/5.0/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1909/amd64/Dockerfile
@@ -33,7 +33,7 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
-    $excludedItems = "LICENSE.txt","ThirdPartyNotices.txt","packs","sdk","templates","shared"; `
+    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
     Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 

--- a/5.0/sdk/nanoserver-1909/amd64/Dockerfile
+++ b/5.0/sdk/nanoserver-1909/amd64/Dockerfile
@@ -33,8 +33,8 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
-    $excludedItems = 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared'; `
-    Get-ChildItem -Exclude $excludedItems -Path dotnet | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `
+        | Remove-Item -Force -Recurse; `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image

--- a/manifest.json
+++ b/manifest.json
@@ -1874,6 +1874,9 @@
               "variant": "v8"
             },
             {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
               "dockerfile": "3.1/sdk/nanoserver-1809/amd64",
               "os": "windows",
               "osVersion": "nanoserver-1809",
@@ -1893,6 +1896,9 @@
               }
             },
             {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
               "dockerfile": "3.1/sdk/nanoserver-1903/amd64",
               "os": "windows",
               "osVersion": "nanoserver-1903",
@@ -1902,6 +1908,9 @@
               }
             },
             {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
               "dockerfile": "3.1/sdk/nanoserver-1909/amd64",
               "os": "windows",
               "osVersion": "nanoserver-1909",
@@ -1917,7 +1926,7 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime-deps)"
+                "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "3.1/sdk/alpine3.10/amd64",
               "os": "linux",
@@ -1934,7 +1943,7 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime-deps)"
+                "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "3.1/sdk/alpine3.11/amd64",
               "os": "linux",

--- a/manifest.json
+++ b/manifest.json
@@ -2064,6 +2064,9 @@
               "variant": "v8"
             },
             {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
               "dockerfile": "5.0/sdk/nanoserver-1809/amd64",
               "os": "windows",
               "osVersion": "nanoserver-1809",
@@ -2073,6 +2076,9 @@
               }
             },
             {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
               "dockerfile": "5.0/sdk/nanoserver-1903/amd64",
               "os": "windows",
               "osVersion": "nanoserver-1903",
@@ -2082,6 +2088,9 @@
               }
             },
             {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
               "dockerfile": "5.0/sdk/nanoserver-1909/amd64",
               "os": "windows",
               "osVersion": "nanoserver-1909",
@@ -2097,7 +2106,7 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime-deps)"
+                "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "5.0/sdk/alpine3.11/amd64",
               "os": "linux",


### PR DESCRIPTION
In order to allow for more layer sharing amongst images, the 5.0 SDK images for Alpine and Nano Server have been changed to be based on their respective ASP.NET images.  This requires that the runtime and ASP.NET components of the SDK be omitted when extracting its contents since they are derived from base layers.

Fixes #1351