### PR TITLE
Fix path variables in 5.0 PR pipelines

### DIFF
--- a/eng/pipelines/dotnet-core-nightly-pr-3.1.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-3.1.yml
@@ -24,7 +24,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/*/3.1/*'
+  value: --path 'src/*/3.1/*' --path 'src/*/5.0/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
@@ -24,7 +24,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/runtime-deps/3.1/*' --path 'src/*/5.0/*'
+  value: --path 'src/*/3.1/*' --path 'src/*/5.0/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-5.0.yml
@@ -24,7 +24,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/*/5.0/*'
+  value: --path 'src/runtime-deps/3.1/*' --path 'src/*/5.0/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-nightly-pr-monitor.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-monitor.yml
@@ -21,7 +21,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/*/3.1/alpine*/amd64' --path 'src/monitor/*'
+  value: --path 'src/*/3.1/alpine*/amd64' --path 'src/*/5.0/alpine*/amd64' --path 'src/monitor/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-pr-3.1.yml
+++ b/eng/pipelines/dotnet-core-pr-3.1.yml
@@ -23,7 +23,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/*/3.1/*'
+  value: --path 'src/*/3.1/*' --path 'src/*/5.0/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-pr-5.0.yml
@@ -23,7 +23,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/*/5.0/*'
+  value: --path 'src/runtime-deps/3.1/*' --path 'src/*/5.0/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-pr-5.0.yml
+++ b/eng/pipelines/dotnet-core-pr-5.0.yml
@@ -23,7 +23,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/runtime-deps/3.1/*' --path 'src/*/5.0/*'
+  value: --path 'src/*/3.1/*' --path 'src/*/5.0/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-pr-monitor.yml
+++ b/eng/pipelines/dotnet-core-pr-monitor.yml
@@ -20,7 +20,7 @@ resources:
 variables:
 - template: variables/core.yml
 - name: imageBuilder.pathArgs
-  value: --path 'src/*/3.1/alpine*/amd64' --path 'src/monitor/*'
+  value: --path 'src/*/3.1/alpine*/amd64' --path 'src/*/5.0/alpine*/amd64' --path 'src/monitor/*'
 
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml


### PR DESCRIPTION
The PR build for 5.0 leads to build failures because it doesn't end up building the required runtime-deps that it shares with 3.1.