### PR TITLE
Change permissions on dotnet-monitor

### DIFF
--- a/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
@@ -27,4 +27,6 @@ ENV \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 
+RUN chmod 755 dotnet-monitor
+
 ENTRYPOINT ["dotnet-monitor", "collect"]

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -27,6 +27,6 @@ ENV \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 
-RUN ["chmod", "755", "dotnet-monitor"]
+RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT ["dotnet-monitor", "collect"]

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -27,4 +27,6 @@ ENV \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 
+RUN ["chmod", "755", "dotnet-monitor"]
+
 ENTRYPOINT ["dotnet-monitor", "collect"]


### PR DESCRIPTION
Currently `dotnet-monitor` has permissions of 744. When attempting run as a non-root UID (as is recommended for containers) dotnet-monitor fails to start with the familiar `standard_init_linux.go:211: exec user process caused "exec format error"`.

Given that there are there are no security implications here, I think this change makes sense.

The only limiting thing should be whether dotnet-monitor has access to the AF_UNIX socket created by the target process' runtime which is not impacted by this change