### PR TITLE
Exclude diagnostics on monitor image to prevent self-diagnosis.

### DIFF
--- a/monitor/5.0/alpine/amd64/Dockerfile
+++ b/monitor/5.0/alpine/amd64/Dockerfile
@@ -20,7 +20,11 @@ FROM $ASPNET_REPO:3.1-alpine3.12
 
 WORKDIR /app
 COPY --from=installer /app .
-ENV COMPlus_EnableDiagnostics=0
-ENV PATH="${PATH}:/app"
+
+ENV \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
 
 ENTRYPOINT ["dotnet-monitor", "collect"]

--- a/monitor/5.0/alpine/amd64/Dockerfile
+++ b/monitor/5.0/alpine/amd64/Dockerfile
@@ -20,6 +20,7 @@ FROM $ASPNET_REPO:3.1-alpine3.12
 
 WORKDIR /app
 COPY --from=installer /app .
+ENV COMPlus_EnableDiagnostics=0
 ENV PATH="${PATH}:/app"
 
 ENTRYPOINT ["dotnet-monitor", "collect"]


### PR DESCRIPTION
With dotnet-monitor running in ASP.NET Core 3.1, it establishes its own diagnostics pipe server, which is visible through the REST API that dotnet-monitor provides. We should set the COMPlus_EnableDiagnostics environment variable to 0 in order to disable the diagnostics pipe server within dotnet-monitor. If absolutely necessary, users of the image can override this by setting the value  to 1 within their orchestration environment.