### PR TITLE
Add libldap to 5.0 runtime-deps

### DIFF
--- a/5.0/runtime-deps/alpine3.12/amd64/Dockerfile
+++ b/5.0/runtime-deps/alpine3.12/amd64/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     krb5-libs \
     libgcc \
     libintl \
+    libldap \
     libssl1.1 \
     libstdc++ \
     zlib

--- a/5.0/runtime-deps/buster-slim/amd64/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu63 \
+        libldap-2.4-2 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu63 \
+        libldap-2.4-2 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu63 \
+        libldap-2.4-2 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/amd64/Dockerfile
+++ b/5.0/runtime-deps/focal/amd64/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu66 \
+        libldap-2.4-2 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm32v7/Dockerfile
+++ b/5.0/runtime-deps/focal/arm32v7/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu66 \
+        libldap-2.4-2 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \

--- a/5.0/runtime-deps/focal/arm64v8/Dockerfile
+++ b/5.0/runtime-deps/focal/arm64v8/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         libgcc1 \
         libgssapi-krb5-2 \
         libicu66 \
+        libldap-2.4-2 \
         libssl1.1 \
         libstdc++6 \
         zlib1g \


### PR DESCRIPTION
Adds the libldap package to runtime-deps images in order to support System.DirectoryServices.Protocols having a dependency on it.

Fixes #1946