### PR TITLE
Update image size baselines for Focal images

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -6,7 +6,7 @@
     "2.1/runtime-deps/alpine3.11/amd64": 12333463,
     "2.1/runtime-deps/bionic/amd64": 111095589,
     "2.1/runtime-deps/bionic/arm32v7": 87327705,
-    "2.1/runtime-deps/focal/amd64": 134806530,
+    "2.1/runtime-deps/focal/amd64": 119203506,
     "3.1/runtime-deps/buster-slim/amd64": 110537404,
     "3.1/runtime-deps/buster-slim/arm32v7": 85810304,
     "3.1/runtime-deps/buster-slim/arm64v8": 104153752,
@@ -17,15 +17,15 @@
     "3.1/runtime-deps/bionic/amd64": 106459634,
     "3.1/runtime-deps/bionic/arm32v7": 84576709,
     "3.1/runtime-deps/bionic/arm64v8": 99094631,
-    "3.1/runtime-deps/focal/amd64": 134806530,
-    "3.1/runtime-deps/focal/arm64v8": 123921698,
+    "3.1/runtime-deps/focal/amd64": 119203506,
+    "3.1/runtime-deps/focal/arm64v8": 111261028,
     "5.0/runtime-deps/buster-slim/amd64": 110537404,
     "5.0/runtime-deps/buster-slim/arm32v7": 85810304,
     "5.0/runtime-deps/buster-slim/arm64v8": 104153752,
     "5.0/runtime-deps/alpine3.11/amd64": 9407340,
     "5.0/runtime-deps/alpine3.11/arm64v8": 9207485,
-    "5.0/runtime-deps/focal/amd64": 133175902,
-    "5.0/runtime-deps/focal/arm64v8": 122336678
+    "5.0/runtime-deps/focal/amd64": 117572886,
+    "5.0/runtime-deps/focal/arm64v8": 109676004
   },
   "dotnet/core-nightly/runtime": {
     "2.1/runtime/stretch-slim/amd64": 180258057,
@@ -34,7 +34,7 @@
     "2.1/runtime/alpine3.11/amd64": 86692780,
     "2.1/runtime/bionic/amd64": 191246153,
     "2.1/runtime/bionic/arm32v7": 160181517,
-    "2.1/runtime/focal/amd64": 216565144,
+    "2.1/runtime/focal/amd64": 200955744,
     "3.1/runtime/buster-slim/amd64": 189547466,
     "3.1/runtime/buster-slim/arm32v7": 165337028,
     "3.1/runtime/buster-slim/arm64v8": 197045040,
@@ -45,15 +45,15 @@
     "3.1/runtime/bionic/amd64": 186917824,
     "3.1/runtime/bionic/arm32v7": 164509053,
     "3.1/runtime/bionic/arm64v8": 192660378,
-    "3.1/runtime/focal/amd64": 219056468,
+    "3.1/runtime/focal/amd64": 203447068,
     "3.1/runtime/focal/arm64v8": 216615477,
     "5.0/runtime/buster-slim/amd64": 189547466,
     "5.0/runtime/buster-slim/arm32v7": 165337028,
     "5.0/runtime/buster-slim/arm64v8": 197045040,
     "5.0/runtime/alpine3.11/amd64": 92129520,
     "5.0/runtime/alpine3.11/arm64v8": 99614022,
-    "5.0/runtime/focal/amd64": 215282137,
-    "5.0/runtime/focal/arm64v8": 215010843
+    "5.0/runtime/focal/amd64": 199679121,
+    "5.0/runtime/focal/arm64v8": 202350169
   },
   "dotnet/core-nightly/aspnet": {
     "2.1/aspnet/stretch-slim/amd64": 253015005,
@@ -73,15 +73,15 @@
     "3.1/aspnet/bionic/amd64": 204690508,
     "3.1/aspnet/bionic/arm32v7": 184974857,
     "3.1/aspnet/bionic/arm64v8": 213885488,
-    "3.1/aspnet/focal/amd64": 236857434,
+    "3.1/aspnet/focal/amd64": 221248034,
     "3.1/aspnet/focal/arm64v8": 237840587,
     "5.0/aspnet/buster-slim/amd64": 207319902,
     "5.0/aspnet/buster-slim/arm32v7": 185802832,
     "5.0/aspnet/buster-slim/arm64v8": 218270150,
     "5.0/aspnet/alpine3.11/amd64": 104956138,
     "5.0/aspnet/alpine3.11/arm64v8": 120839157,
-    "5.0/aspnet/focal/amd64": 233514089,
-    "5.0/aspnet/focal/arm64v8": 236806837
+    "5.0/aspnet/focal/amd64": 217911073,
+    "5.0/aspnet/focal/arm64v8": 224146163
   },
   "dotnet/core-nightly/sdk": {
     "2.1/sdk/stretch/amd64": 1728622878,
@@ -105,7 +105,7 @@
     "5.0/sdk/buster-slim/arm32v7": 564714978,
     "5.0/sdk/buster-slim/arm64v8": 631997544,
     "5.0/sdk/alpine3.11/amd64": 465060167,
-    "5.0/sdk/focal/amd64": 656452398,
+    "5.0/sdk/focal/amd64": 615235315,
     "5.0/sdk/focal/arm64v8": 672793717
   }
 }


### PR DESCRIPTION
A size change occurred in the runtime-deps layer that installs packages.  This was most likely a result of the official release of Focal.  Updating the baseline numbers to reflect the change in image size.