### PR TITLE
Regenerate out of date monitor Dockerfile

### DIFF
--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/core/sdk
 FROM $SDK_REPO:3.1-alpine3.12 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.2.20367.1
+ENV DOTNET_MONITOR_VERSION=5.0.0-preview.2.20371.2
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor5.0/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='c496303b167a2c41548f0f599db36f050346d6a7545564ec57b279f08b73be09f6ef909d2fa9cae7be00f5ac7640196e98e66d1fdd8dac6858c77bd0243c5539' \
+    && dotnetmonitor_sha512='1351df234e647ee8f69a7246812d7a81017e9c649c53ec66ff69a9a74fb611c911c01ef63cff8748258c0ba101fbf7601214f032d92a3814ddee07060a85d03d' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.


### PR DESCRIPTION
As part of https://github.com/dotnet/dotnet-docker/pull/2115, the Dockerfiles were not regenerated.  The infrastructure issues that caused this is being fixed with #2114