### PR TITLE
Update job name for Windows 20H2 to match build matrix output

### DIFF
--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -257,11 +257,11 @@ stages:
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
-        name: Windows2009_amd64
+        name: Windows20H2_amd64
         pool:
           name: DotNetCore-Docker
           demands: VSTS_OS -equals Windows-ServerDatacenter-2009
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2009Amd64']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -138,14 +138,14 @@ stages:
       noCache: ${{ parameters.noCache }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Windows2009_amd64
+      name: Windows20H2_amd64
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: DotNetCore-Docker-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: DotNetCore-Docker
         demands: VSTS_OS -equals Windows-ServerDatacenter-2009
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2009Amd64']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows20H2Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}


### PR DESCRIPTION
Fixes an issue that prevents the pipeline from generating build jobs for Windows 20H2.  Will port this to docker-tools once things are verified.