### PR TITLE
Define Alpine 3.13 runtime-deps in 5.0 folder

### DIFF
--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -46,7 +46,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/master/sa
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.2-buster-slim-amd64, 5.0-buster-slim-amd64, 5.0.2, 5.0.2-buster-slim, 5.0, 5.0-buster-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-5.0.2-alpine3.13-amd64, 5.0-alpine3.13-amd64, 5.0-alpine-amd64, 5.0.2-alpine3.13, 5.0-alpine3.13, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile) | Alpine 3.13
+5.0.2-alpine3.13-amd64, 5.0-alpine3.13-amd64, 5.0-alpine-amd64, 5.0.2-alpine3.13, 5.0-alpine3.13, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/alpine3.13/amd64/Dockerfile) | Alpine 3.13
 5.0.2-alpine3.12-amd64, 5.0-alpine3.12-amd64, 5.0.2-alpine3.12, 5.0-alpine3.12 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile) | Alpine 3.12
 5.0.2-focal-amd64, 5.0-focal-amd64, 5.0.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.11-buster-slim, 3.1-buster-slim, 3.1.11, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
@@ -64,14 +64,14 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 6.0.0-preview.1-buster-slim-amd64, 6.0-buster-slim-amd64, 6.0.0-preview.1, 6.0.0-preview.1-buster-slim, 6.0, 6.0-buster-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile) | Debian 10
-6.0.0-preview.1-alpine3.13-amd64, 6.0-alpine3.13-amd64, 6.0-alpine-amd64, 6.0.0-preview.1-alpine3.13, 6.0-alpine3.13, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile) | Alpine 3.13
+6.0.0-preview.1-alpine3.13-amd64, 6.0-alpine3.13-amd64, 6.0-alpine-amd64, 6.0.0-preview.1-alpine3.13, 6.0-alpine3.13, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/alpine3.13/amd64/Dockerfile) | Alpine 3.13
 6.0.0-preview.1-focal-amd64, 6.0-focal-amd64, 6.0.0-preview.1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 5.0.2-buster-slim-arm64v8, 5.0-buster-slim-arm64v8, 5.0.2, 5.0.2-buster-slim, 5.0, 5.0-buster-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10
-5.0.2-alpine3.13-arm64v8, 5.0-alpine3.13-arm64v8, 5.0-alpine-arm64v8, 5.0.2-alpine3.13, 5.0-alpine3.13, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.13/arm64v8/Dockerfile) | Alpine 3.13
+5.0.2-alpine3.13-arm64v8, 5.0-alpine3.13-arm64v8, 5.0-alpine-arm64v8, 5.0.2-alpine3.13, 5.0-alpine3.13, 5.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/5.0/alpine3.13/arm64v8/Dockerfile) | Alpine 3.13
 5.0.2-alpine3.12-arm64v8, 5.0-alpine3.12-arm64v8, 5.0.2-alpine3.12, 5.0-alpine3.12 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile) | Alpine 3.12
 5.0.2-focal-arm64v8, 5.0-focal-arm64v8, 5.0.2-focal, 5.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.11-buster-slim-arm64v8, 3.1-buster-slim-arm64v8, 3.1.11, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile) | Debian 10

--- a/manifest.json
+++ b/manifest.json
@@ -647,7 +647,7 @@
           },
           "platforms": [
             {
-              "dockerfile": "src/runtime-deps/3.1/alpine3.13/amd64",
+              "dockerfile": "src/runtime-deps/5.0/alpine3.13/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine",
               "os": "linux",
               "osVersion": "alpine3.13",
@@ -672,7 +672,7 @@
             },
             {
               "architecture": "arm64",
-              "dockerfile": "src/runtime-deps/3.1/alpine3.13/arm64v8",
+              "dockerfile": "src/runtime-deps/5.0/alpine3.13/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine",
               "os": "linux",
               "osVersion": "alpine3.13",
@@ -737,7 +737,7 @@
           },
           "platforms": [
             {
-              "dockerfile": "src/runtime-deps/3.1/alpine3.13/amd64",
+              "dockerfile": "src/runtime-deps/5.0/alpine3.13/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine",
               "os": "linux",
               "osVersion": "alpine3.13",

--- a/src/runtime-deps/5.0/alpine3.13/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.13/amd64/Dockerfile
@@ -1,0 +1,20 @@
+FROM amd64/alpine:3.13
+
+RUN apk add --no-cache \
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
+
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/5.0/alpine3.13/arm64v8/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.13/arm64v8/Dockerfile
@@ -1,0 +1,20 @@
+FROM arm64v8/alpine:3.13
+
+RUN apk add --no-cache \
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib
+
+ENV \
+    # Configure web servers to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -22,7 +22,9 @@
     "src/runtime-deps/3.1/focal/arm32v7": 91727521,
     "src/runtime-deps/3.1/focal/arm64v8": 111261028,
     "src/runtime-deps/5.0/alpine3.12/arm32v7": 6783323,
-    "src/runtime-deps/5.0/alpine3.13/arm32v7": 6973412
+    "src/runtime-deps/5.0/alpine3.13/amd64": 9964359,
+    "src/runtime-deps/5.0/alpine3.13/arm32v7": 6973412,
+    "src/runtime-deps/5.0/alpine3.13/arm64v8": 9641621
   },
   "dotnet/nightly/runtime": {
     "src/runtime/2.1/stretch-slim/amd64": 180258057,


### PR DESCRIPTION
Because we will not be publishing Alpine 3.13 images for the servicing release of .NET Core 2.1 and 3.1 next week, I'm restructuring the files here in order to prep for that release next week.  We will be publishing Alpine 3.13 images for 5.0 and 6.0 Preview 1.  So I'm making a copy of the runtime-deps Dockerfile to be contained in the 5.0 folder and shared between 5.0 and 6.0 instead of before where it was shared by 3.1, 5.0, and 6.0.  It wouldn't have made sense to have the 3.1 folder contain a Alpine 3.13 Dockerfile when aren't going to be release that Alpine version for 3.1.

It still will use the `runtime-deps/3.1/Dockerfile.alpine` Dockerfile template because the content we need is still exactly the same; it's just the placement of the generated Dockerfile that's being changed.

Once we're ready to ship Alpine 3.13 images for .NET Core 3.1, we can have them share a single Dockerfile again.  I'll log an issue after merging this PR to ensure that work gets done.

Related to https://github.com/dotnet/dotnet-docker/issues/2530