### PR TITLE
Add PublishSingleFile option for slim samples

### DIFF
--- a/samples/aspnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-x64-slim
@@ -10,7 +10,7 @@ RUN dotnet restore -r linux-musl-x64
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
-RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine-amd64

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -12,7 +12,7 @@ RUN dotnet restore -r win-x64
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
-RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 # Uses the 20H2 release; 2004, 1909, and 1809 are other choices

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
@@ -13,7 +13,7 @@ WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-buster-slim-amd64
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-focal-amd64
 WORKDIR /app
 COPY --from=build /app ./
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
@@ -12,7 +12,7 @@ RUN dotnet restore -r win-x64
 # copy everything else and build app
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
-RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 # Uses the ltsc2019 release; 20H2, 2004, 1909, 1809, and ltsc2016 are other choices

--- a/samples/dotnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine-amd64

--- a/samples/dotnetapp/Dockerfile.debian-x64-slim
+++ b/samples/dotnetapp/Dockerfile.debian-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-buster-slim-amd64

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r win-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 # Uses the 20H2 release; Other choices: 2004, 1909, 1809

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-focal-amd64

--- a/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r win-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
+RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 # Uses the ltsc2019 release; 20H2, 2004, 1909, 1809, and ltsc2016 are other choices


### PR DESCRIPTION
The slim variants of the sample Dockerfiles are intended to be optimized for size.  So we should probably make them smaller by using the `PublishSingleFile` publish option.  This wraps all the published files into a single file and actually ends up with a net decrease in disk size used (see results published in [App Trimming in .NET 5](https://devblogs.microsoft.com/dotnet/app-trimming-in-net-5/)).

By applying this option to the slim variants of the sample Dockerfiles I was able to get a worthwhile reduction in the overall image size: 12 MB for Linux and 6 MB for Windows.  In the case of Alpine, that 12 MB is significant, percentage-wise, resulting in a 12% reduction in the image size.