### PR TITLE
Maintain generated tags with new ImageBuilder version

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -27,9 +27,9 @@ jobs:
       echo "##vso[task.setvariable variable=imageQueueTime]$(date --rfc-2822)"
     displayName: Set Publish Variables
   - script: >
-      $(runImageBuilderCmd) trimCachedPlatforms
+      $(runImageBuilderCmd) trimUnchangedPlatforms
       '$(artifactsPath)/image-info.json'
-    displayName: Trim Cached Images
+    displayName: Trim Unchanged Images
   - script: >
       $(runImageBuilderCmd) copyAcrImages
       '$(acr.servicePrincipalName)'

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:835340
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:835770
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:831194
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:835340
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/dockerfile-templates/aspnet/2.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/2.1/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
-FROM $REPO:2.1-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:2.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/eng/dockerfile-templates/aspnet/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/3.1/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
-FROM $REPO:3.1-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:3.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 # Install ASP.NET Core
 RUN aspnetcore_version={{VARIABLES["aspnet|3.1|build-version"]}} \

--- a/eng/dockerfile-templates/aspnet/3.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/3.1/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime
-FROM $REPO:3.1-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:3.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 # Install ASP.NET Core
 RUN aspnetcore_version={{VARIABLES["aspnet|3.1|build-version"]}} \

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 # Install ASP.NET Core
 ENV ASPNET_VERSION {{VARIABLES["aspnet|5.0|build-version"]}}

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
@@ -14,7 +14,7 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/eng/dockerfile-templates/runtime/2.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/2.1/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
-FROM $REPO:2.1-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:2.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
-FROM $REPO:3.1-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:3.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 # Install .NET Core
 RUN dotnet_version={{VARIABLES["runtime|3.1|build-version"]}} \

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/core/runtime-deps
-FROM $REPO:3.1-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:3.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 # Install .NET
 ENV DOTNET_VERSION {{VARIABLES["runtime|5.0|build-version"]}}

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -15,7 +15,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 
 
 # .NET runtime image
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 ARG DOTNET_VERSION
 
 ENV DOTNET_VERSION $DOTNET_VERSION

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image


### PR DESCRIPTION
References the new version of Image Builder that now always sets `ARCH_TAG_SUFFIX` template variable to a value, instead of leaving it blank for AMD64 arch.  This requires updates to the Dockerfile templates to compensate for this change, using conditional logic to only output an arch suffix if the arch is not AMD64.