### PR TITLE
Remove 'core' terminology from 5.0 Dockerfiles

### DIFF
--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 # Install ASP.NET Core

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
 
 # Installer image

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
 
 # Installer image
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
     Remove-Item -Force aspnetcore.zip
 
 
-# Runtime image
+# ASP.NET Core image
 FROM $REPO:5.0-{{OS_VERSION}}
 ARG ASPNET_VERSION
 

--- a/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.alpine
@@ -3,7 +3,7 @@ FROM {{ARCH_VERSIONED}}/alpine:{{OS_VERSION_NUMBER}}
 RUN apk add --no-cache \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         krb5-libs \
         libgcc \
         libintl \

--- a/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime-deps/5.0/Dockerfile.linux
@@ -4,7 +4,7 @@ RUN apt-get update \
     &&{{if OS_VERSION = "focal": DEBIAN_FRONTEND=noninteractive}} apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -1,7 +1,7 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-# Install .NET Core
+# Install .NET
 ENV DOTNET_VERSION {{VARIABLES["runtime|5.0|build-version"]}}
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -1,11 +1,11 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 ARG DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 # Installer image
 FROM {{ARCH_VERSIONED}}/buildpack-deps:{{OS_VERSION_BASE}}-curl as installer
 ARG DOTNET_VERSION
 
-# Retrieve .NET Core
+# Retrieve .NET
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|5.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
@@ -14,7 +14,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
     && rm dotnet.tar.gz
 
 
-# .NET Core runtime image
+# .NET runtime image
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG DOTNET_VERSION
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
@@ -8,7 +8,7 @@ ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core Runtime
+# Retrieve .NET Runtime
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = '{{VARIABLES["runtime|5.0|win|x64|sha"]}}'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-{{OS_VERSION}}
 
 ENV \
@@ -12,14 +12,14 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-{{OS_ARCH_HYPHENATED}}
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}
 
 RUN apk add --no-cache \
     curl \
     icu-libs \
     git
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='{{VARIABLES["sdk|5.0|linux-musl|x64|sha"]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 ENV \
@@ -10,7 +10,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-{{OS_ARCH_HYPHENATED}}
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("sdk|5.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION={{VARIABLES["sdk|5.0|build-version"]}}
 
 # Installer image
@@ -10,7 +10,7 @@ ARG DOTNET_SDK_VERSION
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN `
-    # Retrieve .NET Core SDK
+    # Retrieve .NET SDK
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '{{VARIABLES["sdk|5.0|win|x64|sha"]}}'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
@@ -51,7 +51,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-{{OS_ARCH_HYPHENATED}}
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/src/aspnet/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/aspnet/5.0/alpine3.12/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-alpine3.12
 
 # Install ASP.NET Core

--- a/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-alpine3.12-arm64v8
 
 # Install ASP.NET Core

--- a/src/aspnet/5.0/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image

--- a/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image

--- a/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image

--- a/src/aspnet/5.0/focal/amd64/Dockerfile
+++ b/src/aspnet/5.0/focal/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image

--- a/src/aspnet/5.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/focal/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
     Remove-Item -Force aspnetcore.zip
 
 
-# Runtime image
+# ASP.NET Core image
 FROM $REPO:5.0-nanoserver-1809
 ARG ASPNET_VERSION
 

--- a/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
     Remove-Item -Force aspnetcore.zip
 
 
-# Runtime image
+# ASP.NET Core image
 FROM $REPO:5.0-nanoserver-1903
 ARG ASPNET_VERSION
 

--- a/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
     Remove-Item -Force aspnetcore.zip
 
 
-# Runtime image
+# ASP.NET Core image
 FROM $REPO:5.0-nanoserver-1909
 ARG ASPNET_VERSION
 

--- a/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
     Remove-Item -Force aspnetcore.zip
 
 
-# Runtime image
+# ASP.NET Core image
 FROM $REPO:5.0-nanoserver-2004
 ARG ASPNET_VERSION
 

--- a/src/runtime-deps/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.12/amd64/Dockerfile
@@ -3,7 +3,7 @@ FROM amd64/alpine:3.12
 RUN apk add --no-cache \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         krb5-libs \
         libgcc \
         libintl \

--- a/src/runtime-deps/5.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.12/arm64v8/Dockerfile
@@ -3,7 +3,7 @@ FROM arm64v8/alpine:3.12
 RUN apk add --no-cache \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         krb5-libs \
         libgcc \
         libintl \

--- a/src/runtime-deps/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/buster-slim/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/5.0/buster-slim/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/5.0/buster-slim/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/focal/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/focal/amd64/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime-deps/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime-deps/5.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         \
-        # .NET Core dependencies
+        # .NET dependencies
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \

--- a/src/runtime/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.12/amd64/Dockerfile
@@ -1,7 +1,7 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-alpine3.12
 
-# Install .NET Core
+# Install .NET
 ENV DOTNET_VERSION 5.0.0-preview.7.20364.11
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-alpine3.12-arm64v8
 
-# Install .NET Core
+# Install .NET
 ENV DOTNET_VERSION 5.0.0-preview.7.20364.11
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -1,11 +1,11 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
 FROM amd64/buildpack-deps:buster-curl as installer
 ARG DOTNET_VERSION
 
-# Retrieve .NET Core
+# Retrieve .NET
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='409802189c72820e67a5b064b8f2997095bc5b0be7a4c6734473c6aa56220ff60c758e4c12d2e99e2cf93cf8510e9bbe66e26e68abbe85085c28c5bc9428e77f' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
@@ -14,7 +14,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
     && rm dotnet.tar.gz
 
 
-# .NET Core runtime image
+# .NET runtime image
 FROM $REPO:5.0-buster-slim
 ARG DOTNET_VERSION
 

--- a/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
@@ -1,11 +1,11 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
 FROM arm32v7/buildpack-deps:buster-curl as installer
 ARG DOTNET_VERSION
 
-# Retrieve .NET Core
+# Retrieve .NET
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='1d65f3e708da676c5b9295048af240143c7efdb34dfe616edf50fbcaea3747bb4607afb5af5dfda664a512004ad3c31aeae4c142cda3d06ef51ade1832655bd6' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
@@ -14,7 +14,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
     && rm dotnet.tar.gz
 
 
-# .NET Core runtime image
+# .NET runtime image
 FROM $REPO:5.0-buster-slim-arm32v7
 ARG DOTNET_VERSION
 

--- a/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
@@ -1,11 +1,11 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
 FROM arm64v8/buildpack-deps:buster-curl as installer
 ARG DOTNET_VERSION
 
-# Retrieve .NET Core
+# Retrieve .NET
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz \
     && dotnet_sha512='ea62c09ce3de2732dc94c3384dc7c6ae580703b671dd2670b53a587603c778ba5d399544d3a5c8cbcaad95f4bdc4cad905776247000265bbc6a6ee647f83a96a' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
@@ -14,7 +14,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
     && rm dotnet.tar.gz
 
 
-# .NET Core runtime image
+# .NET runtime image
 FROM $REPO:5.0-buster-slim-arm64v8
 ARG DOTNET_VERSION
 

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -1,11 +1,11 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
 FROM amd64/buildpack-deps:focal-curl as installer
 ARG DOTNET_VERSION
 
-# Retrieve .NET Core
+# Retrieve .NET
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='409802189c72820e67a5b064b8f2997095bc5b0be7a4c6734473c6aa56220ff60c758e4c12d2e99e2cf93cf8510e9bbe66e26e68abbe85085c28c5bc9428e77f' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
@@ -14,7 +14,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
     && rm dotnet.tar.gz
 
 
-# .NET Core runtime image
+# .NET runtime image
 FROM $REPO:5.0-focal
 ARG DOTNET_VERSION
 

--- a/src/runtime/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/5.0/focal/arm64v8/Dockerfile
@@ -1,11 +1,11 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
 FROM arm64v8/buildpack-deps:focal-curl as installer
 ARG DOTNET_VERSION
 
-# Retrieve .NET Core
+# Retrieve .NET
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz \
     && dotnet_sha512='ea62c09ce3de2732dc94c3384dc7c6ae580703b671dd2670b53a587603c778ba5d399544d3a5c8cbcaad95f4bdc4cad905776247000265bbc6a6ee647f83a96a' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
@@ -14,7 +14,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
     && rm dotnet.tar.gz
 
 
-# .NET Core runtime image
+# .NET runtime image
 FROM $REPO:5.0-focal-arm64v8
 ARG DOTNET_VERSION
 

--- a/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
@@ -8,7 +8,7 @@ ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core Runtime
+# Retrieve .NET Runtime
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = 'f4769be164dd465b957db9308a5478f5089f8d8736b08940ce9a09c5adcf03734ad5ba8dace9b5ca85604665afa0c20c5563a7ed5fc97bcc7c18971206bbe4c7'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile
@@ -8,7 +8,7 @@ ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core Runtime
+# Retrieve .NET Runtime
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = 'f4769be164dd465b957db9308a5478f5089f8d8736b08940ce9a09c5adcf03734ad5ba8dace9b5ca85604665afa0c20c5563a7ed5fc97bcc7c18971206bbe4c7'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile
@@ -8,7 +8,7 @@ ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core Runtime
+# Retrieve .NET Runtime
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = 'f4769be164dd465b957db9308a5478f5089f8d8736b08940ce9a09c5adcf03734ad5ba8dace9b5ca85604665afa0c20c5563a7ed5fc97bcc7c18971206bbe4c7'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile
@@ -8,7 +8,7 @@ ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Retrieve .NET Core Runtime
+# Retrieve .NET Runtime
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = 'f4769be164dd465b957db9308a5478f5089f8d8736b08940ce9a09c5adcf03734ad5ba8dace9b5ca85604665afa0c20c5563a7ed5fc97bcc7c18971206bbe4c7'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/src/sdk/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/sdk/5.0/alpine3.12/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-alpine3.12
 
 ENV \
@@ -12,14 +12,14 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Alpine-3.12
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.12
 
 RUN apk add --no-cache \
     curl \
     icu-libs \
     git
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='001e0d48ab8e735549908ae23cd0e391e6cc0057502efdad253c492c570a35831f958692ef3efae4d8b8059339f5a568ef540818ddfecfaa83f8204f995f8b4f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \

--- a/src/sdk/5.0/buster-slim/amd64/Dockerfile
+++ b/src/sdk/5.0/buster-slim/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-buster-slim
 
 ENV \
@@ -10,7 +10,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Debian-10
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-10
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='caf54286afdd17fc39cc27b01f1997b4aec4c74493cdae5f3d56ad3262dc5bc53d8a704e8387b645b7d788da64c5ed05f42366f0f15589c642d2f25147e3f007' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \

--- a/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-buster-slim-arm32v7
 
 ENV \
@@ -10,7 +10,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Debian-10-arm32
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-10-arm32
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='92d7dce81172e49fe061be1aaff4d934a3339977a862eb765b6c6aaf45740a1a7c08abbf089c89818361c48a9699c7eebdad6514ae350ddb095e74b3781d2135' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \

--- a/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-buster-slim-arm64v8
 
 ENV \
@@ -10,7 +10,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Debian-10-arm64
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-10-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz \
     && dotnet_sha512='8bc7f4e833224596ce3adac7600f77db07ecc22b8ed883a811d4bdcffb97d68c31e9dadb46fb5218c8e2bea24fc45000bc84b39d4f3e580a3f6414e6e9fa90e6' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \

--- a/src/sdk/5.0/focal/amd64/Dockerfile
+++ b/src/sdk/5.0/focal/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-focal
 
 ENV \
@@ -10,7 +10,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Ubuntu-20.04
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-20.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='caf54286afdd17fc39cc27b01f1997b4aec4c74493cdae5f3d56ad3262dc5bc53d8a704e8387b645b7d788da64c5ed05f42366f0f15589c642d2f25147e3f007' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \

--- a/src/sdk/5.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/5.0/focal/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-focal-arm64v8
 
 ENV \
@@ -10,7 +10,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Ubuntu-20.04-arm64
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-20.04-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
+# Install .NET SDK
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz \
     && dotnet_sha512='8bc7f4e833224596ce3adac7600f77db07ecc22b8ed883a811d4bdcffb97d68c31e9dadb46fb5218c8e2bea24fc45000bc84b39d4f3e580a3f6414e6e9fa90e6' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
@@ -10,7 +10,7 @@ ARG DOTNET_SDK_VERSION
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN `
-    # Retrieve .NET Core SDK
+    # Retrieve .NET SDK
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '6caff10ee37a3ec2d3460daa231b470275c2601d8a6fa8db9a1399d208c2959d485531dcc671808ad50ac6eb7c0923c08a187c6a46a2ffb130eb348c5de618da'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
@@ -51,7 +51,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1809
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-1809
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
@@ -10,7 +10,7 @@ ARG DOTNET_SDK_VERSION
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN `
-    # Retrieve .NET Core SDK
+    # Retrieve .NET SDK
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '6caff10ee37a3ec2d3460daa231b470275c2601d8a6fa8db9a1399d208c2959d485531dcc671808ad50ac6eb7c0923c08a187c6a46a2ffb130eb348c5de618da'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
@@ -51,7 +51,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1903
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-1903
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
@@ -10,7 +10,7 @@ ARG DOTNET_SDK_VERSION
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN `
-    # Retrieve .NET Core SDK
+    # Retrieve .NET SDK
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '6caff10ee37a3ec2d3460daa231b470275c2601d8a6fa8db9a1399d208c2959d485531dcc671808ad50ac6eb7c0923c08a187c6a46a2ffb130eb348c5de618da'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
@@ -51,7 +51,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-1909
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-1909
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
@@ -10,7 +10,7 @@ ARG DOTNET_SDK_VERSION
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN `
-    # Retrieve .NET Core SDK
+    # Retrieve .NET SDK
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '6caff10ee37a3ec2d3460daa231b470275c2601d8a6fa8db9a1399d208c2959d485531dcc671808ad50ac6eb7c0923c08a187c6a46a2ffb130eb348c5de618da'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
@@ -51,7 +51,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-NanoServer-2004
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-2004
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator


### PR DESCRIPTION
Fixes #2084 

Remove 'core' terminology from:

- REPO ARG
- Comments
- POWERSHELL_DISTRIBUTION_CHANNEL ENV 

The 'core' terminology was left for places referencing ASP.NET Core.