### PR TITLE
Fix update-dependencies to handle separate branches

### DIFF
--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -135,9 +135,11 @@ namespace Dotnet.Docker
 
             GitHubAuth gitHubAuth = new GitHubAuth(Options.GitHubPassword, Options.GitHubUser, Options.GitHubEmail);
             PullRequestCreator prCreator = new PullRequestCreator(gitHubAuth, Options.GitHubUser);
+
+            string branchSuffix = $"UpdateDependencies-{Options.GitHubUpstreamBranch}-From-{versionSourceNameForBranch}";
             PullRequestOptions prOptions = new PullRequestOptions()
             {
-                BranchNamingStrategy = new SingleBranchNamingStrategy($"UpdateDependencies-{Options.GitHubUpstreamBranch}-From-{versionSourceNameForBranch}")
+                BranchNamingStrategy = new SingleBranchNamingStrategy(branchSuffix)
             };
 
             string commitMessage = $"[{Options.GitHubUpstreamBranch}] Update dependencies from {Options.VersionSourceName}";
@@ -151,7 +153,7 @@ namespace Dotnet.Docker
                     upstreamBranch.Name,
                     await client.GetMyAuthorIdAsync());
 
-                if (pullRequestToUpdate == null)
+                if (pullRequestToUpdate == null || pullRequestToUpdate.Head.Ref != $"{upstreamBranch.Name}-{branchSuffix}")
                 {
                     await prCreator.CreateOrUpdateAsync(
                         commitMessage,


### PR DESCRIPTION
With the inclusion of https://github.com/dotnet/dotnet-docker/pull/2027, a separate PR will be generated for changes to dotnet-monitor.  The update-dependencies tool now doesn't correctly handle the situation when it is executed and an existing PR already exists.  It makes no distinction between whether the PR is for core-sdk or for dotnet-monitor.  If the PR had changes for core-sdk and the tool found changes for dotnet-monitor, it would attempt to update the core-sdk branch's PR with the dotnet-monitor changes.  And vice versa.

Fixed the logic to check that the branch of the PR matches what is expected before attempting to update that PR.