### PR TITLE
Remove default hosting URL for dotnet-monitor

### DIFF
--- a/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
@@ -22,6 +22,8 @@ WORKDIR /app
 COPY --from=installer /app .
 
 ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
     # Disable debugger and profiler diagnostics to avoid diagnosing self.
     COMPlus_EnableDiagnostics=0 \
     # Logging: JSON format so that analytic platforms can get discrete entry information

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -22,6 +22,8 @@ WORKDIR /app
 COPY --from=installer /app .
 
 ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
     # Disable debugger and profiler diagnostics to avoid diagnosing self.
     COMPlus_EnableDiagnostics=0 \
     # Logging: JSON format so that analytic platforms can get discrete entry information


### PR DESCRIPTION
dotnet-monitor uses arguments to specify default bindings, and uses configuration to alter these. Remove the default binding url from the image.