### PR TITLE
Update dotnet-monitor latest version URL.

### DIFF
--- a/eng/get-drop-versions-monitor.sh
+++ b/eng/get-drop-versions-monitor.sh
@@ -5,7 +5,7 @@ set -e
 # Stop script if unbound variable found (use ${var:-} if intentional)
 set -u
 
-curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/diagnostics/monitor5.0/dotnet-monitor.nupkg.version
+curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/dotnet-monitor.nupkg.version
 
 # Read version file and remove newlines
 monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.version)


### PR DESCRIPTION
Arcade now shortens aka.ms latest URLs to only include the channel name and the file name.