### PR TITLE
Update aka.ms path to sdk zip file

### DIFF
--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -10,7 +10,7 @@ channel=$1
 sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends libxml2-utils
 
-curl -SLo sdk.zip https://aka.ms/dotnet/$channel/Sdk/dotnet-sdk-win-x64.zip
+curl -SLo sdk.zip https://aka.ms/dotnet/$channel/dotnet-sdk-win-x64.zip
 
 unzip -p sdk.zip "sdk/*/.version" > sdkversion
 


### PR DESCRIPTION
There have been some recent changes to the generated aka.ms links that point to the blob locations for .NET bits.  The `Sdk` portion of the path is no longer needed since the link implicitly points to that location.