### PR TITLE
Define arch-specific tags for samples

### DIFF
--- a/README.samples.md
+++ b/README.samples.md
@@ -62,8 +62,8 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-dotnetapp-buster-slim, dotnetapp, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile) | Debian 10
-aspnetapp-buster-slim, aspnetapp | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile) | Debian 10
+dotnetapp-buster-slim-amd64, dotnetapp, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile) | Debian 10
+aspnetapp-buster-slim-amd64, aspnetapp | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile) | Debian 10
 
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version

--- a/eng/mcr-tags-metadata-templates/samples-tags.yml
+++ b/eng/mcr-tags-metadata-templates/samples-tags.yml
@@ -1,6 +1,6 @@
 $(McrTagsYmlRepo:samples)
-$(McrTagsYmlTagGroup:dotnetapp-buster-slim)
-$(McrTagsYmlTagGroup:aspnetapp-buster-slim)
+$(McrTagsYmlTagGroup:dotnetapp-buster-slim-amd64)
+$(McrTagsYmlTagGroup:aspnetapp-buster-slim-amd64)
 $(McrTagsYmlTagGroup:dotnetapp-buster-slim-arm32v7)
 $(McrTagsYmlTagGroup:aspnetapp-buster-slim-arm32v7)
 $(McrTagsYmlTagGroup:dotnetapp-buster-slim-arm64v8)

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -19,7 +19,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "dotnetapp-buster-slim": {}
+                "dotnetapp-buster-slim-amd64": {}
               }
             },
             {
@@ -86,14 +86,14 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "aspnetapp-buster-slim": {}
+                "aspnetapp-buster-slim-amd64": {}
               },
               "customBuildLegGroups": [
                 {
                   "name": "pr-build",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:samples):dotnetapp-buster-slim"
+                    "$(Repo:samples):dotnetapp-buster-slim-amd64"
                   ]
                 }
               ]

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -103,17 +103,20 @@ namespace Microsoft.DotNet.Docker.Tests
 
         protected virtual string GetArchTagSuffix()
         {
-            string arch = string.Empty;
-            if (Arch == Arch.Arm)
+            if (Arch == Arch.Amd64 && DockerHelper.IsLinuxContainerModeEnabled)
             {
-                arch = "-arm32v7";
+                return "-amd64";
+            }
+            else if (Arch == Arch.Arm)
+            {
+                return "-arm32v7";
             }
             else if (Arch == Arch.Arm64)
             {
-                arch = "-arm64v8";
+                return "-arm64v8";
             }
 
-            return arch;
+            return string.Empty;
         }
 
         private static string GetRegistryName(string repo, string tag)

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -101,9 +101,9 @@ namespace Microsoft.DotNet.Docker.Tests
 
         protected override string GetArchTagSuffix()
         {
-            if (Arch == Arch.Amd64 && Version.Major >= 5 && DockerHelper.IsLinuxContainerModeEnabled)
+            if (Arch == Arch.Amd64 && Version.Major < 5)
             {
-                return "-amd64";
+                return string.Empty;
             }
 
             return base.GetArchTagSuffix();


### PR DESCRIPTION
Maintains the tagging pattern used in https://github.com/dotnet/dotnet-docker/issues/2182 by ensuring that all concrete Linux tags for the samples are arch-specific.

Fixes #2284