### PR TITLE
Update image size baselines

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -147,8 +147,8 @@
     "src/sdk/6.0/bullseye-slim/arm32v7": 585340315,
     "src/sdk/6.0/bullseye-slim/arm64v8": 660030347,
     "src/sdk/6.0/alpine3.13/amd64": 530126770,
-    "src/sdk/6.0/alpine3.13/arm32v7": 521464732,
-    "src/sdk/6.0/alpine3.13/arm64v8": 494767769,
+    "src/sdk/6.0/alpine3.13/arm32v7": 475126787,
+    "src/sdk/6.0/alpine3.13/arm64v8": 521464732,
     "src/sdk/6.0/focal/amd64": 652648922,
     "src/sdk/6.0/focal/arm32v7": 591681171,
     "src/sdk/6.0/focal/arm64v8": 669929244


### PR DESCRIPTION
This corrects the values that weren't updated correctly in https://github.com/dotnet/dotnet-docker/pull/2767.