### PR TITLE
Add SDK Dockerfiles for Arm arch on Alpine

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -98,6 +98,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 6.0.100-preview.1-buster-slim-arm64v8, 6.0-buster-slim-arm64v8, 6.0.100-preview.1-buster-slim, 6.0-buster-slim, 6.0.100-preview.1, 6.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/buster-slim/arm64v8/Dockerfile) | Debian 10
+6.0.100-preview.1-alpine3.13-arm64v8, 6.0-alpine3.13-arm64v8, 6.0-alpine-arm64v8, 6.0.100-preview.1-alpine3.13, 6.0-alpine3.13, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.13/arm64v8/Dockerfile) | Alpine 3.13
 6.0.100-preview.1-focal-arm64v8, 6.0-focal-arm64v8, 6.0.100-preview.1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm32 Tags
@@ -116,6 +117,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 6.0.100-preview.1-buster-slim-arm32v7, 6.0-buster-slim-arm32v7, 6.0.100-preview.1-buster-slim, 6.0-buster-slim, 6.0.100-preview.1, 6.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/buster-slim/arm32v7/Dockerfile) | Debian 10
+6.0.100-preview.1-alpine3.13-arm32v7, 6.0-alpine3.13-arm32v7, 6.0-alpine-arm32v7, 6.0.100-preview.1-alpine3.13, 6.0-alpine3.13, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.13/arm32v7/Dockerfile) | Alpine 3.13
 6.0.100-preview.1-focal-arm32v7, 6.0-focal-arm32v7, 6.0.100-preview.1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ## Nano Server, version 20H2 amd64 Tags

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
@@ -20,14 +20,14 @@ RUN apk add --no-cache \
         git
 
 # Install .NET SDK
-RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='{{VARIABLES["sdk|6.0|linux-musl|x64|sha"]}}' \
+RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \
+    && dotnet_sha512='{{VARIABLES[cat("sdk|6.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
-    && dotnet help
+    && dotnet help{{if ARCH_VERSIONED = "amd64":
 
 # Install PowerShell global tool
 RUN powershell_version={{VARIABLES["powershell|6.0|build-version"]}} \
@@ -43,4 +43,4 @@ RUN powershell_version={{VARIABLES["powershell|6.0|build-version"]}} \
     # To reduce image size, remove the copy nupkg that nuget keeps.
     && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm \
     # Add ncurses-terminfo-base to resolve psreadline dependency
-    && apk add --no-cache ncurses-terminfo-base
+    && apk add --no-cache ncurses-terminfo-base}}

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -21,6 +21,8 @@ $(McrTagsYmlTagGroup:2.1-focal)
 $(McrTagsYmlTagGroup:2.1-bionic)
 $(McrTagsYmlTagGroup:6.0-buster-slim-arm64v8)
     customSubTableTitle: .NET 6.0 Preview Tags
+$(McrTagsYmlTagGroup:6.0-alpine3.13-arm64v8)
+    customSubTableTitle: .NET 6.0 Preview Tags
 $(McrTagsYmlTagGroup:6.0-focal-arm64v8)
     customSubTableTitle: .NET 6.0 Preview Tags
 $(McrTagsYmlTagGroup:5.0-buster-slim-arm64v8)
@@ -29,6 +31,8 @@ $(McrTagsYmlTagGroup:3.1-buster-arm64v8)
 $(McrTagsYmlTagGroup:3.1-focal-arm64v8)
 $(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:6.0-buster-slim-arm32v7)
+    customSubTableTitle: .NET 6.0 Preview Tags
+$(McrTagsYmlTagGroup:6.0-alpine3.13-arm32v7)
     customSubTableTitle: .NET 6.0 Preview Tags
 $(McrTagsYmlTagGroup:6.0-focal-arm32v7)
     customSubTableTitle: .NET 6.0 Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -2095,16 +2095,7 @@
                 "6.0-alpine3.13-arm32v7": {},
                 "6.0-alpine-arm32v7": {}
               },
-              "variant": "v7",
-              "customBuildLegGroups": [
-                {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):6.0-buster-slim-arm32v7"
-                  ]
-                }
-              ]
+              "variant": "v7"
             },
             {
               "architecture": "arm64",
@@ -2120,16 +2111,7 @@
                 "6.0-alpine3.13-arm64v8": {},
                 "6.0-alpine-arm64v8": {}
               },
-              "variant": "v8",
-              "customBuildLegGroups": [
-                {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):6.0-buster-slim-arm64v8"
-                  ]
-                }
-              ]
+              "variant": "v8"
             }
           ]
         },
@@ -3552,16 +3534,7 @@
                 "6.0-alpine3.13-arm32v7": {},
                 "6.0-alpine-arm32v7": {}
               },
-              "variant": "v7",
-              "customBuildLegGroups": [
-                {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):6.0-buster-slim-arm32v7"
-                  ]
-                }
-              ]
+              "variant": "v7"
             },
             {
               "architecture": "arm64",
@@ -3577,16 +3550,7 @@
                 "6.0-alpine3.13-arm64v8": {},
                 "6.0-alpine-arm64v8": {}
               },
-              "variant": "v8",
-              "customBuildLegGroups": [
-                {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):6.0-buster-slim-arm64v8"
-                  ]
-                }
-              ]
+              "variant": "v8"
             }
           ]
         },
@@ -4926,6 +4890,38 @@
                 "6.0-alpine3.13-amd64": {},
                 "6.0-alpine-amd64": {}
               }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "architecture": "arm",
+              "dockerfile": "src/sdk/6.0/alpine3.13/arm32v7",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine",
+              "os": "linux",
+              "osVersion": "alpine3.13",
+              "tags": {
+                "$(sdk|6.0|product-version)-alpine3.13-arm32v7": {},
+                "6.0-alpine3.13-arm32v7": {},
+                "6.0-alpine-arm32v7": {}
+              },
+              "variant": "v7"
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "architecture": "arm64",
+              "dockerfile": "src/sdk/6.0/alpine3.13/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine",
+              "os": "linux",
+              "osVersion": "alpine3.13",
+              "tags": {
+                "$(sdk|6.0|product-version)-alpine3.13-arm64v8": {},
+                "6.0-alpine3.13-arm64v8": {},
+                "6.0-alpine-arm64v8": {}
+              },
+              "variant": "v8"
             }
           ]
         },

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -153,6 +153,8 @@
 
     "sdk|6.0|build-version": "6.0.100-preview.1.21075.9",
     "sdk|6.0|product-version": "6.0.100-preview.1",
+    "sdk|6.0|linux-musl|arm|sha": "dc2ca32a68468f4a64adc276b1a08eb193e661c55d0aa9265c10772cc1b20ac28ae3154d5825459ac668d29a83841d1a22170f649bbee2acf9c3a3f1c069b024",
+    "sdk|6.0|linux-musl|arm64|sha": "5cc10a05aa7b574dc42c63bdb7bdbb558437ef2787e5329742c16161b5d460ff3da8bb87bcbd47ad59e3c0fecd57dae185dd81266c7ea78e7f0a7096233d28de",
     "sdk|6.0|linux-musl|x64|sha": "853f7f2cdc64d7a76de439f1558cd05fd77c65116f57e0e7c85d9a568b8e542f160fb6b349dac266104483c88e87f0cd14e115455d59213e79b697a328dbe38d",
     "sdk|6.0|linux|arm|sha": "ca8bb1168246623976e6f0383242697f679bf2438d409d615c03bfd7caa2521bd931fc8841bfcda5347be7067bf3f5d9beff21fb8fdf8d51e60d94ba67ac3ae9",
     "sdk|6.0|linux|arm64|sha": "eac96f6499a826aad04be59964ea9ff30caf8f57faca3cd2d61ebd2a1b2cde82391b4d2349ea9ca37ef70f5ef5c8b5672faffff01d2b793ae3efd7e5640a6aba",

--- a/src/sdk/6.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.13/arm32v7/Dockerfile
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:6.0-alpine3.13-arm32v7
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    DOTNET_SDK_VERSION=6.0.100-preview.1.21075.9 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.13-arm32
+
+RUN apk add --no-cache \
+        curl \
+        icu-libs \
+        git
+
+# Install .NET SDK
+RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-arm.tar.gz \
+    && dotnet_sha512='dc2ca32a68468f4a64adc276b1a08eb193e661c55d0aa9265c10772cc1b20ac28ae3154d5825459ac668d29a83841d1a22170f649bbee2acf9c3a3f1c069b024' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help

--- a/src/sdk/6.0/alpine3.13/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.13/arm64v8/Dockerfile
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:6.0-alpine3.13-arm64v8
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    DOTNET_SDK_VERSION=6.0.100-preview.1.21075.9 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.13-arm64
+
+RUN apk add --no-cache \
+        curl \
+        icu-libs \
+        git
+
+# Install .NET SDK
+RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-arm64.tar.gz \
+    && dotnet_sha512='5cc10a05aa7b574dc42c63bdb7bdbb558437ef2787e5329742c16161b5d460ff3da8bb87bcbd47ad59e3c0fecd57dae185dd81266c7ea78e7f0a7096233d28de' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -165,6 +165,12 @@ namespace Microsoft.DotNet.Docker.Tests
                 return;
             }
 
+            // Disable this test for Arm-based Alpine on 6.0 until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
+            if (imageData.Version.Major == 6 && imageData.OS.Contains("alpine") && imageData.IsArm)
+            {
+                return;
+            }
+
             if (!(imageData.Version.Major >= 5 ||
                 (imageData.Version.Major >= 3 &&
                     (imageData.SdkOS.StartsWith(OS.AlpinePrefix) || !DockerHelper.IsLinuxContainerModeEnabled))))

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -54,8 +54,8 @@ namespace Microsoft.DotNet.Docker.Tests
             new ProductImageData { Version = V6_0, OS = OS.BusterSlim,   Arch = Arch.Arm64 },
             new ProductImageData { Version = V6_0, OS = OS.Focal,        Arch = Arch.Arm },
             new ProductImageData { Version = V6_0, OS = OS.Focal,        Arch = Arch.Arm64 },
-            new ProductImageData { Version = V6_0, OS = OS.Alpine313,    Arch = Arch.Arm,     SdkOS = OS.BusterSlim },
-            new ProductImageData { Version = V6_0, OS = OS.Alpine313,    Arch = Arch.Arm64,   SdkOS = OS.BusterSlim },
+            new ProductImageData { Version = V6_0, OS = OS.Alpine313,    Arch = Arch.Arm },
+            new ProductImageData { Version = V6_0, OS = OS.Alpine313,    Arch = Arch.Arm64 },
         };
         private static readonly ProductImageData[] s_windowsTestData =
         {

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -144,6 +144,8 @@
     "src/sdk/6.0/buster-slim/arm32v7": 560467682,
     "src/sdk/6.0/buster-slim/arm64v8": 630849653,
     "src/sdk/6.0/alpine3.13/amd64": 483297399,
+    "src/sdk/6.0/alpine3.13/arm32v7": 479381569,
+    "src/sdk/6.0/alpine3.13/arm64v8": 521161475,
     "src/sdk/6.0/focal/amd64": 631776580,
     "src/sdk/6.0/focal/arm32v7": 570689058,
     "src/sdk/6.0/focal/arm64v8": 644325728


### PR DESCRIPTION
Things of note:
* Buster SDK is now no longer needed in order to test the runtime and aspnet images for Arm.
* PowerShell doesn't provide an Arm version of Alpine (see https://github.com/PowerShell/PowerShell/issues/12937 and https://github.com/PowerShell/PowerShell/issues/14667) so PowerShell needed to be removed from the sdk for Arm.

Related to #2504