### PR TITLE
Use scale set agent pools for internal builds

### DIFF
--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -39,8 +39,7 @@ jobs:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: Docker-20H2-Public
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: DotNetCore-Docker
-      demands: VSTS_OS -equals Windows-ServerDatacenter-2009
+      name: Docker-20H2-Internal
   workspace:
     clean: all
   steps:

--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -35,11 +35,7 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  pool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: Docker-20H2-Public
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: Docker-20H2-Internal
+  pool: Docker-20H2-${{ variables['System.TeamProject'] }}
   workspace:
     clean: all
   steps:

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -91,8 +91,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: Docker-1809-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+          name: Docker-1809-Internal
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -105,8 +104,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: Docker-2004-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2004
+          name: Docker-2004-Internal
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -119,8 +117,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: Docker-20H2-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2009
+          name: Docker-20H2-Internal
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows20H2Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -133,8 +130,7 @@ stages:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: Docker-2016-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+          name: Docker-2016-Internal
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2016Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -203,32 +199,28 @@ stages:
       parameters:
         name: Windows1809_amd64
         pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2019_Data_Center_RS5
+          name: Docker-1809-Internal
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2004_amd64
         pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2004
+          name: Docker-2004-Internal
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows20H2_amd64
         pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows-ServerDatacenter-2009
+          name: Docker-20H2-Internal
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: WindowsLtsc2016_amd64
         pool:
-          name: DotNetCore-Docker
-          demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
+          name: Docker-2016-Internal
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
 

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -87,11 +87,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows1809_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-1809-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: Docker-1809-Internal
+      pool: Docker-1809-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -100,11 +96,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows2004_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-2004-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: Docker-2004-Internal
+      pool: Docker-2004-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -113,11 +105,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows20H2_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-20H2-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: Docker-20H2-Internal
+      pool: Docker-20H2-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows20H2Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -126,11 +114,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: WindowsLtsc2016_amd64
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: Docker-2016-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: Docker-2016-Internal
+      pool: Docker-2016-${{ variables['System.TeamProject'] }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2016Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -198,29 +182,25 @@ stages:
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows1809_amd64
-        pool:
-          name: Docker-1809-Internal
+        pool: Docker-1809-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2004_amd64
-        pool:
-          name: Docker-2004-Internal
+        pool: Docker-2004-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows20H2_amd64
-        pool:
-          name: Docker-20H2-Internal
+        pool: Docker-20H2-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: WindowsLtsc2016_amd64
-        pool:
-          name: Docker-2016-Internal
+        pool: Docker-2016-${{ variables['System.TeamProject'] }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
 


### PR DESCRIPTION
Rolling out the changes to consume scale set agent pools for internal builds in the nightly branch for testing.

Related to https://github.com/dotnet/docker-tools/issues/532