### PR TITLE
Update dotnet-monitor version detection and pull package from Azure Artifacts feed.

### DIFF
--- a/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
@@ -6,7 +6,7 @@ FROM $SDK_REPO:3.1-alpine3.12 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|5.0|build-version"]}}
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor5.0/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|5.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \

--- a/eng/get-drop-versions-monitor.sh
+++ b/eng/get-drop-versions-monitor.sh
@@ -5,14 +5,11 @@ set -e
 # Stop script if unbound variable found (use ${var:-} if intentional)
 set -u
 
-channel=$1
+curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/diagnostics/monitor5.0/dotnet-monitor.nupkg.version
 
-curl -SLo dotnet-monitor.nupkg https://aka.ms/dotnet/$channel/diagnostics/monitor5.0/dotnet-monitor.nupkg
-# In nuspec, there is only one element named "version" and it is the version of the nupkg.
-# All other uses of "version" are attributes on other elements. grep using Perl regex, reporting
-# the first match, and only printing what was matched.
-monitorVer=$(unzip -p dotnet-monitor.nupkg dotnet-monitor.nuspec | cat | grep -oPm1 "(?<=<version>)[^<]+")
+# Read version file and remove newlines
+monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.version)
 
-rm dotnet-monitor.nupkg
+rm dotnet-monitor.nupkg.version
 
 echo "##vso[task.setvariable variable=monitorVer]$monitorVer"

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -43,7 +43,7 @@ stages:
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
-    - script: $(engPath)/get-drop-versions-monitor.sh $(monitorChannel)
+    - script: $(engPath)/get-drop-versions-monitor.sh
       displayName: Get Versions
     - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
       displayName: Build Update Dependencies Tool

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -25,9 +25,9 @@
     "dotnet|3.1|product-version": "3.1.10",
     "dotnet|5.0|product-version": "5.0.0",
 
-    "monitor|5.0|build-version": "5.0.0-preview.3.20523.1",
+    "monitor|5.0|build-version": "5.0.0-preview.3.20607.1",
     "monitor|5.0|product-version": "5.0.0-preview.3",
-    "monitor|5.0|sha": "86936df6ff763d5eceba18490dd1a745d7cf8b84a0999a408415bdfb35c687dc023caa5eb66cbea09a33065f36470400f09be3d7456de80911a87415aaaadc01",
+    "monitor|5.0|sha": "204ff40de0da864004754d8cb6e16c621c0f8efe1b7a04ffff70a930f220ea2f2dadae618daf6d0d139e235c266ab5e8ae28fdc6c4ba94972d03b6b963ab7ffc",
 
     "lzma|2.1|sha": "24b3f39ebdf1baf0965a6d17f1b9895dd9e959b29e99037d5d7b244c04008d3d4bc6638d600276947bb19d59d1dc77f0a17b3a1e75d1b39e0bf5af37cf3e9cc9",
 

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:3.1-alpine3.12 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.3.20523.1
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor5.0/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='86936df6ff763d5eceba18490dd1a745d7cf8b84a0999a408415bdfb35c687dc023caa5eb66cbea09a33065f36470400f09be3d7456de80911a87415aaaadc01' \
+ENV DOTNET_MONITOR_VERSION=5.0.0-preview.3.20607.1
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
+    && dotnetmonitor_sha512='204ff40de0da864004754d8cb6e16c621c0f8efe1b7a04ffff70a930f220ea2f2dadae618daf6d0d139e235c266ab5e8ae28fdc6c4ba94972d03b6b963ab7ffc' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.


### PR DESCRIPTION
The ability to scrape the dotnet-monitor package version from the nupkg file located at the aka.ms link was broken. I've updated dotnet/diagnostics to publish a version file which contains the version of the dotnet-monitor package and generate a latest aka.ms link for it. The link no longer contains the dotnet product version, so there is no longer an update channel for dotnet-montior. I've also updated the docker image to pull the package from the Azure Artifacts NuGet feed rather than from blob storage since the NuGet package is no longer published to blob storage.