### PR TITLE
Removed <Major.Minor.Patch .NET Version>-alpine tags

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -63,12 +63,12 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 3.1.7-buster-slim, 3.1-buster-slim, 3.1.7, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-3.1.7-alpine3.12, 3.1-alpine3.12, 3.1.7-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+3.1.7-alpine3.12, 3.1-alpine3.12, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 3.1.7-alpine3.11, 3.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 3.1.7-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.7-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 2.1.21-stretch-slim, 2.1-stretch-slim, 2.1.21, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/2.1/stretch-slim/amd64/Dockerfile) | Debian 9
-2.1.21-alpine3.12, 2.1-alpine3.12, 2.1.21-alpine, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+2.1.21-alpine3.12, 2.1-alpine3.12, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 2.1.21-alpine3.11, 2.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/2.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 2.1.21-focal, 2.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/2.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 2.1.21-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/2.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
@@ -77,7 +77,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 3.1.7-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.7, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10
-3.1.7-alpine3.12-arm64v8, 3.1-alpine3.12-arm64v8, 3.1.7-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+3.1.7-alpine3.12-arm64v8, 3.1-alpine3.12-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 3.1.7-alpine3.11-arm64v8, 3.1-alpine3.11-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/alpine3.11/arm64v8/Dockerfile) | Alpine 3.11
 3.1.7-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.7-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/bionic/arm64v8/Dockerfile) | Ubuntu 18.04

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -60,7 +60,7 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.1-buster-slim, 5.0-buster-slim, 5.0.0-rc.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.1-alpine3.12, 5.0-alpine3.12, 5.0.0-rc.1-alpine, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.1-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.0-rc.1-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
@@ -68,7 +68,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.1-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.1-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0.0-rc.1-alpine-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.1-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 5.0.0-rc.1-focal-arm64v8, 5.0-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -25,7 +25,7 @@ TBD
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-preview.2-alpine, 5.0-alpine, 5.0.0-preview.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/5.0/alpine/amd64/Dockerfile) | Alpine 3.12
+5.0-alpine, 5.0.0-preview.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/5.0/alpine/amd64/Dockerfile) | Alpine 3.12
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -51,12 +51,12 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 3.1.7-buster-slim, 3.1-buster-slim, 3.1.7, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-3.1.7-alpine3.12, 3.1-alpine3.12, 3.1.7-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+3.1.7-alpine3.12, 3.1-alpine3.12, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 3.1.7-alpine3.11, 3.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 3.1.7-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.7-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 2.1.21-stretch-slim, 2.1-stretch-slim, 2.1.21, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile) | Debian 9
-2.1.21-alpine3.12, 2.1-alpine3.12, 2.1.21-alpine, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+2.1.21-alpine3.12, 2.1-alpine3.12, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 2.1.21-alpine3.11, 2.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/2.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 2.1.21-focal, 2.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/2.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 2.1.21-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/2.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
@@ -65,7 +65,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 3.1.7-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.7, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10
-3.1.7-alpine3.12-arm64v8, 3.1-alpine3.12-arm64v8, 3.1.7-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+3.1.7-alpine3.12-arm64v8, 3.1-alpine3.12-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 3.1.7-alpine3.11-arm64v8, 3.1-alpine3.11-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.11/arm64v8/Dockerfile) | Alpine 3.11
 3.1.7-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.7-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile) | Ubuntu 18.04

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -48,7 +48,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.1-buster-slim, 5.0-buster-slim, 5.0.0-rc.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.1-alpine3.12, 5.0-alpine3.12, 5.0.0-rc.1-alpine, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.1-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.0-rc.1-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
@@ -56,7 +56,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.1-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.1-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0.0-rc.1-alpine-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.1-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 5.0.0-rc.1-focal-arm64v8, 5.0-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -59,12 +59,12 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 3.1.7-buster-slim, 3.1-buster-slim, 3.1.7, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-3.1.7-alpine3.12, 3.1-alpine3.12, 3.1.7-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+3.1.7-alpine3.12, 3.1-alpine3.12, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 3.1.7-alpine3.11, 3.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 3.1.7-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.7-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 2.1.21-stretch-slim, 2.1-stretch-slim, 2.1.21, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/2.1/stretch-slim/amd64/Dockerfile) | Debian 9
-2.1.21-alpine3.12, 2.1-alpine3.12, 2.1.21-alpine, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+2.1.21-alpine3.12, 2.1-alpine3.12, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 2.1.21-alpine3.11, 2.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/2.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 2.1.21-focal, 2.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/2.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 2.1.21-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/2.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
@@ -73,7 +73,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 3.1.7-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.7, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10
-3.1.7-alpine3.12-arm64v8, 3.1-alpine3.12-arm64v8, 3.1.7-alpine-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+3.1.7-alpine3.12-arm64v8, 3.1-alpine3.12-arm64v8, 3.1-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 3.1.7-alpine3.11-arm64v8, 3.1-alpine3.11-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/alpine3.11/arm64v8/Dockerfile) | Alpine 3.11
 3.1.7-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.7-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/bionic/arm64v8/Dockerfile) | Ubuntu 18.04

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -56,7 +56,7 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.1-buster-slim, 5.0-buster-slim, 5.0.0-rc.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.1-alpine3.12, 5.0-alpine3.12, 5.0.0-rc.1-alpine, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.1-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.0-rc.1-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
@@ -64,7 +64,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.1-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.1-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0.0-rc.1-alpine-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.1-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 5.0.0-rc.1-focal-arm64v8, 5.0-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -63,12 +63,12 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 3.1.401-buster, 3.1-buster, 3.1.401, 3.1, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/buster/amd64/Dockerfile) | Debian 10
-3.1.401-alpine3.12, 3.1-alpine3.12, 3.1.401-alpine, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+3.1.401-alpine3.12, 3.1-alpine3.12, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 3.1.401-alpine3.11, 3.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 3.1.401-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.401-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 2.1.809-stretch, 2.1-stretch, 2.1.809, 2.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/2.1/stretch/amd64/Dockerfile) | Debian 9
-2.1.809-alpine3.12, 2.1-alpine3.12, 2.1.809-alpine, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+2.1.809-alpine3.12, 2.1-alpine3.12, 2.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/2.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 2.1.809-alpine3.11, 2.1-alpine3.11 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/2.1/alpine3.11/amd64/Dockerfile) | Alpine 3.11
 2.1.809-focal, 2.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/2.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 2.1.809-bionic, 2.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/2.1/bionic/amd64/Dockerfile) | Ubuntu 18.04

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -60,7 +60,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.100-rc.1-buster-slim, 5.0-buster-slim, 5.0.100-rc.1, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.100-rc.1-alpine3.12, 5.0-alpine3.12, 5.0.100-rc.1-alpine, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.100-rc.1-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.100-rc.1-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags

--- a/manifest.json
+++ b/manifest.json
@@ -88,9 +88,6 @@
                 "2.1-alpine3.12": {
                   "documentationGroup": "2.1"
                 },
-                "$(dotnet|2.1|product-version)-alpine": {
-                  "documentationGroup": "2.1"
-                },
                 "2.1-alpine": {
                   "documentationGroup": "2.1"
                 }
@@ -292,9 +289,6 @@
                 "3.1-alpine3.12": {
                   "documentationGroup": "3.1"
                 },
-                "$(dotnet|3.1|product-version)-alpine": {
-                  "documentationGroup": "3.1"
-                },
                 "3.1-alpine": {
                   "documentationGroup": "3.1"
                 }
@@ -316,9 +310,6 @@
                   "documentationGroup": "3.1"
                 },
                 "3.1-alpine3.12-arm64v8": {
-                  "documentationGroup": "3.1"
-                },
-                "$(dotnet|3.1|product-version)-alpine-arm64v8": {
                   "documentationGroup": "3.1"
                 },
                 "3.1-alpine-arm64v8": {
@@ -502,7 +493,6 @@
               "tags": {
                 "$(dotnet|5.0|product-version)-alpine3.12": {},
                 "5.0-alpine3.12": {},
-                "$(dotnet|5.0|product-version)-alpine": {},
                 "5.0-alpine": {}
               }
             }
@@ -520,7 +510,6 @@
               "tags": {
                 "$(dotnet|5.0|product-version)-alpine3.12-arm64v8": {},
                 "5.0-alpine3.12-arm64v8": {},
-                "$(dotnet|5.0|product-version)-alpine-arm64v8": {},
                 "5.0-alpine-arm64v8": {}
               },
               "variant": "v8"
@@ -693,7 +682,6 @@
               "tags": {
                 "$(dotnet|2.1|product-version)-alpine3.12": {},
                 "2.1-alpine3.12": {},
-                "$(dotnet|2.1|product-version)-alpine": {},
                 "2.1-alpine": {}
               }
             }
@@ -929,7 +917,6 @@
               "tags": {
                 "$(dotnet|3.1|product-version)-alpine3.12": {},
                 "3.1-alpine3.12": {},
-                "$(dotnet|3.1|product-version)-alpine": {},
                 "3.1-alpine": {}
               }
             }
@@ -950,7 +937,6 @@
               "tags": {
                 "$(dotnet|3.1|product-version)-alpine3.12-arm64v8": {},
                 "3.1-alpine3.12-arm64v8": {},
-                "$(dotnet|3.1|product-version)-alpine-arm64v8": {},
                 "3.1-alpine-arm64v8": {}
               },
               "variant": "v8",
@@ -1197,7 +1183,6 @@
               "tags": {
                 "$(dotnet|5.0|product-version)-alpine3.12": {},
                 "5.0-alpine3.12": {},
-                "$(dotnet|5.0|product-version)-alpine": {},
                 "5.0-alpine": {}
               }
             }
@@ -1218,7 +1203,6 @@
               "tags": {
                 "$(dotnet|5.0|product-version)-alpine3.12-arm64v8": {},
                 "5.0-alpine3.12-arm64v8": {},
-                "$(dotnet|5.0|product-version)-alpine-arm64v8": {},
                 "5.0-alpine-arm64v8": {}
               },
               "variant": "v8",
@@ -1445,7 +1429,6 @@
               "tags": {
                 "$(dotnet|2.1|product-version)-alpine3.12": {},
                 "2.1-alpine3.12": {},
-                "$(dotnet|2.1|product-version)-alpine": {},
                 "2.1-alpine": {}
               }
             }
@@ -1693,7 +1676,6 @@
               "tags": {
                 "$(dotnet|3.1|product-version)-alpine3.12": {},
                 "3.1-alpine3.12": {},
-                "$(dotnet|3.1|product-version)-alpine": {},
                 "3.1-alpine": {}
               }
             }
@@ -1714,7 +1696,6 @@
               "tags": {
                 "$(dotnet|3.1|product-version)-alpine3.12-arm64v8": {},
                 "3.1-alpine3.12-arm64v8": {},
-                "$(dotnet|3.1|product-version)-alpine-arm64v8": {},
                 "3.1-alpine-arm64v8": {}
               },
               "variant": "v8",
@@ -1973,7 +1954,6 @@
               "tags": {
                 "$(dotnet|5.0|product-version)-alpine3.12": {},
                 "5.0-alpine3.12": {},
-                "$(dotnet|5.0|product-version)-alpine": {},
                 "5.0-alpine": {}
               }
             }
@@ -1994,7 +1974,6 @@
               "tags": {
                 "$(dotnet|5.0|product-version)-alpine3.12-arm64v8": {},
                 "5.0-alpine3.12-arm64v8": {},
-                "$(dotnet|5.0|product-version)-alpine-arm64v8": {},
                 "5.0-alpine-arm64v8": {}
               },
               "variant": "v8",
@@ -2233,7 +2212,6 @@
               "tags": {
                 "$(sdk|2.1|product-version)-alpine3.12": {},
                 "2.1-alpine3.12": {},
-                "$(sdk|2.1|product-version)-alpine": {},
                 "2.1-alpine": {}
               }
             }
@@ -2494,7 +2472,6 @@
               "tags": {
                 "$(sdk|3.1|product-version)-alpine3.12": {},
                 "3.1-alpine3.12": {},
-                "$(sdk|3.1|product-version)-alpine": {},
                 "3.1-alpine": {}
               }
             }
@@ -2779,7 +2756,6 @@
               "tags": {
                 "$(sdk|5.0|product-version)-alpine3.12": {},
                 "5.0-alpine3.12": {},
-                "$(sdk|5.0|product-version)-alpine": {},
                 "5.0-alpine": {}
               }
             }
@@ -2869,7 +2845,6 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(monitor|5.0|product-version)-alpine": {},
                 "5.0-alpine": {}
               }
             }


### PR DESCRIPTION
Related to #2188 

The plan would be to merge these changes to master during the next servicing event at which point the current tags become unsupported because of the new .NET version.