### PR TITLE
Remove unintended syndication of 20H2 tags

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1758,16 +1758,8 @@
               "os": "windows",
               "osVersion": "nanoserver-20H2",
               "tags": {
-                "$(dotnet|2.1|product-version)-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedAspnetRepo)"
-                  }
-                },
-                "2.1-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedAspnetRepo)"
-                  }
-                },
+                "$(dotnet|2.1|product-version)-nanoserver-20H2": {},
+                "2.1-nanoserver-20H2": {},
                 "$(dotnet|2.1|product-version)-nanoserver-2009": {
                   "docType": "Undocumented",
                   "syndication": {
@@ -2111,16 +2103,8 @@
               "os": "windows",
               "osVersion": "nanoserver-20H2",
               "tags": {
-                "$(dotnet|3.1|product-version)-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedAspnetRepo)"
-                  }
-                },
-                "3.1-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedAspnetRepo)"
-                  }
-                },
+                "$(dotnet|3.1|product-version)-nanoserver-20H2": {},
+                "3.1-nanoserver-20H2": {},
                 "$(dotnet|3.1|product-version)-nanoserver-2009": {
                   "docType": "Undocumented",
                   "syndication": {
@@ -2842,16 +2826,8 @@
               "os": "windows",
               "osVersion": "nanoserver-20H2",
               "tags": {
-                "$(sdk|2.1|product-version)-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedSdkRepo)"
-                  }
-                },
-                "2.1-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedSdkRepo)"
-                  }
-                },
+                "$(sdk|2.1|product-version)-nanoserver-20H2": {},
+                "2.1-nanoserver-20H2": {},
                 "$(sdk|2.1|product-version)-nanoserver-2009": {
                   "docType": "Undocumented",
                   "syndication": {
@@ -3237,16 +3213,8 @@
               "os": "windows",
               "osVersion": "nanoserver-20H2",
               "tags": {
-                "$(sdk|3.1|product-version)-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedSdkRepo)"
-                  }
-                },
-                "3.1-nanoserver-20H2": {
-                  "syndication": {
-                    "repo": "$(syndicatedSdkRepo)"
-                  }
-                },
+                "$(sdk|3.1|product-version)-nanoserver-20H2": {},
+                "3.1-nanoserver-20H2": {},
                 "$(sdk|3.1|product-version)-nanoserver-2009": {
                   "docType": "Undocumented",
                   "syndication": {


### PR DESCRIPTION
The manifest was misconfigured for 2.1 and 3.1 to include 20H2 tags for syndication to the "core" repos.