### PR TITLE
Adds pipeline to wait for MCR ingestion

### DIFF
--- a/eng/pipelines/wait-for-ingestion.yml
+++ b/eng/pipelines/wait-for-ingestion.yml
@@ -1,0 +1,7 @@
+trigger: none
+pr: none
+
+variables:
+- template: variables/common.yml
+jobs:
+- template: ../common/templates/jobs/wait-for-ingestion.yml


### PR DESCRIPTION
This pipeline can be used to wait for MCR ingestion on any publish for this repo. This is intended to be used to monitor official builds from the master branch which aren't currently configured to wait for ingestion since the implementation is still being validated.  So if anything goes wrong with the logic in this pipeline, it won't affect the result of the official build pipeline.

The following queue-time variables will be defined for this pipeline:
* manifest (default: manifest.json)
* sourceBuildId
* commitDigest