### PR TITLE
Update readme content

### DIFF
--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -5,20 +5,16 @@ To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.msc
 For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
 ---------------------------------------------------------------------------------
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet/dotnet-docker](https://hub.docker.com/r/microsoft/dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
-
 # Featured Tags
 
 * `5.0` (Preview)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:5.0`
+  * `docker pull mcr.microsoft.com/dotnet/aspnet:5.0`
 
 # About This Image
 
-This image contains the ASP.NET Core and .NET Core runtimes and libraries and is optimized for running ASP.NET Core apps in production.
+This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
+
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
@@ -50,10 +46,10 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 .NET 5.0+:
 
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 
 .NET Framework:
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@ For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules)
 
 # Featured Repos
 
+## .NET Core 2.1/3.1
+
 * [dotnet/core/sdk](https://hub.docker.com/_/microsoft-dotnet-core-sdk/): .NET Core SDK
 * [dotnet/core/aspnet](https://hub.docker.com/_/microsoft-dotnet-core-aspnet/): ASP.NET Core Runtime
 * [dotnet/core/runtime](https://hub.docker.com/_/microsoft-dotnet-core-runtime/): .NET Core Runtime
 * [dotnet/core/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-core-runtime-deps/): .NET Core Runtime Dependencies
 * [dotnet/core/samples](https://hub.docker.com/_/microsoft-dotnet-core-samples/): .NET Core Samples
+
+## .NET 5.0+
+
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 
 # About .NET
 
@@ -61,7 +70,8 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 .NET:
 
-* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET Core (Preview)
+* [dotnet/core-nightly](https://hub.docker.com/_/microsoft-dotnet-core-nightly/): .NET Core 2.1/3.1 (Preview)
+* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET 5.0+ (Preview)
 
 .NET Framework:
 

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -5,20 +5,16 @@ To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.msc
 For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
 ---------------------------------------------------------------------------------
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime Dependencies can be found at `mcr.microsoft.com/dotnet/nightly/runtime-deps:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime-deps:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
-
 # Featured Tags
 
 * `5.0` (Preview)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:5.0`
+  * `docker pull mcr.microsoft.com/dotnet/runtime-deps:5.0`
 
 # About This Image
 
 This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
+
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime Dependencies can be found at `mcr.microsoft.com/dotnet/runtime-deps:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/runtime-deps:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
@@ -38,10 +34,10 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 .NET 5.0+:
 
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
 
 .NET Framework:
 

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -9,7 +9,7 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/runtime-deps:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime-deps:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime Dependencies can be found at `mcr.microsoft.com/dotnet/nightly/runtime-deps:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime-deps:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 # Featured Tags
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -5,20 +5,16 @@ To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.msc
 For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
 ---------------------------------------------------------------------------------
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime can be found at `mcr.microsoft.com/dotnet/nightly/runtime:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
-
 # Featured Tags
 
 * `5.0` (Preview)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:5.0`
+  * `docker pull mcr.microsoft.com/dotnet/runtime:5.0`
 
 # About This Image
 
 This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
+
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime can be found at `mcr.microsoft.com/dotnet/runtime:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/runtime:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
@@ -46,10 +42,10 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 .NET 5.0+:
 
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 
 .NET Framework:
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -9,7 +9,7 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/runtime:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime can be found at `mcr.microsoft.com/dotnet/nightly/runtime:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/runtime:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 # Featured Tags
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -9,7 +9,7 @@ The images from the dotnet/nightly repositories include last-known-good (LKG) bu
 
 See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/nightly/sdk:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/sdk:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 SDK can be found at `mcr.microsoft.com/dotnet/nightly/sdk:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/sdk:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 # Featured Tags
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -5,16 +5,10 @@ To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.msc
 For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
 ---------------------------------------------------------------------------------
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 SDK can be found at `mcr.microsoft.com/dotnet/nightly/sdk:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core-nightly/sdk:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
-
 # Featured Tags
 
 * `5.0` (Preview)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:5.0`
+  * `docker pull mcr.microsoft.com/dotnet/sdk:5.0`
 
 # About This Image
 
@@ -25,6 +19,8 @@ This image contains the .NET SDK which is comprised of three parts:
 1. ASP.NET Core
 
 Use this image for your development process (developing, building and testing applications).
+
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 SDK can be found at `mcr.microsoft.com/dotnet/sdk:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/sdk:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
 
 # How to Use the Image
 
@@ -50,10 +46,10 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 .NET 5.0+:
 
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 
 .NET Framework:
 


### PR DESCRIPTION
Merged in a change from nightly branch (#1915).

Updated the base readme to reference both `dotnet` and `dotnet-core` product families.  

Updated the 5.0 readmes to not reference nightly content.