### PR TITLE
Add channel differentiation to get-drop-versions-monitor.sh

### DIFF
--- a/eng/get-drop-versions-monitor.sh
+++ b/eng/get-drop-versions-monitor.sh
@@ -5,7 +5,9 @@ set -e
 # Stop script if unbound variable found (use ${var:-} if intentional)
 set -u
 
-curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/diagnostics/monitor5.0/dotnet-monitor.nupkg.version
+channel=$1
+
+curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/diagnostics/monitor$channel/dotnet-monitor.nupkg.version
 
 # Read version file and remove newlines
 monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.version)

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -43,7 +43,7 @@ stages:
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
-    - script: $(engPath)/get-drop-versions-monitor.sh
+    - script: $(engPath)/get-drop-versions-monitor.sh $(monitorChannel)
       displayName: Get Versions
     - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
       displayName: Build Update Dependencies Tool


### PR DESCRIPTION
A change was made to the aka.ms link generation for dotnet-monitor to allow differentiating build channels. The anticipated channel values are:
- "5.0/daily": corresponds to daily builds from the dotnet-monitor main branch
- "5.0/preview.#": corresponds to builds from a dotnet-monitor prerelease branch
- "5.0/release": corresponds to builds from the dotnet-monitor release branch.

The preview.# and release names allow for stabilizing dotnet-monitor for the corresponding release while the main branch cotinues to evolve more changes. This should allow dotnet-docker to consume deliberately updated builds as we approach preview and final releases.

With the channel set to "5.0/daily" for now, the nightly branch will consume the latest version from the https://aka.ms/dotnet/diagnostics/monitor5.0/daily/dotnet-monitor.nupkg.version link.

Upon completing this PR, I will update the dotnet-docker-update-dependencies pipeline with the new variable and value.