### PR TITLE
Update Windows image size baseline w/non-core repos

### DIFF
--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -7,7 +7,9 @@
     "src/runtime/3.1/nanoserver-1809/amd64": 321408734,
     "src/runtime/3.1/nanoserver-1903/amd64": 326438075,
     "src/runtime/3.1/nanoserver-1909/amd64": 328083762,
-    "src/runtime/3.1/nanoserver-2004/amd64": 333119873,
+    "src/runtime/3.1/nanoserver-2004/amd64": 333119873
+  },
+  "dotnet/nightly/runtime": {
     "src/runtime/5.0/nanoserver-1809/amd64": 321408734,
     "src/runtime/5.0/nanoserver-1903/amd64": 326438075,
     "src/runtime/5.0/nanoserver-1909/amd64": 328083762,
@@ -21,7 +23,9 @@
     "src/aspnet/3.1/nanoserver-1809/amd64": 341072949,
     "src/aspnet/3.1/nanoserver-1903/amd64": 346102290,
     "src/aspnet/3.1/nanoserver-1909/amd64": 347747977,
-    "src/aspnet/3.1/nanoserver-2004/amd64": 352805234,
+    "src/aspnet/3.1/nanoserver-2004/amd64": 352805234
+  },
+  "dotnet/nightly/aspnet": {
     "src/aspnet/5.0/nanoserver-1809/amd64": 341072949,
     "src/aspnet/5.0/nanoserver-1903/amd64": 346102290,
     "src/aspnet/5.0/nanoserver-1909/amd64": 347747977,
@@ -35,7 +39,9 @@
     "src/sdk/3.1/nanoserver-1809/amd64": 730951559,
     "src/sdk/3.1/nanoserver-1903/amd64": 735894844,
     "src/sdk/3.1/nanoserver-1909/amd64": 737661435,
-    "src/sdk/3.1/nanoserver-2004/amd64": 759552332,
+    "src/sdk/3.1/nanoserver-2004/amd64": 759552332
+  },
+  "dotnet/nightly/sdk": {
     "src/sdk/5.0/nanoserver-1809/amd64": 782722955,
     "src/sdk/5.0/nanoserver-1903/amd64": 787755962,
     "src/sdk/5.0/nanoserver-1909/amd64": 789170333,


### PR DESCRIPTION
This isn't required today because of the way the validate command works but eventually it will be needed once 3.1 reaches EOL.  The Linux baseline already has the 5.0 images within the new non-core repos.