### PR TITLE
Fix script to pull Image Builder

### DIFF
--- a/eng/common/Get-ImageBuilder.ps1
+++ b/eng/common/Get-ImageBuilder.ps1
@@ -9,7 +9,7 @@ ForEach-Object {
 }
 
 & docker inspect ${imageNames.imagebuilder} | Out-Null
-if ($LASTEXITCODE -ne 0) {
+if (-not $?) {
     Write-Output "Pulling"
     & $PSScriptRoot/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder}"
 }


### PR DESCRIPTION
The script that pulls Image Builder just recently started to fail on some of our build agents.  This is the same as what happened in https://github.com/dotnet/docker-tools/pull/735.  By changing the script to use `$?` instead of `$LASTEXITCODE`, it works.