### PR TITLE
Update link to Docker repo name for 5.0

### DIFF
--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -13,7 +13,7 @@ For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules)
 
 This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, ASP.NET Core 5.0 can be found at `mcr.microsoft.com/dotnet/aspnet:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/aspnet:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1939) for more details.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -13,7 +13,7 @@ For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules)
 
 This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime Dependencies can be found at `mcr.microsoft.com/dotnet/runtime-deps:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/runtime-deps:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime Dependencies can be found at `mcr.microsoft.com/dotnet/runtime-deps:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/runtime-deps:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1939) for more details.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -13,7 +13,7 @@ For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules)
 
 This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime can be found at `mcr.microsoft.com/dotnet/runtime:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/runtime:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 Runtime can be found at `mcr.microsoft.com/dotnet/runtime:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/runtime:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1939) for more details.
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -19,7 +19,7 @@ This image contains the .NET SDK which is comprised of three parts:
 
 Use this image for your development process (developing, building and testing applications).
 
-As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 SDK can be found at `mcr.microsoft.com/dotnet/sdk:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/sdk:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1765) for more details.
+As part of the transition to .NET 5.0, Docker repos for .NET 5.0 and higher do not include `core` in the name as was done with older versions. As an example, .NET 5.0 SDK can be found at `mcr.microsoft.com/dotnet/sdk:5.0` while 3.1 is still at `mcr.microsoft.com/dotnet/core/sdk:3.1`. See the [related issue](https://github.com/dotnet/dotnet-docker/issues/1939) for more details.
 
 # How to Use the Image
 


### PR DESCRIPTION
Update the link to point to the official announcement for the Docker repo name change.