### PR TITLE
Update package dependencies in 5.0 images

### DIFF
--- a/5.0/runtime-deps/alpine3.11/amd64/Dockerfile
+++ b/5.0/runtime-deps/alpine3.11/amd64/Dockerfile
@@ -1,7 +1,9 @@
 FROM amd64/alpine:3.11
 
-# .NET Core dependencies
 RUN apk add --no-cache \
+    ca-certificates \
+    \
+# .NET Core dependencies
     krb5-libs \
     libgcc \
     libintl \

--- a/5.0/runtime-deps/alpine3.11/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/alpine3.11/arm64v8/Dockerfile
@@ -1,7 +1,9 @@
 FROM arm64v8/alpine:3.11
 
-# .NET Core dependencies
 RUN apk add --no-cache \
+    ca-certificates \
+    \
+# .NET Core dependencies
     krb5-libs \
     libgcc \
     libintl \

--- a/5.0/sdk/alpine3.11/amd64/Dockerfile
+++ b/5.0/sdk/alpine3.11/amd64/Dockerfile
@@ -15,7 +15,6 @@ ENV \
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Alpine-3.11
 
 RUN apk add --no-cache \
-    ca-certificates \
     curl \
     icu-libs \
     git

--- a/5.0/sdk/buster-slim/amd64/Dockerfile
+++ b/5.0/sdk/buster-slim/amd64/Dockerfile
@@ -14,19 +14,11 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Debian-10
 
-# Install .NET CLI dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu63 \
-        libssl1.1 \
-        libstdc++6 \
         wget \
-        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK

--- a/5.0/sdk/buster-slim/amd64/Dockerfile
+++ b/5.0/sdk/buster-slim/amd64/Dockerfile
@@ -17,7 +17,6 @@ ENV \
 # Install .NET CLI dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
         git \
         libc6 \

--- a/5.0/sdk/buster-slim/arm32v7/Dockerfile
+++ b/5.0/sdk/buster-slim/arm32v7/Dockerfile
@@ -17,7 +17,6 @@ ENV \
 # Install .NET CLI dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
         git \
         libc6 \

--- a/5.0/sdk/buster-slim/arm32v7/Dockerfile
+++ b/5.0/sdk/buster-slim/arm32v7/Dockerfile
@@ -14,19 +14,11 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Debian-10-arm32
 
-# Install .NET CLI dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu63 \
-        libssl1.1 \
-        libstdc++6 \
         wget \
-        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK

--- a/5.0/sdk/buster-slim/arm64v8/Dockerfile
+++ b/5.0/sdk/buster-slim/arm64v8/Dockerfile
@@ -14,19 +14,11 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Debian-10-arm64
 
-# Install .NET CLI dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu63 \
-        libssl1.1 \
-        libstdc++6 \
         wget \
-        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK

--- a/5.0/sdk/buster-slim/arm64v8/Dockerfile
+++ b/5.0/sdk/buster-slim/arm64v8/Dockerfile
@@ -17,7 +17,6 @@ ENV \
 # Install .NET CLI dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
         git \
         libc6 \

--- a/5.0/sdk/focal/amd64/Dockerfile
+++ b/5.0/sdk/focal/amd64/Dockerfile
@@ -17,7 +17,6 @@ ENV \
 # Install .NET CLI dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
         git \
         libc6 \

--- a/5.0/sdk/focal/amd64/Dockerfile
+++ b/5.0/sdk/focal/amd64/Dockerfile
@@ -14,19 +14,11 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Ubuntu-20.04
 
-# Install .NET CLI dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl \
         git \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu66 \
-        libssl1.1 \
-        libstdc++6 \
         wget \
-        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK

--- a/5.0/sdk/focal/arm32v7/Dockerfile
+++ b/5.0/sdk/focal/arm32v7/Dockerfile
@@ -14,19 +14,11 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Ubuntu-20.04-arm32
 
-# Install .NET CLI dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl \
         git \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu66 \
-        libssl1.1 \
-        libstdc++6 \
         wget \
-        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK

--- a/5.0/sdk/focal/arm32v7/Dockerfile
+++ b/5.0/sdk/focal/arm32v7/Dockerfile
@@ -17,7 +17,6 @@ ENV \
 # Install .NET CLI dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
         git \
         libc6 \

--- a/5.0/sdk/focal/arm64v8/Dockerfile
+++ b/5.0/sdk/focal/arm64v8/Dockerfile
@@ -14,19 +14,11 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Ubuntu-20.04-arm64
 
-# Install .NET CLI dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl \
         git \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu66 \
-        libssl1.1 \
-        libstdc++6 \
         wget \
-        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK

--- a/5.0/sdk/focal/arm64v8/Dockerfile
+++ b/5.0/sdk/focal/arm64v8/Dockerfile
@@ -17,7 +17,6 @@ ENV \
 # Install .NET CLI dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
         git \
         libc6 \


### PR DESCRIPTION
Because of the changes in https://github.com/dotnet/dotnet-docker/pull/1908, we no longer need to be installing `ca-certificates` in the SDK images.  These changes remove that package from the Dockerfiles.

Since `ca-certificates` is missing from the Alpine `runtime-deps` image, that package is being moved from `sdk` to `runtime-deps`.  This enables parity across the distros.

It was also found that .NET dependencies were still being installed in the `sdk` images which no longer needs to be done because those `sdk` images have been switched from `buildpack-deps` to `aspnet` as the base image.