### PR TITLE
Quote arguments in docker cp command

### DIFF
--- a/eng/common/Invoke-ReadmeGeneration.ps1
+++ b/eng/common/Invoke-ReadmeGeneration.ps1
@@ -32,7 +32,7 @@ $onTagsGenerated = {
     param($ContainerName)
 
     if (-Not $Validate) {
-        Exec "docker cp ${ContainerName}:/repo/$ReadmePath $repoRoot/$ReadmePath"
+        Exec "docker cp '${ContainerName}:/repo/$ReadmePath' '$repoRoot/$ReadmePath'"
     }
 }
 


### PR DESCRIPTION
Fixes #2223.

Based on https://github.com/dotnet/dotnet-docker/issues/2223#issuecomment-689725236.

However, [`Invoke-Expression` is a bit of a trap and ideally should be removed](https://devblogs.microsoft.com/powershell/invoke-expression-considered-harmful/).

PowerShell is able to do things like scriptblock execution and array splatting to make this easier without needing to do string manipulation or escaping.

For example, [this function](https://github.com/PowerShell/PowerShell/blob/b1e998046e12ebe5da9dee479f20d479aa2256d7/src/PowerShell.Core.Instrumentation/RegisterManifest.ps1#L30-L48) is what's used in the PowerShell repo for native command execution.

Even just replacing the `Invoke-Expression` with an ordinary invocation would probably be an improvement:

```powershell
function Exec {
    param(
        [Parameter(Mandatory, Position=0)
        [string]
        $Cmd,

        [Parameter(ValueFromRemainingArguments)]
        [string[]]
        $Arguments
    )

    Log "Executing: '$Cmd $Arguments'"
    & $Cmd @Arguments
    if ($LastExitCode -ne 0) {
        throw "Failed: '$Cmd $Arguments'"
    }
}

Exec docker cp "${ContainerName}:/repo/$ReadmePath" "$repoRoot/$ReadmePath"
```

Let me know if you want me to make such a change.