### PR TITLE
Modify update-dependencies to handle dotnet-monitor.

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -31,7 +31,7 @@ TBD
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-preview.1-alpine, 5.0-alpine, 5.0.0-preview.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/5.0/alpine/amd64/Dockerfile) | Alpine 3.12
+5.0.0-preview.2-alpine, 5.0-alpine, 5.0.0-preview.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/5.0/alpine/amd64/Dockerfile) | Alpine 3.12
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 

--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -6,6 +6,7 @@ set -e
 set -u
 
 channel=$1
+monitorChannel=$2
 
 curl -SLo sdk.zip https://aka.ms/dotnet/$channel/Sdk/dotnet-sdk-win-x64.zip
 
@@ -15,6 +16,15 @@ aspnetVer=$(unzip -p sdk.zip "shared/Microsoft.AspNetCore.App/*/.version" | cat 
 
 rm sdk.zip
 
+curl -SLo dotnet-monitor.nupkg https://aka.ms/dotnet/$monitorChannel/diagnostics/monitor5.0/dotnet-monitor.nupkg
+# In nuspec, there is only one element named "version" and it is the version of the nupkg.
+# All other uses of "version" are attributes on other elements. grep using Perl regex, reporting
+# the first match, and only printing what was matched.
+monitorVer=$(unzip -p dotnet-monitor.nupkg dotnet-monitor.nuspec | cat | grep -oPm1 "(?<=<version>)[^<]+")
+
+rm dotnet-monitor.nupkg
+
 echo "##vso[task.setvariable variable=sdkVer]$sdkVer"
 echo "##vso[task.setvariable variable=runtimeVer]$runtimeVer"
 echo "##vso[task.setvariable variable=aspnetVer]$aspnetVer"
+echo "##vso[task.setvariable variable=monitorVer]$monitorVer"

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
 - job: UpdateDependencies
   pool: Hosted Ubuntu 1604
   steps:
-  - script: $(engPath)/get-drop-versions.sh $(channel)
+  - script: $(engPath)/get-drop-versions.sh $(channel) $(monitorChannel)
     displayName: Get Versions
   - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
     displayName: Build Update Dependencies Tool
@@ -25,5 +25,6 @@ jobs:
       --runtime-version $(runtimeVer)
       --sdk-version $(sdkVer)
       --aspnet-version $(aspnetVer)
+      --monitor-version $(monitorVer)
       --compute-shas
     displayName: Run Update Dependencies

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -29,7 +29,7 @@ namespace Dotnet.Docker
         private static readonly string s_productUrlPattern = string.Format(s_urlPatternFormat, string.Empty);
         private static readonly string s_lzmaUrlPattern = string.Format(s_urlPatternFormat, "lzma");
         private static readonly string s_shaPatternFormat = $"[ \\$]({{0}})sha512( )*=( )*'(?<{ValueGroupName}>[^'\\s]*)'";
-        private static readonly string s_productShaPattern = string.Format(s_shaPatternFormat, "dotnet_|aspnetcore_");
+        private static readonly string s_productShaPattern = string.Format(s_shaPatternFormat, "dotnet_|aspnetcore_|dotnetmonitor_");
         private static readonly string s_lzmaShaPattern = string.Format(s_shaPatternFormat, "lzma_");
 
         private static readonly Regex s_productDownloadUrlRegex = new Regex(s_productUrlPattern);
@@ -40,7 +40,8 @@ namespace Dotnet.Docker
             VariableHelper.AspNetVersionName,
             VariableHelper.AspNetCoreVersionName,
             VariableHelper.DotnetSdkVersionName,
-            VariableHelper.DotnetVersionName);
+            VariableHelper.DotnetVersionName,
+            VariableHelper.MonitorVersionName);
 
         private static readonly Dictionary<string, string> s_shaCache = new Dictionary<string, string>();
         private static readonly Dictionary<string, Dictionary<string, string>> s_releaseChecksumCache =

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -14,6 +14,7 @@ namespace Dotnet.Docker
         public string GitHubUpstreamBranch => "nightly";
         public string GitHubUpstreamOwner => "dotnet";
         public string GitHubUser { get; private set; }
+        public string MonitorVersion { get; private set; }
         public string RuntimeVersion { get; private set; }
         public string SdkVersion { get; private set; }
         public bool ComputeChecksums { get; private set; }
@@ -43,6 +44,13 @@ namespace Dotnet.Docker
                     ref sdkVersion,
                     "SDK version to update the Dockerfiles with");
                 SdkVersion = sdkVersion;
+
+                string monitorVersion = null;
+                Argument<string> monitorVersionArg = syntax.DefineOption(
+                    "monitor-version",
+                    ref monitorVersion,
+                    ".NET Monitor version to update the Dockerfiles with");
+                MonitorVersion = monitorVersion;
 
                 string gitHubEmail = null;
                 syntax.DefineOption(

--- a/eng/update-dependencies/VariableHelper.cs
+++ b/eng/update-dependencies/VariableHelper.cs
@@ -11,6 +11,7 @@ namespace Dotnet.Docker
         public const string AspNetCoreVersionName = "aspnetcore_version";
         public const string DotnetVersionName = "dotnet_version";
         public const string DotnetSdkVersionName = "dotnet_sdk_version";
+        public const string MonitorVersionName = "dotnet_monitor_version";
         public const string ValueGroupName = "value";
         public const string VariableGroupName = "variable";
 

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "3.1-SdkVersion": "3.1.301",
     "5.0-RuntimeVersion": "5.0.0-preview.6",
     "5.0-SdkVersion": "5.0.100-preview.6",
-    "Monitor-5.0-Version": "5.0.0-preview.1"
+    "5.0-MonitorVersion": "5.0.0-preview.2"
   },
   "repos": [
     {
@@ -2278,7 +2278,7 @@
         {
           "productVersion": "$(3.1-RuntimeVersion)",
           "sharedTags": {
-            "$(Monitor-5.0-Version)": {},
+            "$(5.0-MonitorVersion)": {},
             "5.0": {},
             "latest": {}
           },
@@ -2292,7 +2292,7 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(Monitor-5.0-Version)-alpine": {},
+                "$(5.0-MonitorVersion)-alpine": {},
                 "5.0-alpine": {}
               }
             }

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/core/sdk
 FROM $SDK_REPO:3.1-alpine3.12 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.20311.7
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet5-transport%40Local/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content?api-version=5.1-preview.1 \
-    && dotnetmonitor_sha512='07a53bc09ad9dbc174640a8c8178074f71e5bc7fe322842ec66ec543fcd5e0021fcdfa9f7fd57c07061f0ea718624f48d8e335ff561fadc5429643cf918cd34e' \
+ENV DOTNET_MONITOR_VERSION=5.0.0-preview.2.20318.2
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor5.0/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='9689e21b3de5d71662104b630ed8bc469e3df03f9c2865c62adfac6f153134a0d13ed49e2f55e0efd69e2e56430a85f06ad2d9dd5442f40a93f70e67b46b7cbc' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.


### PR DESCRIPTION
Modify the update-dependencies tool to be able to check for the latest dotnet-monitor 5.0 tool and update its version and checksum in the Dockerfiles as well as update the manifest with corresponding version tag. I will update the update-dependencies pipeline to provide the dotnet-monitor channel, which is currently "net5/dev", after merging in these changes.