### PR TITLE
Enable tests for fixed issues

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
-            // Skip test for Arm32 Alpine 3.13 due to https://github.com/dotnet/runtime/issues/47423
-            if (imageData.OS == "alpine3.13" && imageData.Arch == Arch.Arm)
+            // Skip test for .NET 5 on Arm32 Alpine 3.13 due to https://github.com/dotnet/runtime/issues/47423
+            if (imageData.Version.Major == 5 && imageData.OS == "alpine3.13" && imageData.Arch == Arch.Arm)
             {
                 return;
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 if (DockerHelper.IsLinuxContainerModeEnabled)
                 {
                     // Skip test until end-to-end scenario works for self-contained publishing on Alpine arm32
-                    if ((_imageData.Version.Major == 5 || _imageData.Version.Major == 6) &&
+                    if ((_imageData.Version.Major == 5) &&
                         _imageData.Arch == Arch.Arm && _imageData.OS.Contains("alpine"))
                     {
                         return;

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
-            // Skip test for Arm32 Alpine 3.13 due to https://github.com/dotnet/runtime/issues/47423
-            if (imageData.OS == "alpine3.13" && imageData.Arch == Arch.Arm)
+            // Skip test for .NET 5 on Arm32 Alpine 3.13 due to https://github.com/dotnet/runtime/issues/47423
+            if (imageData.Version.Major == 5 && imageData.OS == "alpine3.13" && imageData.Arch == Arch.Arm)
             {
                 return;
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -155,12 +155,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {
-            // Disable this test for 5.0 due to https://github.com/dotnet/aspnetcore/issues/27670
-            if (imageData.Version.Major == 5)
-            {
-                return;
-            }
-
             // Disable this test for Arm-based Alpine on 6.0 until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
             if (imageData.Version.Major == 6 && imageData.OS.Contains("alpine") && imageData.IsArm)
             {
@@ -181,17 +175,13 @@ namespace Microsoft.DotNet.Docker.Tests
 
             bool hasFileContentDifference = false;
 
-            // Skip file comparisons for 3.1 until https://github.com/dotnet/sdk/issues/11327 is fixed.
-            if (imageData.Version.Major != 3)
+            int fileCount = expectedDotnetFiles.Count();
+            for (int i = 0; i < fileCount; i++)
             {
-                int fileCount = expectedDotnetFiles.Count();
-                for (int i = 0; i < fileCount; i++)
+                if (expectedDotnetFiles.ElementAt(i).CompareTo(actualDotnetFiles.ElementAt(i)) != 0)
                 {
-                    if (expectedDotnetFiles.ElementAt(i).CompareTo(actualDotnetFiles.ElementAt(i)) != 0)
-                    {
-                        hasFileContentDifference = true;
-                        break;
-                    }
+                    hasFileContentDifference = true;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Several test scenarios were disabled due to the following product issues that have been resolved:

* https://github.com/dotnet/runtime/issues/47423: 6.0 works now, 5.0 should be fixed in 5.0.7
* https://github.com/dotnet/aspnetcore/issues/27670
* https://github.com/dotnet/sdk/issues/11327

Related to:
* #2353
* #2373