### PR TITLE
Add .editorconfig and correct problems in tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,190 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Analyzers
+dotnet_code_quality.ca1802.api_surface = private, internal
+dotnet_code_quality.ca2208.api_surface = public
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\n
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+[*.{csproj,vbproj,proj,nativeproj,locproj}]
+charset = utf-8
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
@@ -17,14 +17,14 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public EnvironmentVariableInfo(string name, string expectedValue)
         {
-            this.Name = name;
-            this.ExpectedValue = expectedValue;
+            Name = name;
+            ExpectedValue = expectedValue;
         }
 
         public EnvironmentVariableInfo(string name, bool allowAnyValue)
         {
-            this.Name = name;
-            this.AllowAnyValue = allowAnyValue;
+            Name = name;
+            AllowAnyValue = allowAnyValue;
         }
 
         public static void Validate(
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string combinedValues = dockerHelper.Run(
                 image: imageData.GetImage(imageType, dockerHelper),
                 name: imageData.GetIdentifier($"env"),
-                command: $"{invokeCommand} \"echo {String.Join($"{delimiterEscape}{delimiter}", echoParts)}\"");
+                command: $"{invokeCommand} \"echo {string.Join($"{delimiterEscape}{delimiter}", echoParts)}\"");
 
             string[] values = combinedValues.Split(delimiter);
             Assert.Equal(variables.Count(), values.Count());

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -15,20 +15,20 @@ namespace Microsoft.DotNet.Docker.Tests
 {
     public abstract class ImageData
     {
-        private List<string> _pulledImages = new List<string>();
+        private readonly List<string> _pulledImages = new List<string>();
 
         public Arch Arch { get; set; }
         public bool IsArm => Arch == Arch.Arm || Arch == Arch.Arm64;
         public string OS { get; set; }
 
-        private static readonly Lazy<JObject> ImageInfoData;
+        private static readonly Lazy<JObject> s_imageInfoData;
 
         static ImageData()
         {
-            ImageInfoData = new Lazy<JObject>(() =>
+            s_imageInfoData = new Lazy<JObject>(() =>
             {
                 string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
-                if (!String.IsNullOrEmpty(imageInfoPath))
+                if (!string.IsNullOrEmpty(imageInfoPath))
                 {
                     string imageInfoContents = File.ReadAllText(imageInfoPath);
                     return JsonConvert.DeserializeObject<JObject>(imageInfoContents);
@@ -120,9 +120,9 @@ namespace Microsoft.DotNet.Docker.Tests
             // In the case of running this in a local development environment, there would likely be no image info file
             // provided. In that case, the assumption is that the images exist in the staging location.
 
-            if (ImageData.ImageInfoData.Value != null)
+            if (ImageData.s_imageInfoData.Value != null)
             {
-                JObject repoInfo = (JObject)ImageData.ImageInfoData.Value
+                JObject repoInfo = (JObject)ImageData.s_imageInfoData.Value
                     .Value<JArray>("repos")
                     .FirstOrDefault(imageInfoRepo => imageInfoRepo["repo"].ToString() == repo);
 
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public override string ToString()
         {
-            return this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
+            return GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
                 .Select(propInfo => $"{propInfo.Name}='{propInfo.GetValue(this) ?? "<null>"}'")
                 .Aggregate((working, next) => $"{working}, {next}");
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -99,8 +99,10 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             string tag = _imageData.GetIdentifier(stageTarget);
 
-            List<string> buildArgs = new List<string>();
-            buildArgs.Add($"sdk_image={_imageData.GetImage(DotNetImageType.SDK, _dockerHelper)}");
+            List<string> buildArgs = new List<string>
+            {
+                $"sdk_image={_imageData.GetImage(DotNetImageType.SDK, _dockerHelper)}"
+            };
 
             DotNetImageType runtimeImageType = _isWeb ? DotNetImageType.Aspnet : DotNetImageType.Runtime;
             buildArgs.Add($"runtime_image={_imageData.GetImage(runtimeImageType, _dockerHelper)}");
@@ -209,10 +211,10 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
         {
-            var retries = 30;
+            int retries = 30;
 
             // Can't use localhost when running inside containers or Windows.
-            var url = !Config.IsRunningInContainer && DockerHelper.IsLinuxContainerModeEnabled
+            string url = !Config.IsRunningInContainer && DockerHelper.IsLinuxContainerModeEnabled
                 ? $"http://localhost:{dockerHelper.GetContainerHostPort(containerName)}"
                 : $"http://{dockerHelper.GetContainerAddress(containerName)}";
 
@@ -235,7 +237,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     }
                     catch (Exception ex)
                     {
-                        outputHelper.WriteLine($"Request to {url} failed - retrying: {ex.ToString()}");
+                        outputHelper.WriteLine($"Request to {url} failed - retrying: {ex}");
                     }
                 }
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -60,26 +60,16 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public string GetProductVersion(DotNetImageType imageType, DockerHelper dockerHelper)
         {
-            string version;
             string imageName = GetImage(imageType, dockerHelper);
             string containerName = GetIdentifier($"GetProductVersion-{imageType}");
 
-            switch (imageType)
+            return imageType switch
             {
-                case DotNetImageType.SDK:
-                    version = dockerHelper.Run(imageName, containerName, "dotnet --version");
-                    break;
-                case DotNetImageType.Runtime:
-                    version = GetRuntimeVersion(imageName, containerName, "Microsoft.NETCore.App", dockerHelper);
-                    break;
-                case DotNetImageType.Aspnet:
-                    version = GetRuntimeVersion(imageName, containerName, "Microsoft.AspNetCore.App", dockerHelper);
-                    break;
-                default:
-                    throw new NotSupportedException($"Unsupported image type '{imageType}'");
-            }
-
-            return version;
+                DotNetImageType.SDK => dockerHelper.Run(imageName, containerName, "dotnet --version"),
+                DotNetImageType.Runtime => GetRuntimeVersion(imageName, containerName, "Microsoft.NETCore.App", dockerHelper),
+                DotNetImageType.Aspnet => GetRuntimeVersion(imageName, containerName, "Microsoft.AspNetCore.App", dockerHelper),
+                _ => throw new NotSupportedException($"Unsupported image type '{imageType}'"),
+            };
         }
 
         private string GetRuntimeVersion(string imageName, string containerName, string runtimeName, DockerHelper dockerHelper)
@@ -112,7 +102,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     throw new NotSupportedException($"Unsupported image type '{imageType}'");
             }
 
-            return this.GetTagName(imageVersion.ToString(2), os);
+            return GetTagName(imageVersion.ToString(2), os);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -113,9 +113,9 @@ namespace Microsoft.DotNet.Docker.Tests
 
                 // Open the test log file and verify the tests passed
                 XDocument doc = XDocument.Load(testLogFile);
-                var summary = doc.Root.Element(XName.Get("ResultSummary", doc.Root.Name.NamespaceName));
+                XElement summary = doc.Root.Element(XName.Get("ResultSummary", doc.Root.Name.NamespaceName));
                 Assert.Equal("Completed", summary.Attribute("outcome").Value);
-                var counters = summary.Element(XName.Get("Counters", doc.Root.Name.NamespaceName));
+                XElement counters = summary.Element(XName.Get("Counters", doc.Root.Name.NamespaceName));
                 Assert.Equal("2", counters.Attribute("total").Value);
                 Assert.Equal("2", counters.Attribute("passed").Value);
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Docker.Tests
     [Trait("Category", "sdk")]
     public class SdkImageTests : ProductImageTests
     {
-        private static readonly Dictionary<string, IEnumerable<SdkContentFileInfo>> sdkContentsCache =
+        private static readonly Dictionary<string, IEnumerable<SdkContentFileInfo>> s_sdkContentsCache =
             new Dictionary<string, IEnumerable<SdkContentFileInfo>>();
 
         public SdkImageTests(ITestOutputHelper outputHelper)
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPowerShellScenario_NonDefaultUser(ProductImageData imageData)
         {
-            var optRunArgs = "-u 12345:12345"; // Linux containers test as non-root user
+            string optRunArgs = "-u 12345:12345"; // Linux containers test as non-root user
             if (imageData.OS.Contains("nanoserver", StringComparison.OrdinalIgnoreCase))
             {
                 // windows containers test as Admin, default execution is as ContainerUser
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (hasCountDifference || hasFileContentDifference)
             {
-                OutputHelper.WriteLine(String.Empty);
+                OutputHelper.WriteLine(string.Empty);
                 OutputHelper.WriteLine("EXPECTED FILES:");
                 foreach (SdkContentFileInfo file in expectedDotnetFiles)
                 {
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     OutputHelper.WriteLine($"Checksum: {file.Sha512}");
                 }
                 
-                OutputHelper.WriteLine(String.Empty);
+                OutputHelper.WriteLine(string.Empty);
                 OutputHelper.WriteLine("ACTUAL FILES:");
                 foreach (SdkContentFileInfo file in actualDotnetFiles)
                 {
@@ -247,7 +247,7 @@ namespace Microsoft.DotNet.Docker.Tests
             {
                 using SHA512 sha512 = SHA512.Create();
                 byte[] sha512HashBytes = sha512.ComputeHash(File.ReadAllBytes(file.FullName));
-                string sha512Hash = BitConverter.ToString(sha512HashBytes).Replace("-", String.Empty);
+                string sha512Hash = BitConverter.ToString(sha512HashBytes).Replace("-", string.Empty);
                 yield return new SdkContentFileInfo(
                     file.FullName.Substring(tempFolderContext.Path.Length), sha512Hash);
             }
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string sdkUrl =
                 $"https://dotnetcli.azureedge.net/dotnet/Sdk/{sdkVersion}/dotnet-sdk-{sdkVersion}-{osType}-{architecture}.{fileType}";
 
-            if (!sdkContentsCache.TryGetValue(sdkUrl, out IEnumerable<SdkContentFileInfo> files))
+            if (!s_sdkContentsCache.TryGetValue(sdkUrl, out IEnumerable<SdkContentFileInfo> files))
             {
                 string sdkFile = Path.GetTempFileName();
 
@@ -287,7 +287,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     .OrderBy(file => file.Path)
                     .ToArray();
 
-                sdkContentsCache.Add(sdkUrl, files);
+                s_sdkContentsCache.Add(sdkUrl, files);
             }
 
             return files;
@@ -362,8 +362,8 @@ namespace Microsoft.DotNet.Docker.Tests
             {
                 return path
                     .Replace("\\", "/")
-                    .Replace("/usr/share/dotnet", String.Empty, StringComparison.OrdinalIgnoreCase)
-                    .Replace("c:/program files/dotnet", String.Empty, StringComparison.OrdinalIgnoreCase)
+                    .Replace("/usr/share/dotnet", string.Empty, StringComparison.OrdinalIgnoreCase)
+                    .Replace("c:/program files/dotnet", string.Empty, StringComparison.OrdinalIgnoreCase)
                     .TrimStart('/')
                     .ToLower();
             }


### PR DESCRIPTION
The goal of adding this is to get more consistency in the code style used. This editor config is a copy of what is used in the dotnet/runtime repo. I propose we work on addressing the inconsistencies by proactively addressing the problems within the files we touch. I've included the fixes to the unit tests.