### PR TITLE
Add missing parts of dotnet sdk decompress step

### DIFF
--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='{{VARIABLES[cat("sdk|6.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./dotnet ./host ./packs ./sdk ./sdk-manifests ./shared ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help{{if ARCH_VERSIONED = "amd64":

--- a/src/sdk/6.0/alpine3.13/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.13/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='7b3fa97e37d420d501edd073c97d03c26610491a7cec61f5bb7ef56df98b42e00c4dac704e115136e2788ca0a68c3fffdd428eb3d063e7faeccded934e8572df' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./dotnet ./host ./packs ./sdk ./sdk-manifests ./shared ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.13/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='cb0ef141ae92735033f02ce03eaa7b675dac409a88c0cb2fe89b4f845a9ec66afde04eb523fb5f6dc879235d7b424003f9543e0a8514931f2c86c4bbdf4e6a27' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./dotnet ./host ./packs ./sdk ./sdk-manifests ./shared ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/alpine3.13/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.13/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='e4c334cd2047a507587c030cf6b4e14d6c96a63e25b931118e45e332851b63b82124fa1d2cfd80588f636feeab50095ecd9d83a387058ebeb98cc4fd6e10940f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./dotnet ./host ./packs ./sdk ./sdk-manifests ./shared ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help


### PR DESCRIPTION
I noticed issues when I tried to use the provided docker file with dotnet 6 preview.
Some parts of the .NET SDK were not installed.

After the change the install completes without issues and docker image is built as expected.

I tested with:
DOTNET_SDK_VERSION=6.0.100-preview.3.21202.5

The dotnet SDK is unpacked, but cannot be executed because the correct version of dotnet does not get installed.

This error message is shown instead:
```
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '6.0.0-preview.3.21201.4' was not found.
  - The following frameworks were found:
        5.0.5 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.
```
This message is of course not the best, since we are trying to install the SDK.