### PR TITLE
Additional dotnet-monitor tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
 using System.Threading;
-using System.Runtime;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
@@ -197,6 +195,16 @@ namespace Microsoft.DotNet.Docker.Tests
             string workdirArg = workdir == null ? string.Empty : $" -w {workdir}";
             return ExecuteWithLogging(
                 $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg} {optionalRunArgs} {image} {command}");
+        }
+
+        public string CreateVolume(string name)
+        {
+            return ExecuteWithLogging($"volume create {name}");
+        }
+
+        public string DeleteVolume(string name)
+        {
+            return ExecuteWithLogging($"volume remove {name}");
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    internal class DockerRunArgsBuilder
+    {
+        private readonly StringBuilder _builder =
+            new StringBuilder();
+
+        private DockerRunArgsBuilder()
+        {
+        }
+
+        public static DockerRunArgsBuilder Create()
+        {
+            return new DockerRunArgsBuilder();
+        }
+
+        public string Build()
+        {
+            return _builder.ToString();
+        }
+
+        /// <summary>
+        /// Sets the named environment variable with the specified value.
+        /// </summary>
+        public DockerRunArgsBuilder EnvironmentVariable(string name, string value)
+        {
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "-e {0}={1} ", name, value);
+            return this;
+        }
+
+        /// <summary>
+        /// Exposes the container port to an arbitrary port on the host.
+        /// </summary>
+        public DockerRunArgsBuilder ExposePort(int port)
+        {
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "-p {0} ", port);
+            return this;
+        }
+
+        /// <summary>
+        /// Mounts a volume in the container at the specified path.
+        /// </summary>
+        public DockerRunArgsBuilder VolumeMount(string name, string path)
+        {
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "-v {0}:{1} ", name, path);
+            return this;
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -82,9 +82,9 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public static string GenerateContainerName(string prefix) => $"{prefix}-{DateTime.Now.ToFileTime()}";
 
-        protected void PullImageIfNecessary(string imageName, DockerHelper dockerHelper)
+        protected void PullImageIfNecessary(string imageName, DockerHelper dockerHelper, bool allowPull = false)
         {
-            if (Config.PullImages && !_pulledImages.Contains(imageName))
+            if ((Config.PullImages || allowPull) && !_pulledImages.Contains(imageName))
             {
                 dockerHelper.Pull(imageName);
                 _pulledImages.Add(imageName);

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -216,7 +216,18 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null)
+        public static Task<HttpResponseMessage> GetHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null)
+        {
+            return GetHttpResponseFromContainerAsync(
+                containerName,
+                dockerHelper,
+                outputHelper,
+                containerPort,
+                pathAndQuery,
+                m => m.EnsureSuccessStatusCode());
+        }
+
+        public static async Task<HttpResponseMessage> GetHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null, Action<HttpResponseMessage> validateCallback = null)
         {
             int retries = 30;
 
@@ -232,24 +243,44 @@ namespace Microsoft.DotNet.Docker.Tests
                     retries--;
                     await Task.Delay(TimeSpan.FromSeconds(2));
 
+                    HttpResponseMessage result = null;
                     try
                     {
-                        using (HttpResponseMessage result = await client.GetAsync(url))
+                        result = await client.GetAsync(url);
+                        outputHelper.WriteLine($"HTTP {result.StatusCode}\n{(await result.Content.ReadAsStringAsync())}");
+
+                        if (null != validateCallback)
                         {
-                            outputHelper.WriteLine($"HTTP {result.StatusCode}\n{(await result.Content.ReadAsStringAsync())}");
-                            result.EnsureSuccessStatusCode();
+                            validateCallback(result);
                         }
 
-                        return;
+                        // Store response in local that will not be disposed
+                        HttpResponseMessage returnResult = result;
+                        result = null;
+                        return returnResult;
                     }
                     catch (Exception ex)
                     {
                         outputHelper.WriteLine($"Request to {url} failed - retrying: {ex}");
                     }
+                    finally
+                    {
+                        result?.Dispose();
+                    }
                 }
             }
 
             throw new TimeoutException($"Timed out attempting to access the endpoint {url} on container {containerName}");
+        }
+
+        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null)
+        {
+            (await GetHttpResponseFromContainerAsync(
+                containerName,
+                dockerHelper,
+                outputHelper,
+                containerPort,
+                pathAndQuery)).Dispose();
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -216,17 +216,6 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        public static Task<HttpResponseMessage> GetHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null)
-        {
-            return GetHttpResponseFromContainerAsync(
-                containerName,
-                dockerHelper,
-                outputHelper,
-                containerPort,
-                pathAndQuery,
-                m => m.EnsureSuccessStatusCode());
-        }
-
         public static async Task<HttpResponseMessage> GetHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null, Action<HttpResponseMessage> validateCallback = null)
         {
             int retries = 30;
@@ -249,7 +238,11 @@ namespace Microsoft.DotNet.Docker.Tests
                         result = await client.GetAsync(url);
                         outputHelper.WriteLine($"HTTP {result.StatusCode}\n{(await result.Content.ReadAsStringAsync())}");
 
-                        if (null != validateCallback)
+                        if (null == validateCallback)
+                        {
+                            result.EnsureSuccessStatusCode();
+                        }
+                        else
                         {
                             validateCallback(result);
                         }

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -1,11 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-//
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,6 +17,24 @@ namespace Microsoft.DotNet.Docker.Tests
     [Trait("Category", "monitor")]
     public class MonitorImageTests
     {
+        private const int DefaultHttpPort = 80;
+        private const int DefaultArtifactsPort = 52323;
+        private const int DefaultMetricsPort = 52325;
+
+        private const string UrlPath_Processes = "processes";
+        private const string UrlPath_Metrics = "metrics";
+
+        private const string Directory_Diag = "/diag";
+        private const string Directory_Tmp = "/tmp";
+
+        private const string File_DiagPort = Directory_Diag + "/port";
+
+        /// <summary>
+        /// Command line switch to disable authentication. By default,
+        /// dotnet-monitor requires authentication on the artifacts port.
+        /// </summary>
+        private const string Switch_NoAuthentication = "--no-auth";
+
         public MonitorImageTests(ITestOutputHelper outputHelper)
         {
             OutputHelper = outputHelper;
@@ -31,6 +51,34 @@ namespace Microsoft.DotNet.Docker.Tests
                 .Select(imageData => new object[] { imageData });
         }
 
+        /// <summary>
+        /// Gets each dotnet-monitor image paired with each sample aspnetcore image of the same architecture.
+        /// Allows for testing volume mounts and diagnostic port usage among different distros.
+        /// </summary>
+        public static IEnumerable<object[]> GetScenarioData()
+        {
+            IList<object[]> data = new List<object[]>();
+            foreach (MonitorImageData monitorImageData in TestData.GetMonitorImageData())
+            {
+                foreach (SampleImageData sampleImageData in TestData.GetAllSampleImageData())
+                {
+                    // Only use published images (do not want to build unpublished images in the tests)
+                    if (!sampleImageData.IsPublished)
+                        continue;
+
+                    // Only consider the sample image if it has the same architecture.
+                    if (monitorImageData.Arch != sampleImageData.Arch)
+                        continue;
+
+                    data.Add(new object[] { monitorImageData, sampleImageData });
+                }
+            }
+            return data;
+        }
+
+        /// <summary>
+        /// Verifies that the environment variables essential to dotnet-monitor are set correctly.
+        /// </summary>
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(MonitorImageData imageData)
@@ -50,47 +98,420 @@ namespace Microsoft.DotNet.Docker.Tests
                 DockerHelper);
         }
 
+        /// <summary>
+        /// Tests that the image can run without additional configuration
+        /// and the metrics endpoint is usable without providing authentication.
+        /// </summary>
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
-        public Task VerifyMetricsEndpoint(MonitorImageData imageData)
+        public Task VerifyMonitorDefault(MonitorImageData imageData)
         {
-            return VerifyAsync(imageData, async (image, containerName) =>
-            {
-                try
-                {
-                    DockerHelper.Run(
-                        image: image,
-                        name: containerName,
-                        detach: true,
-                        optionalRunArgs: "-p 52325");
+            return VerifyMonitorAsync(imageData, noAuthentication: false);
+        }
 
+        /// <summary>
+        /// Tests that the image can run without https enabled, that the artifacts ports
+        /// respond with Unauthroized, and the metrics endpoint is usable without
+        /// providing authentication.
+        /// </summary>
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public Task VerifyMonitorNoHttps(MonitorImageData imageData)
+        {
+            return VerifyMonitorAsync(
+                imageData,
+                noAuthentication: false,
+                async containerName =>
+                {
                     if (!Config.IsHttpVerificationDisabled)
                     {
-                        // Verify metrics endpoint is accessible
-                        await ImageScenarioVerifier.VerifyHttpResponseFromContainerAsync(
+                        // Verify processes returns 401 (Unauthorized) since authentication was not provided.
+                        using HttpResponseMessage processesMessage =
+                        await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
                             containerName,
                             DockerHelper,
                             OutputHelper,
-                            52325,
-                            "metrics");
+                            DefaultArtifactsPort,
+                            UrlPath_Processes,
+                            m => VerifyStatusCode(m, HttpStatusCode.Unauthorized));
                     }
-                }
-                finally
+                },
+                builder =>
                 {
-                    DockerHelper.DeleteContainer(containerName);
-                }
-            });
+                    // Reset and expose the artifacts port over http (not secure)
+                    builder.MonitorUrl(DefaultArtifactsPort);
+                });
         }
 
-        private async Task VerifyAsync(
-            MonitorImageData imageData,
-            Func<string, string, Task> verifyImageAsync)
+        /// <summary>
+        /// Tests that the image can run without https and authenciation, thus the artifacts
+        /// and the metrics ports are usable without providing authentication.
+        /// </summary>
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public Task VerifyMonitorNoHttpsNoAuth(MonitorImageData imageData)
         {
-            string image = imageData.GetImage(DockerHelper);
+            return VerifyMonitorAsync(
+                imageData,
+                noAuthentication: true,
+                async containerName =>
+                {
+                    if (!Config.IsHttpVerificationDisabled)
+                    {
+                        // Verify metrics endpoint is accessible and produces zero processes
+                        using HttpResponseMessage processesMessage =
+                        await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                            containerName,
+                            DockerHelper,
+                            OutputHelper,
+                            DefaultArtifactsPort,
+                            UrlPath_Processes);
 
-            string containerName = imageData.GetIdentifier("monitor");
+                        JsonDocument processesDocument = JsonDocument.Parse(processesMessage.Content.ReadAsStream());
+                        JsonElement processesElement = processesDocument.RootElement;
 
-            await verifyImageAsync(image, containerName);
+                        // Verify returns an empty array (should not detect any processes)
+                        Assert.Equal(JsonValueKind.Array, processesElement.ValueKind);
+                        Assert.Equal(0, processesElement.GetArrayLength());
+                    }
+                },
+                builder =>
+                {
+                    // Reset and expose the artifacts port over http (not secure)
+                    builder.MonitorUrl(DefaultArtifactsPort);
+                });
+        }
+
+        /// <summary>
+        /// Verifies that the image can discover a dotnet process
+        /// in another container via mounting the /tmp directory.
+        /// </summary>
+        [LinuxImageTheory]
+        [MemberData(nameof(GetScenarioData))]
+        public Task VerifyConnectMode(MonitorImageData imageData, SampleImageData sampleData)
+        {
+            return VerifyScenarioAsync(
+                monitorImageData: imageData,
+                sampleImageData: sampleData,
+                shareTmpVolume: true,
+                listenDiagPortVolume: false,
+                noAuthentication: true,
+                async (monitorName, sampleName) =>
+                {
+                    if (!Config.IsHttpVerificationDisabled)
+                    {
+                        using HttpResponseMessage responseMessage =
+                            await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                                monitorName,
+                                DockerHelper,
+                                OutputHelper,
+                                DefaultArtifactsPort,
+                                UrlPath_Processes);
+
+                        JsonDocument document = JsonDocument.Parse(responseMessage.Content.ReadAsStream());
+                        JsonElement rootElement = document.RootElement;
+
+                        // Verify returns an array with one element (the sample container process)
+                        Assert.Equal(JsonValueKind.Array, rootElement.ValueKind);
+                        Assert.Equal(1, rootElement.GetArrayLength());
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Verifies that the image can listen for dotnet processes
+        /// in other containers by having them connect to the diagnostic port listener.
+        /// </summary>
+        [LinuxImageTheory]
+        [MemberData(nameof(GetScenarioData))]
+        public Task VerifyListenMode(MonitorImageData imageData, SampleImageData sampleData)
+        {
+            return VerifyScenarioAsync(
+                monitorImageData: imageData,
+                sampleImageData: sampleData,
+                shareTmpVolume: false,
+                listenDiagPortVolume: true,
+                noAuthentication: true,
+                async (monitorName, sampleName) =>
+                {
+                    if (!Config.IsHttpVerificationDisabled)
+                    {
+                        using HttpResponseMessage responseMessage =
+                            await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                                monitorName,
+                                DockerHelper,
+                                OutputHelper,
+                                DefaultArtifactsPort,
+                                UrlPath_Processes);
+
+                        JsonDocument document = JsonDocument.Parse(responseMessage.Content.ReadAsStream());
+                        JsonElement rootElement = document.RootElement;
+
+                        // Verify returns an array with one element (the sample container process)
+                        Assert.Equal(JsonValueKind.Array, rootElement.ValueKind);
+                        Assert.Equal(1, rootElement.GetArrayLength());
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Runs a single instance of the dotnet-monitor image.
+        /// </summary>
+        /// <param name="imageData">The image data of the dotnet-monitor image.</param>
+        /// <param name="noAuthentication">Set to true to disable dotnet-monitor authenication.</param>
+        /// <param name="verifyContainerAsync">Callback to test some aspect of the container.</param>
+        /// <param name="runArgsCallback">Allows for modifying the "docker run" args of the container.</param>
+        private async Task VerifyMonitorAsync(
+            MonitorImageData imageData,
+            bool noAuthentication,
+            Func<string, Task> verifyContainerAsync = null,
+            Action<DockerRunArgsBuilder> runArgsCallback = null)
+        {
+            GetNames(imageData, out string monitorImageName, out string monitorContainerName);
+            try
+            {
+                DockerRunArgsBuilder runArgsBuilder = DockerRunArgsBuilder.Create()
+                    .ExposePort(DefaultMetricsPort);
+
+                if (null != runArgsCallback)
+                {
+                    runArgsCallback(runArgsBuilder);
+                }
+
+                DockerHelper.Run(
+                    image: monitorImageName,
+                    name: monitorContainerName,
+                    command: GetMonitorAdditionalArgs(noAuthentication),
+                    detach: true,
+                    optionalRunArgs: runArgsBuilder.Build());
+
+                if (!Config.IsHttpVerificationDisabled)
+                {
+                    // Verify metrics endpoint is accessible
+                    using HttpResponseMessage metricsMessage =
+                        await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                            monitorContainerName,
+                            DockerHelper,
+                            OutputHelper,
+                            DefaultMetricsPort,
+                            UrlPath_Metrics);
+
+                    string metricsContent = await metricsMessage.Content.ReadAsStringAsync();
+
+                    // Metrics should not return any content if
+                    // no processes are detected.
+                    Assert.Equal(string.Empty, metricsContent);
+                }
+
+                if (null != verifyContainerAsync)
+                {
+                    await verifyContainerAsync(monitorContainerName);
+                }
+            }
+            finally
+            {
+                DockerHelper.DeleteContainer(monitorContainerName);
+            }
+        }
+
+        /// <summary>
+        /// Runs a single instance of each of the dotnet-monitor and samples images.
+        /// </summary>
+        /// <param name="monitorImageData">The image data of the dotnet-monitor image.</param>
+        /// <param name="shareTmpVolume">Set to true to mount the /tmp directory in both containers.</param>
+        /// <param name="listenDiagPortVolume">
+        /// Set to true to have the monitor container listen with a diagnostic port listener
+        /// for diagnostic connections from the samples container.
+        /// </param>
+        /// <param name="noAuthentication">Set to true to disable dotnet-monitor authenication.</param>
+        /// <param name="verifyContainerAsync">Callback to test some aspect of the containers.</param>
+        /// <param name="monitorRunArgsCallback">Allows for modifying the "docker run" args of the dotnet-monitor container.</param>
+        /// <param name="sampleRunArgsCallback">Allows for modifying the "docker run" args of the samples container.</param>
+        private async Task VerifyScenarioAsync(
+            MonitorImageData monitorImageData,
+            SampleImageData sampleImageData,
+            bool shareTmpVolume,
+            bool listenDiagPortVolume,
+            bool noAuthentication,
+            Func<string, string, Task> verifyContainerAsync,
+            Action<DockerRunArgsBuilder> monitorRunArgsCallback = null,
+            Action<DockerRunArgsBuilder> sampleRunArgsCallback = null)
+        {
+            GetNames(monitorImageData, out string monitorImageName, out string monitorContainerName);
+            GetNames(sampleImageData, out string sampleImageName, out string sampleContainerName);
+
+            DockerRunArgsBuilder monitorArgsBuilder = DockerRunArgsBuilder.Create()
+                .MonitorUrl(DefaultArtifactsPort);
+
+            DockerRunArgsBuilder sampleArgsBuilder = DockerRunArgsBuilder.Create()
+                .ExposePort(DefaultHttpPort);
+
+            string diagPortVolumeName = null;
+            string tmpVolumeName = null;
+
+            try
+            {
+                // Create a volume for the two containers to share the /tmp directory.
+                if (shareTmpVolume)
+                {
+                    tmpVolumeName = DockerHelper.CreateVolume(UniqueName("tmpvol"));
+
+                    monitorArgsBuilder.VolumeMount(tmpVolumeName, Directory_Tmp);
+
+                    sampleArgsBuilder.VolumeMount(tmpVolumeName, Directory_Tmp);
+                }
+
+                // Create a volume so that the dotnet-monitor container can provide a
+                // diagnostic listening port to the samples container so that the samples
+                // process can connect to the dotnet-monitor process.
+                if (listenDiagPortVolume)
+                {
+                    diagPortVolumeName = DockerHelper.CreateVolume(UniqueName("diagportvol"));
+
+                    monitorArgsBuilder.VolumeMount(diagPortVolumeName, Directory_Diag);
+                    monitorArgsBuilder.MonitorListen(File_DiagPort);
+
+                    sampleArgsBuilder.VolumeMount(diagPortVolumeName, Directory_Diag);
+                    sampleArgsBuilder.RuntimeSuspend(File_DiagPort);
+                }
+
+                // Allow modification of the "docker run" args of the monitor container
+                if (null != monitorRunArgsCallback)
+                {
+                    monitorRunArgsCallback(monitorArgsBuilder);
+                }
+
+                // Allow modification of the "docker run" args of the samples container
+                if (null != sampleRunArgsCallback)
+                {
+                    sampleRunArgsCallback(sampleArgsBuilder);
+                }
+
+                // Run the sample container
+                DockerHelper.Run(
+                    image: sampleImageName,
+                    name: sampleContainerName,
+                    detach: true,
+                    optionalRunArgs: sampleArgsBuilder.Build());
+
+                // Run the dotnet-monitor container
+                DockerHelper.Run(
+                    image: monitorImageName,
+                    name: monitorContainerName,
+                    command: GetMonitorAdditionalArgs(noAuthentication),
+                    detach: true,
+                    optionalRunArgs: monitorArgsBuilder.Build());
+
+                await verifyContainerAsync(
+                    monitorContainerName,
+                    sampleContainerName);
+            }
+            finally
+            {
+                DockerHelper.DeleteContainer(monitorContainerName);
+
+                DockerHelper.DeleteContainer(sampleContainerName);
+
+                if (!string.IsNullOrEmpty(diagPortVolumeName))
+                {
+                    DockerHelper.DeleteVolume(diagPortVolumeName);
+                }
+
+                if (!string.IsNullOrEmpty(tmpVolumeName))
+                {
+                    DockerHelper.DeleteVolume(tmpVolumeName);
+                }
+            }
+        }
+
+        private static string UniqueName(string name)
+        {
+            return $"{name}-{DateTime.Now.ToFileTime()}";
+        }
+
+        private static SampleImageData GetSampleImageData(MonitorImageData imageData)
+        {
+            return TestData.GetSampleImageData()
+                .First(d => d.IsPublished = true && d.Arch == imageData.Arch);
+        }
+
+        private static string GetMonitorAdditionalArgs(bool noAuthentication)
+        {
+            return noAuthentication ? Switch_NoAuthentication : null;
+        }
+
+        private void GetNames(MonitorImageData imageData, out string imageName, out string containerName)
+        {
+            imageName = imageData.GetImage(DockerHelper);
+            containerName = imageData.GetIdentifier("monitortest");
+        }
+
+        private void GetNames(SampleImageData imageData, out string imageName, out string containerName)
+        {
+            imageName = imageData.GetImage(SampleImageType.Aspnetapp, DockerHelper);
+            containerName = imageData.GetIdentifier("monitortest-sample");
+        }
+
+        private void VerifyStatusCode(HttpResponseMessage message, HttpStatusCode statusCode)
+        {
+            if (message.StatusCode != statusCode)
+            {
+                throw new HttpRequestException($"Expected status code {statusCode}", null, statusCode);
+            }
+        }
+    }
+
+    internal static class MonitorDockerRunArgsBuilderExtensions
+    {
+        // dotnet-monitor variables
+        internal const string EnvVar_DiagnosticPort_ConnectionMode = "DotnetMonitor_DiagnosticPort__ConnectionMode";
+        internal const string EnvVar_DiagnosticPort_EndpointName = "DotnetMonitor_DiagnosticPort__EndpointName";
+        internal const string EnvVar_Metrics_Enabled = "DotnetMonitor_Metrics__Enabled";
+        internal const string EnvVar_Urls = "DotnetMonitor_Urls";
+
+        // runtime variables
+        internal const string EnvVar_DiagnosticPorts = "DOTNET_DiagnosticPorts";
+
+        /// <summary>
+        /// Disables the metrics endpoint in dotnet-monitor.
+        /// </summary>
+        public static DockerRunArgsBuilder MonitorDisableMetrics(this DockerRunArgsBuilder builder)
+        {
+            return builder.EnvironmentVariable(EnvVar_Metrics_Enabled, "false");
+        }
+
+        /// <summary>
+        /// Places dotnet-monitor into listen mode, allowing dotnet processes to connect
+        /// to its diagnostic port listener.
+        /// </summary>
+        public static DockerRunArgsBuilder MonitorListen(this DockerRunArgsBuilder builder, string endpointName)
+        {
+            return builder
+                .EnvironmentVariable(EnvVar_DiagnosticPort_ConnectionMode, "Listen")
+                .EnvironmentVariable(EnvVar_DiagnosticPort_EndpointName, endpointName);
+        }
+
+        /// <summary>
+        /// Sets the artifacts url with the port and exposes the port on the container.
+        /// </summary>
+        public static DockerRunArgsBuilder MonitorUrl(this DockerRunArgsBuilder builder, int port)
+        {
+            return builder.ExposePort(port)
+                .EnvironmentVariable(EnvVar_Urls, WildcardUrl(port));
+        }
+
+        /// <summary>
+        /// Suspends a dotnet runtime until it can connect to a diagnostic port listener
+        /// at the specified endpoint name.
+        /// </summary>
+        public static DockerRunArgsBuilder RuntimeSuspend(this DockerRunArgsBuilder builder, string endpointName)
+        {
+            return builder.EnvironmentVariable(EnvVar_DiagnosticPorts, $"{endpointName},suspend");
+        }
+
+        private static string WildcardUrl(int port)
+        {
+            return $"http://*:{port}";
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageData.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public string DockerfileSuffix { get; set; }
 
-        public string GetImage(SampleImageType imageType, DockerHelper dockerHelper)
+        public string GetImage(SampleImageType imageType, DockerHelper dockerHelper, bool allowPull = false)
         {
             string tagPrefix = Enum.GetName(typeof(SampleImageType), imageType).ToLowerInvariant();
             string tag = GetTagName(tagPrefix, OS);
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (IsPublished)
             {
-                PullImageIfNecessary(imageName, dockerHelper);
+                PullImageIfNecessary(imageName, dockerHelper, allowPull);
             }
             
             return imageName;

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -128,10 +128,13 @@ namespace Microsoft.DotNet.Docker.Tests
                 .FilterImagesByOs()
                 .Cast<ProductImageData>();
         }
-        
+
+        public static IEnumerable<SampleImageData> GetAllSampleImageData() =>
+            DockerHelper.IsLinuxContainerModeEnabled ? s_linuxSampleTestData : s_windowsSampleTestData;
+
         public static IEnumerable<SampleImageData> GetSampleImageData()
         {
-            return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxSampleTestData : s_windowsSampleTestData)
+            return GetAllSampleImageData()
                 .FilterImagesByArch()
                 .FilterImagesByOs()
                 .Cast<SampleImageData>();


### PR DESCRIPTION
These changes refactor the existing tests and add a few more.

Basic container tests:
- VerifyMonitorDefault: Run image without modification and test that it has a viable metrics endpoint.
- VerifyMonitorNoHttps: Disables HTTPS on the artifacts port and checks that /processes returns 401 due to lack of authentication.
- VerifyMonitorNoHttpsNoAuth: Disables HTTPS and authentication and checks that /processes returns empty list of processes.

Basic scenario tests:
- VerifyConnectModeNoAuth: Verifies that dotnet-monitor can discover the samples app running in another container when both have a mounted volumne at /tmp.
- VerifyListenModeNoAuth: Verifies that dotnet-monitor can be set to listening mode and the samples app in the other container can connect to dotnet-monitor and dotnet-monitor is able to see that process.

closes #2117 