### PR TITLE
Fix broken links in the SDK readme

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -30,8 +30,12 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 
 ## Develop .NET Apps in a Container
 
-* [Develop .NET Applications](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/dotnet-docker-dev-in-container.md) - This sample shows how to develop, build and test .NET applications with Docker without the need to install the .NET SDK.
-* [Develop ASP.NET Core Applications](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/aspnet-docker-dev-in-container.md) - This sample shows how to develop and test ASP.NET Core applications with Docker without the need to install the .NET SDK.
+The following samples show how to develop, build and test .NET applications with Docker without the need to install the .NET SDK.
+
+* [Build .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/master/samples/build-in-sdk-container.md)
+* [Test .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/master/samples/run-tests-in-sdk-container.md)
+* [Run .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/master/samples/run-in-sdk-container.md)
+
 
 # Related Repos
 

--- a/eng/readme-templates/Use.sdk.md
+++ b/eng/readme-templates/Use.sdk.md
@@ -5,5 +5,9 @@
 
 ## Develop .NET Apps in a Container
 
-* [Develop .NET Applications](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/dotnet-docker-dev-in-container.md) - This sample shows how to develop, build and test .NET applications with Docker without the need to install the .NET SDK.
-* [Develop ASP.NET Core Applications](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/aspnet-docker-dev-in-container.md) - This sample shows how to develop and test ASP.NET Core applications with Docker without the need to install the .NET SDK.
+The following samples show how to develop, build and test .NET applications with Docker without the need to install the .NET SDK.
+
+* [Build .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/master/samples/build-in-sdk-container.md)
+* [Test .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/master/samples/run-tests-in-sdk-container.md)
+* [Run .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/master/samples/run-in-sdk-container.md)
+


### PR DESCRIPTION
These links have been broken for a long time.  It looks like they regressed with https://github.com/dotnet/dotnet-docker/pull/1538.  Surprising nobody pointed them out.  It makes me question the value of them.