### PR TITLE
Enable optional jobs for update-dependencies pipeline

### DIFF
--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -9,41 +9,52 @@ schedules:
   always: true
 variables:
 - template: variables/common.yml
-jobs:
-- job: UpdateDependenciesCoreSdk
-  displayName: Update Dependencies (dotnet/core-sdk)
-  pool: Hosted Ubuntu 1604
-  steps:
-  - script: $(engPath)/get-drop-versions.sh $(channel)
-    displayName: Get Versions
-  - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
-    displayName: Build Update Dependencies Tool
-  - script: >
-      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
-      $(dockerfileVersion)
-      --user $(dotnetDockerBot.userName)
-      --email $(dotnetDockerBot.email)
-      --password $(BotAccount-dotnet-docker-bot-PAT)
-      --product-version runtime=$(runtimeVer)
-      --product-version sdk=$(sdkVer)
-      --product-version aspnet=$(aspnetVer)
-      --version-source-name dotnet/core-sdk
-      --compute-shas
-    displayName: Run Update Dependencies
-- job: UpdateDependenciesDiagnostics
-  displayName: Update Dependencies (dotnet/diagnostics)
-  pool: Hosted Ubuntu 1604
-  steps:
-  - script: $(engPath)/get-drop-versions-monitor.sh $(monitorChannel)
-    displayName: Get Versions
-  - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
-    displayName: Build Update Dependencies Tool
-  - script: >
-      docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
-      $(dockerfileVersion)
-      --user $(dotnetDockerBot.userName)
-      --email $(dotnetDockerBot.email)
-      --password $(BotAccount-dotnet-docker-bot-PAT)
-      --product-version monitor=$(monitorVer)
-      --version-source-name dotnet/diagnostics
-    displayName: Run Update Dependencies
+stages:
+- stage: DotNet
+  condition: eq(variables['update-dotnet-enabled'], 'true')
+  jobs:
+  - job: UpdateDependencies
+    displayName: Update Dependencies (dotnet/installer)
+    pool:
+      vmImage: $(defaultLinuxAmd64PoolImage)
+    steps:
+    - script: $(engPath)/get-drop-versions.sh $(channel)
+      displayName: Get Versions
+    - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
+      displayName: Build Update Dependencies Tool
+    - script: >
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
+        $(dockerfileVersion)
+        --user $(dotnetDockerBot.userName)
+        --email $(dotnetDockerBot.email)
+        --password $(BotAccount-dotnet-docker-bot-PAT)
+        --product-version runtime=$(runtimeVer)
+        --product-version sdk=$(sdkVer)
+        --product-version aspnet=$(aspnetVer)
+        --version-source-name dotnet/core-sdk
+        --compute-shas
+      displayName: Run Update Dependencies
+- stage: Diagnostics
+  condition: eq(variables['update-diagnostics-enabled'], 'true')
+  dependsOn: [] # Allows it to run in parallel
+  jobs:
+  - job: UpdateDependencies
+    displayName: Update Dependencies (dotnet/diagnostics)
+    variables:
+      isEnabled: $(update-diagnostics-enabled)
+    pool:
+      vmImage: $(defaultLinuxAmd64PoolImage)
+    steps:
+    - script: $(engPath)/get-drop-versions-monitor.sh $(monitorChannel)
+      displayName: Get Versions
+    - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
+      displayName: Build Update Dependencies Tool
+    - script: >
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
+        $(dockerfileVersion)
+        --user $(dotnetDockerBot.userName)
+        --email $(dotnetDockerBot.email)
+        --password $(BotAccount-dotnet-docker-bot-PAT)
+        --product-version monitor=$(monitorVer)
+        --version-source-name dotnet/diagnostics
+      displayName: Run Update Dependencies

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -40,8 +40,6 @@ stages:
   jobs:
   - job: UpdateDependencies
     displayName: Update Dependencies (dotnet/diagnostics)
-    variables:
-      isEnabled: $(update-diagnostics-enabled)
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:


### PR DESCRIPTION
There's a need to be able to optionally define which of the products gets updated by the update-dependencies pipeline.  These changes define two queue-time variables for controlling this behavior: `update-dotnet-enabled` and `update-diagnostics-enabled`. It turns out that the easiest way to consume these was through the use of stages since a stage can have a condition.  Using `${{ if }}` expressions isn't possible because they can't reference custom variables.  I also looked at templatizing the UpdateDependencies jobs but it turned out there's just enough variation between them that it made it pointless.

Fixes #2125