### PR TITLE
Update Server Core Dockerfiles to reference latest 5.0 build

### DIFF
--- a/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-windowsservercore-ltsc2019
 
-ENV ASPNET_VERSION 5.0.0-rc.2.20473.3
+ENV ASPNET_VERSION 5.0.0-rc.2.20475.17
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
@@ -11,7 +11,7 @@ RUN powershell -Command `
         `
         # Install ASP.NET Core Runtime
         Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNET_VERSION/aspnetcore-runtime-$Env:ASPNET_VERSION-win-x64.zip; `
-        $aspnetcore_sha512 = 'b6e6c59d80ec48af488286282c6a1ba799a24cd24bebce90ea5261aa3768efe30294a4163adba81c7a97ef5cdfc0964fe05f818713a066215842769932173e9f'; `
+        $aspnetcore_sha512 = '0085b9fa0580a3e35e7bed3fbcce313750abed3acc62a2d9a295d4f2fa144434ef5b47e352d43586bb48fe356c4f3eb4eccb0edb8dd3e6f763dbf7e50963ea73'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -7,7 +7,7 @@ ENV `
     ASPNETCORE_URLS=http://+:80 `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
-    DOTNET_VERSION=5.0.0-rc.2.20472.7
+    DOTNET_VERSION=5.0.0-rc.2.20475.5
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
@@ -15,7 +15,7 @@ RUN powershell -Command `
         `
         # Install .NET
         Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
-        $dotnet_sha512 = 'eeb4c61d4c2b8db086d958328da4d18b775433889e3d703e3a3d222297b882e31ce3e82114ed1b9573149fbcb00cf675e71381568deff18b127558b6f03479f2'; `
+        $dotnet_sha512 = 'c30f33faacf5c2672339a29337984b7dbf64ba989a19396f9bb1858e5dfc4ce758787cae3c08580f864f30c491721d5a22a6f54ebd89deed1135b44181f901fe'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $REPO:5.0-windowsservercore-ltsc2019
 ENV `
     # Unset ASPNETCORE_URLS from aspnet base image
     ASPNETCORE_URLS= `
-    DOTNET_SDK_VERSION=5.0.100-rc.2.20473.16 `
+    DOTNET_SDK_VERSION=5.0.100-rc.2.20479.4 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
@@ -20,7 +20,7 @@ RUN powershell -Command "`
         `
         # Retrieve .NET SDK
         Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
-        $dotnet_sha512 = '29a5006504076bac5cd8ed1c6584a8e97cc4812bbb230be0b4057c76f3cb385e1ae2b6366dc528d12c0bbbc7cb1302951b77455e3973adbd3055c5e13b14dd17'; `
+        $dotnet_sha512 = 'c168e9a7bde629013bf617abafc72f7d72907ee478813558b82bda8e4203649f246504ff7cd0e8e5772acab53235aa7d307411ed73c82db95e538fde692f23f6'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `


### PR DESCRIPTION
An update was made in https://github.com/dotnet/dotnet-docker/pull/2267 without updating the new Server Core Dockerfiles.