### PR TITLE
Cleanup formatting of the readme License

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -139,8 +139,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -125,8 +125,8 @@ See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/micr
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/micr
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -49,7 +49,7 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/nightly/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/nightly/documentation/image-artifact-details.md)

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -103,8 +103,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -89,8 +89,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -135,8 +135,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -121,8 +121,8 @@ See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/micr
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.samples.md
+++ b/README.samples.md
@@ -122,8 +122,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -137,8 +137,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
 * [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -124,8 +124,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
-- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)
 * [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)


### PR DESCRIPTION
https://github.com/dotnet/dotnet-docker/pull/2143 didn't get merged from master to nightly.  This is a direct result of the READMEs being different between the two branches and therefore difficult to merge.