### PR TITLE
Define multi-arch tags for each Linux distro

### DIFF
--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -63,7 +63,7 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.0-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
@@ -71,7 +71,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -85,25 +85,25 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004-amd64, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909-amd64, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903-amd64, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809-amd64, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -85,26 +85,26 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.
 

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -104,7 +104,7 @@ Tag | Dockerfile
 Tag | Dockerfile
 ---------| ---------------
 5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.
 

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -62,49 +62,49 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile) | Debian 10
-5.0.0-rc.2-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile) | Debian 10
+5.0.0-rc.2-focal-arm32v7, 5.0-focal-arm32v7, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ## Windows Server, version 2004 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.
 

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -85,25 +85,25 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004-amd64, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909-amd64, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903-amd64, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809-amd64, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -51,7 +51,7 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0.0-rc.2-buster-slim, 5.0, 5.0-buster-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.0-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
@@ -59,7 +59,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2, 5.0.0-rc.2-buster-slim, 5.0, 5.0-buster-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -50,24 +50,24 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0.0-rc.2-buster-slim, 5.0, 5.0-buster-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2, 5.0.0-rc.2-buster-slim, 5.0, 5.0-buster-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile) | Debian 10
-5.0.0-rc.2-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm32v7/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-rc.2, 5.0.0-rc.2-buster-slim, 5.0, 5.0-buster-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile) | Debian 10
+5.0.0-rc.2-focal-arm32v7, 5.0-focal-arm32v7, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime-deps at https://mcr.microsoft.com/v2/dotnet/nightly/runtime-deps/tags/list.
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -81,25 +81,25 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004-amd64, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909-amd64, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903-amd64, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809-amd64, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -59,7 +59,7 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.0-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
@@ -67,7 +67,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -100,7 +100,7 @@ Tag | Dockerfile
 Tag | Dockerfile
 ---------| ---------------
 5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -58,49 +58,49 @@ docker run --rm mcr.microsoft.com/dotnet/core/samples
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
-5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
+5.0.0-rc.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0-alpine-arm64v8, 5.0.0-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
+5.0.0-rc.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/arm32v7/Dockerfile) | Debian 10
-5.0.0-rc.2-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
+5.0.0-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.0-rc.2-buster-slim, 5.0-buster-slim, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/buster-slim/arm32v7/Dockerfile) | Debian 10
+5.0.0-rc.2-focal-arm32v7, 5.0-focal-arm32v7, 5.0.0-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ## Windows Server, version 2004 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.
 

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -81,25 +81,25 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004-amd64, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909-amd64, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903-amd64, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809-amd64, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -81,26 +81,26 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.0-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -64,48 +64,48 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.100-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.100-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
-5.0.100-rc.2-focal-amd64, 5.0-focal-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+5.0.100-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.100-rc.2-buster-slim, 5.0-buster-slim, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/amd64/Dockerfile) | Debian 10
+5.0.100-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.100-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.100-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.100-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.100-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.100-rc.2-focal-arm64v8, 5.0-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
+5.0.100-rc.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.100-rc.2-buster-slim, 5.0-buster-slim, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/arm64v8/Dockerfile) | Debian 10
+5.0.100-rc.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.100-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags
 ##### .NET 5.0 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.100-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/arm32v7/Dockerfile) | Debian 10
-5.0.100-rc.2-focal-arm32v7, 5.0-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
+5.0.100-rc.2-buster-slim-arm32v7, 5.0-buster-slim-arm32v7, 5.0.100-rc.2-buster-slim, 5.0-buster-slim, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/arm32v7/Dockerfile) | Debian 10
+5.0.100-rc.2-focal-arm32v7, 5.0-focal-arm32v7, 5.0.100-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ## Windows Server, version 2004 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.100-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.100-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.100-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.100-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -86,26 +86,26 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.
 

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -86,25 +86,25 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.100-rc.2-nanoserver-2004, 5.0-nanoserver-2004, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-2004-amd64, 5.0.100-rc.2-nanoserver-2004, 5.0-nanoserver-2004-amd64, 5.0-nanoserver-2004, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.100-rc.2-nanoserver-1909, 5.0-nanoserver-1909, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1909-amd64, 5.0.100-rc.2-nanoserver-1909, 5.0-nanoserver-1909-amd64, 5.0-nanoserver-1909, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.100-rc.2-nanoserver-1903, 5.0-nanoserver-1903, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1903-amd64, 5.0.100-rc.2-nanoserver-1903, 5.0-nanoserver-1903-amd64, 5.0-nanoserver-1903, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1809-amd64, 5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809-amd64, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.100-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -65,7 +65,7 @@ The [.NET Core Docker samples](https://github.com/dotnet/dotnet-docker/blob/mast
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.100-rc.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.100-rc.2-buster-slim, 5.0-buster-slim, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.100-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.100-rc.2-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
+5.0.100-rc.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0-alpine-amd64, 5.0.100-rc.2-alpine3.12, 5.0-alpine3.12, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.100-rc.2-focal-amd64, 5.0-focal-amd64, 5.0.100-rc.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -86,25 +86,25 @@ Tags | Dockerfile | OS Version
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-2004-amd64, 5.0.100-rc.2-nanoserver-2004, 5.0-nanoserver-2004-amd64, 5.0-nanoserver-2004, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-2004-amd64, 5.0-nanoserver-2004-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile)
 
 ## Windows Server, version 1909 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1909-amd64, 5.0.100-rc.2-nanoserver-1909, 5.0-nanoserver-1909-amd64, 5.0-nanoserver-1909, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1909-amd64, 5.0-nanoserver-1909-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1903-amd64, 5.0.100-rc.2-nanoserver-1903, 5.0-nanoserver-1903-amd64, 5.0-nanoserver-1903, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1903-amd64, 5.0-nanoserver-1903-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
-5.0.100-rc.2-nanoserver-1809-amd64, 5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809-amd64, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
+5.0.100-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.100-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -105,7 +105,7 @@ Tag | Dockerfile
 Tag | Dockerfile
 ---------| ---------------
 5.0.100-rc.2-nanoserver-1809-amd64, 5.0-nanoserver-1809-amd64, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
-5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64, 5.0.100-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+5.0.0-rc.2-windowsservercore-ltsc2019-amd64, 5.0-windowsservercore-ltsc2019-amd64 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.
 

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:842810
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:844171
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:839862
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:842810
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:835770
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:839862
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}
 
 ENV ASPNET_VERSION {{VARIABLES["aspnet|5.0|build-version"]}}
 

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $REPO:5.0-{{OS_VERSION}}
 
 ENV `
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -15,13 +15,13 @@ $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-focal-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-2004-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-2004)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1909-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1909)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1903-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1903)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1809-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019-amd64)
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -15,13 +15,13 @@ $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-focal-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-2004-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-2004)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1909-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1909)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1903-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1903)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1809-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019-amd64)
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -13,13 +13,13 @@ $(McrTagsYmlTagGroup:5.0-buster-slim-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-focal-arm32v7)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-2004-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-2004)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1909-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1909)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1903-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1903)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-nanoserver-1809-amd64)
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
     customSubTableTitle: .NET 5.0 Preview Tags
-$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019-amd64)
+$(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -1192,10 +1192,6 @@
           ]
         },
         {
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
-            "5.0-windowsservercore-ltsc2019": {}
-          },
           "productVersion": "$(dotnet|5.0|product-version)",
           "platforms": [
             {
@@ -1958,10 +1954,6 @@
         },
         {
           "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
-            "5.0-windowsservercore-ltsc2019": {}
-          },
           "platforms": [
             {
               "buildArgs": {
@@ -2761,10 +2753,6 @@
         },
         {
           "productVersion": "$(sdk|5.0|product-version)",
-          "sharedTags": {
-            "$(sdk|5.0|product-version)-windowsservercore-ltsc2019": {},
-            "5.0-windowsservercore-ltsc2019": {}
-          },
           "platforms": [
             {
               "buildArgs": {

--- a/manifest.json
+++ b/manifest.json
@@ -1011,6 +1011,7 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
                 "5.0-nanoserver-1809-amd64": {},
                 "5.0-nanoserver-1809": {}
               }
@@ -1022,6 +1023,7 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
                 "5.0-nanoserver-1903-amd64": {},
                 "5.0-nanoserver-1903": {}
               }
@@ -1033,6 +1035,7 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
                 "5.0-nanoserver-1909-amd64": {},
                 "5.0-nanoserver-1909": {}
               }
@@ -1044,6 +1047,7 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
                 "5.0-nanoserver-2004-amd64": {},
                 "5.0-nanoserver-2004": {}
               }
@@ -1771,6 +1775,7 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
                 "5.0-nanoserver-1809-amd64": {},
                 "5.0-nanoserver-1809": {}
               }
@@ -1785,6 +1790,7 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
                 "5.0-nanoserver-1903-amd64": {},
                 "5.0-nanoserver-1903": {}
               }
@@ -1799,6 +1805,7 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
                 "5.0-nanoserver-1909-amd64": {},
                 "5.0-nanoserver-1909": {}
               }
@@ -1813,6 +1820,7 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
+                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
                 "5.0-nanoserver-2004-amd64": {},
                 "5.0-nanoserver-2004": {}
               }
@@ -2603,6 +2611,7 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1809-amd64": {},
+                "$(sdk|5.0|product-version)-nanoserver-1809": {},
                 "5.0-nanoserver-1809-amd64": {},
                 "5.0-nanoserver-1809": {}
               }
@@ -2617,6 +2626,7 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1903-amd64": {},
+                "$(sdk|5.0|product-version)-nanoserver-1903": {},
                 "5.0-nanoserver-1903-amd64": {},
                 "5.0-nanoserver-1903": {}
               }
@@ -2631,6 +2641,7 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1909-amd64": {},
+                "$(sdk|5.0|product-version)-nanoserver-1909": {},
                 "5.0-nanoserver-1909-amd64": {},
                 "5.0-nanoserver-1909": {}
               }
@@ -2645,6 +2656,7 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-2004-amd64": {},
+                "$(sdk|5.0|product-version)-nanoserver-2004": {},
                 "5.0-nanoserver-2004-amd64": {},
                 "5.0-nanoserver-2004": {}
               }

--- a/manifest.json
+++ b/manifest.json
@@ -1011,9 +1011,7 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
-                "5.0-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809": {}
+                "5.0-nanoserver-1809-amd64": {}
               }
             },
             {
@@ -1023,9 +1021,7 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
-                "5.0-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903": {}
+                "5.0-nanoserver-1903-amd64": {}
               }
             },
             {
@@ -1035,9 +1031,7 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
-                "5.0-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909": {}
+                "5.0-nanoserver-1909-amd64": {}
               }
             },
             {
@@ -1047,9 +1041,7 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
-                "5.0-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004": {}
+                "5.0-nanoserver-2004-amd64": {}
               }
             }
           ]
@@ -1775,9 +1767,7 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
-                "5.0-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809": {}
+                "5.0-nanoserver-1809-amd64": {}
               }
             },
             {
@@ -1790,9 +1780,7 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
-                "5.0-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903": {}
+                "5.0-nanoserver-1903-amd64": {}
               }
             },
             {
@@ -1805,9 +1793,7 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
-                "5.0-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909": {}
+                "5.0-nanoserver-1909-amd64": {}
               }
             },
             {
@@ -1820,9 +1806,7 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
-                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
-                "5.0-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004": {}
+                "5.0-nanoserver-2004-amd64": {}
               }
             }
           ]
@@ -2611,9 +2595,7 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1809-amd64": {},
-                "$(sdk|5.0|product-version)-nanoserver-1809": {},
-                "5.0-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809": {}
+                "5.0-nanoserver-1809-amd64": {}
               }
             },
             {
@@ -2626,9 +2608,7 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1903-amd64": {},
-                "$(sdk|5.0|product-version)-nanoserver-1903": {},
-                "5.0-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903": {}
+                "5.0-nanoserver-1903-amd64": {}
               }
             },
             {
@@ -2641,9 +2621,7 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1909-amd64": {},
-                "$(sdk|5.0|product-version)-nanoserver-1909": {},
-                "5.0-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909": {}
+                "5.0-nanoserver-1909-amd64": {}
               }
             },
             {
@@ -2656,9 +2634,7 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-2004-amd64": {},
-                "$(sdk|5.0|product-version)-nanoserver-2004": {},
-                "5.0-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004": {}
+                "5.0-nanoserver-2004-amd64": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -1010,8 +1010,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
+                "5.0-nanoserver-1809": {}
               }
             },
             {
@@ -1020,8 +1020,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
+                "5.0-nanoserver-1903": {}
               }
             },
             {
@@ -1030,8 +1030,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
+                "5.0-nanoserver-1909": {}
               }
             },
             {
@@ -1040,8 +1040,8 @@
               "os": "windows",
               "osVersion": "nanoserver-2004",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
+                "5.0-nanoserver-2004": {}
               }
             }
           ]
@@ -1200,8 +1200,8 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019-amd64": {},
-                "5.0-windowsservercore-ltsc2019-amd64": {}
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+                "5.0-windowsservercore-ltsc2019": {}
               }
             }
           ]
@@ -1762,8 +1762,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
+                "5.0-nanoserver-1809": {}
               }
             },
             {
@@ -1775,8 +1775,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1903": {},
+                "5.0-nanoserver-1903": {}
               }
             },
             {
@@ -1788,8 +1788,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-1909": {},
+                "5.0-nanoserver-1909": {}
               }
             },
             {
@@ -1801,8 +1801,8 @@
               "os": "windows",
               "osVersion": "nanoserver-2004",
               "tags": {
-                "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004-amd64": {}
+                "$(dotnet|5.0|product-version)-nanoserver-2004": {},
+                "5.0-nanoserver-2004": {}
               }
             }
           ]
@@ -1964,8 +1964,8 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019-amd64": {},
-                "5.0-windowsservercore-ltsc2019-amd64": {}
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+                "5.0-windowsservercore-ltsc2019": {}
               }
             }
           ]
@@ -2586,8 +2586,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809-amd64": {}
+                "$(sdk|5.0|product-version)-nanoserver-1809": {},
+                "5.0-nanoserver-1809": {}
               }
             },
             {
@@ -2599,8 +2599,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1903",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903-amd64": {}
+                "$(sdk|5.0|product-version)-nanoserver-1903": {},
+                "5.0-nanoserver-1903": {}
               }
             },
             {
@@ -2612,8 +2612,8 @@
               "os": "windows",
               "osVersion": "nanoserver-1909",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909-amd64": {}
+                "$(sdk|5.0|product-version)-nanoserver-1909": {},
+                "5.0-nanoserver-1909": {}
               }
             },
             {
@@ -2625,8 +2625,8 @@
               "os": "windows",
               "osVersion": "nanoserver-2004",
               "tags": {
-                "$(sdk|5.0|product-version)-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004-amd64": {}
+                "$(sdk|5.0|product-version)-nanoserver-2004": {},
+                "5.0-nanoserver-2004": {}
               }
             }
           ]
@@ -2763,8 +2763,8 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019-amd64": {},
-                "5.0-windowsservercore-ltsc2019-amd64": {}
+                "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+                "5.0-windowsservercore-ltsc2019": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -386,7 +386,9 @@
           "productVersion": "$(dotnet|5.0|product-version)",
           "sharedTags": {
             "$(dotnet|5.0|product-version)": {},
+            "$(dotnet|5.0|product-version)-buster-slim": {},
             "5.0": {},
+            "5.0-buster-slim": {},
             "latest": {}
           },
           "platforms": [
@@ -428,6 +430,10 @@
         },
         {
           "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine": {}
+          },
           "platforms": [
             {
               "dockerfile": "src/runtime-deps/3.1/alpine3.12/amd64",
@@ -439,12 +445,7 @@
                 "5.0-alpine3.12-amd64": {},
                 "5.0-alpine-amd64": {}
               }
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm64",
               "dockerfile": "src/runtime-deps/3.1/alpine3.12/arm64v8",
@@ -462,6 +463,10 @@
         },
         {
           "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-focal": {},
+            "5.0-focal": {}
+          },
           "platforms": [
             {
               "dockerfile": "src/runtime-deps/3.1/focal/amd64",
@@ -472,12 +477,7 @@
                 "$(dotnet|5.0|product-version)-focal-amd64": {},
                 "5.0-focal-amd64": {}
               }
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm",
               "dockerfile": "src/runtime-deps/3.1/focal/arm32v7",
@@ -489,12 +489,7 @@
                 "5.0-focal-arm32v7": {}
               },
               "variant": "v7"
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm64",
               "dockerfile": "src/runtime-deps/3.1/focal/arm64v8",
@@ -1051,7 +1046,123 @@
           ]
         },
         {
+          "id": "buster-slim",
           "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-buster-slim": {},
+            "5.0-buster-slim": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/buster-slim/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {}
+            },
+            {
+              "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(Repo:runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/buster-slim/arm32v7",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {},
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:runtime-deps)"
+              },
+              "dockerfile": "src/runtime/5.0/buster-slim/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {},
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1809",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-1809": {},
+            "5.0-nanoserver-1809": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-1809/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1903",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-1903": {},
+            "5.0-nanoserver-1903": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-1903/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1909",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-1909": {},
+            "5.0-nanoserver-1909": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-1909/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-2004",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-2004": {},
+            "5.0-nanoserver-2004": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/runtime/5.0/nanoserver-2004/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-2004",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine": {}
+          },
           "platforms": [
             {
               "buildArgs": {
@@ -1066,12 +1177,7 @@
                 "5.0-alpine3.12-amd64": {},
                 "5.0-alpine-amd64": {}
               }
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm64",
               "buildArgs": {
@@ -1101,6 +1207,10 @@
         },
         {
           "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-focal": {},
+            "5.0-focal": {}
+          },
           "platforms": [
             {
               "buildArgs": {
@@ -1114,12 +1224,7 @@
                 "$(dotnet|5.0|product-version)-focal-amd64": {},
                 "5.0-focal-amd64": {}
               }
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm",
               "buildArgs": {
@@ -1134,12 +1239,7 @@
                 "5.0-focal-arm32v7": {}
               },
               "variant": "v7"
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm64",
               "buildArgs": {
@@ -1158,6 +1258,10 @@
           ]
         },
         {
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+            "5.0-windowsservercore-ltsc2019": {}
+          },
           "productVersion": "$(dotnet|5.0|product-version)",
           "platforms": [
             {
@@ -1774,7 +1878,135 @@
           ]
         },
         {
+          "id": "buster-slim",
           "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-buster-slim": {},
+            "5.0-buster-slim": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/buster-slim/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {}
+            },
+            {
+              "architecture": "arm",
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/buster-slim/arm32v7",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {},
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/buster-slim/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {},
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1809",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-1809": {},
+            "5.0-nanoserver-1809": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-1809/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1903",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-1903": {},
+            "5.0-nanoserver-1903": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-1903/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1909",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-1909": {},
+            "5.0-nanoserver-1909": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-1909/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-2004",
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-nanoserver-2004": {},
+            "5.0-nanoserver-2004": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-2004/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-2004",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine": {}
+          },
           "platforms": [
             {
               "buildArgs": {
@@ -1789,12 +2021,7 @@
                 "5.0-alpine3.12-amd64": {},
                 "5.0-alpine-amd64": {}
               }
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm64",
               "buildArgs": {
@@ -1824,6 +2051,10 @@
         },
         {
           "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-focal": {},
+            "5.0-focal": {}
+          },
           "platforms": [
             {
               "buildArgs": {
@@ -1837,12 +2068,7 @@
                 "$(dotnet|5.0|product-version)-focal-amd64": {},
                 "5.0-focal-amd64": {}
               }
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm",
               "buildArgs": {
@@ -1857,12 +2083,7 @@
                 "5.0-focal-arm32v7": {}
               },
               "variant": "v7"
-            }
-          ]
-        },
-        {
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "platforms": [
+            },
             {
               "architecture": "arm64",
               "buildArgs": {
@@ -1882,6 +2103,10 @@
         },
         {
           "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)-windowsservercore-ltsc2019": {},
+            "5.0-windowsservercore-ltsc2019": {}
+          },
           "platforms": [
             {
               "buildArgs": {
@@ -2560,7 +2785,135 @@
           ]
         },
         {
+          "id": "buster-slim",
           "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-buster-slim": {},
+            "5.0-buster-slim": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/buster-slim/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {}
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "architecture": "arm",
+              "dockerfile": "src/sdk/5.0/buster-slim/arm32v7",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {},
+              "variant": "v7"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "architecture": "arm64",
+              "dockerfile": "src/sdk/5.0/buster-slim/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {},
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1809",
+          "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-nanoserver-1809": {},
+            "5.0-nanoserver-1809": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-1809/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1903",
+          "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-nanoserver-1903": {},
+            "5.0-nanoserver-1903": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-1903/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1903",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-1909",
+          "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-nanoserver-1909": {},
+            "5.0-nanoserver-1909": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-1909/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1909",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "id": "nanoserver-2004",
+          "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-nanoserver-2004": {},
+            "5.0-nanoserver-2004": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-2004/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-2004",
+              "tags": {}
+            }
+          ]
+        },
+        {
+          "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine": {}
+          },
           "platforms": [
             {
               "buildArgs": {
@@ -2580,6 +2933,10 @@
         },
         {
           "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-focal": {},
+            "5.0-focal": {}
+          },
           "platforms": [
             {
               "buildArgs": {
@@ -2593,12 +2950,7 @@
                 "$(sdk|5.0|product-version)-focal-amd64": {},
                 "5.0-focal-amd64": {}
               }
-            }
-          ]
-        },
-        {
-          "productVersion": "$(sdk|5.0|product-version)",
-          "platforms": [
+            },
             {
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
@@ -2613,12 +2965,7 @@
                 "5.0-focal-arm32v7": {}
               },
               "variant": "v7"
-            }
-          ]
-        },
-        {
-          "productVersion": "$(sdk|5.0|product-version)",
-          "platforms": [
+            },
             {
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
@@ -2638,6 +2985,10 @@
         },
         {
           "productVersion": "$(sdk|5.0|product-version)",
+          "sharedTags": {
+            "$(sdk|5.0|product-version)-windowsservercore-ltsc2019": {},
+            "5.0-windowsservercore-ltsc2019": {}
+          },
           "platforms": [
             {
               "buildArgs": {

--- a/manifest.json
+++ b/manifest.json
@@ -432,6 +432,7 @@
           "productVersion": "$(dotnet|5.0|product-version)",
           "sharedTags": {
             "$(dotnet|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine3.12": {},
             "5.0-alpine": {}
           },
           "platforms": [
@@ -1161,6 +1162,7 @@
           "productVersion": "$(dotnet|5.0|product-version)",
           "sharedTags": {
             "$(dotnet|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine3.12": {},
             "5.0-alpine": {}
           },
           "platforms": [
@@ -2005,6 +2007,7 @@
           "productVersion": "$(dotnet|5.0|product-version)",
           "sharedTags": {
             "$(dotnet|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine3.12": {},
             "5.0-alpine": {}
           },
           "platforms": [
@@ -2912,6 +2915,7 @@
           "productVersion": "$(sdk|5.0|product-version)",
           "sharedTags": {
             "$(sdk|5.0|product-version)-alpine3.12": {},
+            "5.0-alpine3.12": {},
             "5.0-alpine": {}
           },
           "platforms": [

--- a/manifest.json
+++ b/manifest.json
@@ -1011,7 +1011,8 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809-amd64": {}
+                "5.0-nanoserver-1809-amd64": {},
+                "5.0-nanoserver-1809": {}
               }
             },
             {
@@ -1021,7 +1022,8 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903-amd64": {}
+                "5.0-nanoserver-1903-amd64": {},
+                "5.0-nanoserver-1903": {}
               }
             },
             {
@@ -1031,7 +1033,8 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909-amd64": {}
+                "5.0-nanoserver-1909-amd64": {},
+                "5.0-nanoserver-1909": {}
               }
             },
             {
@@ -1041,7 +1044,8 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004-amd64": {}
+                "5.0-nanoserver-2004-amd64": {},
+                "5.0-nanoserver-2004": {}
               }
             }
           ]
@@ -1087,74 +1091,6 @@
               "osVersion": "buster-slim",
               "tags": {},
               "variant": "v8"
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1809",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-1809": {},
-            "5.0-nanoserver-1809": {}
-          },
-          "platforms": [
-            {
-              "dockerfile": "src/runtime/5.0/nanoserver-1809/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1809",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1903",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-1903": {},
-            "5.0-nanoserver-1903": {}
-          },
-          "platforms": [
-            {
-              "dockerfile": "src/runtime/5.0/nanoserver-1903/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1903",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1909",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-1909": {},
-            "5.0-nanoserver-1909": {}
-          },
-          "platforms": [
-            {
-              "dockerfile": "src/runtime/5.0/nanoserver-1909/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1909",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-2004",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-2004": {},
-            "5.0-nanoserver-2004": {}
-          },
-          "platforms": [
-            {
-              "dockerfile": "src/runtime/5.0/nanoserver-2004/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-2004",
-              "tags": {}
             }
           ]
         },
@@ -1835,7 +1771,8 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809-amd64": {}
+                "5.0-nanoserver-1809-amd64": {},
+                "5.0-nanoserver-1809": {}
               }
             },
             {
@@ -1848,7 +1785,8 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903-amd64": {}
+                "5.0-nanoserver-1903-amd64": {},
+                "5.0-nanoserver-1903": {}
               }
             },
             {
@@ -1861,7 +1799,8 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909-amd64": {}
+                "5.0-nanoserver-1909-amd64": {},
+                "5.0-nanoserver-1909": {}
               }
             },
             {
@@ -1874,7 +1813,8 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(dotnet|5.0|product-version)-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004-amd64": {}
+                "5.0-nanoserver-2004-amd64": {},
+                "5.0-nanoserver-2004": {}
               }
             }
           ]
@@ -1920,86 +1860,6 @@
               "osVersion": "buster-slim",
               "tags": {},
               "variant": "v8"
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1809",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-1809": {},
-            "5.0-nanoserver-1809": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/aspnet/5.0/nanoserver-1809/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1809",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1903",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-1903": {},
-            "5.0-nanoserver-1903": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/aspnet/5.0/nanoserver-1903/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1903",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1909",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-1909": {},
-            "5.0-nanoserver-1909": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/aspnet/5.0/nanoserver-1909/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1909",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-2004",
-          "productVersion": "$(dotnet|5.0|product-version)",
-          "sharedTags": {
-            "$(dotnet|5.0|product-version)-nanoserver-2004": {},
-            "5.0-nanoserver-2004": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/aspnet/5.0/nanoserver-2004/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-2004",
-              "tags": {}
             }
           ]
         },
@@ -2743,7 +2603,8 @@
               "osVersion": "nanoserver-1809",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1809-amd64": {},
-                "5.0-nanoserver-1809-amd64": {}
+                "5.0-nanoserver-1809-amd64": {},
+                "5.0-nanoserver-1809": {}
               }
             },
             {
@@ -2756,7 +2617,8 @@
               "osVersion": "nanoserver-1903",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1903-amd64": {},
-                "5.0-nanoserver-1903-amd64": {}
+                "5.0-nanoserver-1903-amd64": {},
+                "5.0-nanoserver-1903": {}
               }
             },
             {
@@ -2769,7 +2631,8 @@
               "osVersion": "nanoserver-1909",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-1909-amd64": {},
-                "5.0-nanoserver-1909-amd64": {}
+                "5.0-nanoserver-1909-amd64": {},
+                "5.0-nanoserver-1909": {}
               }
             },
             {
@@ -2782,7 +2645,8 @@
               "osVersion": "nanoserver-2004",
               "tags": {
                 "$(sdk|5.0|product-version)-nanoserver-2004-amd64": {},
-                "5.0-nanoserver-2004-amd64": {}
+                "5.0-nanoserver-2004-amd64": {},
+                "5.0-nanoserver-2004": {}
               }
             }
           ]
@@ -2828,86 +2692,6 @@
               "osVersion": "buster-slim",
               "tags": {},
               "variant": "v8"
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1809",
-          "productVersion": "$(sdk|5.0|product-version)",
-          "sharedTags": {
-            "$(sdk|5.0|product-version)-nanoserver-1809": {},
-            "5.0-nanoserver-1809": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "dockerfile": "src/sdk/5.0/nanoserver-1809/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1809",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1903",
-          "productVersion": "$(sdk|5.0|product-version)",
-          "sharedTags": {
-            "$(sdk|5.0|product-version)-nanoserver-1903": {},
-            "5.0-nanoserver-1903": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "dockerfile": "src/sdk/5.0/nanoserver-1903/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1903",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-1909",
-          "productVersion": "$(sdk|5.0|product-version)",
-          "sharedTags": {
-            "$(sdk|5.0|product-version)-nanoserver-1909": {},
-            "5.0-nanoserver-1909": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "dockerfile": "src/sdk/5.0/nanoserver-1909/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-1909",
-              "tags": {}
-            }
-          ]
-        },
-        {
-          "id": "nanoserver-2004",
-          "productVersion": "$(sdk|5.0|product-version)",
-          "sharedTags": {
-            "$(sdk|5.0|product-version)-nanoserver-2004": {},
-            "5.0-nanoserver-2004": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "dockerfile": "src/sdk/5.0/nanoserver-2004/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
-              "os": "windows",
-              "osVersion": "nanoserver-2004",
-              "tags": {}
             }
           ]
         },

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-1809-amd64
+FROM $REPO:5.0-nanoserver-1809
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1903/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-1903-amd64
+FROM $REPO:5.0-nanoserver-1903
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-1909-amd64
+FROM $REPO:5.0-nanoserver-1909
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 
 
 # ASP.NET Core image
-FROM $REPO:5.0-nanoserver-2004-amd64
+FROM $REPO:5.0-nanoserver-2004
 ARG ASPNET_VERSION
 
 ENV ASPNET_VERSION $ASPNET_VERSION

--- a/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:5.0-windowsservercore-ltsc2019-amd64
+FROM $REPO:5.0-windowsservercore-ltsc2019
 
 ENV ASPNET_VERSION 5.0.0-rc.2.20475.17
 

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-1809-amd64
+FROM $REPO:5.0-nanoserver-1809
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1903/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-1903-amd64
+FROM $REPO:5.0-nanoserver-1903
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-1909-amd64
+FROM $REPO:5.0-nanoserver-1909
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN `
     Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
 
 # SDK image
-FROM $REPO:5.0-nanoserver-2004-amd64
+FROM $REPO:5.0-nanoserver-2004
 ARG DOTNET_SDK_VERSION
 
 ENV `

--- a/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:5.0-windowsservercore-ltsc2019-amd64
+FROM $REPO:5.0-windowsservercore-ltsc2019
 
 ENV `
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         protected override string GetArchTagSuffix()
         {
-            if (Arch == Arch.Amd64 && Version.Major >= 5)
+            if (Arch == Arch.Amd64 && Version.Major >= 5 && DockerHelper.IsLinuxContainerModeEnabled)
             {
                 return "-amd64";
             }


### PR DESCRIPTION
Defines a multi-arch tag for each Linux distro for 5.0.  Because of limitations in the manifest schema, this required duplicating the platforms in order to assign them a distinct set of shared tags.

Related to #2182