### PR TITLE
Update version resolution logic

### DIFF
--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -12,15 +12,19 @@ sudo apt-get update && \
 
 curl -SLo sdk.zip https://aka.ms/dotnet/$channel/Sdk/dotnet-sdk-win-x64.zip
 
-commitSha=$(unzip -p sdk.zip "sdk/*/.version" | cat | head -1)
-# Remove last character (end-of-line)
-commitSha=${commitSha%?}
-sdkVer=$(unzip -p sdk.zip "sdk/*/.version" | cat | head -2 | tail -1)
+unzip -p sdk.zip "sdk/*/.version" > sdkversion
+
+commitSha=$(cat sdkversion | head -1)
+commitSha=${commitSha%?} # Remove last character (newline)
+
+sdkVer=$(cat sdkversion | head -2 | tail -1)
+
+rm sdkversion
 
 curl -SLo versionDetails.xml https://raw.githubusercontent.com/dotnet/installer/$commitSha/eng/Version.Details.xml
 
 runtimeVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'Microsoft.NETCore.App.Internal\']/@Version\) versionDetails.xml)
-aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[contains\(@Name,\'VS.Redist.Common.AspNetCore.TargetingPack.x64\'\)]/@Version\) versionDetails.xml)
+aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[contains\(@Name,\'Microsoft.AspNetCore.App.Ref.Internal\'\)]/@Version\) versionDetails.xml)
 
 rm sdk.zip
 rm versionDetails.xml

--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -24,7 +24,7 @@ rm sdkversion
 curl -SLo versionDetails.xml https://raw.githubusercontent.com/dotnet/installer/$commitSha/eng/Version.Details.xml
 
 runtimeVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'Microsoft.NETCore.App.Internal\']/@Version\) versionDetails.xml)
-aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[contains\(@Name,\'Microsoft.AspNetCore.App.Ref.Internal\'\)]/@Version\) versionDetails.xml)
+aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'Microsoft.AspNetCore.App.Ref.Internal\']/@Version\) versionDetails.xml)
 
 rm sdk.zip
 rm versionDetails.xml

--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -7,13 +7,23 @@ set -u
 
 channel=$1
 
+sudo apt-get update && \
+    sudo apt-get install -y --no-install-recommends libxml2-utils
+
 curl -SLo sdk.zip https://aka.ms/dotnet/$channel/Sdk/dotnet-sdk-win-x64.zip
 
+commitSha=$(unzip -p sdk.zip "sdk/*/.version" | cat | head -1)
+# Remove last character (end-of-line)
+commitSha=${commitSha%?}
 sdkVer=$(unzip -p sdk.zip "sdk/*/.version" | cat | head -2 | tail -1)
-runtimeVer=$(unzip -p sdk.zip "shared/Microsoft.NETCore.App/*/.version" | cat | tail -1)
-aspnetVer=$(unzip -p sdk.zip "shared/Microsoft.AspNetCore.App/*/.version" | cat | tail -1)
+
+curl -SLo versionDetails.xml https://raw.githubusercontent.com/dotnet/installer/$commitSha/eng/Version.Details.xml
+
+runtimeVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'Microsoft.NETCore.App.Internal\']/@Version\) versionDetails.xml)
+aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[contains\(@Name,\'VS.Redist.Common.AspNetCore.TargetingPack.x64\'\)]/@Version\) versionDetails.xml)
 
 rm sdk.zip
+rm versionDetails.xml
 
 echo "##vso[task.setvariable variable=sdkVer]$sdkVer"
 echo "##vso[task.setvariable variable=runtimeVer]$runtimeVer"

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -25,9 +25,6 @@ stages:
     - script: >
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
         $(dockerfileVersion)
-        --user $(dotnetDockerBot.userName)
-        --email $(dotnetDockerBot.email)
-        --password $(BotAccount-dotnet-docker-bot-PAT)
         --product-version runtime=$(runtimeVer)
         --product-version sdk=$(sdkVer)
         --product-version aspnet=$(aspnetVer)

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -25,6 +25,9 @@ stages:
     - script: >
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
         $(dockerfileVersion)
+        --user $(dotnetDockerBot.userName)
+        --email $(dotnetDockerBot.email)
+        --password $(BotAccount-dotnet-docker-bot-PAT)
         --product-version runtime=$(runtimeVer)
         --product-version sdk=$(sdkVer)
         --product-version aspnet=$(aspnetVer)

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -29,12 +29,12 @@ namespace Dotnet.Docker
         private static readonly Dictionary<string, Dictionary<string, string>> s_releaseChecksumCache =
              new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> s_urls = new Dictionary<string, string> {
-            {"powershell", "https://pwshtool.blob.core.windows.net/tool/$VERSION/PowerShell.$OS.$ARCH.$VERSION.nupkg"},
-            {"monitor", "https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor5.0/dotnet-monitor.$VERSION.nupkg"},
-            {"runtime", "https://dotnetcli.azureedge.net/dotnet/Runtime/$VERSION/dotnet-runtime-$VERSION-$OS-$ARCH.$ARCHIVE_EXT"},
-            {"aspnet", "https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VERSION/aspnetcore-runtime-$VERSION-$OS-$ARCH.$ARCHIVE_EXT"},
-            {"sdk", "https://dotnetcli.azureedge.net/dotnet/Sdk/$VERSION/dotnet-sdk-$VERSION-$OS-$ARCH.$ARCHIVE_EXT"},
-            {"lzma", "https://dotnetcli.azureedge.net/dotnet/Sdk/$VERSION/nuGetPackagesArchive.lzma"}
+            {"powershell", "https://pwshtool.blob.core.windows.net/tool/$VERSION_DIR/PowerShell.$OS.$ARCH.$VERSION_FILE.nupkg"},
+            {"monitor", "https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor5.0/dotnet-monitor.$VERSION_FILE.nupkg"},
+            {"runtime", "https://dotnetcli.azureedge.net/dotnet/Runtime/$VERSION_DIR/dotnet-runtime-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"},
+            {"aspnet", "https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VERSION_DIR/aspnetcore-runtime-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"},
+            {"sdk", "https://dotnetcli.azureedge.net/dotnet/Sdk/$VERSION_DIR/dotnet-sdk-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"},
+            {"lzma", "https://dotnetcli.azureedge.net/dotnet/Sdk/$VERSION_DIR/nuGetPackagesArchive.lzma"}
         };
 
         private string _productName;
@@ -98,9 +98,19 @@ namespace Dotnet.Docker
 
             usedBuildInfos = new IDependencyInfo[] { productInfo };
 
+            const string RtmSubstring = "-rtm.";
+
+            string versionDir = _buildVersion;
+            string versionFile = _buildVersion;
+            if (versionFile.Contains(RtmSubstring))
+            {
+                versionFile = versionFile.Substring(0, versionFile.IndexOf(RtmSubstring));
+            }
+
             string downloadUrl = s_urls[_productName]
                 .Replace("$ARCHIVE_EXT", _os.Contains("win") ? "zip" : "tar.gz")
-                .Replace("$VERSION", _buildVersion)
+                .Replace("$VERSION_DIR", versionDir)
+                .Replace("$VERSION_FILE", versionFile)
                 .Replace("$OS", _os)
                 .Replace("$ARCH", _arch)
                 .Replace("..", ".");


### PR DESCRIPTION
When nearing release, .NET switches to stable branding for its versioning scheme.  This means that the versions of shared frameworks contained in the SDK zip file are not build-specific.  In the case of the upcoming 5.0 release, the versions of runtime and ASP.NET Core being referenced are just labeled as 5.0.0.  This breaks the existing logic in the `get-drop-versions.sh` script because it relies on this value being build-specific in order to generate the correct input to the update-dependencies tool.

I've updated the logic to account for this scenario by not relying on the .version files for the shared frameworks and instead lookup up the build-specific version numbers associated with the SDK build by using the Version.Details.xml file.

This also required changes to the update-dependencies tool because the URL path to the files is different.  The folder name contains the build version but the filename does not.  The simplest way I could think of this was just to use a heuristic that accounts for this URL format in the case when the version string contains `-rtm.`.