### PR TITLE
Update dotnet-monitor version aka.ms link

### DIFF
--- a/eng/get-drop-versions-monitor.sh
+++ b/eng/get-drop-versions-monitor.sh
@@ -5,7 +5,7 @@ set -e
 # Stop script if unbound variable found (use ${var:-} if intentional)
 set -u
 
-curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/dotnet-monitor.nupkg.version
+curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/diagnostics/monitor5.0/dotnet-monitor.nupkg.version
 
 # Read version file and remove newlines
 monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.version)


### PR DESCRIPTION
Arcade has fixed the flattening of the aka.ms link generation (see https://github.com/dotnet/arcade/pull/7036). Update the link in get-drop-versions-monitor.sh to reflect the change.