### PR TITLE
Update samples

### DIFF
--- a/samples/aspnetapp/Dockerfile.alpine-arm64
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64
@@ -14,7 +14,7 @@ RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-res
 
 # final stage/image
 # Uses the 1809 release; 20H2, 2004, and 1909 are other choices
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809
 WORKDIR /app
 COPY --from=build /app ./
 ENTRYPOINT ["aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64
@@ -13,8 +13,10 @@ WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
-# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809
+# Relies on 5.0 multi-arch tag to pick the same Windows version as the host. 
+# Alternatively, a release specific tag can be used, like: `5.0-nanoserver-1809`
+# Other versions are 20H2, 2004, and 1909 (in place of the `1809` substring above)
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
 WORKDIR /app
 COPY --from=build /app ./
 ENTRYPOINT ["aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64
@@ -13,8 +13,8 @@ WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
-# Uses the 20H2 release; 2004, 1909, and 1809 are other choices
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-20H2 AS runtime
+# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809 AS runtime
 WORKDIR /app
 COPY --from=build /app ./
 ENTRYPOINT ["aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -16,7 +16,7 @@ RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-rest
 
 # final stage/image
 # Uses the 1809 release; 20H2, 2004, and 1909 are other choices
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809 AS runtime
+FROM mcr.microsoft.com/windows/nanoserver:1809
 WORKDIR /app
 COPY --from=build /app ./
 

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -15,8 +15,8 @@ WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
-# Uses the 20H2 release; 2004, 1909, and 1809 are other choices
-FROM mcr.microsoft.com/windows/nanoserver:20H2 AS runtime
+# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-nanoserver-1809 AS runtime
 WORKDIR /app
 COPY --from=build /app ./
 

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -15,8 +15,8 @@ WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
-# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
-FROM mcr.microsoft.com/windows/nanoserver:1809
+# Uses the 20H2 release; 20H2, 2004, 1909, and 1809 are other choices
+FROM mcr.microsoft.com/windows/nanoserver:20H2
 WORKDIR /app
 COPY --from=build /app ./
 

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/aspnetapp/aspnetapp/aspnetapp.csproj
+++ b/samples/aspnetapp/aspnetapp/aspnetapp.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>57393389627611478466</UserSecretsId>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/samples/aspnetapp/aspnetapp/aspnetapp.csproj
+++ b/samples/aspnetapp/aspnetapp/aspnetapp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>57393389627611478466</UserSecretsId>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/samples/complexapp/complexapp/complexapp.csproj
+++ b/samples/complexapp/complexapp/complexapp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dotnetapp/Dockerfile.alpine-arm64
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/dotnetapp/Dockerfile.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.alpine-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64
@@ -11,8 +11,10 @@ COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
-# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
-FROM mcr.microsoft.com/dotnet/runtime:5.0-nanoserver-1809 AS runtime
+# Relies on 5.0 multi-arch tag to pick the same Windows version as the host. 
+# Alternatively, a release specific tag can be used, like: `5.0-nanoserver-1809`
+# Other versions are 20H2, 2004, and 1909 (in place of the `1809` substring above)
+FROM mcr.microsoft.com/dotnet/runtime:5.0
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64
@@ -11,8 +11,8 @@ COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
-# Uses the 20H2 release; Other choices: 2004, 1909, 1809
-FROM mcr.microsoft.com/dotnet/runtime:5.0-nanoserver-20H2
+# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
+FROM mcr.microsoft.com/dotnet/runtime:5.0-nanoserver-1809 AS runtime
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
@@ -11,8 +11,8 @@ COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
-# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
-FROM mcr.microsoft.com/windows/nanoserver:1809
+# Uses the 20H2 release; 20H2, 2004, 1909, and 1809 are other choices
+FROM mcr.microsoft.com/windows/nanoserver:20H2
 WORKDIR /app
 COPY --from=build /app .
 

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
@@ -11,8 +11,8 @@ COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
-# Uses the 20H2 release; Other choices: 2004, 1909, 1809
-FROM mcr.microsoft.com/windows/nanoserver:20H2
+# Uses the 1809 release; 20H2, 2004, and 1909 are other choices
+FROM mcr.microsoft.com/windows/nanoserver:1809
 WORKDIR /app
 COPY --from=build /app .
 

--- a/samples/dotnetapp/Dockerfile.ubuntu-arm32
+++ b/samples/dotnetapp/Dockerfile.ubuntu-arm32
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/dotnetapp/Dockerfile.ubuntu-arm64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-arm64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -66,8 +66,11 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
     string usageBytes = File.ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0];
     string limitBytes = File.ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0];
 
-    long.TryParse(usageBytes, out long usage);
-    long.TryParse(limitBytes, out long limit);
+    if (!long.TryParse(usageBytes, out long usage) ||
+        !long.TryParse(limitBytes, out long limit))
+    {
+        return;
+    }
 
     // above this size is unlikely to be an intentionally constrained cgroup
     if (limit < 10 * gibi)

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -1,64 +1,58 @@
 using System;
+using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using static System.Console;
+using static System.IO.File;
 
-public static class Program
+// Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
+
+WriteLine("\r\n" +
+"         42\r\n" +
+"         42              ,d                             ,d\r\n" +  
+"         42              42                             42\r\n" +
+" ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM\r\n" +
+"a8\"    `Y42 a8\"     \"8a  42    42P\'   `\"8a a8P_____42   42\r\n" +  
+"8b       42 8b       d8  42    42       42 8PP\"\"\"\"\"\"\"   42\r\n" +    
+"\"8a,   ,d42 \"8a,   ,a8\"  42,   42       42 \"8b,   ,aa   42,\r\n" +
+" `\"8bbdP\"Y8  `\"YbbdP\"\'   \"Y428 42       42  `\"Ybbd8\"\'   \"Y428\r\n");
+
+
+// .NET information
+WriteLine(RuntimeInformation.FrameworkDescription);
+
+// OS information
+string osrel = "/etc/os-release";
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && 
+    File.Exists(osrel))
 {
-    public static void Main(string[] args) 
-    {
-          var defaultMessage = "Hello from .NET!";
-          var message = args is object && args.Length > 0 ? string.Join(' ', args): defaultMessage;
-
-          WriteLine();
-          WriteLine($"      {message}{GetBot()}");
-          
-          WriteLine("Environment:");
-          WriteLine($"{RuntimeInformation.FrameworkDescription} ({RuntimeInformation.ProcessArchitecture})");
-          WriteLine(RuntimeInformation.OSDescription);
-
-    }
-
-    private static string GetBot() 
-    {
-            
-            return @"
-      __________________
-                        \
-                        \
-                            ....
-                            ....'
-                            ....
-                          ..........
-                      .............'..'..
-                  ................'..'.....
-                .......'..........'..'..'....
-                ........'..........'..'..'.....
-              .'....'..'..........'..'.......'.
-              .'..................'...   ......
-              .  ......'.........         .....
-              .                           ......
-              ..    .            ..        ......
-            ....       .                 .......
-            ......  .......          ............
-              ................  ......................
-              ........................'................
-            ......................'..'......    .......
-          .........................'..'.....       .......
-      ........    ..'.............'..'....      ..........
-    ..'..'...      ...............'.......      ..........
-    ...'......     ...... ..........  ......         .......
-  ...........   .......              ........        ......
-  .......        '...'.'.              '.'.'.'         ....
-  .......       .....'..               ..'.....
-    ..       ..........               ..'........
-            ............               ..............
-          .............               '..............
-          ...........'..              .'.'............
-        ...............              .'.'.............
-        .............'..               ..'..'...........
-        ...............                 .'..............
-        .........                        ..............
-          .....
-  ";
-    }
+  string prettyname = "PRETTY_NAME";
+  foreach(string line in File.ReadAllLines(osrel))
+  {
+      if (line.StartsWith(prettyname))
+      {
+          ReadOnlySpan<char> value = line.AsSpan()[(prettyname.Length + 2)..^1];
+          Console.WriteLine(value.ToString());
+      }
+  }
 }
+else
+{
+    WriteLine(RuntimeInformation.OSDescription);
+}
+
+WriteLine();
+
+// Environment information
+WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {RuntimeInformation.OSArchitecture}");
+WriteLine($"{nameof(Environment.ProcessorCount)}: {Environment.ProcessorCount}");
+
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && 
+    Directory.Exists("/sys/fs/cgroup/cpu") &&
+    Directory.Exists("/sys/fs/cgroup/memory"))
+{
+    WriteLine($"cfs_quota_us: {ReadAllLines("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")[0]}");
+    WriteLine($"memory.limit_in_bytes: {ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0]}");
+    WriteLine($"memory.usage_in_bytes: {ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0]}");
+}
+

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -33,6 +33,7 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
       {
           ReadOnlySpan<char> value = line.AsSpan()[(prettyname.Length + 2)..^1];
           Console.WriteLine(value.ToString());
+          break;
       }
   }
 }

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -25,14 +25,14 @@ WriteLine(RuntimeInformation.FrameworkDescription);
 // OS information
 const string OSRel = "/etc/os-release";
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && 
-    File.Exists(osrel))
+    File.Exists(OSRel))
 {
   const string PrettyName = "PRETTY_NAME";
-  foreach(string line in File.ReadAllLines(osrel))
+  foreach(string line in File.ReadAllLines(OSRel))
   {
-      if (line.StartsWith(prettyname))
+      if (line.StartsWith(PrettyName))
       {
-          ReadOnlySpan<char> value = line.AsSpan()[(prettyname.Length + 2)..^1];
+          ReadOnlySpan<char> value = line.AsSpan()[(PrettyName.Length + 2)..^1];
           WriteLine(value.ToString());
           break;
       }
@@ -49,8 +49,8 @@ WriteLine();
 WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {RuntimeInformation.OSArchitecture}");
 WriteLine($"{nameof(Environment.ProcessorCount)}: {Environment.ProcessorCount}");
 
-const long Mebi = 1048576;
-const long Gibi = mebi * 1024;
+const long Mebi = 1024 * 1024;
+const long Gibi = Mebi * 1024;
 
 // cgroup information
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && 
@@ -71,7 +71,7 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
     if (long.TryParse(usageBytes, out long usage) &&
         long.TryParse(limitBytes, out long limit) &&
         // above this size is unlikely to be an intentionally constrained cgroup
-        limit < 10 * gibi)
+        limit < 10 * Gibi)
     {
         WriteLine($"usage_in_bytes: {usageBytes} {GetInBiggerUnit(usage)}");
         WriteLine($"limit_in_bytes: {limitBytes} {GetInBiggerUnit(limit)}");
@@ -80,18 +80,18 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
 
 string GetInBiggerUnit(long size)
 {
-    if (size < mebi)
+    if (size < Mebi)
     {
         return string.Empty;
     }
-    else if (size < gibi)
+    else if (size < Gibi)
     {
-        long mebibytes = size / mebi;
+        long mebibytes = size / Mebi;
         return $"({mebibytes} MiB)";
     }
     else
     {
-        long gibibytes = size / gibi;
+        long gibibytes = size / Gibi;
         return $"({gibibytes} GiB)";
     }
 }

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -57,23 +57,21 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
     Directory.Exists("/sys/fs/cgroup/cpu") &&
     Directory.Exists("/sys/fs/cgroup/memory"))
 {
+    // get cpu cgroup information
     string cpuquota = File.ReadAllLines("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")[0];
-    if (int.TryParse(cpuquota, out int quota) && quota > 0)
+    if (int.TryParse(cpuquota, out int quota) &&
+        quota > 0)
     {
         WriteLine($"cfs_quota_us: {quota}");
     }
 
+    // get memory cgroup information
     string usageBytes = File.ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0];
     string limitBytes = File.ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0];
-
-    if (!long.TryParse(usageBytes, out long usage) ||
-        !long.TryParse(limitBytes, out long limit))
-    {
-        return;
-    }
-
-    // above this size is unlikely to be an intentionally constrained cgroup
-    if (limit < 10 * gibi)
+    if (long.TryParse(usageBytes, out long usage) &&
+        long.TryParse(limitBytes, out long limit) &&
+        // above this size is unlikely to be an intentionally constrained cgroup
+        limit < 10 * gibi)
     {
         WriteLine($"usage_in_bytes: {usageBytes} {GetInBiggerUnit(usage)}");
         WriteLine($"limit_in_bytes: {limitBytes} {GetInBiggerUnit(limit)}");

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -1,21 +1,22 @@
 using System;
 using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using static System.Console;
 
 // Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
 // Ascii text: https://ascii.co.uk/text (Univers font)
 
+string nl = Environment.NewLine;
+
 WriteLine(
-"         42\r\n" +
-"         42              ,d                             ,d\r\n" +  
-"         42              42                             42\r\n" +
-" ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM\r\n" +
-"a8\"    `Y42 a8\"     \"8a  42    42P\'   `\"8a a8P_____42   42\r\n" +  
-"8b       42 8b       d8  42    42       42 8PP\"\"\"\"\"\"\"   42\r\n" +    
-"\"8a,   ,d42 \"8a,   ,a8\"  42,   42       42 \"8b,   ,aa   42,\r\n" +
-" `\"8bbdP\"Y8  `\"YbbdP\"\'   \"Y428 42       42  `\"Ybbd8\"\'   \"Y428\r\n");
+$"         42{nl}" +
+$"         42              ,d                             ,d{nl}" +
+$"         42              42                             42{nl}" +
+$" ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM{nl}" +
+$"a8\"    `Y42 a8\"     \"8a  42    42P\'   `\"8a a8P_____42   42{nl}" +
+$"8b       42 8b       d8  42    42       42 8PP\"\"\"\"\"\"\"   42{nl}" +
+$"\"8a,   ,d42 \"8a,   ,a8\"  42,   42       42 \"8b,   ,aa   42,{nl}" +
+$" `\"8bbdP\"Y8  `\"YbbdP\"\'   \"Y428 42       42  `\"Ybbd8\"\'   \"Y428{nl}");
 
 
 // .NET information

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -7,7 +7,7 @@ using static System.Console;
 // Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
 // Ascii text: https://ascii.co.uk/text (Univers font)
 
-WriteLine("\r\n" +
+WriteLine(
 "         42\r\n" +
 "         42              ,d                             ,d\r\n" +  
 "         42              42                             42\r\n" +

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -3,9 +3,9 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using static System.Console;
-using static System.IO.File;
 
 // Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
+// Ascii text: https://ascii.co.uk/text (Univers font)
 
 WriteLine("\r\n" +
 "         42\r\n" +
@@ -51,8 +51,7 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
     Directory.Exists("/sys/fs/cgroup/cpu") &&
     Directory.Exists("/sys/fs/cgroup/memory"))
 {
-    WriteLine($"cfs_quota_us: {ReadAllLines("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")[0]}");
-    WriteLine($"memory.limit_in_bytes: {ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0]}");
-    WriteLine($"memory.usage_in_bytes: {ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0]}");
+    WriteLine($"cfs_quota_us: {File.ReadAllLines("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")[0]}");
+    WriteLine($"memory.limit_in_bytes: {File.ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0]}");
+    WriteLine($"memory.usage_in_bytes: {File.ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0]}");
 }
-

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -23,17 +23,17 @@ $" `\"8bbdP\"Y8  `\"YbbdP\"\'   \"Y428 42       42  `\"Ybbd8\"\'   \"Y428{nl}");
 WriteLine(RuntimeInformation.FrameworkDescription);
 
 // OS information
-string osrel = "/etc/os-release";
+const string OSRel = "/etc/os-release";
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && 
     File.Exists(osrel))
 {
-  string prettyname = "PRETTY_NAME";
+  const string PrettyName = "PRETTY_NAME";
   foreach(string line in File.ReadAllLines(osrel))
   {
       if (line.StartsWith(prettyname))
       {
           ReadOnlySpan<char> value = line.AsSpan()[(prettyname.Length + 2)..^1];
-          Console.WriteLine(value.ToString());
+          WriteLine(value.ToString());
           break;
       }
   }
@@ -49,8 +49,8 @@ WriteLine();
 WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {RuntimeInformation.OSArchitecture}");
 WriteLine($"{nameof(Environment.ProcessorCount)}: {Environment.ProcessorCount}");
 
-long mebi = 1048576;
-long gibi = mebi * 1024;
+const long Mebi = 1048576;
+const long Gibi = mebi * 1024;
 
 // cgroup information
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && 

--- a/samples/dotnetapp/dotnetapp.csproj
+++ b/samples/dotnetapp/dotnetapp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Docker.Tests
             await VerifySampleAsync(imageData, SampleImageType.Dotnetapp, (image, containerName) =>
             {
                 string output = DockerHelper.Run(image, containerName);
-                Assert.StartsWith("Hello from .NET!", output);
+                Assert.Contains("42", output);
 
                 ValidateEnvironmentVariables(imageData, image, SampleImageType.Dotnetapp);
 

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Docker.Tests
             await VerifySampleAsync(imageData, SampleImageType.Dotnetapp, (image, containerName) =>
             {
                 string output = DockerHelper.Run(image, containerName);
-                Assert.Contains("42", output);
+                Assert.True(output.Contains("42") || output.StartsWith("Hello"));
 
                 ValidateEnvironmentVariables(imageData, image, SampleImageType.Dotnetapp);
 


### PR DESCRIPTION
- Updated dotnetapp to be more directly helpful in testing .NET in containers, based on https://github.com/dotnet/core/blob/main/samples/dotnet-runtimeinfo/Program.cs.
- Enabled nulllable for the console samples (for good measure). The ASP.NET app didn't just work for nullable, so will wait until we upgrade to the .NET 6.
- This replaces `dotnetapp` @ https://hub.docker.com/_/microsoft-dotnet-samples

New experience:

![image](https://user-images.githubusercontent.com/2608468/112233340-846f4600-8bf7-11eb-9d8c-37c874a25972.png)
 
And `dotnet run` on Windows:

![image](https://user-images.githubusercontent.com/2608468/112206157-d651a500-8bd2-11eb-8607-a5da1a6c5ee0.png)

Current experience:

![image](https://user-images.githubusercontent.com/2608468/112226015-d9588f80-8bea-11eb-9ded-b2a7da2a42b3.png)
