### PR TITLE
Add UserSecretsId to ASP.NET Core sample

### DIFF
--- a/samples/aspnetapp/aspnetapp/aspnetapp.csproj
+++ b/samples/aspnetapp/aspnetapp/aspnetapp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>57393389627611478466</UserSecretsId>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The ASP.NET Core sample project is not defined with a `UserSecretsId` property by default, even though the [instructions](https://github.com/dotnet/dotnet-docker/blob/master/samples/run-aspnetcore-https-development.md#application-secrets) state that it is already configured.  Since it is not set, the following error will occur when attempting to run the `dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "crypticpassword"` command of the sample: `Could not find the global property 'UserSecretsId' in MSBuild project 'C:\repos\dotnet-docker\samples\aspnetapp\aspnetapp\aspnetapp.csproj'. Ensure this property is set in the project or use the '--id' command line option.`