### PR TITLE
Update Windows Dockerfiles to utilize architecture specific tag in FROM

### DIFF
--- a/eng/dockerfile-templates/aspnet/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/2.1/Dockerfile.nanoserver
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}
+FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}-amd64
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 

--- a/eng/dockerfile-templates/aspnet/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/3.1/Dockerfile.nanoserver
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 ARG ASPNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/eng/dockerfile-templates/runtime/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/2.1/Dockerfile.nanoserver
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}
+FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -19,7 +19,7 @@ RUN $dotnet_version = '{{VARIABLES["runtime|3.1|build-version"]}}'; `
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}
+FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}-amd64
 
 ENV `
     # Configure web servers to bind to port 80 when present

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
@@ -3,7 +3,7 @@
 ARG DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}
+FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}-amd64
 ARG DOTNET_VERSION
 
 ENV `

--- a/eng/dockerfile-templates/sdk/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/2.1/Dockerfile.nanoserver
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}
+FROM mcr.microsoft.com/windows/nanoserver:{{OS_VERSION_NUMBER}}-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION={{VARIABLES["sdk|5.0|build-version"]}}
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}} AS installer
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS installer
 ARG DOTNET_SDK_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 

--- a/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM mcr.microsoft.com/windows/nanoserver:1903-amd64
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 

--- a/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1909
+FROM mcr.microsoft.com/windows/nanoserver:1909-amd64
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 

--- a/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:2004
+FROM mcr.microsoft.com/windows/nanoserver:2004-amd64
 
 # Note: Runtime image's SHELL is the CMD shell (different than the installer image).
 

--- a/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/aspnet/3.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-1903/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/aspnet/3.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-1909/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/aspnet/3.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-2004/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 ARG ASPNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 ARG ASPNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 ARG ASPNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 ARG ASPNET_VERSION=5.0.0-preview.7.20365.19
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 ARG ASPNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM mcr.microsoft.com/windows/nanoserver:1903-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1909
+FROM mcr.microsoft.com/windows/nanoserver:1909-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:2004
+FROM mcr.microsoft.com/windows/nanoserver:2004-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -19,7 +19,7 @@ RUN $dotnet_version = '3.1.6'; `
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
 
 ENV `
     # Configure web servers to bind to port 80 when present

--- a/src/runtime/3.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1903/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -19,7 +19,7 @@ RUN $dotnet_version = '3.1.6'; `
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM mcr.microsoft.com/windows/nanoserver:1903-amd64
 
 ENV `
     # Configure web servers to bind to port 80 when present

--- a/src/runtime/3.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1909/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -19,7 +19,7 @@ RUN $dotnet_version = '3.1.6'; `
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1909
+FROM mcr.microsoft.com/windows/nanoserver:1909-amd64
 
 ENV `
     # Configure web servers to bind to port 80 when present

--- a/src/runtime/3.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-2004/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -19,7 +19,7 @@ RUN $dotnet_version = '3.1.6'; `
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:2004
+FROM mcr.microsoft.com/windows/nanoserver:2004-amd64
 
 ENV `
     # Configure web servers to bind to port 80 when present

--- a/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
 ARG DOTNET_VERSION
 
 ENV `

--- a/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM mcr.microsoft.com/windows/nanoserver:1903-amd64
 ARG DOTNET_VERSION
 
 ENV `

--- a/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:1909
+FROM mcr.microsoft.com/windows/nanoserver:1909-amd64
 ARG DOTNET_VERSION
 
 ENV `

--- a/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG DOTNET_VERSION=5.0.0-preview.7.20364.11
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 ARG DOTNET_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # Runtime image
-FROM mcr.microsoft.com/windows/nanoserver:2004
+FROM mcr.microsoft.com/windows/nanoserver:2004-amd64
 ARG DOTNET_VERSION
 
 ENV `

--- a/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM mcr.microsoft.com/windows/nanoserver:1903-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:1909
+FROM mcr.microsoft.com/windows/nanoserver:1909-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,7 +20,7 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
 
 
 # SDK image
-FROM mcr.microsoft.com/windows/nanoserver:2004
+FROM mcr.microsoft.com/windows/nanoserver:2004-amd64
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/sdk/3.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1903/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/sdk/3.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1909/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/sdk/3.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-2004/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1809 AS installer
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 ARG DOTNET_SDK_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1903 AS installer
+FROM mcr.microsoft.com/windows/servercore:1903-amd64 AS installer
 ARG DOTNET_SDK_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:1909 AS installer
+FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 ARG DOTNET_SDK_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 ARG DOTNET_SDK_VERSION=5.0.100-preview.7.20366.15
 
 # Installer image
-FROM mcr.microsoft.com/windows/servercore:2004 AS installer
+FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 ARG DOTNET_SDK_VERSION
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]


### PR DESCRIPTION
The tags utilized in the Windows Dockerfiles were multi-platform tags.  Since the Dockerfiles are arch specific, the tags used in the FROM should also be.  The primary reason for this is to ensure the builds are producing images for the intended arch.