### PR TITLE
Fix update-dependencies to update 5.0 Dockerfiles for dotnet-monitor.

### DIFF
--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -49,7 +49,7 @@ stages:
       displayName: Build Update Dependencies Tool
     - script: >
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
-        $(dockerfileVersion)
+        $(monitorDockerfileVersion)
         --user $(dotnetDockerBot.userName)
         --email $(dotnetDockerBot.email)
         --password $(BotAccount-dotnet-docker-bot-PAT)

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -35,9 +35,9 @@
     "dotnet|5.0|product-version": "5.0.2",
     "dotnet|6.0|product-version": "6.0.0-alpha.1",
 
-    "monitor|5.0|build-version": "5.0.0-preview.3.21063.1",
+    "monitor|5.0|build-version": "5.0.0-preview.3.21068.1",
     "monitor|5.0|product-version": "5.0.0-preview.3",
-    "monitor|5.0|sha": "eb0294db84cf7ab09d1ac6cb02b1cf25109f2a688116ea0bc5e1a713e935bf900e615359376af22fc176292fb3cc1264b868b18cbb507cfb3394f61d25ae1626",
+    "monitor|5.0|sha": "c3b10ecd8fd80535dce26bfcff19dc8c30b34894c4137021e3fb82d2be272b703f1b69e1a5c47ef46589c848f4d18e594b9133f34b090c4282b5f63464089e59",
 
     "lzma|2.1|sha": "c4c81218e250242410bc4fe9039fc7f39dc5603febbe04605d6b9abc21c45273b79f12122bab973d49eacd4eefe38b2bc38a6f6cd30260e5613cabfb36e82a62",
 

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:3.1-alpine3.12 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.3.21063.1
+ENV DOTNET_MONITOR_VERSION=5.0.0-preview.3.21068.1
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
-    && dotnetmonitor_sha512='eb0294db84cf7ab09d1ac6cb02b1cf25109f2a688116ea0bc5e1a713e935bf900e615359376af22fc176292fb3cc1264b868b18cbb507cfb3394f61d25ae1626' \
+    && dotnetmonitor_sha512='c3b10ecd8fd80535dce26bfcff19dc8c30b34894c4137021e3fb82d2be272b703f1b69e1a5c47ef46589c848f4d18e594b9133f34b090c4282b5f63464089e59' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.


### PR DESCRIPTION
Since moving the nightly update dependencies pipeline to the 6.0 product version, dotnet-monitor has not had its Dockerfile updated. This change fixes the Dockerfile version passed into the update-dependencies tool to move the version back to 5.0 for dotnet-monitor only. This change will require an update to the pipeline to include monitorDockerfileVersion as a new variable with a value of 5.0 to complete the fix.