### PR TITLE
Default process filter for dotnet-monitor

### DIFF
--- a/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
@@ -24,6 +24,9 @@ COPY --from=installer /app .
 ENV \
     # Disable debugger and profiler diagnostics to avoid diagnosing self.
     COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DotnetMonitor_DefaultProcess__Filters__0__Key=ProcessId \
+    DotnetMonitor_DefaultProcess__Filters__0__Value=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -24,6 +24,9 @@ COPY --from=installer /app .
 ENV \
     # Disable debugger and profiler diagnostics to avoid diagnosing self.
     COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DotnetMonitor_DefaultProcess__Filters__0__Key=ProcessId \
+    DotnetMonitor_DefaultProcess__Filters__0__Value=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)


### PR DESCRIPTION
As a result of https://github.com/dotnet/dotnet-monitor/pull/299, we will need to add a default process filter for the docker image.