### PR TITLE
Disabling content verification test

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -143,11 +143,17 @@ namespace Microsoft.DotNet.Docker.Tests
         /// <summary>
         /// Verifies that the dotnet folder contents of an SDK container match the contents in the official SDK archive file.
         /// </summary>
-        //[Theory]
-        // Disabled this test due to https://github.com/dotnet/aspnetcore/issues/27670
+        [Theory]
+        
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {
+            // Disable this test for 5.0 due to https://github.com/dotnet/aspnetcore/issues/27670
+            if (imageData.Version.Major == 5)
+            {
+                return;
+            }
+
             if (!(imageData.Version.Major >= 5 ||
                 (imageData.Version.Major >= 3 &&
                     (imageData.SdkOS.StartsWith(OS.AlpinePrefix) || !DockerHelper.IsLinuxContainerModeEnabled))))

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -144,7 +144,6 @@ namespace Microsoft.DotNet.Docker.Tests
         /// Verifies that the dotnet folder contents of an SDK container match the contents in the official SDK archive file.
         /// </summary>
         [Theory]
-        
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -143,7 +143,8 @@ namespace Microsoft.DotNet.Docker.Tests
         /// <summary>
         /// Verifies that the dotnet folder contents of an SDK container match the contents in the official SDK archive file.
         /// </summary>
-        [Theory]
+        //[Theory]
+        // Disabled this test due to https://github.com/dotnet/aspnetcore/issues/27670
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {


### PR DESCRIPTION
The comparison of the contents of SDK archive's shared aspnetcore runtime folder is different than the contents of the sdk image which derives its content from the aspnet image.  This is because of https://github.com/dotnet/aspnetcore/issues/27670.
