### PR TITLE
Set default value for additionalGenerateBuildMatrixOptions var

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -18,6 +18,9 @@ jobs:
         artifactName: image-info
     - script: echo "##vso[task.setvariable variable=additionalGenerateBuildMatrixOptions]--image-info $(artifactsPath)/image-info.json"
       displayName: Set GenerateBuildMatrix Variables
+  - ${{ if eq(parameters.isTestStage, false) }}:
+    - script: echo "##vso[task.setvariable variable=additionalGenerateBuildMatrixOptions]"
+      displayName: Set GenerateBuildMatrix Variables
   - script: >
       $(runImageBuilderCmd) generateBuildMatrix
       --manifest $(manifest)

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -18,7 +18,7 @@ variables:
 - name: manifestVariables
   value: ""
 - name: defaultLinuxAmd64PoolImage
-  value: ubuntu-18.04
+  value: ubuntu-latest
 - name: mcrImageIngestionTimeout
   value: "00:20:00"
 - name: mcrDocIngestionTimeout


### PR DESCRIPTION
Reverts https://github.com/dotnet/dotnet-docker/pull/2654

Sets a default value for the additionalGenerateBuildMatrixOptions variable to ensure it's always set.  If it's not set, it results in the following error: `/home/vsts/work/_temp/c2410e43-b3c7-4799-bd06-9b9dbd8833f5.sh: line 1: additionalGenerateBuildMatrixOptions: command not found`.  Before today, that error was still occurring but being ignored.  Today, it causes the script task to fail.