### PR TITLE
Update release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/dotnet-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/dotnet-release.md
@@ -33,11 +33,12 @@ _The set of .NET versions that are being released as a unit._
 
       Servicing release (exclude 5.0 if separate runtime-deps Dockerfiles were defined):
 
-          imageBuilder.pathArgs: --path 'src/*/2.1/*' --path 'src/*/3.1/*' --path 'src/*/5.0/*'
+          noCache: true
+          imageBuilder.pathArgs: --path 'src/*/2.1/*' --path 'src/*/3.1/*' --path 'src/*/5.0/*' --path 'src/*/6.0/*'
 
       Preview release (exclude 3.1 if separate runtime-deps Dockerfiles were defined):
 
-          imageBuilder.pathArgs: --path 'src/*/3.1/*' --path 'src/*/5.0/*'
+          imageBuilder.pathArgs: --path 'src/*/3.1/*' --path 'src/*/5.0/*' --path 'src/*/6.0/*'
 1. - [ ] Wait for NuGet packages to be published during release tic-toc
 1. - [ ] Test and publish images - Queue build of [dotnet-docker pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=373) (internal MSFT link) with variables:
 
@@ -48,11 +49,11 @@ _The set of .NET versions that are being released as a unit._
 
       Servicing release (exclude 5.0 if separate runtime-deps Dockerfiles were defined):
 
-          imageBuilder.pathArgs: --path 'src/*/2.1/*' --path 'src/*/3.1/*' --path 'src/*/5.0/*'
+          imageBuilder.pathArgs: --path 'src/*/2.1/*' --path 'src/*/3.1/*' --path 'src/*/5.0/*' --path 'src/*/6.0/*'
 
       Preview release (exclude 3.1 if separate runtime-deps Dockerfiles were defined):
 
-          imageBuilder.pathArgs: --path 'src/*/3.1/*' --path 'src/*/5.0/*'
+          imageBuilder.pathArgs: --path 'src/*/3.1/*' --path 'src/*/5.0/*' --path 'src/*/6.0/*'
 1. - [ ] Confirm images have been ingested by MCR
 1. - [ ] Confirm READMEs have been updated in [Docker Hub](https://hub.docker.com/_/microsoft-dotnet)
 


### PR DESCRIPTION
In order to ensure we rebuild the runtime-deps images to include any new package updates, I've updated the release workflow to se the `noCache` option.  This will disable the image caching behavior and always rebuild images even if their Dockerfile or base image has not changed.