### PR TITLE
Update amd64 buildpack-deps references

### DIFF
--- a/src/aspnet/5.0/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 ARG ASPNET_VERSION=5.0.0-preview.6.20312.15
 
 # Installer image
-FROM buildpack-deps:buster-curl as installer
+FROM amd64/buildpack-deps:buster-curl as installer
 ARG ASPNET_VERSION
 
 # Retrieve ASP.NET Core

--- a/src/aspnet/5.0/focal/amd64/Dockerfile
+++ b/src/aspnet/5.0/focal/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 ARG ASPNET_VERSION=5.0.0-preview.6.20312.15
 
 # Installer image
-FROM buildpack-deps:focal-curl as installer
+FROM amd64/buildpack-deps:focal-curl as installer
 ARG ASPNET_VERSION
 
 # Retrieve ASP.NET Core

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
 ARG DOTNET_VERSION=5.0.0-preview.6.20305.6
 
 # Installer image
-FROM buildpack-deps:buster-curl as installer
+FROM amd64/buildpack-deps:buster-curl as installer
 ARG DOTNET_VERSION
 
 # Retrieve .NET Core

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
 ARG DOTNET_VERSION=5.0.0-preview.6.20305.6
 
 # Installer image
-FROM buildpack-deps:focal-curl as installer
+FROM amd64/buildpack-deps:focal-curl as installer
 ARG DOTNET_VERSION
 
 # Retrieve .NET Core

--- a/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
@@ -39,7 +39,6 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-
 FROM $REPO:5.0-nanoserver-1903
 ARG DOTNET_SDK_VERSION
 


### PR DESCRIPTION
Update amd64 buildpack-deps references to be explicit.  The explicit references make the Dockerfiles consistent across the various Dockerfiles (e.g. `amd64/alpine:3.12`).  These changes also make it easier to define the Dockerfile templates as part of #1933.