### PR TITLE
Correctly indent 'apk add' packages in alpine sdk Dockerfiles

### DIFF
--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
@@ -15,9 +15,9 @@ ENV \
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}
 
 RUN apk add --no-cache \
-    curl \
-    icu-libs \
-    git
+        curl \
+        icu-libs \
+        git
 
 # Install .NET SDK
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
@@ -15,9 +15,9 @@ ENV \
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}
 
 RUN apk add --no-cache \
-    curl \
-    icu-libs \
-    git
+        curl \
+        icu-libs \
+        git
 
 # Install .NET SDK
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \

--- a/src/sdk/5.0/alpine3.12/amd64/Dockerfile
+++ b/src/sdk/5.0/alpine3.12/amd64/Dockerfile
@@ -15,9 +15,9 @@ ENV \
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.12
 
 RUN apk add --no-cache \
-    curl \
-    icu-libs \
-    git
+        curl \
+        icu-libs \
+        git
 
 # Install .NET SDK
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \

--- a/src/sdk/6.0/alpine3.12/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.12/amd64/Dockerfile
@@ -15,9 +15,9 @@ ENV \
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.12
 
 RUN apk add --no-cache \
-    curl \
-    icu-libs \
-    git
+        curl \
+        icu-libs \
+        git
 
 # Install .NET SDK
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \


### PR DESCRIPTION
This corrects a minor formatting difference between the alpine sdk and [runtime-deps](https://github.com/dotnet/dotnet-docker/blob/master/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile#L3) Dockerfiles.