### PR TITLE
Update dotnet-monitor version source and manually update to latest version

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -45,7 +45,7 @@ TBD
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0-alpine, 5.0.0-preview.3, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/5.0/alpine/amd64/Dockerfile) | Alpine 3.12
+5.0-alpine, 5.0.0-preview.4, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/5.0/alpine/amd64/Dockerfile) | Alpine 3.12
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/get-drop-versions-monitor.sh
+++ b/eng/get-drop-versions-monitor.sh
@@ -12,6 +12,4 @@ monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.version)
 
 rm dotnet-monitor.nupkg.version
 
-#echo "##vso[task.setvariable variable=monitorVer]$monitorVer"
-# Temporarily fix the version since Arcade cannot properly create aka.ms for assets without an aka.ms channel name.
-echo "##vso[task.setvariable variable=monitorVer]5.0.0-preview.4.21117.6"
+echo "##vso[task.setvariable variable=monitorVer]$monitorVer"

--- a/eng/get-drop-versions-monitor.sh
+++ b/eng/get-drop-versions-monitor.sh
@@ -12,4 +12,6 @@ monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.version)
 
 rm dotnet-monitor.nupkg.version
 
-echo "##vso[task.setvariable variable=monitorVer]$monitorVer"
+#echo "##vso[task.setvariable variable=monitorVer]$monitorVer"
+# Temporarily fix the version since Arcade cannot properly create aka.ms for assets without an aka.ms channel name.
+echo "##vso[task.setvariable variable=monitorVer]5.0.0-preview.4.21117.6"

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -34,12 +34,12 @@ stages:
         --version-source-name dotnet/core-sdk
         --compute-shas
       displayName: Run Update Dependencies
-- stage: Diagnostics
-  condition: eq(variables['update-diagnostics-enabled'], 'true')
+- stage: Monitor
+  condition: eq(variables['update-monitor-enabled'], 'true')
   dependsOn: [] # Allows it to run in parallel
   jobs:
   - job: UpdateDependencies
-    displayName: Update Dependencies (dotnet/diagnostics)
+    displayName: Update Dependencies (dotnet/dotnet-monitor)
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -54,5 +54,5 @@ stages:
         --email $(dotnetDockerBot.email)
         --password $(BotAccount-dotnet-docker-bot-PAT)
         --product-version monitor=$(monitorVer)
-        --version-source-name dotnet/diagnostics
+        --version-source-name dotnet/dotnet-monitor
       displayName: Run Update Dependencies

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -37,9 +37,9 @@
     "dotnet|5.0|product-version": "5.0.3",
     "dotnet|6.0|product-version": "6.0.0-preview.2",
 
-    "monitor|5.0|build-version": "5.0.0-preview.3.21105.1",
-    "monitor|5.0|product-version": "5.0.0-preview.3",
-    "monitor|5.0|sha": "d01212f1a8e55341288e4840df5435ed9692df72d4f209a8bf3aca835748e376c43e2591028c3e55637ecb87e1c9dbaa719951753881c80c46b80f22faa96186",
+    "monitor|5.0|build-version": "5.0.0-preview.4.21117.6",
+    "monitor|5.0|product-version": "5.0.0-preview.4",
+    "monitor|5.0|sha": "2cb87af45138e664ab54db2c8e53b5458979e9e463c237c6d5afe09bb848c5835007d203b4f406c198d416a308fe431d048dfee25ba2109c7ceca1cea6d2bf31",
 
     "lzma|2.1|sha": "5604734ce516940fc37759c82aa6e9f26bb7391e2d6c2881ee0352ddcfff6f2c61db18fbed4bb03fcb81d77a6c1dbfdec0fea475226cee9715c9f2db28fa2ab9",
 

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -37,9 +37,9 @@
     "dotnet|5.0|product-version": "5.0.3",
     "dotnet|6.0|product-version": "6.0.0-preview.2",
 
-    "monitor|5.0|build-version": "5.0.0-preview.4.21117.6",
+    "monitor|5.0|build-version": "5.0.0-preview.4.21117.7",
     "monitor|5.0|product-version": "5.0.0-preview.4",
-    "monitor|5.0|sha": "2cb87af45138e664ab54db2c8e53b5458979e9e463c237c6d5afe09bb848c5835007d203b4f406c198d416a308fe431d048dfee25ba2109c7ceca1cea6d2bf31",
+    "monitor|5.0|sha": "3e67e53f51601cc701b66074b7b77a214a56c914955214ceb1e3379762424791c41b89bc1b874c8b35af267f225a2cb90764d9b24f3592deb24308e525501566",
 
     "lzma|2.1|sha": "5604734ce516940fc37759c82aa6e9f26bb7391e2d6c2881ee0352ddcfff6f2c61db18fbed4bb03fcb81d77a6c1dbfdec0fea475226cee9715c9f2db28fa2ab9",
 

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:3.1-alpine3.12 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.3.21105.1
+ENV DOTNET_MONITOR_VERSION=5.0.0-preview.4.21117.6
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
-    && dotnetmonitor_sha512='d01212f1a8e55341288e4840df5435ed9692df72d4f209a8bf3aca835748e376c43e2591028c3e55637ecb87e1c9dbaa719951753881c80c46b80f22faa96186' \
+    && dotnetmonitor_sha512='2cb87af45138e664ab54db2c8e53b5458979e9e463c237c6d5afe09bb848c5835007d203b4f406c198d416a308fe431d048dfee25ba2109c7ceca1cea6d2bf31' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:3.1-alpine3.12 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.4.21117.6
+ENV DOTNET_MONITOR_VERSION=5.0.0-preview.4.21117.7
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
-    && dotnetmonitor_sha512='2cb87af45138e664ab54db2c8e53b5458979e9e463c237c6d5afe09bb848c5835007d203b4f406c198d416a308fe431d048dfee25ba2109c7ceca1cea6d2bf31' \
+    && dotnetmonitor_sha512='3e67e53f51601cc701b66074b7b77a214a56c914955214ceb1e3379762424791c41b89bc1b874c8b35af267f225a2cb90764d9b24f3592deb24308e525501566' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.


### PR DESCRIPTION
Arcade made a change recently that prevented the ability to create aka.ms latest links for repositories that do not have aka.ms channel names. Thus dotnet-monitor has not been able to provide updated versions to dotnet-docker. This change temporarily fixes the version of dotnet-monitor while Arcade resolves the issue and pushes out a new SDK.

Additionally, dotnet-monitor has moved to its own repository (https://github.com/dotnet/dotnet-monitor) so I've updated the version source to reflect that.

I'll create an issue in dotnet-docker and assign it to myself to undo the temporary version fixing.