### PR TITLE
Fix inconsistent PowerShell nupkg Dockerfile comment

### DIFF
--- a/src/sdk/3.1/buster/arm32v7/Dockerfile
+++ b/src/sdk/3.1/buster/arm32v7/Dockerfile
@@ -45,5 +45,5 @@ RUN powershell_version=7.0.2 \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \
-    # Remove the copy nupkg that nuget keeps to reduce size.
+    # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/src/sdk/3.1/focal/arm32v7/Dockerfile
+++ b/src/sdk/3.1/focal/arm32v7/Dockerfile
@@ -45,5 +45,5 @@ RUN powershell_version=7.0.2 \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \
-    # Remove the copy nupkg that nuget keeps to reduce size.
+    # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
@@ -40,5 +40,5 @@ RUN powershell_version=7.1.0-preview.3 \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \
-    # Remove the copy nupkg that nuget keeps to reduce size.
+    # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/src/sdk/5.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/5.0/focal/arm32v7/Dockerfile
@@ -40,5 +40,5 @@ RUN powershell_version=7.1.0-preview.3 \
     && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
     && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
     && chmod 755 /usr/share/powershell/pwsh \
-    # Remove the copy nupkg that nuget keeps to reduce size.
+    # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm


### PR DESCRIPTION
This fixes an inconsistency in the sdk Dockerfiles regarding a PowerShell code comment.

https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/amd64/Dockerfile#L43
`# To reduce image size, remove the copy nupkg that nuget keeps.`

vs

https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/arm32v7/Dockerfile#L43
`# Remove the copy nupkg that nuget keeps to reduce size.`

This is being fixed in preparation for introducing Dockerfile templates (#1933)


