### PR TITLE
Upgrade System.CommandLine version

### DIFF
--- a/eng/update-dependencies/NuGet.config
+++ b/eng/update-dependencies/NuGet.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-    <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/" />
   </packageSources>
 </configuration>

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
@@ -22,61 +21,29 @@ namespace Dotnet.Docker
         public string VersionSourceName { get; private set; }
         public bool UpdateOnly => GitHubEmail == null || GitHubPassword == null || GitHubUser == null;
 
-        public void Parse(string[] args)
+        public Options(string dockerfileVersion, string[] productVersion, string versionSourceName, string email, string password, string user, bool computeShas)
         {
-            ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, syntax =>
-            {
-                IReadOnlyList<string> productVersions = Array.Empty<string>();
-                syntax.DefineOptionList(
-                    "product-version",
-                    ref productVersions,
-                    "Product versions to update (<product-name>=<version>)");
-                ProductVersions = productVersions
-                    .Select(pair => pair.Split(new char[] { '=' }, 2))
-                    .ToDictionary(split => split[0].ToLower(), split => split[1]);
-
-                string versionSourceName = null;
-                syntax.DefineOption(
-                    "version-source-name",
-                    ref versionSourceName,
-                    "The name of the source from which the version information was acquired.");
-                VersionSourceName = versionSourceName;
-
-                string gitHubEmail = null;
-                syntax.DefineOption(
-                    "email",
-                    ref gitHubEmail,
-                    "GitHub email used to make PR (if not specified, a PR will not be created)");
-                GitHubEmail = gitHubEmail;
-
-                string gitHubPassword = null;
-                syntax.DefineOption(
-                    "password",
-                    ref gitHubPassword,
-                    "GitHub password used to make PR (if not specified, a PR will not be created)");
-                GitHubPassword = gitHubPassword;
-
-                string gitHubUser = null;
-                syntax.DefineOption(
-                    "user",
-                    ref gitHubUser,
-                    "GitHub user used to make PR (if not specified, a PR will not be created)");
-                GitHubUser = gitHubUser;
-
-                bool computeChecksums = false;
-                syntax.DefineOption(
-                    "compute-shas",
-                    ref computeChecksums,
-                    "Compute the checksum if a published checksum cannot be found");
-                ComputeChecksums = computeChecksums;
-
-                string dockerfileVersion = null;
-                syntax.DefineParameter(
-                    "dockerfile-version",
-                    ref dockerfileVersion,
-                    "Version to the Dockerfiles to update");
-                DockerfileVersion = dockerfileVersion;
-            });
+            DockerfileVersion = dockerfileVersion;
+            ProductVersions = productVersion
+                .Select(pair => pair.Split(new char[] { '=' }, 2))
+                .ToDictionary(split => split[0].ToLower(), split => split[1]);
+            VersionSourceName = versionSourceName;
+            GitHubEmail = email;
+            GitHubPassword = password;
+            GitHubUser = user;
+            ComputeChecksums = computeShas;
         }
+
+        public static IEnumerable<Symbol> GetCliSymbols() =>
+            new Symbol[]
+            {
+                new Argument<string>("dockerfile-version", "Version to the Dockerfiles to update"),
+                new Option<string[]>("--product-version", "Product versions to update (<product-name>=<version>)"),
+                new Option<string>("--version-source-name", "The name of the source from which the version information was acquired."),
+                new Option<string>("--email", "GitHub email used to make PR (if not specified, a PR will not be created)"),
+                new Option<string>("--password", "GitHub password used to make PR (if not specified, a PR will not be created)"),
+                new Option<string>("--user", "GitHub user used to make PR (if not specified, a PR will not be created)"),
+                new Option<bool>("--compute-shas", "Compute the checksum if a published checksum cannot be found")
+            };
     }
 }

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -32,12 +32,28 @@ namespace Dotnet.Docker
             GitHubPassword = password;
             GitHubUser = user;
             ComputeChecksums = computeShas;
+
+            // Special case for handling the lzma NuGet package cache.
+            if (ProductVersions.ContainsKey("sdk") && DockerfileVersion == "2.1")
+            {
+                ProductVersions["lzma"] = ProductVersions["sdk"];
+            }
+
+            // Special case for handling the shared dotnet product version variables.
+            if (ProductVersions.ContainsKey("runtime"))
+            {
+                ProductVersions["dotnet"] = ProductVersions["runtime"];
+            }
+            else if (ProductVersions.ContainsKey("aspnet"))
+            {
+                ProductVersions["dotnet"] = ProductVersions["aspnet"];
+            }
         }
 
         public static IEnumerable<Symbol> GetCliSymbols() =>
             new Symbol[]
             {
-                new Argument<string>("dockerfile-version", "Version to the Dockerfiles to update"),
+                new Argument<string>("dockerfile-version", "Version of the Dockerfiles to update"),
                 new Option<string[]>("--product-version", "Product versions to update (<product-name>=<version>)"),
                 new Option<string>("--version-source-name", "The name of the source from which the version information was acquired."),
                 new Option<string>("--email", "GitHub email used to make PR (if not specified, a PR will not be created)"),

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -40,7 +40,7 @@ namespace Dotnet.Docker
 
         private static async Task ExecuteAsync(Options options)
         {
-            InitOptions(options);
+            Options = options;
 
             try
             {
@@ -81,27 +81,6 @@ namespace Dotnet.Docker
             }
 
             Environment.Exit(0);
-        }
-
-        private static void InitOptions(Options options)
-        {
-            Options = options;
-
-            // Special case for handling the lzma NuGet package cache.
-            if (Options.ProductVersions.ContainsKey("sdk") && Options.DockerfileVersion == "2.1")
-            {
-                Options.ProductVersions["lzma"] = Options.ProductVersions["sdk"];
-            }
-
-            // Special case for handling the shared dotnet product version variables.
-            if (Options.ProductVersions.ContainsKey("runtime"))
-            {
-                Options.ProductVersions["dotnet"] = Options.ProductVersions["runtime"];
-            }
-            else if (Options.ProductVersions.ContainsKey("aspnet"))
-            {
-                Options.ProductVersions["dotnet"] = Options.ProductVersions["aspnet"];
-            }
         }
 
         private static DependencyUpdateResults UpdateFiles(IEnumerable<IDependencyInfo> buildInfos)

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -20,18 +22,31 @@ namespace Dotnet.Docker
     {
         public const string VersionsFilename = "manifest.versions.json";
 
-        private static Options Options { get; } = new Options();
+        private static Options Options { get; set; }
         private static string RepoRoot { get; } = Directory.GetCurrentDirectory();
 
-        public static async Task Main(string[] args)
+        public static Task Main(string[] args)
         {
+            RootCommand command = new RootCommand();
+            foreach (Symbol option in Options.GetCliSymbols())
+            {
+                command.Add(option);
+            };
+
+            command.Handler = CommandHandler.Create<Options>(ExecuteAsync);
+
+            return command.InvokeAsync(args);
+        }
+
+        private static async Task ExecuteAsync(Options options)
+        {
+            InitOptions(options);
+
             try
             {
                 ErrorTraceListener errorTraceListener = new ErrorTraceListener();
                 Trace.Listeners.Add(errorTraceListener);
                 Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
-
-                ParseOptions(args);
 
                 IEnumerable<IDependencyInfo> buildInfos = Options.ProductVersions
                     .Select(kvp => CreateDependencyBuildInfo(kvp.Key, kvp.Value))
@@ -68,9 +83,9 @@ namespace Dotnet.Docker
             Environment.Exit(0);
         }
 
-        private static void ParseOptions(string[] args)
+        private static void InitOptions(Options options)
         {
-            Options.Parse(args);
+            Options = options;
 
             // Special case for handling the lzma NuGet package cache.
             if (Options.ProductVersions.ContainsKey("sdk") && Options.DockerfileVersion == "2.1")

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="5.0.0-beta.19617.1" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e170603-2"/>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removes the use of an older, unsupported version of `System.CommandLine` that is no longer available from the deprecated `dotnet.myget.org` feed.  Replaces it with the new version of `System.CommandLine` from https://github.com/dotnet/command-line-api. This has a new API model that the code has been refactored to consume.

Fixes #2493