### PR TITLE
Correct inconsistent formatting in runtime-deps Dockerfiles

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/2.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime-deps/2.1/Dockerfile.linux
@@ -4,7 +4,7 @@ RUN apt-get update \
     &&{{if OS_VERSION = "focal": DEBIAN_FRONTEND=noninteractive}} apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
@@ -1,15 +1,15 @@
 FROM {{ARCH_VERSIONED}}/alpine:{{OS_VERSION_NUMBER}}
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-    # .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.linux
@@ -4,7 +4,7 @@ RUN apt-get update \
     &&{{if OS_VERSION = "focal": DEBIAN_FRONTEND=noninteractive}} apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.alpine
@@ -1,15 +1,15 @@
 FROM {{ARCH_VERSIONED}}/alpine:{{OS_VERSION_NUMBER}}
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-# .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.linux
@@ -4,7 +4,7 @@ RUN apt-get update \
     &&{{if OS_VERSION = "focal": DEBIAN_FRONTEND=noninteractive}} apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/2.1/bionic/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/bionic/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/2.1/bionic/arm32v7/Dockerfile
+++ b/src/runtime-deps/2.1/bionic/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/2.1/focal/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/focal/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/alpine3.11/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.11/amd64/Dockerfile
@@ -1,15 +1,15 @@
 FROM amd64/alpine:3.11
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-    # .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/alpine3.11/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.11/arm64v8/Dockerfile
@@ -1,15 +1,15 @@
 FROM arm64v8/alpine:3.11
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-    # .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile
@@ -1,15 +1,15 @@
 FROM amd64/alpine:3.12
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-    # .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile
@@ -1,15 +1,15 @@
 FROM arm64v8/alpine:3.12
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-    # .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/bionic/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/bionic/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/bionic/arm32v7/Dockerfile
+++ b/src/runtime-deps/3.1/bionic/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/focal/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/focal/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/3.1/focal/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/focal/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.12/amd64/Dockerfile
@@ -1,15 +1,15 @@
 FROM amd64/alpine:3.12
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-# .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/5.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.12/arm64v8/Dockerfile
@@ -1,15 +1,15 @@
 FROM arm64v8/alpine:3.12
 
 RUN apk add --no-cache \
-    ca-certificates \
-    \
-# .NET Core dependencies
-    krb5-libs \
-    libgcc \
-    libintl \
-    libssl1.1 \
-    libstdc++ \
-    zlib
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/buster-slim/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/5.0/buster-slim/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/5.0/buster-slim/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/focal/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/focal/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime-deps/5.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-# .NET Core dependencies
+        # .NET Core dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \


### PR DESCRIPTION
The inconsistencies are around indentation of the list of packages getting installed and the `.NET Core dependencies` code comment.