### PR TITLE
Fix update-dependencies for .NET 6.0

### DIFF
--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -23,8 +23,8 @@ rm sdkversion
 
 curl -SLo versionDetails.xml https://raw.githubusercontent.com/dotnet/installer/$commitSha/eng/Version.Details.xml
 
-runtimeVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'Microsoft.NETCore.App.Internal\']/@Version\) versionDetails.xml)
-aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'Microsoft.AspNetCore.App.Ref.Internal\']/@Version\) versionDetails.xml)
+runtimeVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'VS.Redist.Common.NetCore.SharedFramework.x64.6.0\']/@Version\) versionDetails.xml)
+aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0\']/@Version\) versionDetails.xml)
 
 rm sdk.zip
 rm versionDetails.xml

--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -23,8 +23,8 @@ rm sdkversion
 
 curl -SLo versionDetails.xml https://raw.githubusercontent.com/dotnet/installer/$commitSha/eng/Version.Details.xml
 
-runtimeVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'VS.Redist.Common.NetCore.SharedFramework.x64.6.0\']/@Version\) versionDetails.xml)
-aspnetVer=$(xmllint --xpath string\(//ProductDependencies/Dependency[@Name=\'VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0\']/@Version\) versionDetails.xml)
+runtimeVer=$(xmllint --xpath "string(//ProductDependencies/Dependency[starts-with(@Name,'VS.Redist.Common.NetCore.SharedFramework.x64')]/@Version)" versionDetails.xml)
+aspnetVer=$(xmllint --xpath "string(//ProductDependencies/Dependency[starts-with(@Name,'VS.Redist.Common.AspNetCore.SharedFramework.x64')]/@Version)" versionDetails.xml)
 
 rm sdk.zip
 rm versionDetails.xml


### PR DESCRIPTION
The content of the `Version.Details.xml` file has changed for .NET 6.0 which requires some updates to the target dependency names in order to gather the correct version numbers to pass to the update-dependencies tool.

Example of `Version.Details.xml` that is being used: https://raw.githubusercontent.com/dotnet/installer/8efbfffe79d15d851d2a34ae502fa53f9430a708/eng/Version.Details.xml