### PR TITLE
Use consistent formatting for multi-line ENV instructions

### DIFF
--- a/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
@@ -31,8 +31,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677

--- a/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile
@@ -31,8 +31,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677

--- a/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
@@ -31,8 +31,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677

--- a/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
@@ -31,8 +31,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Deprecated, use `DOTNET_RUNNING_IN_CONTAINER` instead - https://github.com/dotnet/dotnet-docker/issues/677

--- a/src/runtime-deps/2.1/alpine3.11/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/alpine3.11/amd64/Dockerfile
@@ -14,8 +14,9 @@ RUN apk add --no-cache \
         userspace-rcu \
         zlib
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)

--- a/src/runtime-deps/2.1/alpine3.12/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/alpine3.12/amd64/Dockerfile
@@ -14,8 +14,9 @@ RUN apk add --no-cache \
         userspace-rcu \
         zlib
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)

--- a/src/runtime-deps/2.1/bionic/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/bionic/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/2.1/bionic/arm32v7/Dockerfile
+++ b/src/runtime-deps/2.1/bionic/arm32v7/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/2.1/focal/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/focal/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/3.1/alpine3.11/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.11/amd64/Dockerfile
@@ -11,8 +11,9 @@ RUN apk add --no-cache \
     libstdc++ \
     zlib
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)

--- a/src/runtime-deps/3.1/alpine3.11/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.11/arm64v8/Dockerfile
@@ -11,8 +11,9 @@ RUN apk add --no-cache \
     libstdc++ \
     zlib
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)

--- a/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile
@@ -11,8 +11,9 @@ RUN apk add --no-cache \
     libstdc++ \
     zlib
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)

--- a/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile
@@ -11,8 +11,9 @@ RUN apk add --no-cache \
     libstdc++ \
     zlib
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)

--- a/src/runtime-deps/3.1/bionic/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/bionic/amd64/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/3.1/bionic/arm32v7/Dockerfile
+++ b/src/runtime-deps/3.1/bionic/arm32v7/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
@@ -29,7 +29,8 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile
@@ -29,7 +29,8 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
@@ -29,7 +29,8 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
@@ -29,7 +29,8 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/sdk/2.1/alpine3.11/amd64/Dockerfile
+++ b/src/sdk/2.1/alpine3.11/amd64/Dockerfile
@@ -19,8 +19,9 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
 
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER=true \ 
+ENV \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \ 
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 

--- a/src/sdk/2.1/alpine3.12/amd64/Dockerfile
+++ b/src/sdk/2.1/alpine3.12/amd64/Dockerfile
@@ -19,8 +19,9 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
 
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER=true \ 
+ENV \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \ 
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 

--- a/src/sdk/2.1/bionic/amd64/Dockerfile
+++ b/src/sdk/2.1/bionic/amd64/Dockerfile
@@ -24,8 +24,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/bionic/arm32v7/Dockerfile
+++ b/src/sdk/2.1/bionic/arm32v7/Dockerfile
@@ -28,8 +28,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && lzma_sha512='f6038cd8524d0b9389704687f603fd1d68fab3b2dff1650829d2ce253a754b681c83aa93388124c463e71d5f9413325c7a4b599d453b1bbddb8f25bdbc25f5be' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/focal/amd64/Dockerfile
+++ b/src/sdk/2.1/focal/amd64/Dockerfile
@@ -24,8 +24,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
@@ -29,8 +29,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile
@@ -29,8 +29,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
@@ -29,8 +29,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
@@ -29,8 +29,9 @@ USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 USER ContainerUser
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 `
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/stretch/amd64/Dockerfile
+++ b/src/sdk/2.1/stretch/amd64/Dockerfile
@@ -24,8 +24,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/2.1/stretch/arm32v7/Dockerfile
+++ b/src/sdk/2.1/stretch/arm32v7/Dockerfile
@@ -28,8 +28,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && lzma_sha512='f6038cd8524d0b9389704687f603fd1d68fab3b2dff1650829d2ce253a754b681c83aa93388124c463e71d5f9413325c7a4b599d453b1bbddb8f25bdbc25f5be' \
     && echo "$lzma_sha512 /usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/nuGetPackagesArchive.lzma" | sha512sum -c -
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80 \
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Enable correct mode for dotnet watch (only mode supported in a container)


### PR DESCRIPTION
There is an inconsistent multi-line `ENV` format used within the Dockerfiles.  The following pattern should be avoided because the top level comment does not apply to the entire `ENV` instruction, rather it only applies to the first variable.

```
# Configure web servers to bind to port 80 when present
ENV ASPNETCORE_URLS=http://+:80 \
    # Enable detection of running in a container
    DOTNET_RUNNING_IN_CONTAINER=true \
    # Enable correct mode for dotnet watch (only mode supported in a container)
    DOTNET_USE_POLLING_FILE_WATCHER=true \
    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
    NUGET_XMLDOC_MODE=skip
```

The following is the preferred pattern:

```
ENV \
    # Configure web servers to bind to port 80 when present
    ASPNETCORE_URLS=http://+:80 \
    # Enable detection of running in a container
    DOTNET_RUNNING_IN_CONTAINER=true \
    # Enable correct mode for dotnet watch (only mode supported in a container)
    DOTNET_USE_POLLING_FILE_WATCHER=true \
    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
    NUGET_XMLDOC_MODE=skip
```

Consistency across the Dockerfiles is required as part of the [Dockerfile template feature](#1933).