### PR TITLE
Remove usage of deprecated syntax for ENV instruction

### DIFF
--- a/documentation/scenarios/installing-dotnet.md
+++ b/documentation/scenarios/installing-dotnet.md
@@ -95,7 +95,7 @@ This provides full transparency to consumers of the image in regard to where the
 
 By having the version of .NET you're installing explicitly defined in the Dockerfile, as should be done for clarity reasons, it means the Dockerfile must be regularly maintained to account for servicing releases of .NET. There are two parts of the install steps that will need to updated in order to reference a new release:
 
-* Version environment variable that is referenced in the download URL (e.g. `ENV DOTNET_VERSION 5.0.0`)
+* Version environment variable that is referenced in the download URL (e.g. `ENV DOTNET_VERSION=5.0.0`)
 * SHA value (e.g. `dotnet_sha512='d4d67df5ff5f6dde0d865a6e87559955bd57429df396cf7d05fe77f09e6220c67dc5e66439b1801ca4d301a62f81f666122bf4b623b31a46b861677dcafc62a4'`)
 
 You can track these values by making use of the information contained in the `releases.json` of the relevant release. For example, the [`releases.json`](https://dotnetcli.azureedge.net/dotnet/release-metadata/5.0/releases.json) for 5.0 contains all the metadata for the 5.0 releases including download links of the binary archives as well as their hash values. The release information is described on the main [release notes](https://github.com/dotnet/core/blob/master/release-notes/README.md) page.

--- a/documentation/scenarios/nuget-credentials.md
+++ b/documentation/scenarios/nuget-credentials.md
@@ -156,8 +156,7 @@ RUN curl -L https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/m
 COPY *.csproj .
 COPY ./nuget.config .
 ARG FEED_ACCESSTOKEN
-ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS \
-    "{\"endpointCredentials\": [{\"endpoint\":\"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json\", \"username\":\"docker\", \"password\":\"${FEED_ACCESSTOKEN}\"}]}"
+ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{\"endpointCredentials\": [{\"endpoint\":\"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json\", \"username\":\"docker\", \"password\":\"${FEED_ACCESSTOKEN}\"}]}"
 RUN dotnet restore
 
 # Copy and publish app and libraries
@@ -194,8 +193,7 @@ WORKDIR /app
 COPY *.csproj .
 COPY nuget.config .
 ARG FEED_ACCESSTOKEN
-ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS `
-    "{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
+ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
 RUN dotnet restore
 
 # Copy and publish app and libraries
@@ -226,24 +224,21 @@ If you are having authentication issues, try adding a command to the Dockerfile 
 Example (Linux):
 
 ```Dockerfile
-ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS `
-    "{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
+ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
 RUN echo $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
 ```
 
 Example (Windows PowerShell):
 
 ```Dockerfile
-ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS `
-    "{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
+ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
 RUN echo $Env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
 ```
 
 Example (Windows Cmd):
 
 ```Dockerfile
-ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS `
-    "{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
+ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS="{`"endpointCredentials`": [{`"endpoint`":`"https://fabrikam.pkgs.visualstudio.com/_packaging/MyGreatFeed/nuget/v3/index.json`", `"username`":`"docker`", `"password`":`"${FEED_ACCESSTOKEN}`"}]}"
 RUN echo %VSS_NUGET_EXTERNAL_FEED_ENDPOINTS%
 ```
 

--- a/eng/dockerfile-templates/aspnet/2.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/2.1/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-{{OS_VERSION}}
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION {{VARIABLES["aspnet|2.1|build-version"]}}
+ENV ASPNETCORE_VERSION={{VARIABLES["aspnet|2.1|build-version"]}}
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='{{VARIABLES["aspnet|2.1|linux-musl|x64|sha"]}}' \

--- a/eng/dockerfile-templates/aspnet/2.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/2.1/Dockerfile.linux
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION {{VARIABLES["aspnet|2.1|build-version"]}}
+ENV ASPNETCORE_VERSION={{VARIABLES["aspnet|2.1|build-version"]}}
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-{{ARCH_SHORT}}.tar.gz \
     && aspnetcore_sha512='{{VARIABLES[cat("aspnet|2.1|linux|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/aspnet/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/2.1/Dockerfile.nanoserver
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS install
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION {{VARIABLES["aspnet|2.1|build-version"]}}
+ENV ASPNETCORE_VERSION={{VARIABLES["aspnet|2.1|build-version"]}}
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
     $aspnetcore_sha512 = '{{VARIABLES["aspnet|2.1|win|x64|sha"]}}'; `

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 # Install ASP.NET Core
-ENV ASPNET_VERSION {{VARIABLES["aspnet|5.0|build-version"]}}
+ENV ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \
     && aspnetcore_sha512='{{VARIABLES[cat("aspnet|5.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.linux
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.nanoserver
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:5.0-{{OS_VERSION}}
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-{{OS_VERSION}}
 
-ENV ASPNET_VERSION {{VARIABLES["aspnet|5.0|build-version"]}}
+ENV ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `

--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 # Install ASP.NET Core
-ENV ASPNET_VERSION {{VARIABLES["aspnet|6.0|build-version"]}}
+ENV ASPNET_VERSION={{VARIABLES["aspnet|6.0|build-version"]}}
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \
     && aspnetcore_sha512='{{VARIABLES[cat("aspnet|6.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.linux
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:6.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.nanoserver
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:6.0-{{OS_VERSION}}
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-{{OS_VERSION}}
 
-ENV ASPNET_VERSION {{VARIABLES["aspnet|6.0|build-version"]}}
+ENV ASPNET_VERSION={{VARIABLES["aspnet|6.0|build-version"]}}
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `

--- a/eng/dockerfile-templates/runtime/2.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/2.1/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-{{OS_VERSION}}
 
 # Install .NET Core
-ENV DOTNET_VERSION {{VARIABLES["runtime|2.1|build-version"]}}
+ENV DOTNET_VERSION={{VARIABLES["runtime|2.1|build-version"]}}
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='{{VARIABLES["runtime|2.1|linux-musl|x64|sha"]}}' \

--- a/eng/dockerfile-templates/runtime/2.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/2.1/Dockerfile.linux
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION {{VARIABLES["runtime|2.1|build-version"]}}
+ENV DOTNET_VERSION={{VARIABLES["runtime|2.1|build-version"]}}
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|2.1|linux|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/runtime/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/2.1/Dockerfile.nanoserver
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS install
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION {{VARIABLES["runtime|2.1|build-version"]}}
+ENV DOTNET_VERSION={{VARIABLES["runtime|2.1|build-version"]}}
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = '{{VARIABLES["runtime|2.1|win|x64|sha"]}}'; `

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 # Install .NET
-ENV DOTNET_VERSION {{VARIABLES["runtime|5.0|build-version"]}}
+ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|5.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 # Install .NET
-ENV DOTNET_VERSION {{VARIABLES["runtime|6.0|build-version"]}}
+ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|6.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:6.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/sdk/2.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/2.1/Dockerfile.alpine
@@ -9,7 +9,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION {{VARIABLES["sdk|2.1|build-version"]}}
+ENV DOTNET_SDK_VERSION={{VARIABLES["sdk|2.1|build-version"]}}
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='{{VARIABLES["sdk|2.1|linux-musl|x64|sha"]}}' \

--- a/eng/dockerfile-templates/sdk/2.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/2.1/Dockerfile.linux
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION {{VARIABLES["sdk|2.1|build-version"]}}
+ENV DOTNET_SDK_VERSION={{VARIABLES["sdk|2.1|build-version"]}}
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("sdk|2.1|linux|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/sdk/2.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/2.1/Dockerfile.nanoserver
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64 AS install
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION {{VARIABLES["sdk|2.1|build-version"]}}
+ENV DOTNET_SDK_VERSION={{VARIABLES["sdk|2.1|build-version"]}}
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '{{VARIABLES["sdk|2.1|win|x64|sha"]}}'; `

--- a/samples/aspnetapp/Dockerfile.alpine-arm64
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64
@@ -19,9 +19,9 @@ COPY --from=build /app ./
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 #RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+#ENV LC_ALL=en_US.UTF-8
+#ENV LANG=en_US.UTF-8
 
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -19,9 +19,9 @@ COPY --from=build /app ./
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 #RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+#ENV LC_ALL=en_US.UTF-8
+#ENV LANG=en_US.UTF-8
 
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-x64-slim
@@ -19,9 +19,9 @@ COPY --from=build /app ./
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 #RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+#ENV LC_ALL=en_US.UTF-8
+#ENV LANG=en_US.UTF-8
 
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/dotnetapp/Dockerfile.alpine-arm64
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64
@@ -17,9 +17,9 @@ COPY --from=build /app .
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 #RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+#ENV LC_ALL=en_US.UTF-8
+#ENV LANG=en_US.UTF-8
 
 ENTRYPOINT ["./dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.alpine-x64
@@ -17,9 +17,9 @@ COPY --from=build /app .
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 #RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+#ENV LC_ALL=en_US.UTF-8
+#ENV LANG=en_US.UTF-8
 
 ENTRYPOINT ["./dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-x64-slim
@@ -17,9 +17,9 @@ COPY --from=build /app .
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 #RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+#ENV LC_ALL=en_US.UTF-8
+#ENV LANG=en_US.UTF-8
 
 ENTRYPOINT ["./dotnetapp"]

--- a/src/aspnet/2.1/alpine3.12/amd64/Dockerfile
+++ b/src/aspnet/2.1/alpine3.12/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-alpine3.12
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='0d7fed7f3673b9f267bbdae9eac0558275d88c0df9550595eb84f333fa0c04d072f1c3be0591133369be586ed9f0e0d8f4d1f7f4ba562d435f77bde48d789e91' \

--- a/src/aspnet/2.1/bionic/amd64/Dockerfile
+++ b/src/aspnet/2.1/bionic/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
     && aspnetcore_sha512='47df15608671ace7a13f7ba03d74a34fa8b396344409cb2cc4daeafdda8b22dc7309dd60b1f469aadeb89cfc0e22b7b9aebde3ffeaedad431ad4f4f51296030d' \

--- a/src/aspnet/2.1/bionic/arm32v7/Dockerfile
+++ b/src/aspnet/2.1/bionic/arm32v7/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
     && aspnetcore_sha512='0855087a9855c4809d19fc351fbe717a6aede8c048cdb47443e8a516722b5411b0fad12caa2524d6fa803292783bc8c1dc4c09a2bd9becc61c0df33819364f27' \

--- a/src/aspnet/2.1/focal/amd64/Dockerfile
+++ b/src/aspnet/2.1/focal/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
     && aspnetcore_sha512='47df15608671ace7a13f7ba03d74a34fa8b396344409cb2cc4daeafdda8b22dc7309dd60b1f469aadeb89cfc0e22b7b9aebde3ffeaedad431ad4f4f51296030d' \

--- a/src/aspnet/2.1/focal/arm32v7/Dockerfile
+++ b/src/aspnet/2.1/focal/arm32v7/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
     && aspnetcore_sha512='0855087a9855c4809d19fc351fbe717a6aede8c048cdb47443e8a516722b5411b0fad12caa2524d6fa803292783bc8c1dc4c09a2bd9becc61c0df33819364f27' \

--- a/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
     $aspnetcore_sha512 = 'fbd00d08c701dfadd98c205e5182f330842efad8500c1f75f6b7ef5ea4eac8569dd283c61ed00baf57155dcb11434242a9e44fcc650655b3cc0651ed6364ce39'; `

--- a/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
     $aspnetcore_sha512 = 'fbd00d08c701dfadd98c205e5182f330842efad8500c1f75f6b7ef5ea4eac8569dd283c61ed00baf57155dcb11434242a9e44fcc650655b3cc0651ed6364ce39'; `

--- a/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
     $aspnetcore_sha512 = 'fbd00d08c701dfadd98c205e5182f330842efad8500c1f75f6b7ef5ea4eac8569dd283c61ed00baf57155dcb11434242a9e44fcc650655b3cc0651ed6364ce39'; `

--- a/src/aspnet/2.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/2.1/nanoserver-20H2/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:20H2-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install ASP.NET Core Runtime
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$Env:ASPNETCORE_VERSION/aspnetcore-runtime-$Env:ASPNETCORE_VERSION-win-x64.zip; `
     $aspnetcore_sha512 = 'fbd00d08c701dfadd98c205e5182f330842efad8500c1f75f6b7ef5ea4eac8569dd283c61ed00baf57155dcb11434242a9e44fcc650655b3cc0651ed6364ce39'; `

--- a/src/aspnet/2.1/stretch-slim/amd64/Dockerfile
+++ b/src/aspnet/2.1/stretch-slim/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz \
     && aspnetcore_sha512='47df15608671ace7a13f7ba03d74a34fa8b396344409cb2cc4daeafdda8b22dc7309dd60b1f469aadeb89cfc0e22b7b9aebde3ffeaedad431ad4f4f51296030d' \

--- a/src/aspnet/2.1/stretch-slim/arm32v7/Dockerfile
+++ b/src/aspnet/2.1/stretch-slim/arm32v7/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.1.23
+ENV ASPNETCORE_VERSION=2.1.23
 
 RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
     && aspnetcore_sha512='0855087a9855c4809d19fc351fbe717a6aede8c048cdb47443e8a516722b5411b0fad12caa2524d6fa803292783bc8c1dc4c09a2bd9becc61c0df33819364f27' \

--- a/src/aspnet/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/aspnet/5.0/alpine3.12/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-alpine3.12-amd64
 
 # Install ASP.NET Core
-ENV ASPNET_VERSION 5.0.1
+ENV ASPNET_VERSION=5.0.1
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='004fe94ba94b23eadd91ac2a95d175ee41b5550cdda9c5f48b0c090848562e1b5a33c9875517e9ff4d3c3a18b7c6f2c74d14c0860d3f4c68d388939412a72452' \

--- a/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-alpine3.12-arm64v8
 
 # Install ASP.NET Core
-ENV ASPNET_VERSION 5.0.1
+ENV ASPNET_VERSION=5.0.1
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='62e72900eb433c32d26efd975ad41bcc934959e67c34c8a6176056da0856ee6918dd526dc66d01316ac5773061bd0b691e224d5fd581c8ecbdd9255d5bb8b8d4' \

--- a/src/aspnet/5.0/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/amd64/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:5.0-buster-slim-amd64
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:5.0-buster-slim-arm32v7
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:5.0-buster-slim-arm64v8
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/focal/amd64/Dockerfile
+++ b/src/aspnet/5.0/focal/amd64/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:5.0-focal-amd64
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/focal/arm32v7/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:5.0-focal-arm32v7
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/focal/arm64v8/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:5.0-focal-arm64v8
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:5.0-nanoserver-1809
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:5.0-nanoserver-1909
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:5.0-nanoserver-2004
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:5.0-nanoserver-20H2
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-windowsservercore-ltsc2019
 
-ENV ASPNET_VERSION 5.0.1
+ENV ASPNET_VERSION=5.0.1
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `

--- a/src/aspnet/6.0/alpine3.12/amd64/Dockerfile
+++ b/src/aspnet/6.0/alpine3.12/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-alpine3.12-amd64
 
 # Install ASP.NET Core
-ENV ASPNET_VERSION 6.0.0-alpha.1.20629.3
+ENV ASPNET_VERSION=6.0.0-alpha.1.20629.3
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='ebc5e7eb17a703ac703d3dcccd0003b3bea69234244a4de9494a2efd839ab93a3ceb0950f49dfe964c6fe71854cdf79c8f9644a39b206b431a26fe13bf5165f1' \

--- a/src/aspnet/6.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/alpine3.12/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-alpine3.12-arm64v8
 
 # Install ASP.NET Core
-ENV ASPNET_VERSION 6.0.0-alpha.1.20629.3
+ENV ASPNET_VERSION=6.0.0-alpha.1.20629.3
 
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='92ccd5f30eab542aeb08f736ff5a3b50ec88fe4ee4f164932620fcea4dbc498ece2617d0d80a7ae777bc857e8c313ca27e9e7be942ccafe9bf704faf0cf2d36d' \

--- a/src/aspnet/6.0/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/6.0/buster-slim/amd64/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:6.0-buster-slim-amd64
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/buster-slim/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/buster-slim/arm32v7/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:6.0-buster-slim-arm32v7
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/buster-slim/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/buster-slim/arm64v8/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:6.0-buster-slim-arm64v8
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/focal/amd64/Dockerfile
+++ b/src/aspnet/6.0/focal/amd64/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:6.0-focal-amd64
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/focal/arm32v7/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:6.0-focal-arm32v7
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/focal/arm64v8/Dockerfile
@@ -17,6 +17,6 @@ RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/a
 FROM $REPO:6.0-focal-arm64v8
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:6.0-nanoserver-1809
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/nanoserver-1909/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-1909/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:6.0-nanoserver-1909
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-2004/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:6.0-nanoserver-2004
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -26,6 +26,6 @@ RUN Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/do
 FROM $REPO:6.0-nanoserver-20H2
 ARG ASPNET_VERSION
 
-ENV ASPNET_VERSION $ASPNET_VERSION
+ENV ASPNET_VERSION=$ASPNET_VERSION
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-windowsservercore-ltsc2019
 
-ENV ASPNET_VERSION 6.0.0-alpha.1.20629.3
+ENV ASPNET_VERSION=6.0.0-alpha.1.20629.3
 
 RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `

--- a/src/runtime/2.1/alpine3.12/amd64/Dockerfile
+++ b/src/runtime/2.1/alpine3.12/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-alpine3.12
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='262cffc456722edc154927fa94785bb4aef95cd2043ed6a6018ba17ba6f36e88a18fcddafa181c214f862db1747b5a90e271a23cc1bd5dd2c929e576896f93a0' \

--- a/src/runtime/2.1/bionic/amd64/Dockerfile
+++ b/src/runtime/2.1/bionic/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='9663a204abb74016113ae0db6c184598a6e5efc6126e35e275d81594432f75f186af781b3b352c8fe8527c690711820bfdd6271424b56e272f73ebe2d666bab5' \

--- a/src/runtime/2.1/bionic/arm32v7/Dockerfile
+++ b/src/runtime/2.1/bionic/arm32v7/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='0ac5a730b90f8e0b7c792a03d4977abd9a5464258dfc0b8ac71237a540993bf89843f6e66a311664c23e366ff505eaffd5341e34455a72033d6a41d2e2944f0c' \

--- a/src/runtime/2.1/focal/amd64/Dockerfile
+++ b/src/runtime/2.1/focal/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='9663a204abb74016113ae0db6c184598a6e5efc6126e35e275d81594432f75f186af781b3b352c8fe8527c690711820bfdd6271424b56e272f73ebe2d666bab5' \

--- a/src/runtime/2.1/focal/arm32v7/Dockerfile
+++ b/src/runtime/2.1/focal/arm32v7/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='0ac5a730b90f8e0b7c792a03d4977abd9a5464258dfc0b8ac71237a540993bf89843f6e66a311664c23e366ff505eaffd5341e34455a72033d6a41d2e2944f0c' \

--- a/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = '2705a18a0c1ecf9ed2811f437b55ac1f87c4b2ce80f866145fb2191baf885950498647d52d132be8f066b15b29e45204cd6aab3918acdd53706d22d9bfac7205'; `

--- a/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = '2705a18a0c1ecf9ed2811f437b55ac1f87c4b2ce80f866145fb2191baf885950498647d52d132be8f066b15b29e45204cd6aab3918acdd53706d22d9bfac7205'; `

--- a/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = '2705a18a0c1ecf9ed2811f437b55ac1f87c4b2ce80f866145fb2191baf885950498647d52d132be8f066b15b29e45204cd6aab3918acdd53706d22d9bfac7205'; `

--- a/src/runtime/2.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/2.1/nanoserver-20H2/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:20H2-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core Runtime
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$Env:DOTNET_VERSION/dotnet-runtime-$Env:DOTNET_VERSION-win-x64.zip; `
     $dotnet_sha512 = '2705a18a0c1ecf9ed2811f437b55ac1f87c4b2ce80f866145fb2191baf885950498647d52d132be8f066b15b29e45204cd6aab3918acdd53706d22d9bfac7205'; `

--- a/src/runtime/2.1/stretch-slim/amd64/Dockerfile
+++ b/src/runtime/2.1/stretch-slim/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='9663a204abb74016113ae0db6c184598a6e5efc6126e35e275d81594432f75f186af781b3b352c8fe8527c690711820bfdd6271424b56e272f73ebe2d666bab5' \

--- a/src/runtime/2.1/stretch-slim/arm32v7/Dockerfile
+++ b/src/runtime/2.1/stretch-slim/arm32v7/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.1.23
+ENV DOTNET_VERSION=2.1.23
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='0ac5a730b90f8e0b7c792a03d4977abd9a5464258dfc0b8ac71237a540993bf89843f6e66a311664c23e366ff505eaffd5341e34455a72033d6a41d2e2944f0c' \

--- a/src/runtime/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.12/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-alpine3.12-amd64
 
 # Install .NET
-ENV DOTNET_VERSION 5.0.1
+ENV DOTNET_VERSION=5.0.1
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='9a6eef8077f2d1a25a1b4ee9dd9300ac6ddd51b59ce14dd80e105cb18c27f8337517548595b8081be959d4c4d40339997931ed14b4d43aeca8d335c58bc382de' \

--- a/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-alpine3.12-arm64v8
 
 # Install .NET
-ENV DOTNET_VERSION 5.0.1
+ENV DOTNET_VERSION=5.0.1
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \
     && dotnet_sha512='a09c5fea4e5ad30ae4d112290ab5bd88a5861bf3f7e1ef830e9eab8100aace3d81d4ceaa1fa34203b489708979a5f61792f26bd216d6f92ce59e0c87850960ef' \

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:5.0-buster-slim-amd64
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:5.0-buster-slim-arm32v7
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:5.0-buster-slim-arm64v8
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:5.0-focal-amd64
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/5.0/focal/arm32v7/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:5.0-focal-arm32v7
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/5.0/focal/arm64v8/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:5.0-focal-arm64v8
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/alpine3.12/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.12/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0-alpine3.12-amd64
 
 # Install .NET
-ENV DOTNET_VERSION 6.0.0-alpha.1.21052.6
+ENV DOTNET_VERSION=6.0.0-alpha.1.21052.6
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='8ce8805c7f517eadf96ac23f782d0c4055717815dc8e656198b6c3ebecde77ad82fde2b3555a599ceaf9fe4e5c85ad1a7005704adb0c0da9466f0635c7b2f79f' \

--- a/src/runtime/6.0/alpine3.12/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.12/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0-alpine3.12-arm64v8
 
 # Install .NET
-ENV DOTNET_VERSION 6.0.0-alpha.1.21052.6
+ENV DOTNET_VERSION=6.0.0-alpha.1.21052.6
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \
     && dotnet_sha512='c833d0ce59f19bcbc1c4afa20a04ac0fcd8b2f9c5d5b99319f4d7d8c62a236e397d569e40c610c3797e527a1b996574c4922cd487fc1d0b3d6269b08ece8ae1e' \

--- a/src/runtime/6.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/6.0/buster-slim/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:6.0-buster-slim-amd64
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/6.0/buster-slim/arm32v7/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:6.0-buster-slim-arm32v7
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/6.0/buster-slim/arm64v8/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:6.0-buster-slim-arm64v8
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/amd64/Dockerfile
+++ b/src/runtime/6.0/focal/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:6.0-focal-amd64
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/6.0/focal/arm32v7/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:6.0-focal-arm32v7
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/6.0/focal/arm64v8/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runti
 FROM $REPO:6.0-focal-arm64v8
 ARG DOTNET_VERSION
 
-ENV DOTNET_VERSION $DOTNET_VERSION
+ENV DOTNET_VERSION=$DOTNET_VERSION
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/sdk/2.1/alpine3.12/amd64/Dockerfile
+++ b/src/sdk/2.1/alpine3.12/amd64/Dockerfile
@@ -9,7 +9,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
     && dotnet_sha512='b808643e955c2e3bfcd713623ddaf69999af43966bafedd1af4124e7faa1cebbfefe891d2e540643754c451018ba52d2afca8c27b6d598ceb01a07040864e807' \

--- a/src/sdk/2.1/bionic/amd64/Dockerfile
+++ b/src/sdk/2.1/bionic/amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='ddc6a583c90405a1cf57c33b2ee285ce34d59f82c4f7bc01900f4ce87c45e295de96a0293ad51937ac1935611b87bc73cdafa8acd93b6fda5a2c624b00070326' \

--- a/src/sdk/2.1/bionic/arm32v7/Dockerfile
+++ b/src/sdk/2.1/bionic/arm32v7/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='b53a1a603528a07a94fc494ef92b900633b91b95f74661738e705748207d401c5910ca00f742ca844d3ad31f430837da78604ca53f96eea104ae8233aeb9c207' \

--- a/src/sdk/2.1/focal/amd64/Dockerfile
+++ b/src/sdk/2.1/focal/amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='ddc6a583c90405a1cf57c33b2ee285ce34d59f82c4f7bc01900f4ce87c45e295de96a0293ad51937ac1935611b87bc73cdafa8acd93b6fda5a2c624b00070326' \

--- a/src/sdk/2.1/focal/arm32v7/Dockerfile
+++ b/src/sdk/2.1/focal/arm32v7/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='b53a1a603528a07a94fc494ef92b900633b91b95f74661738e705748207d401c5910ca00f742ca844d3ad31f430837da78604ca53f96eea104ae8233aeb9c207' \

--- a/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '422db6523cdbb116741c60e967ad463e4870aecbc342e7f856bb4f672780b8bb82fce221dc534ba52f974b412b04605b28c31a3ee8269b06258526739af11afb'; `

--- a/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:1909-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '422db6523cdbb116741c60e967ad463e4870aecbc342e7f856bb4f672780b8bb82fce221dc534ba52f974b412b04605b28c31a3ee8269b06258526739af11afb'; `

--- a/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:2004-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '422db6523cdbb116741c60e967ad463e4870aecbc342e7f856bb4f672780b8bb82fce221dc534ba52f974b412b04605b28c31a3ee8269b06258526739af11afb'; `

--- a/src/sdk/2.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/2.1/nanoserver-20H2/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/windows/servercore:20H2-amd64 AS installer
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$Env:DOTNET_SDK_VERSION/dotnet-sdk-$Env:DOTNET_SDK_VERSION-win-x64.zip; `
     $dotnet_sha512 = '422db6523cdbb116741c60e967ad463e4870aecbc342e7f856bb4f672780b8bb82fce221dc534ba52f974b412b04605b28c31a3ee8269b06258526739af11afb'; `

--- a/src/sdk/2.1/stretch/amd64/Dockerfile
+++ b/src/sdk/2.1/stretch/amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='ddc6a583c90405a1cf57c33b2ee285ce34d59f82c4f7bc01900f4ce87c45e295de96a0293ad51937ac1935611b87bc73cdafa8acd93b6fda5a2c624b00070326' \

--- a/src/sdk/2.1/stretch/arm32v7/Dockerfile
+++ b/src/sdk/2.1/stretch/arm32v7/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.811
+ENV DOTNET_SDK_VERSION=2.1.811
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='b53a1a603528a07a94fc494ef92b900633b91b95f74661738e705748207d401c5910ca00f742ca844d3ad31f430837da78604ca53f96eea104ae8233aeb9c207' \


### PR DESCRIPTION
Updates the usage of `ENV name value` syntax to `ENV name=value`.

Fixes #2449