### PR TITLE
Add back nanoserver-1809 support for 5.0

### DIFF
--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -97,6 +97,7 @@ Tag | Dockerfile
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
+5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -93,6 +93,7 @@ Tag | Dockerfile
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
+5.0.0-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.0-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -98,6 +98,7 @@ Tag | Dockerfile
 ##### .NET 5.0 Preview Tags
 Tag | Dockerfile
 ---------| ---------------
+5.0.100-rc.2-nanoserver-1809, 5.0-nanoserver-1809, 5.0.100-rc.2, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile)
 5.0.0-rc.2-windowsservercore-ltsc2019, 5.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -19,5 +19,7 @@ $(McrTagsYmlTagGroup:5.0-nanoserver-2004)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-nanoserver-1909)
     customSubTableTitle: .NET 5.0 Preview Tags
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
+    customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -19,5 +19,7 @@ $(McrTagsYmlTagGroup:5.0-nanoserver-2004)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-nanoserver-1909)
     customSubTableTitle: .NET 5.0 Preview Tags
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
+    customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -17,5 +17,7 @@ $(McrTagsYmlTagGroup:5.0-nanoserver-2004)
     customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-nanoserver-1909)
     customSubTableTitle: .NET 5.0 Preview Tags
+$(McrTagsYmlTagGroup:5.0-nanoserver-1809)
+    customSubTableTitle: .NET 5.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-windowsservercore-ltsc2019)
     customSubTableTitle: .NET 5.0 Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -1005,6 +1005,16 @@
               "variant": "v8"
             },
             {
+              "dockerfile": "src/runtime/5.0/nanoserver-1809/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
+                "5.0-nanoserver-1809": {}
+              }
+            },
+            {
               "dockerfile": "src/runtime/5.0/nanoserver-1909/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver",
               "os": "windows",
@@ -1732,6 +1742,19 @@
                 "5.0-buster-slim-arm64v8": {}
               },
               "variant": "v8"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/5.0/nanoserver-1809/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "$(dotnet|5.0|product-version)-nanoserver-1809": {},
+                "5.0-nanoserver-1809": {}
+              }
             },
             {
               "buildArgs": {
@@ -2530,6 +2553,19 @@
                 "5.0-buster-slim-arm64v8": {}
               },
               "variant": "v8"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/sdk/5.0/nanoserver-1809/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "$(sdk|5.0|product-version)-nanoserver-1809": {},
+                "5.0-nanoserver-1809": {}
+              }
             },
             {
               "buildArgs": {

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -1,0 +1,31 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG ASPNET_VERSION=5.0.0-rc.2.20475.17
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+ARG ASPNET_VERSION
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Install ASP.NET Core Runtime
+RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNET_VERSION/aspnetcore-runtime-$Env:ASPNET_VERSION-win-x64.zip; `
+    $aspnetcore_sha512 = '0085b9fa0580a3e35e7bed3fbcce313750abed3acc62a2d9a295d4f2fa144434ef5b47e352d43586bb48fe356c4f3eb4eccb0edb8dd3e6f763dbf7e50963ea73'; `
+    if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+    tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+    Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:5.0-nanoserver-1809
+ARG ASPNET_VERSION
+
+ENV ASPNET_VERSION $ASPNET_VERSION
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
@@ -1,0 +1,40 @@
+# escape=`
+
+ARG DOTNET_VERSION=5.0.0-rc.2.20475.5
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+ARG DOTNET_VERSION
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Retrieve .NET Runtime
+RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
+    $dotnet_sha512 = 'c30f33faacf5c2672339a29337984b7dbf64ba989a19396f9bb1858e5dfc4ce758787cae3c08580f864f30c491721d5a22a6f54ebd89deed1135b44181f901fe'; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
+    Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
+ARG DOTNET_VERSION
+
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    DOTNET_VERSION=$DOTNET_VERSION
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -1,0 +1,67 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG DOTNET_SDK_VERSION=5.0.100-rc.2.20479.15
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+ARG DOTNET_SDK_VERSION
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN `
+    # Retrieve .NET SDK
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
+    $dotnet_sha512 = '49ea4f9e0fdc51bfd46b1269b84dd09f26be957c3a81c80203a0b0d521c8ec190d0d2d631a4e1899c83b604bf9a529698f19eccdf4aed3d0fd2f89102f6556e1'; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    mkdir dotnet; `
+    tar -C dotnet -oxzf dotnet.zip; `
+    Remove-Item -Force dotnet.zip; `
+    `
+    # Install PowerShell global tool
+    $powershell_version = '7.1.0-rc.1'; `
+    Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+    $powershell_sha512 = '11548549314d2e940210ef1d79b6948ca14a6ad1296591ad115a292b4003ff5090ea376b2d7957c00b88b153c9e043b95cf91e3ff20bd74c6e8ba44a763ec957'; `
+    if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+    \dotnet\dotnet nuget locals all --clear; `
+    Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+    Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+    `
+    # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+    Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','templates','shared' -Path dotnet `
+        | Remove-Item -Force -Recurse; `
+    Get-ChildItem -Exclude Microsoft.WindowsDesktop.App -Path dotnet\shared | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:5.0-nanoserver-1809
+ARG DOTNET_SDK_VERSION
+
+ENV `
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= `
+    DOTNET_SDK_VERSION=$DOTNET_SDK_VERSION `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-1809
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -51,6 +51,7 @@ namespace Microsoft.DotNet.Docker.Tests
             new ProductImageData { Version = V3_1, OS = OS.NanoServer1903,     Arch = Arch.Amd64 },
             new ProductImageData { Version = V3_1, OS = OS.NanoServer1909,     Arch = Arch.Amd64 },
             new ProductImageData { Version = V3_1, OS = OS.NanoServer2004,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V5_0, OS = OS.NanoServer1809,     Arch = Arch.Amd64 },
             new ProductImageData { Version = V5_0, OS = OS.NanoServer1909,     Arch = Arch.Amd64 },
             new ProductImageData { Version = V5_0, OS = OS.NanoServer2004,     Arch = Arch.Amd64 },
             new ProductImageData { Version = V5_0, OS = OS.ServerCoreLtsc2019, Arch = Arch.Amd64 },

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -10,6 +10,7 @@
     "src/runtime/3.1/nanoserver-2004/amd64": 333119873
   },
   "dotnet/nightly/runtime": {
+    "src/runtime/5.0/nanoserver-1809/amd64": 321408734,
     "src/runtime/5.0/nanoserver-1909/amd64": 328083762,
     "src/runtime/5.0/nanoserver-2004/amd64": 332279013,
     "src/runtime/5.0/windowsservercore-ltsc2019/amd64": 5179432868
@@ -25,11 +26,13 @@
     "src/aspnet/3.1/nanoserver-2004/amd64": 352805234
   },
   "dotnet/nightly/aspnet": {
+    "src/aspnet/5.0/nanoserver-1809/amd64": 341072949,
     "src/aspnet/5.0/nanoserver-1909/amd64": 347747977,
     "src/aspnet/5.0/nanoserver-2004/amd64": 352472752,
     "src/aspnet/5.0/windowsservercore-ltsc2019/amd64": 5230505064
   },
   "dotnet/core-nightly/sdk": {
+    "src/sdk/5.0/nanoserver-1809/amd64": 782722955,
     "src/sdk/2.1/nanoserver-1809/amd64": 1651068899,
     "src/sdk/2.1/nanoserver-1903/amd64": 1666573518,
     "src/sdk/2.1/nanoserver-1909/amd64": 1672306130,


### PR DESCRIPTION
This PR adds back .NET 5.0 support for nanoserver-1809 which was recently removed in https://github.com/dotnet/dotnet-docker/pull/2298