### PR TITLE
Include ca-certificates pkg in 5.0 runtime-deps

### DIFF
--- a/5.0/runtime-deps/buster-slim/amd64/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/amd64/Dockerfile
@@ -1,9 +1,10 @@
 FROM amd64/debian:buster-slim
 
-# .NET Core dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        \
+# .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/buster-slim/amd64/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/amd64/Dockerfile
@@ -3,6 +3,7 @@ FROM amd64/debian:buster-slim
 # .NET Core dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        ca-certificates \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile
@@ -3,6 +3,7 @@ FROM arm32v7/debian:buster-slim
 # .NET Core dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        ca-certificates \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile
@@ -1,9 +1,10 @@
 FROM arm32v7/debian:buster-slim
 
-# .NET Core dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        \
+# .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile
@@ -1,9 +1,10 @@
 FROM arm64v8/debian:buster-slim
 
-# .NET Core dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        \
+# .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile
@@ -3,6 +3,7 @@ FROM arm64v8/debian:buster-slim
 # .NET Core dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        ca-certificates \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -1,9 +1,10 @@
 FROM amd64/ubuntu:focal
 
-# .NET Core dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        \
+# .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -3,6 +3,7 @@ FROM amd64/ubuntu:focal
 # .NET Core dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/focal/arm32v7/Dockerfile
@@ -3,6 +3,7 @@ FROM arm32v7/ubuntu:focal
 # .NET Core dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/focal/arm32v7/Dockerfile
@@ -1,9 +1,10 @@
 FROM arm32v7/ubuntu:focal
 
-# .NET Core dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        \
+# .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/focal/arm64v8/Dockerfile
@@ -1,9 +1,10 @@
 FROM arm64v8/ubuntu:focal
 
-# .NET Core dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        \
+# .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/5.0/runtime-deps/focal/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/focal/arm64v8/Dockerfile
@@ -3,6 +3,7 @@ FROM arm64v8/ubuntu:focal
 # .NET Core dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="SharpCompress" Version="0.25.0" />


### PR DESCRIPTION
Adds the `ca-certificates` package to the runtime-deps images to allow HTTPS connections to succeed by default.  Alpine doesn't require this package in order for this scenario to work since it has the `ca-certificates-cacert` package by default.

Updates the tests to inject custom logic to the `Main` method which verifies the scenario.

Related to #1897