### PR TITLE
Add procps package to 5.0 SDK

### DIFF
--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
+        procps \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/sdk/5.0/buster-slim/amd64/Dockerfile
+++ b/src/sdk/5.0/buster-slim/amd64/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
+        procps \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
+        procps \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
+        procps \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/sdk/5.0/focal/amd64/Dockerfile
+++ b/src/sdk/5.0/focal/amd64/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
+        procps \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/sdk/5.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/5.0/focal/arm32v7/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
+        procps \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/sdk/5.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/5.0/focal/arm64v8/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         git \
+        procps \
         wget \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The `pgrep` utility is needed in order to run `dotnet watch` in a 5.0 sdk container.  This utility does not exist in the Debian base images.  It does exist in the base Alpine images.  For Ubuntu, the base image has it as well due to having the `procps` package installed.  

These changes update the 5.0 sdk Dockerfiles to explicitly ensure that the `procps` package is installed for Debian and Ubuntu in order to provide the `pgrep` utility.  The `procps` package will not be added to the Alpine Dockerfile because Alpine already provides `pgrep` and the intent is to keep Alpine images lean.  So adding `procps` just to make it consistent is not the right choice.

Fixes #2396