### PR TITLE
Ensure all concrete tags have arch in name

### DIFF
--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -62,9 +62,9 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags
@@ -85,26 +85,26 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.
 

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -50,9 +50,9 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -58,9 +58,9 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags
@@ -81,26 +81,26 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -64,9 +64,9 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.100-rc.2-buster-slim, 5.0-buster-slim, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.100-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.100-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.100-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.100-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.100-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags
@@ -86,26 +86,26 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.
 

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 # Install ASP.NET Core
 ENV ASPNET_VERSION {{VARIABLES["aspnet|5.0|build-version"]}}

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
@@ -14,7 +14,7 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-{{OS_VERSION}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:5.0-{{OS_VERSION}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 ENV ASPNET_VERSION {{VARIABLES["aspnet|5.0|build-version"]}}
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
-FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 # Install .NET
 ENV DOTNET_VERSION {{VARIABLES["runtime|5.0|build-version"]}}

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -15,7 +15,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 
 
 # .NET runtime image
-FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG DOTNET_VERSION
 
 ENV DOTNET_VERSION $DOTNET_VERSION

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-{{OS_VERSION}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-{{OS_VERSION}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-{{OS_VERSION}}
+FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 ENV `
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -1,9 +1,9 @@
 $(McrTagsYmlRepo:aspnet)
-$(McrTagsYmlTagGroup:5.0-buster-slim)
+$(McrTagsYmlTagGroup:5.0-buster-slim-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-alpine3.12)
+$(McrTagsYmlTagGroup:5.0-alpine3.12-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal)
+$(McrTagsYmlTagGroup:5.0-focal-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm64v8)
     customSubTableTitle: .NET 5.0 Preview Tags
@@ -15,13 +15,13 @@ $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-focal-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-2004)
+$(McrTagsYmlTagGroup:5.0-nanoserver-2004-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1909)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1909-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1903)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1903-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
@@ -1,9 +1,9 @@
 $(McrTagsYmlRepo:runtime-deps)
-$(McrTagsYmlTagGroup:5.0-buster-slim)
+$(McrTagsYmlTagGroup:5.0-buster-slim-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-alpine3.12)
+$(McrTagsYmlTagGroup:5.0-alpine3.12-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal)
+$(McrTagsYmlTagGroup:5.0-focal-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm64v8)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -1,9 +1,9 @@
 $(McrTagsYmlRepo:runtime)
-$(McrTagsYmlTagGroup:5.0-buster-slim)
+$(McrTagsYmlTagGroup:5.0-buster-slim-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-alpine3.12)
+$(McrTagsYmlTagGroup:5.0-alpine3.12-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal)
+$(McrTagsYmlTagGroup:5.0-focal-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm64v8)
     customSubTableTitle: .NET 5.0 Preview Tags
@@ -15,13 +15,13 @@ $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-focal-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-2004)
+$(McrTagsYmlTagGroup:5.0-nanoserver-2004-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1909)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1909-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1903)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1903-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -1,9 +1,9 @@
 $(McrTagsYmlRepo:sdk)
-$(McrTagsYmlTagGroup:5.0-buster-slim)
+$(McrTagsYmlTagGroup:5.0-buster-slim-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-alpine3.12)
+$(McrTagsYmlTagGroup:5.0-alpine3.12-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-focal)
+$(McrTagsYmlTagGroup:5.0-focal-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm64v8)
     customSubTableTitle: .NET 5.0 Preview Tags
@@ -13,13 +13,13 @@ $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-focal-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-2004)
+$(McrTagsYmlTagGroup:5.0-nanoserver-2004-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1909)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1909-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1903)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1903-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019-amd64)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/pipelines/dotnet-core-nightly-pr.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr.yml
@@ -3,6 +3,7 @@ pr:
   branches:
     include:
     - nightly
+    - feature/*
   paths:
     include:
     - manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -396,8 +396,8 @@
               "os": "linux",
               "osVersion": "buster-slim",
               "tags": {
-                "$(dotnet|5.0|product-version)-buster-slim": {},
-                "5.0-buster-slim": {}
+                "$(dotnet|5.0|product-version)-buster-slim-amd64": {},
+                "5.0-buster-slim-amd64": {}
               }
             },
             {
@@ -435,9 +435,9 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(dotnet|5.0|product-version)-alpine3.12": {},
-                "5.0-alpine3.12": {},
-                "5.0-alpine": {}
+                "$(dotnet|5.0|product-version)-alpine3.12-amd64": {},
+                "5.0-alpine3.12-amd64": {},
+                "5.0-alpine-amd64": {}
               }
             }
           ]
@@ -469,8 +469,8 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(dotnet|5.0|product-version)-focal": {},
-                "5.0-focal": {}
+                "$(dotnet|5.0|product-version)-focal-amd64": {},
+                "5.0-focal-amd64": {}
               }
             }
           ]
@@ -974,8 +974,8 @@
               "os": "linux",
               "osVersion": "buster-slim",
               "tags": {
-                "$(dotnet|5.0|product-version)-buster-slim": {},
-                "5.0-buster-slim": {}
+                "$(dotnet|5.0|product-version)-buster-slim-amd64": {},
+                "5.0-buster-slim-amd64": {}
               }
             },
             {
@@ -1014,8 +1014,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
-                "5.0-nanoserver-1809": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
+                "5.0-nanoserver-1809-amd64": {}
               }
             },
             {
@@ -1024,8 +1024,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
-                "5.0-nanoserver-1903": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
+                "5.0-nanoserver-1903-amd64": {}
               }
             },
             {
@@ -1034,8 +1034,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
-                "5.0-nanoserver-1909": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
+                "5.0-nanoserver-1909-amd64": {}
               }
             },
             {
@@ -1044,8 +1044,8 @@
               "os": "windows",
               "osVersion": "nanoserver-2004",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
-                "5.0-nanoserver-2004": {}
+                "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
+                "5.0-nanoserver-2004-amd64": {}
               }
             }
           ]
@@ -1062,9 +1062,9 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(dotnet|5.0|product-version)-alpine3.12": {},
-                "5.0-alpine3.12": {},
-                "5.0-alpine": {}
+                "$(dotnet|5.0|product-version)-alpine3.12-amd64": {},
+                "5.0-alpine3.12-amd64": {},
+                "5.0-alpine-amd64": {}
               }
             }
           ]
@@ -1111,8 +1111,8 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(dotnet|5.0|product-version)-focal": {},
-                "5.0-focal": {}
+                "$(dotnet|5.0|product-version)-focal-amd64": {},
+                "5.0-focal-amd64": {}
               }
             }
           ]
@@ -1166,8 +1166,8 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
-                "5.0-windowsservercore-ltsc2019": {}
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019-amd64": {},
+                "5.0-windowsservercore-ltsc2019-amd64": {}
               }
             }
           ]
@@ -1685,8 +1685,8 @@
               "os": "linux",
               "osVersion": "buster-slim",
               "tags": {
-                "$(dotnet|5.0|product-version)-buster-slim": {},
-                "5.0-buster-slim": {}
+                "$(dotnet|5.0|product-version)-buster-slim-amd64": {},
+                "5.0-buster-slim-amd64": {}
               }
             },
             {
@@ -1728,8 +1728,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
-                "5.0-nanoserver-1809": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
+                "5.0-nanoserver-1809-amd64": {}
               }
             },
             {
@@ -1741,8 +1741,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
-                "5.0-nanoserver-1903": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
+                "5.0-nanoserver-1903-amd64": {}
               }
             },
             {
@@ -1754,8 +1754,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
-                "5.0-nanoserver-1909": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
+                "5.0-nanoserver-1909-amd64": {}
               }
             },
             {
@@ -1767,8 +1767,8 @@
               "os": "windows",
               "osVersion": "nanoserver-2004",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
-                "5.0-nanoserver-2004": {}
+                "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
+                "5.0-nanoserver-2004-amd64": {}
               }
             }
           ]
@@ -1785,9 +1785,9 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(dotnet|5.0|product-version)-alpine3.12": {},
-                "5.0-alpine3.12": {},
-                "5.0-alpine": {}
+                "$(dotnet|5.0|product-version)-alpine3.12-amd64": {},
+                "5.0-alpine3.12-amd64": {},
+                "5.0-alpine-amd64": {}
               }
             }
           ]
@@ -1834,8 +1834,8 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(dotnet|5.0|product-version)-focal": {},
-                "5.0-focal": {}
+                "$(dotnet|5.0|product-version)-focal-amd64": {},
+                "5.0-focal-amd64": {}
               }
             }
           ]
@@ -1892,8 +1892,8 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
-                "5.0-windowsservercore-ltsc2019": {}
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019-amd64": {},
+                "5.0-windowsservercore-ltsc2019-amd64": {}
               }
             }
           ]
@@ -2471,8 +2471,8 @@
               "os": "linux",
               "osVersion": "buster-slim",
               "tags": {
-                "$(sdk|5.0|product-version)-buster-slim": {},
-                "5.0-buster-slim": {}
+                "$(sdk|5.0|product-version)-buster-slim-amd64": {},
+                "5.0-buster-slim-amd64": {}
               }
             },
             {
@@ -2514,8 +2514,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-1809": {},
-                "5.0-nanoserver-1809": {}
+                "$(sdk|5.0|product-version)-nanoserver-1809-amd64": {},
+                "5.0-nanoserver-1809-amd64": {}
               }
             },
             {
@@ -2527,8 +2527,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-1903": {},
-                "5.0-nanoserver-1903": {}
+                "$(sdk|5.0|product-version)-nanoserver-1903-amd64": {},
+                "5.0-nanoserver-1903-amd64": {}
               }
             },
             {
@@ -2540,8 +2540,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-1909": {},
-                "5.0-nanoserver-1909": {}
+                "$(sdk|5.0|product-version)-nanoserver-1909-amd64": {},
+                "5.0-nanoserver-1909-amd64": {}
               }
             },
             {
@@ -2553,8 +2553,8 @@
               "os": "windows",
               "osVersion": "nanoserver-2004",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-2004": {},
-                "5.0-nanoserver-2004": {}
+                "$(sdk|5.0|product-version)-nanoserver-2004-amd64": {},
+                "5.0-nanoserver-2004-amd64": {}
               }
             }
           ]
@@ -2571,9 +2571,9 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(sdk|5.0|product-version)-alpine3.12": {},
-                "5.0-alpine3.12": {},
-                "5.0-alpine": {}
+                "$(sdk|5.0|product-version)-alpine3.12-amd64": {},
+                "5.0-alpine3.12-amd64": {},
+                "5.0-alpine-amd64": {}
               }
             }
           ]
@@ -2590,8 +2590,8 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(sdk|5.0|product-version)-focal": {},
-                "5.0-focal": {}
+                "$(sdk|5.0|product-version)-focal-amd64": {},
+                "5.0-focal-amd64": {}
               }
             }
           ]
@@ -2648,8 +2648,8 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
-                "5.0-windowsservercore-ltsc2019": {}
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019-amd64": {},
+                "5.0-windowsservercore-ltsc2019-amd64": {}
               }
             }
           ]

--- a/src/aspnet/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/aspnet/5.0/alpine3.12/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:5.0-alpine3.12
+FROM $REPO:5.0-alpine3.12-amd64
 
 # Install ASP.NET Core
 ENV ASPNET_VERSION 5.0.0-rc.2.20475.17

--- a/src/aspnet/5.0/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-buster-slim
+FROM $REPO:5.0-buster-slim-amd64
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/focal/amd64/Dockerfile
+++ b/src/aspnet/5.0/focal/amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-focal
+FROM $REPO:5.0-focal-amd64
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-1809
+FROM $REPO:5.0-nanoserver-1809-amd64
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-1903
+FROM $REPO:5.0-nanoserver-1903-amd64
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-1909
+FROM $REPO:5.0-nanoserver-1909-amd64
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-2004
+FROM $REPO:5.0-nanoserver-2004-amd64
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:5.0-windowsservercore-ltsc2019
+FROM $REPO:5.0-windowsservercore-ltsc2019-amd64
 
 ENV ASPNET_VERSION 5.0.0-rc.2.20475.17
 

--- a/src/runtime/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.12/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
-FROM $REPO:5.0-alpine3.12
+FROM $REPO:5.0-alpine3.12-amd64
 
 # Install .NET
 ENV DOTNET_VERSION 5.0.0-rc.2.20475.5

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 
 
 # .NET runtime image
-FROM $REPO:5.0-buster-slim
+FROM $REPO:5.0-buster-slim-amd64
 ARG DOTNET_VERSION
 
 ENV DOTNET_VERSION $DOTNET_VERSION

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 
 
 # .NET runtime image
-FROM $REPO:5.0-focal
+FROM $REPO:5.0-focal-amd64
 ARG DOTNET_VERSION
 
 ENV DOTNET_VERSION $DOTNET_VERSION

--- a/src/sdk/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/sdk/5.0/alpine3.12/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-alpine3.12
+FROM $REPO:5.0-alpine3.12-amd64
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/5.0/buster-slim/amd64/Dockerfile
+++ b/src/sdk/5.0/buster-slim/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-buster-slim
+FROM $REPO:5.0-buster-slim-amd64
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/5.0/focal/amd64/Dockerfile
+++ b/src/sdk/5.0/focal/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-focal
+FROM $REPO:5.0-focal-amd64
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-1809
+FROM $REPO:5.0-nanoserver-1809-amd64
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-1903
+FROM $REPO:5.0-nanoserver-1903-amd64
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-1909
+FROM $REPO:5.0-nanoserver-1909-amd64
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-2004
+FROM $REPO:5.0-nanoserver-2004-amd64
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-windowsservercore-ltsc2019
+FROM $REPO:5.0-windowsservercore-ltsc2019-amd64
 
 ENV `
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -98,7 +98,10 @@ namespace Microsoft.DotNet.Docker.Tests
             return $"{registry}{repo}:{tag}";
         }
 
-        protected string GetTagName(string tagPrefix, string os)
+        protected string GetTagName(string tagPrefix, string os) =>
+            $"{tagPrefix}-{os}{GetArchTagSuffix()}";
+
+        protected virtual string GetArchTagSuffix()
         {
             string arch = string.Empty;
             if (Arch == Arch.Arm)
@@ -110,7 +113,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 arch = "-arm64v8";
             }
 
-            return $"{tagPrefix}-{os}{arch}";
+            return arch;
         }
 
         private static string GetRegistryName(string repo, string tag)

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -104,5 +104,15 @@ namespace Microsoft.DotNet.Docker.Tests
 
             return GetTagName(imageVersion.ToString(2), os);
         }
+
+        protected override string GetArchTagSuffix()
+        {
+            if (Arch == Arch.Amd64 && Version.Major >= 5)
+            {
+                return "-amd64";
+            }
+
+            return base.GetArchTagSuffix();
+        }
     }
 }


### PR DESCRIPTION
The first phase of #2182 is to update all existing concrete 5.0 tags so that they explicitly include an architecture suffix.