### PR TITLE
Remove locale env vars from 5.0 SDK on Alpine

### DIFF
--- a/5.0/sdk/alpine3.11/amd64/Dockerfile
+++ b/5.0/sdk/alpine3.11/amd64/Dockerfile
@@ -9,8 +9,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -77,8 +77,12 @@ namespace Microsoft.DotNet.Docker.Tests
             if (imageData.SdkOS.StartsWith(OS.AlpinePrefix))
             {
                 variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "false"));
-                variables.Add(new EnvironmentVariableInfo("LC_ALL", "en_US.UTF-8"));
-                variables.Add(new EnvironmentVariableInfo("LANG", "en_US.UTF-8"));
+
+                if (imageData.Version.Major < 5)
+                {
+                    variables.Add(new EnvironmentVariableInfo("LC_ALL", "en_US.UTF-8"));
+                    variables.Add(new EnvironmentVariableInfo("LANG", "en_US.UTF-8"));
+                }
             }
 
             EnvironmentVariableInfo.Validate(variables, DotNetImageType.SDK, imageData, DockerHelper);


### PR DESCRIPTION
Removes the `LC_ALL` and `LANG` environment variables from the 5.0 SDK image for Alpine in order to be consistent with all SDK images.

Fixes #1516