### PR TITLE
Add procps package to Debian-based SDK images

### DIFF
--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
@@ -17,6 +17,8 @@ RUN apt-get update \
         curl \
         git \
         wget \
+        # Required for "dotnet watch" to run in Debian based SDK images
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK

--- a/src/sdk/5.0/buster-slim/amd64/Dockerfile
+++ b/src/sdk/5.0/buster-slim/amd64/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         curl \
         git \
         wget \
+        # Required for "dotnet watch" to run in Debian based SDK images
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK

--- a/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         curl \
         git \
         wget \
+        # Required for "dotnet watch" to run in Debian based SDK images
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK

--- a/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         curl \
         git \
         wget \
+        # Required for "dotnet watch" to run in Debian based SDK images
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK

--- a/src/sdk/5.0/focal/amd64/Dockerfile
+++ b/src/sdk/5.0/focal/amd64/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         curl \
         git \
         wget \
+        # Required for "dotnet watch" to run in Debian based SDK images
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK

--- a/src/sdk/5.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/5.0/focal/arm32v7/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         curl \
         git \
         wget \
+        # Required for "dotnet watch" to run in Debian based SDK images
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK

--- a/src/sdk/5.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/5.0/focal/arm64v8/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         curl \
         git \
         wget \
+        # Required for "dotnet watch" to run in Debian based SDK images
+        procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK


### PR DESCRIPTION
This package is now required for "dotnet watch" to actually watch for
file changes on Debian based images.

NOTE: with this patch we're installing the package on Ubuntu
based-distributions as well, as a (undesired?) side-effect.

The alternative would be to use Cottle templating language to only add
this patch for debian-based images.
The problem is their name varies accross versions (buster, bullseye...)
this would have made this bugfix less change-resistant.

Caused by: https://github.com/dotnet/dotnet-docker/issues/2376

Github issue: https://github.com/dotnet/dotnet-docker/issues/2396