### PR TITLE
Remove 6.0 SDK content verification workaround

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -160,8 +160,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {
             // Disable this test for 5.0 due to https://github.com/dotnet/aspnetcore/issues/27670
-            // Disable this test for 6.0 due to https://github.com/dotnet/aspnetcore/issues/29092
-            if (imageData.Version.Major == 5 || imageData.Version.Major == 6)
+            if (imageData.Version.Major == 5)
             {
                 return;
             }


### PR DESCRIPTION
The fix for https://github.com/dotnet/aspnetcore/issues/29092 is now available in the 6.0 builds so the test workaround can be removed.  The fix for 5.0 (https://github.com/dotnet/aspnetcore/issues/27670) should be available in the next 5.0 servicing release.

Related to https://github.com/dotnet/dotnet-docker/issues/2373