### PR TITLE
Fix Start-Job issue in Alpine images and add test

### DIFF
--- a/3.1/sdk/alpine3.11/amd64/Dockerfile
+++ b/3.1/sdk/alpine3.11/amd64/Dockerfile
@@ -40,6 +40,8 @@ RUN powershell_version=7.0.1 \
     && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && chmod 755 /usr/share/powershell/pwsh \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && rm /usr/share/powershell/.store/powershell.linux.alpine/$powershell_version/powershell.linux.alpine/$powershell_version/tools/netcoreapp3.1/any/pwsh \
+    && ln -s /usr/bin/pwsh /usr/share/powershell/.store/powershell.linux.alpine/$powershell_version/powershell.linux.alpine/$powershell_version/tools/netcoreapp3.1/any/pwsh \
     # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm \
     # Add ncurses-terminfo-base to resolve psreadline dependency

--- a/5.0/sdk/alpine3.11/amd64/Dockerfile
+++ b/5.0/sdk/alpine3.11/amd64/Dockerfile
@@ -40,6 +40,8 @@ RUN powershell_version=7.1.0-preview.3 \
     && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && chmod 755 /usr/share/powershell/pwsh \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && rm /usr/share/powershell/.store/powershell.linux.alpine/$powershell_version/powershell.linux.alpine/$powershell_version/tools/net5.0/any/pwsh \
+    && ln -s /usr/bin/pwsh /usr/share/powershell/.store/powershell.linux.alpine/$powershell_version/powershell.linux.alpine/$powershell_version/tools/net5.0/any/pwsh \
     # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm \
     # Add ncurses-terminfo-base to resolve psreadline dependency

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPowerShellScenario_Jobs(ProductImageData imageData)
         {
-            string command = $"pwsh -c '(Start-Job { "test" } | Receive-Job -Wait) -eq 'test''";
+            string command = @"pwsh -c '(Start-Job { 'test' } | Receive-Job -Wait) -eq 'test'";
             PowerShellScenario_Execute(imageData, optionalArgs: null, command);
         }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPowerShellScenario_Jobs(ProductImageData imageData)
         {
-            string command = @"pwsh -c '(Start-Job { 'test' } | Receive-Job -Wait) -eq 'test''";
+            string command = @"pwsh -c '(Start-Job { 1 } | Receive-Job -Wait) -eq 1'";
             PowerShellScenario_Execute(imageData, optionalArgs: null, command);
         }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -146,7 +146,9 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPowerShellScenario_Jobs(ProductImageData imageData)
         {
-            string command = @"pwsh -c '(Start-Job { 1 } | Receive-Job -Wait) -eq 1'";
+            string powerShellCommand = "(Start-Job -ScriptBlock { '1' } | Receive-Job -Wait ) -eq '1'";
+
+            string command = $"pwsh -Command \"{powerShellCommand}\"";
             PowerShellScenario_Execute(imageData, optionalArgs: null, command);
         }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPowerShellScenario_Jobs(ProductImageData imageData)
         {
-            string command = @"pwsh -c '(Start-Job { 'test' } | Receive-Job -Wait) -eq 'test'";
+            string command = @"pwsh -c '(Start-Job { 'test' } | Receive-Job -Wait) -eq 'test''";
             PowerShellScenario_Execute(imageData, optionalArgs: null, command);
         }
 


### PR DESCRIPTION
Fixes #1922

The executable `pwsh` that is under $pshome is not compiled for Alpine. Mae sure the `pwsh` executable calls the global tool entry point when invoked using `Start-Job`.

Add a test to make sure `Start-Job` scenario works for all platforms. The fix is only required for Alpine.