### PR TITLE
Define more granular PR pipelines

### DIFF
--- a/eng/pipelines/dotnet-core-nightly-pr-2.1.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-2.1.yml
@@ -7,7 +7,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/aspnet/2.1/*
     - src/runtime/2.1/*

--- a/eng/pipelines/dotnet-core-nightly-pr-2.1.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-2.1.yml
@@ -1,0 +1,34 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - nightly
+    - feature/*
+  paths:
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/aspnet/2.1/*
+    - src/runtime/2.1/*
+    - src/runtime-deps/2.1/*
+    - src/sdk/2.1/*
+    - tests/*
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/2.1/*'
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies

--- a/eng/pipelines/dotnet-core-nightly-pr-3.1.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-3.1.yml
@@ -7,7 +7,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/aspnet/3.1/*
     - src/runtime/3.1/*

--- a/eng/pipelines/dotnet-core-nightly-pr-3.1.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-3.1.yml
@@ -1,0 +1,34 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - nightly
+    - feature/*
+  paths:
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/aspnet/3.1/*
+    - src/runtime/3.1/*
+    - src/runtime-deps/3.1/*
+    - src/sdk/3.1/*
+    - tests/*
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/3.1/*'
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies

--- a/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
@@ -7,7 +7,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/aspnet/5.0/*
     - src/runtime/5.0/*

--- a/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
@@ -1,0 +1,34 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - nightly
+    - feature/*
+  paths:
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/aspnet/5.0/*
+    - src/runtime/5.0/*
+    - src/runtime-deps/5.0/*
+    - src/sdk/5.0/*
+    - tests/*
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/5.0/*'
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies

--- a/eng/pipelines/dotnet-core-nightly-pr-monitor.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-monitor.yml
@@ -7,7 +7,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/monitor/*
     - tests/*

--- a/eng/pipelines/dotnet-core-nightly-pr-monitor.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-monitor.yml
@@ -1,0 +1,31 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - nightly
+    - feature/*
+  paths:
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/monitor/*
+    - tests/*
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/3.1/alpine*/amd64' --path 'src/monitor/*'
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies

--- a/eng/pipelines/dotnet-core-pr-2.1.yml
+++ b/eng/pipelines/dotnet-core-pr-2.1.yml
@@ -1,0 +1,33 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/aspnet/2.1/*
+    - src/runtime/2.1/*
+    - src/runtime-deps/2.1/*
+    - src/sdk/2.1/*
+    - tests/*
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/2.1/*'
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies

--- a/eng/pipelines/dotnet-core-pr-2.1.yml
+++ b/eng/pipelines/dotnet-core-pr-2.1.yml
@@ -6,7 +6,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/aspnet/2.1/*
     - src/runtime/2.1/*

--- a/eng/pipelines/dotnet-core-pr-3.1.yml
+++ b/eng/pipelines/dotnet-core-pr-3.1.yml
@@ -8,7 +8,10 @@ pr:
     - manifest.json
     - manifest.versions.json
     - eng/*
-    - src/*
+    - src/aspnet/3.1/*
+    - src/runtime/3.1/*
+    - src/runtime-deps/3.1/*
+    - src/sdk/3.1/*
     - tests/*
 
 resources:
@@ -20,6 +23,8 @@ resources:
 
 variables:
 - template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/3.1/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-pr-3.1.yml
+++ b/eng/pipelines/dotnet-core-pr-3.1.yml
@@ -6,7 +6,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/aspnet/3.1/*
     - src/runtime/3.1/*

--- a/eng/pipelines/dotnet-core-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-pr-5.0.yml
@@ -2,14 +2,16 @@ trigger: none
 pr:
   branches:
     include:
-    - nightly
-    - feature/*
+    - master
   paths:
     include:
     - manifest.json
     - manifest.versions.json
     - eng/*
-    - src/*
+    - src/aspnet/5.0/*
+    - src/runtime/5.0/*
+    - src/runtime-deps/5.0/*
+    - src/sdk/5.0/*
     - tests/*
 
 resources:
@@ -21,6 +23,8 @@ resources:
 
 variables:
 - template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/5.0/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-pr-5.0.yml
@@ -6,7 +6,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/aspnet/5.0/*
     - src/runtime/5.0/*

--- a/eng/pipelines/dotnet-core-pr-monitor.yml
+++ b/eng/pipelines/dotnet-core-pr-monitor.yml
@@ -1,0 +1,30 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - eng/*
+    - src/monitor/*
+    - tests/*
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+- name: imageBuilder.pathArgs
+  value: --path 'src/*/3.1/alpine*/amd64' --path 'src/monitor/*'
+
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    buildMatrixType: platformVersionedOs
+    buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies

--- a/eng/pipelines/dotnet-core-pr-monitor.yml
+++ b/eng/pipelines/dotnet-core-pr-monitor.yml
@@ -6,7 +6,6 @@ pr:
   paths:
     include:
     - manifest.json
-    - manifest.versions.json
     - eng/*
     - src/monitor/*
     - tests/*


### PR DESCRIPTION
Breaks up the single PR pipeline that we had into more granular pipelines that are triggered by changes to specific folders in the repo.  This allows us to only run builds for .NET Core 2.1, 3.1, 5.0, or the monitor images based on which Dockerfiles had changed.

Fixes #2161