### PR TITLE
Use channel name parameter in update-dependencies for dotnet-monitor

### DIFF
--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -54,5 +54,6 @@ stages:
         --email $(dotnetDockerBot.email)
         --password $(BotAccount-dotnet-docker-bot-PAT)
         --product-version monitor=$(monitorVer)
+        --channel-name $(monitorChannel)
         --version-source-name dotnet/dotnet-monitor
       displayName: Run Update Dependencies

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -30,7 +30,7 @@ namespace Dotnet.Docker
              new Dictionary<string, Dictionary<string, string>>();
         private static readonly Dictionary<string, string> s_urls = new Dictionary<string, string> {
             {"powershell", "https://pwshtool.blob.core.windows.net/tool/$VERSION_DIR/PowerShell.$OS.$ARCH.$VERSION_FILE.nupkg"},
-            {"monitor", "https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor5.0/dotnet-monitor.$VERSION_FILE.nupkg"},
+            {"monitor", "https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor$CHANNEL_NAME/dotnet-monitor.$VERSION_FILE.nupkg"},
             {"runtime", "https://dotnetcli.azureedge.net/dotnet/Runtime/$VERSION_DIR/dotnet-runtime-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"},
             {"aspnet", "https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$VERSION_DIR/aspnetcore-runtime-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"},
             {"sdk", "https://dotnetcli.azureedge.net/dotnet/Sdk/$VERSION_DIR/dotnet-sdk-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"},
@@ -112,6 +112,7 @@ namespace Dotnet.Docker
                 .Replace("$ARCHIVE_EXT", _os.Contains("win") ? "zip" : "tar.gz")
                 .Replace("$VERSION_DIR", versionDir)
                 .Replace("$VERSION_FILE", versionFile)
+                .Replace("$CHANNEL_NAME", _options.ChannelName)
                 .Replace("$OS", _os)
                 .Replace("$ARCH", _arch)
                 .Replace("..", ".");

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -11,6 +11,7 @@ namespace Dotnet.Docker
     {
         public bool ComputeChecksums { get; private set; }
         public string DockerfileVersion { get; private set; }
+        public string ChannelName { get; private set; }
         public string GitHubEmail { get; private set; }
         public string GitHubPassword { get; private set; }
         public string GitHubProject => "dotnet-docker";
@@ -21,12 +22,13 @@ namespace Dotnet.Docker
         public string VersionSourceName { get; private set; }
         public bool UpdateOnly => GitHubEmail == null || GitHubPassword == null || GitHubUser == null;
 
-        public Options(string dockerfileVersion, string[] productVersion, string versionSourceName, string email, string password, string user, bool computeShas)
+        public Options(string dockerfileVersion, string[] productVersion, string channelName, string versionSourceName, string email, string password, string user, bool computeShas)
         {
             DockerfileVersion = dockerfileVersion;
             ProductVersions = productVersion
                 .Select(pair => pair.Split(new char[] { '=' }, 2))
                 .ToDictionary(split => split[0].ToLower(), split => split[1]);
+            ChannelName = channelName;
             VersionSourceName = versionSourceName;
             GitHubEmail = email;
             GitHubPassword = password;
@@ -55,6 +57,7 @@ namespace Dotnet.Docker
             {
                 new Argument<string>("dockerfile-version", "Version of the Dockerfiles to update"),
                 new Option<string[]>("--product-version", "Product versions to update (<product-name>=<version>)"),
+                new Option<string>("--channel-name", "The name of the channel from which to find product files."),
                 new Option<string>("--version-source-name", "The name of the source from which the version information was acquired."),
                 new Option<string>("--email", "GitHub email used to make PR (if not specified, a PR will not be created)"),
                 new Option<string>("--password", "GitHub password used to make PR (if not specified, a PR will not be created)"),

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -37,9 +37,9 @@
     "dotnet|5.0|product-version": "5.0.4",
     "dotnet|6.0|product-version": "6.0.0-preview.3",
 
-    "monitor|5.0|build-version": "5.0.0-preview.4.21174.1",
+    "monitor|5.0|build-version": "5.0.0-preview.4.21177.1",
     "monitor|5.0|product-version": "5.0.0-preview.4",
-    "monitor|5.0|sha": "791413986dccd0c2b86e871b814a3f42f1069fc743f661449d47421aac3ae351d5a850db5e5bfba9703539210934daeb5eb0382c3f5037fff3d8b248cb1a3ecb",
+    "monitor|5.0|sha": "0d3c186a6066766dd7f881562d41307aab5e6b981f87509d9ebbac47e46f865db1aa0c52afa85d2eee1359578fdd0b94b8d76df412df9f43f284d44688762f35",
 
     "lzma|2.1|sha": "0c5bdda138cd6dee49a42e6200fe385e37796cb79cad50bc4c234f9949c2faf5bcf84c70cb2dd2a6999090c0db708a40fc93ce1669cd3019bba0e3ef2e64025f",
 

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:3.1-alpine3.13 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.4.21174.1
+ENV DOTNET_MONITOR_VERSION=5.0.0-preview.4.21177.1
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
-    && dotnetmonitor_sha512='791413986dccd0c2b86e871b814a3f42f1069fc743f661449d47421aac3ae351d5a850db5e5bfba9703539210934daeb5eb0382c3f5037fff3d8b248cb1a3ecb' \
+    && dotnetmonitor_sha512='0d3c186a6066766dd7f881562d41307aab5e6b981f87509d9ebbac47e46f865db1aa0c52afa85d2eee1359578fdd0b94b8d76df412df9f43f284d44688762f35' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.


### PR DESCRIPTION
The dotnet-monitor tool changed its version and hash file naming to include a channel name. This broke update-dependencies because it was not aware of the channel differentiation. This change adds the optional channel name notion that can be used in the url templates for the checksum files.

Overview of changes:
- Add optional --channel-name parameter to update-dependencies.
- Use --channel-name when updating dotnet-monitor.
- Update dotnet-monitor version using '5.0/daily' channel name.