### PR TITLE
Remove unused documentationGroups from the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,12 +16,8 @@
         {
           "productVersion": "$(dotnet|2.1|product-version)",
           "sharedTags": {
-            "$(dotnet|2.1|product-version)": {
-              "documentationGroup": "2.1"
-            },
-            "2.1": {
-              "documentationGroup": "2.1"
-            }
+            "$(dotnet|2.1|product-version)": {},
+            "2.1": {}
           },
           "platforms": [
             {
@@ -30,12 +26,8 @@
               "os": "linux",
               "osVersion": "stretch-slim",
               "tags": {
-                "$(dotnet|2.1|product-version)-stretch-slim": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-stretch-slim": {
-                  "documentationGroup": "2.1"
-                }
+                "$(dotnet|2.1|product-version)-stretch-slim": {},
+                "2.1-stretch-slim": {}
               }
             },
             {
@@ -45,12 +37,8 @@
               "os": "linux",
               "osVersion": "stretch-slim",
               "tags": {
-                "$(dotnet|2.1|product-version)-stretch-slim-arm32v7": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-stretch-slim-arm32v7": {
-                  "documentationGroup": "2.1"
-                }
+                "$(dotnet|2.1|product-version)-stretch-slim-arm32v7": {},
+                "2.1-stretch-slim-arm32v7": {}
               },
               "variant": "v7"
             }
@@ -65,15 +53,9 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(dotnet|2.1|product-version)-alpine3.12": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-alpine3.12": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-alpine": {
-                  "documentationGroup": "2.1"
-                }
+                "$(dotnet|2.1|product-version)-alpine3.12": {},
+                "2.1-alpine3.12": {},
+                "2.1-alpine": {}
               }
             }
           ]
@@ -87,12 +69,8 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "$(dotnet|2.1|product-version)-bionic": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-bionic": {
-                  "documentationGroup": "2.1"
-                }
+                "$(dotnet|2.1|product-version)-bionic": {},
+                "2.1-bionic": {}
               }
             }
           ]
@@ -107,12 +85,8 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "$(dotnet|2.1|product-version)-bionic-arm32v7": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-bionic-arm32v7": {
-                  "documentationGroup": "2.1"
-                }
+                "$(dotnet|2.1|product-version)-bionic-arm32v7": {},
+                "2.1-bionic-arm32v7": {}
               },
               "variant": "v7"
             }
@@ -127,12 +101,8 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(dotnet|2.1|product-version)-focal": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-focal": {
-                  "documentationGroup": "2.1"
-                }
+                "$(dotnet|2.1|product-version)-focal": {},
+                "2.1-focal": {}
               }
             }
           ]
@@ -147,12 +117,8 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(dotnet|2.1|product-version)-focal-arm32v7": {
-                  "documentationGroup": "2.1"
-                },
-                "2.1-focal-arm32v7": {
-                  "documentationGroup": "2.1"
-                }
+                "$(dotnet|2.1|product-version)-focal-arm32v7": {},
+                "2.1-focal-arm32v7": {}
               },
               "variant": "v7"
             }
@@ -161,12 +127,8 @@
         {
           "productVersion": "$(dotnet|3.1|product-version)",
           "sharedTags": {
-            "$(dotnet|3.1|product-version)": {
-              "documentationGroup": "3.1"
-            },
-            "3.1": {
-              "documentationGroup": "3.1"
-            }
+            "$(dotnet|3.1|product-version)": {},
+            "3.1": {}
           },
           "platforms": [
             {
@@ -175,12 +137,8 @@
               "os": "linux",
               "osVersion": "buster-slim",
               "tags": {
-                "$(dotnet|3.1|product-version)-buster-slim": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-buster-slim": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-buster-slim": {},
+                "3.1-buster-slim": {}
               }
             },
             {
@@ -190,12 +148,8 @@
               "os": "linux",
               "osVersion": "buster-slim",
               "tags": {
-                "$(dotnet|3.1|product-version)-buster-slim-arm32v7": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-buster-slim-arm32v7": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-buster-slim-arm32v7": {},
+                "3.1-buster-slim-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -206,12 +160,8 @@
               "os": "linux",
               "osVersion": "buster-slim",
               "tags": {
-                "$(dotnet|3.1|product-version)-buster-slim-arm64v8": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-buster-slim-arm64v8": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-buster-slim-arm64v8": {},
+                "3.1-buster-slim-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -226,15 +176,9 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(dotnet|3.1|product-version)-alpine3.12": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-alpine3.12": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-alpine": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-alpine3.12": {},
+                "3.1-alpine3.12": {},
+                "3.1-alpine": {}
               }
             }
           ]
@@ -249,15 +193,9 @@
               "os": "linux",
               "osVersion": "alpine3.12",
               "tags": {
-                "$(dotnet|3.1|product-version)-alpine3.12-arm64v8": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-alpine3.12-arm64v8": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-alpine-arm64v8": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-alpine3.12-arm64v8": {},
+                "3.1-alpine3.12-arm64v8": {},
+                "3.1-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -272,12 +210,8 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "$(dotnet|3.1|product-version)-bionic": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-bionic": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-bionic": {},
+                "3.1-bionic": {}
               }
             }
           ]
@@ -292,12 +226,8 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "$(dotnet|3.1|product-version)-bionic-arm32v7": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-bionic-arm32v7": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-bionic-arm32v7": {},
+                "3.1-bionic-arm32v7": {}
               },
               "variant": "v7"
             }
@@ -313,12 +243,8 @@
               "os": "linux",
               "osVersion": "bionic",
               "tags": {
-                "$(dotnet|3.1|product-version)-bionic-arm64v8": {
-                  "documentationGroup": "3.1"
-                },
-                "3.1-bionic-arm64v8": {
-                  "documentationGroup": "3.1"
-                }
+                "$(dotnet|3.1|product-version)-bionic-arm64v8": {},
+                "3.1-bionic-arm64v8": {}
               },
               "variant": "v8"
             }


### PR DESCRIPTION
I don't think these are needed any longer. They were needed when we were sharing the runtime-deps between multiple versions.  This pattern has been replaced with defining multiple manifest entries in order to avoid rebuilding the runtime-deps when they haven't changed.