### PR TITLE
Include 5.0 in core repos

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -389,6 +389,150 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "sharedTags": {
+            "$(5.0-RuntimeVersion)": {
+              "isUndocumented": true
+            },
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime-deps/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "5.0/runtime-deps/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "5.0/runtime-deps/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime-deps/alpine3.11/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.11",
+              "tags": {
+                "$(5.0-RuntimeVersion)-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "$(5.0-RuntimeVersion)-alpine": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "5.0/runtime-deps/alpine3.11/arm64v8",
+              "os": "linux",
+              "osVersion": "alpine3.11",
+              "tags": {
+                "$(5.0-RuntimeVersion)-alpine3.11-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine3.11-arm64v8": {
+                  "isUndocumented": true
+                },
+                "$(5.0-RuntimeVersion)-alpine-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime-deps/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-RuntimeVersion)-focal": {
+                  "isUndocumented": true
+                },
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "5.0/runtime-deps/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-RuntimeVersion)-focal-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
         }
       ]
     },
@@ -916,6 +1060,210 @@
               "tags": {
                 "$(3.1-RuntimeVersion)-focal-arm64v8": {},
                 "3.1-focal-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "sharedTags": {
+            "$(5.0-RuntimeVersion)": {
+              "isUndocumented": true
+            },
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "5.0/runtime/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "5.0/runtime/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "5.0/runtime/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            },
+            {
+              "dockerfile": "5.0/runtime/nanoserver-1809/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "$(5.0-RuntimeVersion)-nanoserver-1809": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1809": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "dockerfile": "5.0/runtime/nanoserver-1903/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {
+                "$(5.0-RuntimeVersion)-nanoserver-1903": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1903": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "dockerfile": "5.0/runtime/nanoserver-1909/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {
+                "$(5.0-RuntimeVersion)-nanoserver-1909": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1909": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "5.0/runtime/alpine3.11/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.11",
+              "tags": {
+                "$(5.0-RuntimeVersion)-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "$(5.0-RuntimeVersion)-alpine": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "5.0/runtime/alpine3.11/arm64v8",
+              "os": "linux",
+              "osVersion": "alpine3.11",
+              "tags": {
+                "$(5.0-RuntimeVersion)-alpine3.11-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine3.11-arm64v8": {
+                  "isUndocumented": true
+                },
+                "$(5.0-RuntimeVersion)-alpine-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "5.0/runtime/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-RuntimeVersion)-focal": {
+                  "isUndocumented": true
+                },
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "5.0/runtime/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-RuntimeVersion)-focal-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
               },
               "variant": "v8"
             }
@@ -1516,6 +1864,219 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "sharedTags": {
+            "$(5.0-RuntimeVersion)": {
+              "isUndocumented": true
+            },
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-RuntimeVersion)-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/nanoserver-1809/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "$(5.0-RuntimeVersion)-nanoserver-1809": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1809": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/nanoserver-1903/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {
+                "$(5.0-RuntimeVersion)-nanoserver-1903": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1903": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/nanoserver-1909/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {
+                "$(5.0-RuntimeVersion)-nanoserver-1909": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1909": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/alpine3.11/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.11",
+              "tags": {
+                "$(5.0-RuntimeVersion)-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "$(5.0-RuntimeVersion)-alpine": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/alpine3.11/arm64v8",
+              "os": "linux",
+              "osVersion": "alpine3.11",
+              "tags": {
+                "$(5.0-RuntimeVersion)-alpine3.11-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine3.11-arm64v8": {
+                  "isUndocumented": true
+                },
+                "$(5.0-RuntimeVersion)-alpine-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-RuntimeVersion)-focal": {
+                  "isUndocumented": true
+                },
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-RuntimeVersion)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "5.0/aspnet/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-RuntimeVersion)-focal-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
         }
       ]
     },
@@ -2022,6 +2583,190 @@
               "tags": {
                 "$(3.1-SdkVersion)-focal-arm64v8": {},
                 "3.1-focal-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-SdkVersion)",
+          "sharedTags": {
+            "$(5.0-SdkVersion)": {
+              "isUndocumented": true
+            },
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "5.0/sdk/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-SdkVersion)-buster-slim": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "architecture": "arm",
+              "dockerfile": "5.0/sdk/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-SdkVersion)-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "architecture": "arm64",
+              "dockerfile": "5.0/sdk/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "$(5.0-SdkVersion)-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "5.0/sdk/nanoserver-1809/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "$(5.0-SdkVersion)-nanoserver-1809": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1809": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "5.0/sdk/nanoserver-1903/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {
+                "$(5.0-SdkVersion)-nanoserver-1903": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1903": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "5.0/sdk/nanoserver-1909/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {
+                "$(5.0-SdkVersion)-nanoserver-1909": {
+                  "isUndocumented": true
+                },
+                "5.0-nanoserver-1909": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-SdkVersion)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "5.0/sdk/alpine3.11/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.11",
+              "tags": {
+                "$(5.0-SdkVersion)-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine3.11": {
+                  "isUndocumented": true
+                },
+                "$(5.0-SdkVersion)-alpine": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-SdkVersion)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "5.0/sdk/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-SdkVersion)-focal": {
+                  "isUndocumented": true
+                },
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(5.0-SdkVersion)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "architecture": "arm64",
+              "dockerfile": "5.0/sdk/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "$(5.0-SdkVersion)-focal-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
               },
               "variant": "v8"
             }

--- a/manifest.json
+++ b/manifest.json
@@ -2496,9 +2496,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-SdkVersion)-buster-slim": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim": {
                   "isUndocumented": true
                 },
@@ -2516,9 +2513,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-SdkVersion)-buster-slim-arm32v7": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm32v7": {
                   "isUndocumented": true
                 },
@@ -2537,9 +2531,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-SdkVersion)-buster-slim-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm64v8": {
                   "isUndocumented": true
                 },

--- a/manifest.json
+++ b/manifest.json
@@ -2516,6 +2516,12 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
+                "$(5.0-SdkVersion)-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                },
                 "5.0-buster-arm32v7": {
                   "isUndocumented": true
                 }
@@ -2531,6 +2537,12 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
+                "$(5.0-SdkVersion)-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                },
                 "5.0-buster-arm64v8": {
                   "isUndocumented": true
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -393,9 +393,6 @@
         {
           "productVersion": "$(5.0-RuntimeVersion)",
           "sharedTags": {
-            "$(5.0-RuntimeVersion)": {
-              "isUndocumented": true
-            },
             "5.0": {
               "isUndocumented": true
             }
@@ -406,9 +403,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim": {
                   "isUndocumented": true
                 }
@@ -420,9 +414,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim-arm32v7": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm32v7": {
                   "isUndocumented": true
                 }
@@ -435,9 +426,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm64v8": {
                   "isUndocumented": true
                 }
@@ -454,13 +442,7 @@
               "os": "linux",
               "osVersion": "alpine3.11",
               "tags": {
-                "$(5.0-RuntimeVersion)-alpine3.11": {
-                  "isUndocumented": true
-                },
                 "5.0-alpine3.11": {
-                  "isUndocumented": true
-                },
-                "$(5.0-RuntimeVersion)-alpine": {
                   "isUndocumented": true
                 },
                 "5.0-alpine": {
@@ -479,13 +461,7 @@
               "os": "linux",
               "osVersion": "alpine3.11",
               "tags": {
-                "$(5.0-RuntimeVersion)-alpine3.11-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-alpine3.11-arm64v8": {
-                  "isUndocumented": true
-                },
-                "$(5.0-RuntimeVersion)-alpine-arm64v8": {
                   "isUndocumented": true
                 },
                 "5.0-alpine-arm64v8": {
@@ -504,9 +480,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-RuntimeVersion)-focal": {
-                  "isUndocumented": true
-                },
                 "5.0-focal": {
                   "isUndocumented": true
                 }
@@ -523,9 +496,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-RuntimeVersion)-focal-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-focal-arm64v8": {
                   "isUndocumented": true
                 }
@@ -1068,9 +1038,6 @@
         {
           "productVersion": "$(5.0-RuntimeVersion)",
           "sharedTags": {
-            "$(5.0-RuntimeVersion)": {
-              "isUndocumented": true
-            },
             "5.0": {
               "isUndocumented": true
             }
@@ -1084,9 +1051,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim": {
                   "isUndocumented": true
                 }
@@ -1101,9 +1065,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim-arm32v7": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm32v7": {
                   "isUndocumented": true
                 }
@@ -1119,9 +1080,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm64v8": {
                   "isUndocumented": true
                 }
@@ -1133,9 +1091,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(5.0-RuntimeVersion)-nanoserver-1809": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1809": {
                   "isUndocumented": true
                 }
@@ -1146,9 +1101,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(5.0-RuntimeVersion)-nanoserver-1903": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1903": {
                   "isUndocumented": true
                 }
@@ -1159,9 +1111,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(5.0-RuntimeVersion)-nanoserver-1909": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1909": {
                   "isUndocumented": true
                 }
@@ -1180,13 +1129,7 @@
               "os": "linux",
               "osVersion": "alpine3.11",
               "tags": {
-                "$(5.0-RuntimeVersion)-alpine3.11": {
-                  "isUndocumented": true
-                },
                 "5.0-alpine3.11": {
-                  "isUndocumented": true
-                },
-                "$(5.0-RuntimeVersion)-alpine": {
                   "isUndocumented": true
                 },
                 "5.0-alpine": {
@@ -1208,13 +1151,7 @@
               "os": "linux",
               "osVersion": "alpine3.11",
               "tags": {
-                "$(5.0-RuntimeVersion)-alpine3.11-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-alpine3.11-arm64v8": {
-                  "isUndocumented": true
-                },
-                "$(5.0-RuntimeVersion)-alpine-arm64v8": {
                   "isUndocumented": true
                 },
                 "5.0-alpine-arm64v8": {
@@ -1236,9 +1173,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-RuntimeVersion)-focal": {
-                  "isUndocumented": true
-                },
                 "5.0-focal": {
                   "isUndocumented": true
                 }
@@ -1258,9 +1192,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-RuntimeVersion)-focal-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-focal-arm64v8": {
                   "isUndocumented": true
                 }
@@ -1868,9 +1799,6 @@
         {
           "productVersion": "$(5.0-RuntimeVersion)",
           "sharedTags": {
-            "$(5.0-RuntimeVersion)": {
-              "isUndocumented": true
-            },
             "5.0": {
               "isUndocumented": true
             }
@@ -1884,9 +1812,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim": {
                   "isUndocumented": true
                 }
@@ -1901,9 +1826,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim-arm32v7": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm32v7": {
                   "isUndocumented": true
                 }
@@ -1919,9 +1841,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-RuntimeVersion)-buster-slim-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-slim-arm64v8": {
                   "isUndocumented": true
                 }
@@ -1936,9 +1855,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(5.0-RuntimeVersion)-nanoserver-1809": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1809": {
                   "isUndocumented": true
                 }
@@ -1952,9 +1868,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(5.0-RuntimeVersion)-nanoserver-1903": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1903": {
                   "isUndocumented": true
                 }
@@ -1968,9 +1881,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(5.0-RuntimeVersion)-nanoserver-1909": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1909": {
                   "isUndocumented": true
                 }
@@ -1989,13 +1899,7 @@
               "os": "linux",
               "osVersion": "alpine3.11",
               "tags": {
-                "$(5.0-RuntimeVersion)-alpine3.11": {
-                  "isUndocumented": true
-                },
                 "5.0-alpine3.11": {
-                  "isUndocumented": true
-                },
-                "$(5.0-RuntimeVersion)-alpine": {
                   "isUndocumented": true
                 },
                 "5.0-alpine": {
@@ -2017,13 +1921,7 @@
               "os": "linux",
               "osVersion": "alpine3.11",
               "tags": {
-                "$(5.0-RuntimeVersion)-alpine3.11-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-alpine3.11-arm64v8": {
-                  "isUndocumented": true
-                },
-                "$(5.0-RuntimeVersion)-alpine-arm64v8": {
                   "isUndocumented": true
                 },
                 "5.0-alpine-arm64v8": {
@@ -2045,9 +1943,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-RuntimeVersion)-focal": {
-                  "isUndocumented": true
-                },
                 "5.0-focal": {
                   "isUndocumented": true
                 }
@@ -2067,9 +1962,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-RuntimeVersion)-focal-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-focal-arm64v8": {
                   "isUndocumented": true
                 }
@@ -2591,9 +2483,6 @@
         {
           "productVersion": "$(5.0-SdkVersion)",
           "sharedTags": {
-            "$(5.0-SdkVersion)": {
-              "isUndocumented": true
-            },
             "5.0": {
               "isUndocumented": true
             }
@@ -2650,9 +2539,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(5.0-SdkVersion)-nanoserver-1809": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1809": {
                   "isUndocumented": true
                 }
@@ -2666,9 +2552,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(5.0-SdkVersion)-nanoserver-1903": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1903": {
                   "isUndocumented": true
                 }
@@ -2682,9 +2565,6 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(5.0-SdkVersion)-nanoserver-1909": {
-                  "isUndocumented": true
-                },
                 "5.0-nanoserver-1909": {
                   "isUndocumented": true
                 }
@@ -2703,13 +2583,7 @@
               "os": "linux",
               "osVersion": "alpine3.11",
               "tags": {
-                "$(5.0-SdkVersion)-alpine3.11": {
-                  "isUndocumented": true
-                },
                 "5.0-alpine3.11": {
-                  "isUndocumented": true
-                },
-                "$(5.0-SdkVersion)-alpine": {
                   "isUndocumented": true
                 },
                 "5.0-alpine": {
@@ -2730,9 +2604,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-SdkVersion)-focal": {
-                  "isUndocumented": true
-                },
                 "5.0-focal": {
                   "isUndocumented": true
                 }
@@ -2752,9 +2623,6 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(5.0-SdkVersion)-focal-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-focal-arm64v8": {
                   "isUndocumented": true
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -2612,6 +2612,9 @@
                 },
                 "5.0-buster-slim": {
                   "isUndocumented": true
+                },
+                "5.0-buster": {
+                  "isUndocumented": true
                 }
               }
             },
@@ -2628,6 +2631,9 @@
                   "isUndocumented": true
                 },
                 "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-arm32v7": {
                   "isUndocumented": true
                 }
               },
@@ -2646,6 +2652,9 @@
                   "isUndocumented": true
                 },
                 "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-arm64v8": {
                   "isUndocumented": true
                 }
               },

--- a/manifest.json
+++ b/manifest.json
@@ -2496,6 +2496,12 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
+                "$(5.0-SdkVersion)-buster-slim": {
+                  "isUndocumented": true
+                },
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                },
                 "5.0-buster": {
                   "isUndocumented": true
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -2621,12 +2621,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-SdkVersion)-buster-slim-arm32v7": {
-                  "isUndocumented": true
-                },
-                "5.0-buster-slim-arm32v7": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-arm32v7": {
                   "isUndocumented": true
                 }
@@ -2642,12 +2636,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-SdkVersion)-buster-slim-arm64v8": {
-                  "isUndocumented": true
-                },
-                "5.0-buster-slim-arm64v8": {
-                  "isUndocumented": true
-                },
                 "5.0-buster-arm64v8": {
                   "isUndocumented": true
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -2607,12 +2607,6 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "$(5.0-SdkVersion)-buster-slim": {
-                  "isUndocumented": true
-                },
-                "5.0-buster-slim": {
-                  "isUndocumented": true
-                },
                 "5.0-buster": {
                   "isUndocumented": true
                 }


### PR DESCRIPTION
Updates the manifest so that 5.0 images are published to the `dotnet/core` repo in addition to the `dotnet` repo.  For example, the 5.0 SDK image for Ubuntu Focal will have a tag like `mcr.microsoft.com/dotnet/core/sdk:5.0-focal` in addition to `mcr.microsoft.com/dotnet/sdk:5.0-focal`.  The 5.0 tags using the `dotnet/core` repo will not be published in readme tags table.

This ensures that consumers of the old repo, `dotnet/core`, will continue to get the latest 5.0 images.  This is intended to be a temporary measure for the transition to the new repo name.  The intent is to no longer tag the images with the `dotnet/core` repo in .NET 5 Preview 5.

Related to #1765