### PR TITLE
Pipeline to validate PR without caching

### DIFF
--- a/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
@@ -23,3 +23,4 @@ stages:
   parameters:
     buildMatrixType: platformVersionedOs
     buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies
+    noCache: true

--- a/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
@@ -1,0 +1,25 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - nightly
+  paths:
+    include:
+    - eng/*
+    - tests/*
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies


### PR DESCRIPTION
Defines a new pipeline YAML file that is intended to be used to validate PRs without caching enabled.  The pipeline should only build/test a subset of the images.  Rather than defining that subset within the YAML, I felt it more appropriate to define it in the variables of the build definition in AzDO where it can be more easily adjusted as necessary.  See https://github.com/dotnet/dotnet-docker/issues/2247#issuecomment-704325852 for the suggested set of paths to use.

This pipeline is configured to be triggered only by changes to the eng and tests folders.  A change to the src folder would likely end up causing a cache miss in the existing PR pipeline so this one wouldn't need to run in that case.  The primary use case for this pipeline is to validate infrastructure changes in the eng folder.

Fixes #2247