### PR TITLE
Readme updates for 5.0 repo name change

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -16,7 +16,7 @@ See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for image
 
 # About This Image
 
-This image contains the ASP.NET Core and .NET Core runtimes and libraries and is optimized for running ASP.NET Core apps in production. This repository is limited to .NET Core 2.1 and 3.1. For .NET 5.0 and higher, see the [readme](README.aspnet.preview.md) for those versions.
+This image contains the ASP.NET Core and .NET Core runtimes and libraries and is optimized for running ASP.NET Core apps in production. This repository is limited to .NET Core 2.1 and 3.1. For .NET 5.0 and higher, see [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/) for those versions.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
@@ -40,24 +40,19 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 # Related Repos
 
-.NET Core:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
-
-.NET Core (Preview):
-
 * [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
 * [dotnet/core-nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-core-nightly-sdk/): .NET Core SDK (Preview)
 * [dotnet/core-nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime/): .NET Core Runtime (Preview)
 * [dotnet/core-nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime-deps/): .NET Core Runtime Dependencies (Preview)
 
-.NET (Preview):
+.NET 5.0+:
 
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 
 .NET Framework:
 

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -46,7 +46,6 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
-* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
 
 .NET 5.0+:
 

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -42,20 +42,15 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 # Related Repos
 
-.NET Core:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
-
-.NET Core (Preview):
-
 * [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
-* [dotnet/core-nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-core-nightly-sdk/): .NET Core SDK (Preview)
-* [dotnet/core-nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime/): .NET Core Runtime (Preview)
-* [dotnet/core-nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime-deps/): .NET Core Runtime Dependencies (Preview)
 
-.NET (Preview):
+.NET 5.0+:
 
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 * [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -16,7 +16,7 @@ See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images wi
 
 # About This Image
 
-This image contains the native dependencies needed by .NET Core. It does not include .NET Core. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
+This image contains the native dependencies needed by .NET Core. It does not include .NET Core. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications. This repository is limited to .NET Core 2.1 and 3.1. For .NET 5.0 and higher, see [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/) for those versions.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
@@ -28,7 +28,7 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 
 # Related Repos
 
-.NET Core:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
@@ -36,6 +36,11 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 * [dotnet/core-nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-core-nightly-sdk/): .NET Core SDK (Preview)
 * [dotnet/core-nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-core-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/core-nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime/): .NET Core Runtime (Preview)
+
+.NET 5.0+:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -9,6 +9,8 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+
 # Featured Tags
 
 * `5.0` (Preview)
@@ -28,10 +30,15 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 
 # Related Repos
 
-.NET:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
+* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
+
+.NET 5.0+:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 * [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -9,7 +9,7 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/runtime-deps:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime-deps:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 # Featured Tags
 
@@ -34,7 +34,6 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
-* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
 
 .NET 5.0+:
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -16,7 +16,7 @@ See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images wi
 
 # About This Image
 
-This image contains the .NET Core runtimes and libraries and is optimized for running .NET Core apps in production.
+This image contains the .NET Core runtimes and libraries and is optimized for running .NET Core apps in production. This repository is limited to .NET Core 2.1 and 3.1. For .NET 5.0 and higher, see [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/) for those versions.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
@@ -36,7 +36,7 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 
 # Related Repos
 
-.NET Core:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
@@ -44,6 +44,11 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 * [dotnet/core-nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-core-nightly-sdk/): .NET Core SDK (Preview)
 * [dotnet/core-nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-core-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/core-nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime-deps/): .NET Core Runtime Dependencies (Preview)
+
+.NET 5.0+:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -9,6 +9,8 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+
 # Featured Tags
 
 * `5.0` (Preview)
@@ -36,10 +38,15 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 
 # Related Repos
 
-.NET:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
+* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
+
+.NET 5.0+:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 * [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -9,7 +9,7 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/runtime:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 # Featured Tags
 
@@ -42,7 +42,6 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
-* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
 
 .NET 5.0+:
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -22,7 +22,7 @@ This image contains the .NET Core SDK which is comprised of three parts:
 1. .NET Core
 1. ASP.NET Core
 
-Use this image for your development process (developing, building and testing applications).
+Use this image for your development process (developing, building and testing applications). This repository is limited to .NET Core 2.1 and 3.1. For .NET 5.0 and higher, see [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/) for those versions.
 
 # How to Use the Image
 
@@ -40,7 +40,7 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 
 # Related Repos
 
-.NET Core:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
@@ -48,6 +48,11 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 * [dotnet/core-nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-core-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/core-nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime/): .NET Core Runtime (Preview)
 * [dotnet/core-nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-core-nightly-runtime-deps/): .NET Core Runtime Dependencies (Preview)
+
+.NET 5.0+:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -9,7 +9,7 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/sdk:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/sdk:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 # Featured Tags
 
@@ -46,7 +46,6 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
-* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
 
 .NET 5.0+:
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -9,6 +9,8 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+
 # Featured Tags
 
 * `5.0` (Preview)
@@ -40,10 +42,15 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 
 # Related Repos
 
-.NET:
+.NET Core 2.1/3.1:
 
 * [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/): .NET Core
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
+* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core (Preview)
+
+.NET 5.0+:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)

--- a/eng/Get-TagsDocumentation.ps1
+++ b/eng/Get-TagsDocumentation.ps1
@@ -10,33 +10,33 @@ if (!$Branch) {
     $manifestJson = Get-Content ${repoRoot}/manifest.json | ConvertFrom-Json
     if ($manifestJson.Repos[0].Name.Contains("nightly")) {
         $Branch = "nightly"
-        $coreRepoName = "core-nightly"
-        $previewCoreRepoName = "nightly"
+        $coreRepoName = "core-nightly/"
+        $repoName = "nightly/"
     }
     else {
         $Branch = "master"
-        $coreRepoName = "core"
-        $previewCoreRepoName = ""
+        $coreRepoName = "core/"
+        $repoName = ""
     }
 }
 
 $gitRepo = "https://github.com/dotnet/dotnet-docker"
 
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$coreRepoName/runtime-deps README.runtime-deps.md manifest.json $gitRepo $Branch
+    dotnet/$($coreRepoName)runtime-deps README.runtime-deps.md manifest.json $gitRepo $Branch
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$previewCoreRepoName/runtime-deps README.runtime-deps.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
+    dotnet/$($repoName)runtime-deps README.runtime-deps.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$coreRepoName/runtime README.runtime.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
+    dotnet/$($coreRepoName)runtime README.runtime.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$previewCoreRepoName/runtime README.runtime.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
+    dotnet/$($repoName)runtime README.runtime.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$coreRepoName/aspnet README.aspnet.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
+    dotnet/$($coreRepoName)aspnet README.aspnet.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$previewCoreRepoName/aspnet README.aspnet.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
+    dotnet/$($repoName)aspnet README.aspnet.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$coreRepoName/sdk README.sdk.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
+    dotnet/$($coreRepoName)sdk README.sdk.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
-    dotnet/$previewCoreRepoName/sdk README.sdk.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
+    dotnet/$($repoName)sdk README.sdk.preview.md manifest.json $gitRepo $Branch -ReuseImageBuilderImage
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 `
     dotnet/core/samples README.samples.md manifest.samples.json $gitRepo -ReuseImageBuilderImage


### PR DESCRIPTION
Addresses the remaining review comments from https://github.com/dotnet/dotnet-docker/pull/1888.