### PR TITLE
Include 5.0 images in the "core" repos

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2598,6 +2598,9 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
+                "5.0-buster": {
+                  "isUndocumented": true
+                },
                 "5.0-buster-slim": {
                   "isUndocumented": true
                 }
@@ -2612,6 +2615,9 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
+                "5.0-buster-arm32v7": {
+                  "isUndocumented": true
+                },
                 "5.0-buster-slim-arm32v7": {
                   "isUndocumented": true
                 }
@@ -2627,6 +2633,9 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
+                "5.0-buster-arm64v8": {
+                  "isUndocumented": true
+                },
                 "5.0-buster-slim-arm64v8": {
                   "isUndocumented": true
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -384,6 +384,120 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/runtime-deps/5.0/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "src/runtime-deps/5.0/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/runtime-deps/5.0/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "dockerfile": "src/runtime-deps/5.0/alpine3.12/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.12",
+              "tags": {
+                "5.0-alpine3.12": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/runtime-deps/5.0/alpine3.12/arm64v8",
+              "os": "linux",
+              "osVersion": "alpine3.12",
+              "tags": {
+                "5.0-alpine3.12-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "dockerfile": "src/runtime-deps/5.0/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/runtime-deps/5.0/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
         }
       ]
     },
@@ -930,6 +1044,181 @@
               "tags": {
                 "$(dotnet|3.1|product-version)-focal-arm64v8": {},
                 "3.1-focal-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            },
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-1809/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "5.0-nanoserver-1809": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-1903/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {
+                "5.0-nanoserver-1903": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-1909/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {
+                "5.0-nanoserver-1909": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-2004/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-2004",
+              "tags": {
+                "5.0-nanoserver-2004": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/alpine3.12/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.12",
+              "tags": {
+                "5.0-alpine3.12": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/alpine3.12/arm64v8",
+              "os": "linux",
+              "osVersion": "alpine3.12",
+              "tags": {
+                "5.0-alpine3.12-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
               },
               "variant": "v8"
             }
@@ -1561,6 +1850,193 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-1809/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "5.0-nanoserver-1809": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-1903/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {
+                "5.0-nanoserver-1903": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-1909/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {
+                "5.0-nanoserver-1909": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-2004/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-2004",
+              "tags": {
+                "5.0-nanoserver-2004": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/alpine3.12/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.12",
+              "tags": {
+                "5.0-alpine3.12": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/alpine3.12/arm64v8",
+              "os": "linux",
+              "osVersion": "alpine3.12",
+              "tags": {
+                "5.0-alpine3.12-arm64v8": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:core-runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            }
+          ]
         }
       ]
     },
@@ -2101,6 +2577,170 @@
               "tags": {
                 "$(sdk|3.1|product-version)-focal-arm64v8": {},
                 "3.1-focal-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "5.0": {
+              "isUndocumented": true
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/buster-slim/amd64",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "architecture": "arm",
+              "dockerfile": "src/sdk/5.0/buster-slim/arm32v7",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v7"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "architecture": "arm64",
+              "dockerfile": "src/sdk/5.0/buster-slim/arm64v8",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "5.0-buster-slim-arm64v8": {
+                  "isUndocumented": true
+                }
+              },
+              "variant": "v8"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-1809/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "5.0-nanoserver-1809": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-1903/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {
+                "5.0-nanoserver-1903": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-1909/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {
+                "5.0-nanoserver-1909": {
+                  "isUndocumented": true
+                }
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-2004/amd64",
+              "os": "windows",
+              "osVersion": "nanoserver-2004",
+              "tags": {
+                "5.0-nanoserver-2004": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(sdk|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/alpine3.12/amd64",
+              "os": "linux",
+              "osVersion": "alpine3.12",
+              "tags": {
+                "5.0-alpine3.12": {
+                  "isUndocumented": true
+                },
+                "5.0-alpine": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(sdk|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/focal/amd64",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal": {
+                  "isUndocumented": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(sdk|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:core-aspnet)"
+              },
+              "architecture": "arm64",
+              "dockerfile": "src/sdk/5.0/focal/arm64v8",
+              "os": "linux",
+              "osVersion": "focal",
+              "tags": {
+                "5.0-focal-arm64v8": {
+                  "isUndocumented": true
+                }
               },
               "variant": "v8"
             }


### PR DESCRIPTION
Due to an issue with VS 16.6, 5.0 Dockerfiles are still being generated with "core" in the repo name (see https://github.com/dotnet/dotnet-docker/issues/1939#issuecomment-658252795).  That causes version discrepancies.  Updating the manifest to include 5.0 images in the original "core" repos as undocumented tags to allow for backwards compatibility.  