### PR TITLE
Windows Server Core 2019 Dockerfiles for 5.0

### DIFF
--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -104,6 +104,7 @@ Tag | Dockerfile
 Tag | Dockerfile
 ---------| ---------------
 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -100,6 +100,7 @@ Tag | Dockerfile
 Tag | Dockerfile
 ---------| ---------------
 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -105,6 +105,7 @@ Tag | Dockerfile
 Tag | Dockerfile
 ---------| ---------------
 5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.
 

--- a/eng/dockerfile-templates/aspnet/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/2.1/Dockerfile.nanoserver
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf aspnetcore.zip; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/eng/dockerfile-templates/aspnet/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/3.1/Dockerfile.nanoserver
@@ -16,7 +16,8 @@ RUN $aspnetcore_version = '{{VARIABLES["aspnet|3.1|build-version"]}}'; `
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
@@ -17,7 +17,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
@@ -3,8 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-{{OS_VERSION}}
 
-ARG ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION {{VARIABLES["aspnet|5.0|build-version"]}}
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
@@ -1,0 +1,22 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+FROM $REPO:5.0-{{OS_VERSION}}
+
+ARG ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
+ENV ASPNET_VERSION $ASPNET_VERSION
+
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Install ASP.NET Core Runtime
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNET_VERSION/aspnetcore-runtime-$Env:ASPNET_VERSION-win-x64.zip; `
+        $aspnetcore_sha512 = '{{VARIABLES["aspnet|5.0|win|x64|sha"]}}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip

--- a/eng/dockerfile-templates/runtime/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/2.1/Dockerfile.nanoserver
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
@@ -14,7 +14,8 @@ RUN $dotnet_version = '{{VARIABLES["runtime|3.1|build-version"]}}'; `
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
@@ -16,7 +16,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -1,0 +1,29 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
+
+ARG DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
+
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    DOTNET_VERSION=$DOTNET_VERSION
+
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Install .NET
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
+        $dotnet_sha512 = '{{VARIABLES["runtime|5.0|win|x64|sha"]}}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        Expand-Archive dotnet.zip -DestinationPath 'C:\Program Files\dotnet'; `
+        Remove-Item -Force dotnet.zip
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -2,14 +2,12 @@
 
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
-ARG DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
-
 ENV `
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
-    DOTNET_VERSION=$DOTNET_VERSION
+    DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
@@ -23,7 +21,8 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        Expand-Archive dotnet.zip -DestinationPath 'C:\Program Files\dotnet'; `
+        mkdir $Env:ProgramFiles\dotnet; `
+        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/eng/dockerfile-templates/sdk/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/2.1/Dockerfile.nanoserver
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
@@ -16,7 +16,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
@@ -17,7 +17,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
@@ -1,0 +1,53 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:5.0-{{OS_VERSION}}
+
+ARG DOTNET_SDK_VERSION={{VARIABLES["sdk|5.0|build-version"]}}
+
+ENV `
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= `
+    DOTNET_SDK_VERSION=$DOTNET_SDK_VERSION `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}
+
+RUN `
+    powershell -Command "`
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
+        $dotnet_sha512 = '{{VARIABLES["sdk|5.0|win|x64|sha"]}}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '{{VARIABLES["powershell|5.0|build-version"]}}'; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_sha512 = '{{VARIABLES["powershell|5.0|Windows|x64|sha"]}}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & $Env:ProgramFiles\dotnet\dotnet tool install --add-source . --tool-path $Env:ProgramFiles\powershell --version $powershell_version PowerShell.Windows.x64; `
+        & $Env:ProgramFiles\dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path $Env:ProgramFiles\powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;"
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
+USER ContainerUser
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
@@ -3,12 +3,10 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-{{OS_VERSION}}
 
-ARG DOTNET_SDK_VERSION={{VARIABLES["sdk|5.0|build-version"]}}
-
 ENV `
     # Unset ASPNETCORE_URLS from aspnet base image
     ASPNETCORE_URLS= `
-    DOTNET_SDK_VERSION=$DOTNET_SDK_VERSION `
+    DOTNET_SDK_VERSION={{VARIABLES["sdk|5.0|build-version"]}} `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
@@ -16,8 +14,7 @@ ENV `
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}
 
-RUN `
-    powershell -Command "`
+RUN powershell -Command "`
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
@@ -44,10 +41,7 @@ RUN `
         Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
         Remove-Item -Path $Env:ProgramFiles\powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;"
 
-# In order to set system PATH, ContainerAdministrator must be used
-USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
-USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -23,3 +23,5 @@ $(McrTagsYmlTagGroup:5.0-nanoserver-1903)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-nanoserver-1809)
     customSubTableTitle: .NET 5.0 Preview Tags
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
+    customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -23,3 +23,5 @@ $(McrTagsYmlTagGroup:5.0-nanoserver-1903)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-nanoserver-1809)
     customSubTableTitle: .NET 5.0 Preview Tags
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
+    customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -21,3 +21,5 @@ $(McrTagsYmlTagGroup:5.0-nanoserver-1903)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-nanoserver-1809)
     customSubTableTitle: .NET 5.0 Preview Tags
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
+    customSubTableTitle: .NET 5.0 Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -1156,6 +1156,21 @@
               "variant": "v8"
             }
           ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "dockerfile": "src/runtime/5.0/windowsservercore-ltsc2019/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2019",
+              "tags": {
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+                "5.0-windowsservercore-ltsc2019": {}
+              }
+            }
+          ]
         }
       ]
     },
@@ -1862,6 +1877,24 @@
                 "5.0-focal-arm64v8": {}
               },
               "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/windowsservercore-ltsc2019/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2019",
+              "tags": {
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+                "5.0-windowsservercore-ltsc2019": {}
+              }
             }
           ]
         }
@@ -2600,6 +2633,24 @@
                 "5.0-focal-arm64v8": {}
               },
               "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(sdk|5.0|product-version)",
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/windowsservercore-ltsc2019/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2019",
+              "tags": {
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+                "5.0-windowsservercore-ltsc2019": {}
+              }
             }
           ]
         }

--- a/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf aspnetcore.zip; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf aspnetcore.zip; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf aspnetcore.zip; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf aspnetcore.zip; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN $aspnetcore_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/3.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-1903/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN $aspnetcore_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/3.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-1909/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN $aspnetcore_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/3.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-2004/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN $aspnetcore_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
         exit 1; `
     }; `
     `
-    Expand-Archive aspnetcore.zip -DestinationPath dotnet; `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
     Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,8 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-windowsservercore-ltsc2019
 
-ARG ASPNET_VERSION=5.0.0-rc.2.20473.3
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION 5.0.0-rc.2.20473.3
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `

--- a/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -1,0 +1,22 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+FROM $REPO:5.0-windowsservercore-ltsc2019
+
+ARG ASPNET_VERSION=5.0.0-rc.2.20473.3
+ENV ASPNET_VERSION $ASPNET_VERSION
+
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Install ASP.NET Core Runtime
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNET_VERSION/aspnetcore-runtime-$Env:ASPNET_VERSION-win-x64.zip; `
+        $aspnetcore_sha512 = 'b6e6c59d80ec48af488286282c6a1ba799a24cd24bebce90ea5261aa3768efe30294a4163adba81c7a97ef5cdfc0964fe05f818713a066215842769932173e9f'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip

--- a/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
@@ -14,7 +14,8 @@ RUN $dotnet_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1903/amd64/Dockerfile
@@ -14,7 +14,8 @@ RUN $dotnet_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1909/amd64/Dockerfile
@@ -14,7 +14,8 @@ RUN $dotnet_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-2004/amd64/Dockerfile
@@ -14,7 +14,8 @@ RUN $dotnet_version = '3.1.8'; `
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -2,14 +2,12 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
-ARG DOTNET_VERSION=5.0.0-rc.2.20472.7
-
 ENV `
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
-    DOTNET_VERSION=$DOTNET_VERSION
+    DOTNET_VERSION=5.0.0-rc.2.20472.7
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
@@ -23,7 +21,8 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        Expand-Archive dotnet.zip -DestinationPath 'C:\Program Files\dotnet'; `
+        mkdir $Env:ProgramFiles\dotnet; `
+        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -1,0 +1,29 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
+
+ARG DOTNET_VERSION=5.0.0-rc.2.20472.7
+
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    DOTNET_VERSION=$DOTNET_VERSION
+
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Install .NET
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
+        $dotnet_sha512 = 'eeb4c61d4c2b8db086d958328da4d18b775433889e3d703e3a3d222297b882e31ce3e82114ed1b9573149fbcb00cf675e71381568deff18b127558b6f03479f2'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        Expand-Archive dotnet.zip -DestinationPath 'C:\Program Files\dotnet'; `
+        Remove-Item -Force dotnet.zip
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
@@ -15,7 +15,8 @@ RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet
         exit 1; `
     }; `
     `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip
 
 

--- a/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1903/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1909/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-2004/amd64/Dockerfile
@@ -16,7 +16,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
@@ -17,7 +17,8 @@ RUN `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `
     }; `
-    Expand-Archive dotnet.zip -DestinationPath dotnet; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,12 +3,10 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:5.0-windowsservercore-ltsc2019
 
-ARG DOTNET_SDK_VERSION=5.0.100-rc.2.20473.16
-
 ENV `
     # Unset ASPNETCORE_URLS from aspnet base image
     ASPNETCORE_URLS= `
-    DOTNET_SDK_VERSION=$DOTNET_SDK_VERSION `
+    DOTNET_SDK_VERSION=5.0.100-rc.2.20473.16 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
@@ -16,8 +14,7 @@ ENV `
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2019
 
-RUN `
-    powershell -Command "`
+RUN powershell -Command "`
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
@@ -44,10 +41,7 @@ RUN `
         Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
         Remove-Item -Path $Env:ProgramFiles\powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;"
 
-# In order to set system PATH, ContainerAdministrator must be used
-USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
-USER ContainerUser
 
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -1,0 +1,53 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:5.0-windowsservercore-ltsc2019
+
+ARG DOTNET_SDK_VERSION=5.0.100-rc.2.20473.16
+
+ENV `
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= `
+    DOTNET_SDK_VERSION=$DOTNET_SDK_VERSION `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2019
+
+RUN `
+    powershell -Command "`
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
+        $dotnet_sha512 = '29a5006504076bac5cd8ed1c6584a8e97cc4812bbb230be0b4057c76f3cb385e1ae2b6366dc528d12c0bbbc7cb1302951b77455e3973adbd3055c5e13b14dd17'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '7.1.0-preview.7'; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_sha512 = 'c445ae1ae668c837fb6c05116576118e96b83fca6b7e62cb0303d9cf2a18737c9c4cc9432402ace3be78aba60979e2d0dba3fb209d88a3ab227ece6178b91439'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & $Env:ProgramFiles\dotnet\dotnet tool install --add-source . --tool-path $Env:ProgramFiles\powershell --version $powershell_version PowerShell.Windows.x64; `
+        & $Env:ProgramFiles\dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path $Env:ProgramFiles\powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;"
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
+USER ContainerUser
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Config.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/Config.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Docker.Tests
@@ -22,6 +23,8 @@ namespace Microsoft.DotNet.Docker.Tests
         public static string RepoPrefix { get; } = Environment.GetEnvironmentVariable("REPO_PREFIX") ?? string.Empty;
         public static string Registry { get; } =
             Environment.GetEnvironmentVariable("REGISTRY") ?? (string)Manifest.Value["registry"];
+        public static string Os { get; } =
+            Environment.GetEnvironmentVariable("IMAGE_OS") ?? string.Empty;
 
         private static bool GetIsNightlyRepo()
         {
@@ -35,5 +38,8 @@ namespace Microsoft.DotNet.Docker.Tests
             string manifestJson = File.ReadAllText(manifestPath);
             return JObject.Parse(manifestJson);
         }
+
+        public static string GetFilterRegexPattern(string filter) =>
+            $"^{Regex.Escape(filter).Replace(@"\*", ".*").Replace(@"\?", ".")}$";
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/Config.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/Config.cs
@@ -40,6 +40,6 @@ namespace Microsoft.DotNet.Docker.Tests
         }
 
         public static string GetFilterRegexPattern(string filter) =>
-            $"^{Regex.Escape(filter).Replace(@"\*", ".*").Replace(@"\?", ".")}$";
+            filter is null ? null : $"^{Regex.Escape(filter).Replace(@"\*", ".*").Replace(@"\?", ".")}$";
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/OS.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/OS.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public const string NanoServer1903 = "nanoserver-1903";
         public const string NanoServer1909 = "nanoserver-1909";
         public const string NanoServer2004 = "nanoserver-2004";
+        public const string ServerCoreLtsc2019 = "windowsservercore-ltsc2019";
 
         // Helpers
         public const string AlpinePrefix = "alpine";

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 .Select(imageData => new object[] { imageData });
         }
 
-        [Theory]
+        [SkippableTheory("windowsservercore-ltsc2019")]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetSample(SampleImageData imageData)
         {
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Docker.Tests
             });
         }
 
-        [Theory]
+        [SkippableTheory("windowsservercore-ltsc2019")]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAspnetSample(SampleImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public void VerifyPowerShellScenario_NonDefaultUser(ProductImageData imageData)
         {
             string optRunArgs = "-u 12345:12345"; // Linux containers test as non-root user
-            if (imageData.OS.Contains("nanoserver", StringComparison.OrdinalIgnoreCase))
+            if (!DockerHelper.IsLinuxContainerModeEnabled)
             {
                 // windows containers test as Admin, default execution is as ContainerUser
                 optRunArgs = "-u ContainerAdministrator ";

--- a/tests/Microsoft.DotNet.Docker.Tests/SkippableTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SkippableTheoryAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class SkippableTheoryAttribute : TheoryAttribute
+    {
+        public SkippableTheoryAttribute(params string[] skippedOperatingSystems)
+        {
+            if (!string.IsNullOrEmpty(Config.Os) && Config.Os != "*")
+            {
+                string osPattern =
+                    Config.Os != null ? Config.GetFilterRegexPattern(Config.Os) : null;
+                foreach (string skippedOperatingSystem in skippedOperatingSystems)
+                {
+                    if (Regex.IsMatch(skippedOperatingSystem, osPattern, RegexOptions.IgnoreCase))
+                    {
+                        Skip = $"{skippedOperatingSystem} is unsupported";
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -43,18 +43,19 @@ namespace Microsoft.DotNet.Docker.Tests
         };
         private static readonly ProductImageData[] s_windowsTestData =
         {
-            new ProductImageData { Version = V2_1, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V2_1, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V2_1, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V2_1, OS = OS.NanoServer2004, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V3_1, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V3_1, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V3_1, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V3_1, OS = OS.NanoServer2004, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V5_0, OS = OS.NanoServer1809, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V5_0, OS = OS.NanoServer1903, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V5_0, OS = OS.NanoServer1909, Arch = Arch.Amd64 },
-            new ProductImageData { Version = V5_0, OS = OS.NanoServer2004, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.NanoServer1809,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.NanoServer1903,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.NanoServer1909,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V2_1, OS = OS.NanoServer2004,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer1809,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer1903,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer1909,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V3_1, OS = OS.NanoServer2004,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V5_0, OS = OS.NanoServer1809,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V5_0, OS = OS.NanoServer1903,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V5_0, OS = OS.NanoServer1909,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V5_0, OS = OS.NanoServer2004,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V5_0, OS = OS.ServerCoreLtsc2019, Arch = Arch.Amd64 },
         };
         
         private static readonly SampleImageData[] s_linuxSampleTestData =
@@ -131,7 +132,7 @@ namespace Microsoft.DotNet.Docker.Tests
         private static string GetFilterRegexPattern(string filterEnvName)
         {
             string filter = Environment.GetEnvironmentVariable(filterEnvName);
-            return filter != null ? $"^{Regex.Escape(filter).Replace(@"\*", ".*").Replace(@"\?", ".")}$" : null;
+            return Config.GetFilterRegexPattern(filter);
         }
     }
 }

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -13,7 +13,8 @@
     "src/runtime/5.0/nanoserver-1809/amd64": 321408734,
     "src/runtime/5.0/nanoserver-1903/amd64": 326438075,
     "src/runtime/5.0/nanoserver-1909/amd64": 328083762,
-    "src/runtime/5.0/nanoserver-2004/amd64": 332279013
+    "src/runtime/5.0/nanoserver-2004/amd64": 332279013,
+    "src/runtime/5.0/windowsservercore-ltsc2019/amd64": 5179432868
   },
   "dotnet/core-nightly/aspnet": {
     "src/aspnet/2.1/nanoserver-1809/amd64": 387919601,
@@ -29,7 +30,8 @@
     "src/aspnet/5.0/nanoserver-1809/amd64": 341072949,
     "src/aspnet/5.0/nanoserver-1903/amd64": 346102290,
     "src/aspnet/5.0/nanoserver-1909/amd64": 347747977,
-    "src/aspnet/5.0/nanoserver-2004/amd64": 352472752
+    "src/aspnet/5.0/nanoserver-2004/amd64": 352472752,
+    "src/aspnet/5.0/windowsservercore-ltsc2019/amd64": 5230505064
   },
   "dotnet/core-nightly/sdk": {
     "src/sdk/2.1/nanoserver-1809/amd64": 1651068899,
@@ -45,6 +47,7 @@
     "src/sdk/5.0/nanoserver-1809/amd64": 782722955,
     "src/sdk/5.0/nanoserver-1903/amd64": 787755962,
     "src/sdk/5.0/nanoserver-1909/amd64": 789170333,
-    "src/sdk/5.0/nanoserver-2004/amd64": 820353958
+    "src/sdk/5.0/nanoserver-2004/amd64": 820353958,
+    "src/sdk/5.0/windowsservercore-ltsc2019/amd64": 5746263526
   }
 }


### PR DESCRIPTION
New Dockerfile templates are defined for Windows Server Core since the Nano Server templates are multi-stage while the Server Core templates can be single stage.

Related to #1852