### PR TITLE
Add architecture to samples

### DIFF
--- a/samples/aspnetapp/aspnetapp/Pages/Index.cshtml
+++ b/samples/aspnetapp/aspnetapp/Pages/Index.cshtml
@@ -12,7 +12,7 @@
     <h1 class="display-4">Welcome to .NET</h1>
 
     <h5>Environment</h5>
-    <p>@RuntimeInformation.FrameworkDescription</p>
+    <p>@RuntimeInformation.FrameworkDescription (@RuntimeInformation.ProcessArchitecture)</p>
     <p>@RuntimeInformation.OSDescription</p>
 </div>
 

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -13,8 +13,9 @@ public static class Program
           WriteLine($"      {message}{GetBot()}");
           
           WriteLine("Environment:");
-          WriteLine(RuntimeInformation.FrameworkDescription);
+          WriteLine($"{RuntimeInformation.FrameworkDescription} ({RuntimeInformation.ProcessArchitecture})");
           WriteLine(RuntimeInformation.OSDescription);
+
     }
 
     private static string GetBot() 


### PR DESCRIPTION
I was starting to test our container images on Apple M1 machines. The samples don't demonstrate the architecture. It would be very useful to see that information.