### PR TITLE
Need to explicitly disable pr/trigger in pipelines

### DIFF
--- a/eng/pipelines/dotnet-core-nightly-pr.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr.yml
@@ -1,3 +1,4 @@
+trigger: none
 pr:
   branches:
     include:

--- a/eng/pipelines/dotnet-core-nightly.yml
+++ b/eng/pipelines/dotnet-core-nightly.yml
@@ -8,6 +8,7 @@ trigger:
     - manifest.json
     - manifest.versions.json
     - src/*
+pr: none
 
 variables:
 - template: variables/common.yml


### PR DESCRIPTION
The pipeline YAML needs to explicitly disable the `pr` and `trigger` actions to avoid the default behavior.