### PR TITLE
Remove redundant Related Repos section

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -47,11 +47,6 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
-.NET 5.0+:
-
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-
 .NET Framework:
 
 * [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -35,11 +35,6 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
-.NET 5.0+:
-
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-
 .NET Framework:
 
 * [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -43,11 +43,6 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
-.NET 5.0+:
-
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-
 .NET Framework:
 
 * [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -47,11 +47,6 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 * [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 * [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
-.NET 5.0+:
-
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-
 .NET Framework:
 
 * [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF


### PR DESCRIPTION
The _core_ repo readmes in nightly have a duplicated `.NET 5.0+:` section.  The PR is cleaning that up.