### PR TITLE
Apply WSC 2019 patch

### DIFF
--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/01/windows10.0-kb4601060-x64_b645458f512391ae20e17e21f01d24183b5076c9.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -7,7 +7,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601060-x64.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
     && rmdir /S /Q patch
 
 ENV `

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/01/windows10.0-kb4601060-x64_b645458f512391ae20e17e21f01d24183b5076c9.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
@@ -7,7 +7,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601060-x64.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
     && rmdir /S /Q patch
 
 ENV `

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/01/windows10.0-kb4601060-x64_b645458f512391ae20e17e21f01d24183b5076c9.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601060-x64.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
     && rmdir /S /Q patch
 
 ENV `

--- a/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/01/windows10.0-kb4601060-x64_b645458f512391ae20e17e21f01d24183b5076c9.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/05/windows10.0-kb5003171-x64_30162051d5376b7a19c4c25157347c522e804bbb.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601060-x64.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
     && rmdir /S /Q patch
 
 ENV `


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/issues/2782

Note that the download URL uses KB4601558 but this actually maps to KB5001879 for the 5B release.