### PR TITLE
Split off PR-specific pipeline for nightly pipeline

### DIFF
--- a/eng/pipelines/dotnet-core-nightly-pr.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr.yml
@@ -1,12 +1,13 @@
-trigger:
-  batch: true
+pr:
   branches:
     include:
     - nightly
   paths:
-    include:
-    - manifest.json
-    - src/*
+    exclude:
+    - .github/*
+    - documentation/*
+    - README*
+    - samples/*
 
 variables:
 - template: variables/common.yml
@@ -14,3 +15,6 @@ variables:
   value: manifest.json
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    customBuildLegGrouping: pr-build

--- a/eng/pipelines/dotnet-core-nightly-pr.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr.yml
@@ -3,11 +3,12 @@ pr:
     include:
     - nightly
   paths:
-    exclude:
-    - .github/*
-    - documentation/*
-    - README*
-    - samples/*
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/*
+    - tests/*
 
 variables:
 - template: variables/common.yml

--- a/eng/pipelines/dotnet-core-nightly.yml
+++ b/eng/pipelines/dotnet-core-nightly.yml
@@ -6,6 +6,7 @@ trigger:
   paths:
     include:
     - manifest.json
+    - manifest.versions.json
     - src/*
 
 variables:

--- a/eng/pipelines/dotnet-core-samples.yml
+++ b/eng/pipelines/dotnet-core-samples.yml
@@ -6,6 +6,7 @@ pr:
     - nightly
   paths:
     include:
+    - manifest.samples.json
     - eng/*
     - samples/*
     - tests/*

--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -4,11 +4,12 @@ pr:
     include:
     - master
   paths:
-    exclude:
-    - .github/*
-    - documentation/*
-    - README*
-    - samples/*
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/*
+    - tests/*
 
 variables:
 - template: variables/common.yml


### PR DESCRIPTION
Define separate pipeline YAML file for the nightly pipeline: an internal one to trigger from commits and a public one to trigger from PRs. There's not a way to define a single file with conditional logic around the trigger and pr keywords because AzDO doesn't support that.

Fixes #1991

