### PR TITLE
Update name of ASP.NET versions file

### DIFF
--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -17,7 +17,7 @@ sdkVer=$(cat $sdkVersionsPath | head -2 | tail -1)
 runtimeVersionsPath=$(find sdk/shared/Microsoft.NETCore.App -name .version)
 runtimeVer=$(cat $runtimeVersionsPath | tail -1)
 
-aspnetVersionsPath=$(find sdk/shared/Microsoft.AspNetCore.App -name .version)
+aspnetVersionsPath=$(find sdk/shared/Microsoft.AspNetCore.App -name Microsoft.AspNetCore.App.versions.txt)
 aspnetVer=$(cat $aspnetVersionsPath | tail -1)
 
 rm -rf sdk


### PR DESCRIPTION
The `.version` file for ASP.NET has been renamed to `Microsoft.AspNetCore.App.versions.txt` which broke the automation from determining the version of ASP.NET in the downloaded the SDK.  See https://github.com/dotnet/aspnetcore/issues/21177.  Updating the script to look for the new file name.