### PR TITLE
Add required env vars to samples

### DIFF
--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -1,3 +1,5 @@
+# escape=`
+
 # https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /source
@@ -18,7 +20,10 @@ FROM mcr.microsoft.com/windows/nanoserver:2009 AS runtime
 WORKDIR /app
 COPY --from=build /app ./
 
-# Configure web servers to bind to port 80 when present
-ENV ASPNETCORE_URLS=http://+:80
+ENV `
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
 
 ENTRYPOINT ["aspnetapp"]

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
@@ -15,4 +15,8 @@ RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-rest
 FROM mcr.microsoft.com/windows/nanoserver:2009
 WORKDIR /app
 COPY --from=build /app .
+
+# Enable detection of running in a container
+ENV DOTNET_RUNNING_IN_CONTAINER=true
+
 ENTRYPOINT ["dotnetapp"]

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true"));
             }
 
-            EnvironmentVariableInfo.Validate(variables, ImageType, imageData, DockerHelper);
+            EnvironmentVariableInfo.Validate(variables, imageData.GetImage(ImageType, DockerHelper), imageData, DockerHelper);
         }
 
         [LinuxImageTheory]

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Docker.Tests
             Assert.Empty(output);
         }
 
-        protected static IEnumerable<EnvironmentVariableInfo> GetCommonEnvironmentVariables()
+        public static IEnumerable<EnvironmentVariableInfo> GetCommonEnvironmentVariables()
         {
             yield return new EnvironmentVariableInfo("DOTNET_RUNNING_IN_CONTAINER", "true");
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -132,6 +132,45 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
+        [SkippableTheory("windowsservercore-ltsc2019")]
+        [MemberData(nameof(GetImageData))]
+        public async Task VerifyAspnetEnvironmentVariables(SampleImageData imageData)
+        {
+            await VerifySampleAsync(imageData, SampleImageType.Aspnetapp, (image, containerName) =>
+            {
+                List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
+                variables.AddRange(ProductImageTests.GetCommonEnvironmentVariables());
+                variables.Add(new EnvironmentVariableInfo("ASPNETCORE_URLS", "http://+:80"));
+
+                EnvironmentVariableInfo.Validate(
+                    variables,
+                    image,
+                    imageData,
+                    DockerHelper);
+
+                return Task.CompletedTask;
+            });
+        }
+
+        [SkippableTheory("windowsservercore-ltsc2019")]
+        [MemberData(nameof(GetImageData))]
+        public async Task VerifyDotnetEnvironmentVariables(SampleImageData imageData)
+        {
+            await VerifySampleAsync(imageData, SampleImageType.Dotnetapp, (image, containerName) =>
+            {
+                List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
+                variables.AddRange(ProductImageTests.GetCommonEnvironmentVariables());
+
+                EnvironmentVariableInfo.Validate(
+                    variables,
+                    image,
+                    imageData,
+                    DockerHelper);
+
+                return Task.CompletedTask;
+            });
+        }
+
         private async Task VerifySampleAsync(
             SampleImageData imageData,
             SampleImageType sampleImageType,

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 }
             }
 
-            EnvironmentVariableInfo.Validate(variables, DotNetImageType.SDK, imageData, DockerHelper);
+            EnvironmentVariableInfo.Validate(variables, imageData.GetImage(DotNetImageType.SDK, DockerHelper), imageData, DockerHelper);
         }
 
         [Theory]


### PR DESCRIPTION
Explicitly adds the `DOTNET_RUNNING_IN_CONTAINER` environment variable to the "slim" variant sample Dockerfiles because it doesn't get the benefit of deriving from the `runtime` image which defines that variable.

Add unit tests to ensure sample Dockerfiles have the required environment variables in the same way as is done for the product.

Fixes #2319