### PR TITLE
Replace references to dotnet-nightly product family in Docker Hub

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/dotnet-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/dotnet-release.md
@@ -72,4 +72,4 @@ _The set of .NET versions that are being released as a unit._
 1. - [ ] Get PR signoff
 1. - [ ] Merge PR
 1. - [ ] Wait for automatically queued CI build to finish on [dotnet-docker-nightly pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=359) (internal MSFT link)
-1. - [ ] Confirm READMEs have been updated in [Docker Hub](https://hub.docker.com/_/microsoft-dotnet-nightly)
+1. - [ ] Confirm READMEs have been updated in [Docker Hub](https://hub.docker.com/_/microsoft-dotnet)

--- a/.github/ISSUE_TEMPLATE/releases/new-distro-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/new-distro-release.md
@@ -24,7 +24,7 @@ Distro: &lt;name/version&gt;
 1. - [ ] Get PR signoff
 1. - [ ] Merge PR to nightly branch
 1. - [ ] Wait for automatically queued CI build to finish on [dotnet-docker-nightly pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=359) (internal MSFT link)
-1. - [ ] Confirm READMEs have been updated in [Docker Hub](https://hub.docker.com/_/microsoft-dotnet-nightly)
+1. - [ ] Confirm READMEs have been updated in [Docker Hub](https://hub.docker.com/_/microsoft-dotnet)
 
 ## Main Branch Tasks
 

--- a/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/new-windows-release.md
@@ -22,7 +22,7 @@ Windows version: &lt;version&gt;
 1. - [ ] Get PR signoff
 1. - [ ] Merge PR as part of the main branch [release process](dotnet-release.md) for the next .NET release
 1. - [ ] Wait for automatically queued CI build to finish on [dotnet-docker-nightly pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=359) (internal MSFT link)
-1. - [ ] Confirm READMEs have been updated in [Docker Hub](https://hub.docker.com/_/microsoft-dotnet-nightly)
+1. - [ ] Confirm READMEs have been updated in [Docker Hub](https://hub.docker.com/_/microsoft-dotnet)
 1. - [ ] Create an announcement (example: [Nano Server, version 1909](https://github.com/dotnet/dotnet-docker/issues/1460))
 1. - [ ] Update the samples to reference the new Windows version:
       - [ ] [Nano Server sample Dockerfiles](https://github.com/dotnet/dotnet-docker/tree/main/samples)

--- a/.github/ISSUE_TEMPLATE/releases/patch-tuesday-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/patch-tuesday-release.md
@@ -12,7 +12,6 @@
 
           imageBuilder.pathArgs: --path '*nanoserver*' --path '*windowsservercore*'
 1. - [ ] Confirm `Last Modified` field has been updated in Docker Hub for [microsoft-dotnet](https://hub.docker.com/_/microsoft-dotnet)
-1. - [ ] Confirm `Last Modified` field has been updated in Docker Hub for [microsoft-dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly)
 1. - [ ] Confirm build for [dotnet-docker-samples](https://dev.azure.com/dnceng/internal/_build?definitionId=376) (internal MSFT link) was queued. This will be queued automatically by [dotnet-docker-tools-check-base-image-updates](https://dev.azure.com/dnceng/internal/_build?definitionId=536) when it detects that the product images have been updated (detection runs on a schedule). Alternatively, you can manually queue the samples build.
 1. - [ ] Confirm sample images have been ingested by MCR
 1. - [ ] Confirm `Last Modified` field has been updated in Docker Hub for [microsoft-dotnet-samples](https://hub.docker.com/_/microsoft-dotnet-samples/)

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -39,7 +39,6 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -38,7 +38,7 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 * [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 
 .NET Framework:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 .NET:
 
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 .NET:
 
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 
 .NET Framework:
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -30,7 +30,7 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 * [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
 * [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 
 .NET Framework:
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -31,7 +31,6 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 * [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -26,7 +26,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 * [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
 * [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 
 .NET Framework:
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -27,7 +27,6 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 * [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -35,7 +35,6 @@ docker run --rm mcr.microsoft.com/dotnet/samples
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -34,7 +34,7 @@ docker run --rm mcr.microsoft.com/dotnet/samples
 * [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
 
 .NET Framework:
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -49,7 +49,6 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 * [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -45,7 +45,6 @@ The following samples show how to develop, build and test .NET applications with
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 
 .NET Framework:
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -44,7 +44,7 @@ The following samples show how to develop, build and test .NET applications with
 * [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
 
 .NET Framework:
 

--- a/documentation/guiding-principles.md
+++ b/documentation/guiding-principles.md
@@ -39,7 +39,7 @@ See the [supported tags](supported-tags.md) for the tagging practices and polici
 
 1. Images will be rebuilt within hours of base image changes. For example, suppose a particular version of Alpine is patched. The .NET images based on this version of Alpine will be rebuilt with this new base image within hours of its release.
 
-1. Images will never be deleted from the [official Docker repositories](https://hub.docker.com/_/microsoft-dotnet/). This does not apply to the [nightly repositories](https://hub.docker.com/_/microsoft-dotnet-nightly).
+1. Images will never be deleted from the [official Docker repositories](https://hub.docker.com/_/microsoft-dotnet/). This does not apply to the [nightly repositories](https://github.com/dotnet/dotnet-docker/blob/nightly/README.md).
 
 1. The [Dockerfiles](https://github.com/dotnet/dotnet-docker/search?q=filename%3ADockerfile) used to produce all of the images will be publicly available. Customers will be able to take the Dockerfiles and build them to produce their own equivalent images. No special build steps or permissions should be needed to build the Dockerfiles.
 

--- a/documentation/supported-platforms.md
+++ b/documentation/supported-platforms.md
@@ -14,7 +14,7 @@ Each distribution (distro) has a unique approach to releasing, schedule, and end
 - Debian — support the latest *stable* version at the time a `major.minor` version of .NET is released. As new *stable* versions are released, support is added to the latest .NET version and latest LTS (if they differ).
 - Ubuntu — support the latest *LTS* version at the time a `major.minor` version of .NET is released. As new *LTS* versions are released, support is added to the latest .NET version and latest LTS (if they differ).
 
-Pre-release versions of the supported distros will be made available within the [nightly repositories](https://hub.docker.com/_/microsoft-dotnet-nightly) based on the availability of pre-release OS base images.
+Pre-release versions of the supported distros will be made available within the [nightly repositories](https://github.com/dotnet/dotnet-docker/blob/nightly/README.md) based on the availability of pre-release OS base images.
 
 ### Windows
 

--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -70,7 +70,7 @@ _Shared Tags_ reference images for [multiple platforms](https://blog.docker.com/
 1. `latest`
 
     * [dotnet/](https://hub.docker.com/_/microsoft-dotnet) - `latest` will reference the `<Major.Minor.Patch Version>` image for the most recent GA release.
-    * [dotnet/nightly/](https://hub.docker.com/_/microsoft-dotnet-nightly) - `latest` will reference the `<Major.Minor.Patch Version>` image for the most recent release. This implies `latest` will at times reference prerelease versions. In the event when there are multiple active prerelease versions (e.g. 3.1 preview 3 and 5.0 preview 1), `latest` will reference the lower prerelease version (e.g. 3.1 preview 3) until the point when the lower version (e.g. 3.1) is released. Once this happens, `latest` will reference the higher version (e.g. 5.0 preview 1).
+    * [dotnet/nightly/](https://github.com/dotnet/dotnet-docker/blob/nightly/README.md) - `latest` will reference the `<Major.Minor.Patch Version>` image for the most recent release. This implies `latest` will at times reference prerelease versions. In the event when there are multiple active prerelease versions (e.g. 3.1 preview 3 and 5.0 preview 1), `latest` will reference the lower prerelease version (e.g. 3.1 preview 3) until the point when the lower version (e.g. 3.1) is released. Once this happens, `latest` will reference the higher version (e.g. 5.0 preview 1).
 
 ## Tag Parts
 

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -16,7 +16,7 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
   * `docker pull {{FULL_REPO}}:5.0`
 * `3.1` (LTS)
   * `docker pull {{FULL_REPO}}:3.1`
-}}}}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"
+}}}}{{if IS_PRODUCT_FAMILY
 :# Featured Repos
 
 * [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
@@ -25,14 +25,6 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-^elif IS_PRODUCT_FAMILY && VARIABLES["branch"] = "nightly"
-:# Featured Repos
-
-* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 }}
 # About {{if IS_PRODUCT_FAMILY:.NET^else:This Image}}
 
@@ -58,19 +50,17 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
     :* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime-deps")
     :* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-}}{{if PARENT_REPO = "dotnet" && SHORT_REPO != "monitor"
+}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "monitor")
     :* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-}}{{if REPO != "dotnet/samples"
-    :* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-}}{{if (PARENT_REPO = "nightly" && SHORT_REPO != "sdk")
+}}{{if IS_PRODUCT_FAMILY || ((PARENT_REPO = "nightly" && SHORT_REPO != "sdk") || (PARENT_REPO = "dotnet" && SHORT_REPO = "sdk"))
     :* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-}}{{if (PARENT_REPO = "nightly" && SHORT_REPO != "aspnet")
+}}{{if IS_PRODUCT_FAMILY || ((PARENT_REPO = "nightly" && SHORT_REPO != "aspnet") || (PARENT_REPO = "dotnet" && SHORT_REPO = "aspnet"))
     :* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-}}{{if (PARENT_REPO = "nightly" && SHORT_REPO != "runtime")
+}}{{if IS_PRODUCT_FAMILY || ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime"))
     :* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
-}}{{if (PARENT_REPO = "nightly" && SHORT_REPO != "runtime-deps")
+}}{{if IS_PRODUCT_FAMILY || ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime-deps") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime-deps"))
     :* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
-}}{{if PARENT_REPO = "nightly" && SHORT_REPO != "monitor"
+}}{{if IS_PRODUCT_FAMILY || ((PARENT_REPO = "nightly" && SHORT_REPO != "monitor") || (PARENT_REPO = "dotnet" && SHORT_REPO = "monitor"))
     :* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 }}
 .NET Framework:

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -48,7 +48,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 .NET:
 
-{{if !IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly"
+{{if !IS_PRODUCT_FAMILY
     :* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "sdk")
     :* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
@@ -62,8 +62,6 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
     :* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
 }}{{if REPO != "dotnet/samples"
     :* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-}}{{if !IS_PRODUCT_FAMILY || VARIABLES["branch"] = "main"
-    :* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
 }}{{if (PARENT_REPO = "nightly" && SHORT_REPO != "sdk")
     :* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
 }}{{if (PARENT_REPO = "nightly" && SHORT_REPO != "aspnet")

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -15,7 +15,7 @@ There are multiple [.NET Docker repos](https://hub.docker.com/_/microsoft-dotnet
 
 The repos above are commonly used on the command line and in Dockerfiles. There are two more repos that may be useful to you:
 
-* [dotnet/nightly](https://hub.docker.com/_/microsoft-dotnet-nightly) -- A duplicate structure of repos which contain the latest pre-released versions of .NET. (which are not supported in production).
+* [dotnet/nightly](https://github.com/dotnet/dotnet-docker/blob/nightly/README.md) -- A duplicate structure of repos which contain the latest pre-released versions of .NET. (which are not supported in production).
 * [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples) -- A set of samples that demonstrate .NET being used in console and web scenarios.
 
 ## Tags that work everywhere


### PR DESCRIPTION
In some cases there were references to https://hub.docker.com/_/microsoft-dotnet-nightly/ in order to specifically refer to nightly repositories as a whole.  In that case, I replaced it with a link to the [README in the nightly branch](https://github.com/dotnet/dotnet-docker/blob/nightly/README.md).  

Fixes #2361