### PR TITLE
Add dotnet-monitor variable and metrics endpoint tests.

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -20,8 +20,8 @@ param(
     [string]$Mode = "BuildAndTest",
 
     # Categories of tests to run
-    [ValidateSet("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size")]
-    [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size")
+    [ValidateSet("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size", "monitor")]
+    [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size", "monitor")
 )
 
 if (($Mode -eq "BuildAndTest" -or $Mode -eq "Test") -and $TestCategories.Contains("pre-build")) {

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         protected override DotNetImageType ImageType => DotNetImageType.Aspnet;
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Docker.Tests
             await verifier.Execute();
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/DotNetTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DotNetTheoryAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    [XunitTestCaseDiscoverer("Microsoft.DotNet.Docker.Tests.DotNetTheoryDiscoverer", "Microsoft.DotNet.Docker.Tests")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public class DotNetTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/DotNetTheoryDiscoverer.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DotNetTheoryDiscoverer.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class DotNetTheoryDiscoverer : TheoryDiscoverer
+    {
+        public DotNetTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+        }
+
+        public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            IEnumerable<IXunitTestCase> results = base.Discover(discoveryOptions, testMethod, theoryAttribute);
+
+            if (results.Count() == 1 &&
+                results.First() is ExecutionErrorTestCase errorTestCase &&
+                errorTestCase.ErrorMessage.StartsWith("No data found for"))
+            {
+                return CreateTestCasesForSkippedDataRow(discoveryOptions, testMethod, theoryAttribute, Array.Empty<object>(), errorTestCase.ErrorMessage);
+            }
+
+            return results;
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -216,14 +216,14 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
+        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null)
         {
             int retries = 30;
 
             // Can't use localhost when running inside containers or Windows.
             string url = !Config.IsRunningInContainer && DockerHelper.IsLinuxContainerModeEnabled
-                ? $"http://localhost:{dockerHelper.GetContainerHostPort(containerName)}"
-                : $"http://{dockerHelper.GetContainerAddress(containerName)}";
+                ? $"http://localhost:{dockerHelper.GetContainerHostPort(containerName, containerPort)}/{pathAndQuery}"
+                : $"http://{dockerHelper.GetContainerAddress(containerName)}:{containerPort}/{pathAndQuery}";
 
             using (HttpClient client = new HttpClient())
             {

--- a/tests/Microsoft.DotNet.Docker.Tests/LinuxImageTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/LinuxImageTheoryAttribute.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
-
 namespace Microsoft.DotNet.Docker.Tests
 {
-    public class LinuxImageTheoryAttribute : TheoryAttribute
+    public class LinuxImageTheoryAttribute : DotNetTheoryAttribute
     {
         public LinuxImageTheoryAttribute()
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class MonitorImageData : ImageData
+    {
+        public Version Version { get; set; }
+        public string VersionString => Version.ToString(2);
+
+        public string GetImage(DockerHelper dockerHelper)
+        {
+            string tagVersion = Version.ToString(2);
+
+            string tag = GetTagName(tagVersion, OS);
+
+            string imageName = GetImageName(tag, "monitor");
+
+            PullImageIfNecessary(imageName, dockerHelper);
+
+            return imageName;
+        }
+
+        protected override string GetArchTagSuffix() => string.Empty;
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
@@ -12,12 +12,11 @@ namespace Microsoft.DotNet.Docker.Tests
         public string RuntimeVersionString => RuntimeVersion.ToString(2);
         public Version Version { get; set; }
         public string VersionString => Version.ToString(2);
+        public string OSTag { get; set; }
 
         public string GetImage(DockerHelper dockerHelper)
         {
-            string tagVersion = Version.ToString(2);
-
-            string tag = GetTagName(tagVersion, OS);
+            string tag = GetTagName(VersionString, OSTag);
 
             string imageName = GetImageName(tag, "monitor");
 

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
@@ -8,6 +8,8 @@ namespace Microsoft.DotNet.Docker.Tests
 {
     public class MonitorImageData : ImageData
     {
+        public Version RuntimeVersion { get; set; }
+        public string RuntimeVersionString => RuntimeVersion.ToString(2);
         public Version Version { get; set; }
         public string VersionString => Version.ToString(2);
 

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -15,8 +15,6 @@ namespace Microsoft.DotNet.Docker.Tests
     [Trait("Category", "monitor")]
     public class MonitorImageTests
     {
-        private static readonly string s_samplesPath = Path.Combine(Config.SourceRepoRoot, "samples");
-
         public MonitorImageTests(ITestOutputHelper outputHelper)
         {
             OutputHelper = outputHelper;
@@ -31,13 +29,6 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             return TestData.GetMonitorImageData()
                 .Select(imageData => new object[] { imageData });
-        }
-
-        [Theory]
-        [MemberData(nameof(GetImageData))]
-        public void VerifyEnvironmentVariables(MonitorImageData imageData)
-        {
-            ValidateEnvironmentVariables(imageData, imageData.GetImage(DockerHelper));
         }
 
         [Theory]

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -33,6 +33,25 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [Theory]
         [MemberData(nameof(GetImageData))]
+        public void VerifyEnvironmentVariables(MonitorImageData imageData)
+        {
+            List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
+            variables.AddRange(ProductImageTests.GetCommonEnvironmentVariables());
+
+            // ASPNETCORE_URLS has been unset to allow the default URL binding to occur.
+            variables.Add(new EnvironmentVariableInfo("ASPNETCORE_URLS", string.Empty));
+            // Diagnostics should be disabled
+            variables.Add(new EnvironmentVariableInfo("COMPlus_EnableDiagnostics", "0"));
+
+            EnvironmentVariableInfo.Validate(
+                variables,
+                imageData.GetImage(DockerHelper),
+                imageData,
+                DockerHelper);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetImageData))]
         public Task VerifyMetricsEndpoint(MonitorImageData imageData)
         {
             return VerifyAsync(imageData, async (image, containerName) =>
@@ -55,8 +74,6 @@ namespace Microsoft.DotNet.Docker.Tests
                             52325,
                             "metrics");
                     }
-
-                    ValidateEnvironmentVariables(imageData, image);
                 }
                 finally
                 {
@@ -74,23 +91,6 @@ namespace Microsoft.DotNet.Docker.Tests
             string containerName = imageData.GetIdentifier("monitor");
 
             await verifyImageAsync(image, containerName);
-        }
-
-        private void ValidateEnvironmentVariables(MonitorImageData imageData, string image)
-        {
-            List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
-            variables.AddRange(ProductImageTests.GetCommonEnvironmentVariables());
-
-            // ASPNETCORE_URLS has been unset to allow the default URL binding to occur.
-            variables.Add(new EnvironmentVariableInfo("ASPNETCORE_URLS", string.Empty));
-            // Diagnostics should be disabled
-            variables.Add(new EnvironmentVariableInfo("COMPlus_EnableDiagnostics", "0"));
-
-            EnvironmentVariableInfo.Validate(
-                variables,
-                image,
-                imageData,
-                DockerHelper);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 .Select(imageData => new object[] { imageData });
         }
 
-        [Theory]
+        [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(MonitorImageData imageData)
         {
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 DockerHelper);
         }
 
-        [Theory]
+        [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
         public Task VerifyMetricsEndpoint(MonitorImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    [Trait("Category", "monitor")]
+    public class MonitorImageTests
+    {
+        private static readonly string s_samplesPath = Path.Combine(Config.SourceRepoRoot, "samples");
+
+        public MonitorImageTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+            DockerHelper = new DockerHelper(outputHelper);
+        }
+
+        protected DockerHelper DockerHelper { get; }
+
+        protected ITestOutputHelper OutputHelper { get; }
+
+        public static IEnumerable<object[]> GetImageData()
+        {
+            return TestData.GetMonitorImageData()
+                .Select(imageData => new object[] { imageData });
+        }
+
+        [Theory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyEnvironmentVariables(MonitorImageData imageData)
+        {
+            ValidateEnvironmentVariables(imageData, imageData.GetImage(DockerHelper));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetImageData))]
+        public Task VerifyMetricsEndpoint(MonitorImageData imageData)
+        {
+            return VerifyAsync(imageData, async (image, containerName) =>
+            {
+                try
+                {
+                    DockerHelper.Run(
+                        image: image,
+                        name: containerName,
+                        detach: true,
+                        optionalRunArgs: "-p 52325");
+
+                    if (!Config.IsHttpVerificationDisabled)
+                    {
+                        // Verify metrics endpoint is accessible
+                        await ImageScenarioVerifier.VerifyHttpResponseFromContainerAsync(
+                            containerName,
+                            DockerHelper,
+                            OutputHelper,
+                            52325,
+                            "metrics");
+                    }
+
+                    ValidateEnvironmentVariables(imageData, image);
+                }
+                finally
+                {
+                    DockerHelper.DeleteContainer(containerName);
+                }
+            });
+        }
+
+        private async Task VerifyAsync(
+            MonitorImageData imageData,
+            Func<string, string, Task> verifyImageAsync)
+        {
+            string image = imageData.GetImage(DockerHelper);
+
+            string containerName = imageData.GetIdentifier("monitor");
+
+            await verifyImageAsync(image, containerName);
+        }
+
+        private void ValidateEnvironmentVariables(MonitorImageData imageData, string image)
+        {
+            List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
+            variables.AddRange(ProductImageTests.GetCommonEnvironmentVariables());
+
+            // ASPNETCORE_URLS has been unset to allow the default URL binding to occur.
+            variables.Add(new EnvironmentVariableInfo("ASPNETCORE_URLS", string.Empty));
+            // Diagnostics should be disabled
+            variables.Add(new EnvironmentVariableInfo("COMPlus_EnableDiagnostics", "0"));
+
+            EnvironmentVariableInfo.Validate(
+                variables,
+                image,
+                imageData,
+                DockerHelper);
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         protected override DotNetImageType ImageType => DotNetImageType.Runtime;
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Docker.Tests
             await verifier.Execute();
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 .Select(imageData => new object[] { imageData });
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetSample(SampleImageData imageData)
         {
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Docker.Tests
             });
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAspnetSample(SampleImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Docker.Tests
             base.VerifyCommonInsecureFiles(imageData);
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Docker.Tests
             EnvironmentVariableInfo.Validate(variables, imageData.GetImage(DotNetImageType.SDK, DockerHelper), imageData, DockerHelper);
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyPackageCache(ProductImageData imageData)
         {
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyPowerShellScenario_DefaultUser(ProductImageData imageData)
         {
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Docker.Tests
             PowerShellScenario_Execute(imageData, null);
         }
 
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyPowerShellScenario_NonDefaultUser(ProductImageData imageData)
         {
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Docker.Tests
         /// <summary>
         /// Verifies that the dotnet folder contents of an SDK container match the contents in the official SDK archive file.
         /// </summary>
-        [Theory]
+        [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/SkippableTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SkippableTheoryAttribute.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.RegularExpressions;
-using Xunit;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
-    public class SkippableTheoryAttribute : TheoryAttribute
+    public class SkippableTheoryAttribute : DotNetTheoryAttribute
     {
         public SkippableTheoryAttribute(params string[] skippedOperatingSystems)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -111,6 +111,15 @@ namespace Microsoft.DotNet.Docker.Tests
             new SampleImageData { OS = OS.ServerCoreLtsc2019, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-x64-slim" },
         };
 
+        private static readonly MonitorImageData[] s_linuxMonitorTestData =
+        {
+            new MonitorImageData { Version = V5_0, OS = OS.Alpine, Arch = Arch.Amd64 },
+        };
+
+        private static readonly MonitorImageData[] s_windowsMonitorTestData =
+        {
+        };
+
         public static IEnumerable<ProductImageData> GetImageData()
         {
             return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxTestData : s_windowsTestData)
@@ -126,6 +135,14 @@ namespace Microsoft.DotNet.Docker.Tests
                 .FilterImagesByArch()
                 .FilterImagesByOs()
                 .Cast<SampleImageData>();
+        }
+
+        public static IEnumerable<MonitorImageData> GetMonitorImageData()
+        {
+            return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxMonitorTestData : s_windowsMonitorTestData)
+                .FilterImagesByArch()
+                .FilterImagesByOs()
+                .Cast<MonitorImageData>();
         }
 
         public static IEnumerable<ImageData> FilterImagesByVersion(this IEnumerable<ProductImageData> imageData)

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static readonly MonitorImageData[] s_linuxMonitorTestData =
         {
-            new MonitorImageData { Version = V5_0, OS = OS.Alpine, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V5_0, RuntimeVersion = V3_1, OS = OS.Alpine, Arch = Arch.Amd64 },
         };
 
         private static readonly MonitorImageData[] s_windowsMonitorTestData =
@@ -140,6 +140,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static IEnumerable<MonitorImageData> GetMonitorImageData()
         {
             return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxMonitorTestData : s_windowsMonitorTestData)
+                .FilterImagesByRuntimeVersion()
                 .FilterImagesByArch()
                 .FilterImagesByOs()
                 .Cast<MonitorImageData>();
@@ -151,6 +152,14 @@ namespace Microsoft.DotNet.Docker.Tests
             return imageData
                 .Where(imageData => versionFilterPattern == null
                     || Regex.IsMatch(imageData.VersionString, versionFilterPattern, RegexOptions.IgnoreCase));
+        }
+
+        public static IEnumerable<ImageData> FilterImagesByRuntimeVersion(this IEnumerable<MonitorImageData> imageData)
+        {
+            string versionFilterPattern = GetFilterRegexPattern("IMAGE_VERSION");
+            return imageData
+                .Where(imageData => versionFilterPattern == null
+                    || Regex.IsMatch(imageData.RuntimeVersionString, versionFilterPattern, RegexOptions.IgnoreCase));
         }
 
         public static IEnumerable<ImageData> FilterImagesByArch(this IEnumerable<ImageData> imageData)

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static IEnumerable<MonitorImageData> GetMonitorImageData()
         {
             return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxMonitorTestData : s_windowsMonitorTestData)
-                .FilterImagesByRuntimeVersion()
+                .FilterMonitorImagesByRuntimeVersion()
                 .FilterImagesByArch()
                 .FilterImagesByOs()
                 .Cast<MonitorImageData>();
@@ -154,7 +154,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     || Regex.IsMatch(imageData.VersionString, versionFilterPattern, RegexOptions.IgnoreCase));
         }
 
-        public static IEnumerable<ImageData> FilterImagesByRuntimeVersion(this IEnumerable<MonitorImageData> imageData)
+        public static IEnumerable<ImageData> FilterMonitorImagesByRuntimeVersion(this IEnumerable<MonitorImageData> imageData)
         {
             string versionFilterPattern = GetFilterRegexPattern("IMAGE_VERSION");
             return imageData

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static readonly MonitorImageData[] s_linuxMonitorTestData =
         {
-            new MonitorImageData { Version = V5_0, RuntimeVersion = V3_1, OS = OS.Alpine, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V5_0, RuntimeVersion = V3_1, OS = OS.Alpine312, OSTag = OS.Alpine, Arch = Arch.Amd64 },
         };
 
         private static readonly MonitorImageData[] s_windowsMonitorTestData =

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -15,7 +15,7 @@ param(
     [switch]$PullImages,
     [string]$ImageInfoPath,
     [ValidateSet("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size", "monitor")]
-    [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk")
+    [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk", "monitor")
 )
 
 function Log {

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -14,7 +14,7 @@ param(
     [switch]$DisableHttpVerification,
     [switch]$PullImages,
     [string]$ImageInfoPath,
-    [ValidateSet("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size")]
+    [ValidateSet("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size", "monitor")]
     [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk")
 )
 


### PR DESCRIPTION
These changes add two unit tests for dotnet-monitor:
- Basic environment variable test
- Basic metrics endpoint availability test (tests that the container does run and that the metrics endpoint is accessible).

I plan to add additional tests in a future change for the other endpoints once https://github.com/dotnet/diagnostics/pull/1820 is completed.