### PR TITLE
Set exclude-product-family readme option for nightly branch

### DIFF
--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -3,6 +3,16 @@ parameters:
   condition: true
 
 steps:
+- powershell: >
+    if ($env:BUILD_SOURCEBRANCHNAME -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly") {
+        $additionalPublishMcrDocsArgs = "--exclude-product-family"
+    }
+    else {
+        $additionalPublishMcrDocsArgs = ""
+    }
+
+    echo "##vso[task.setvariable variable=additionalPublishMcrDocsArgs]$additionalPublishMcrDocsArgs"
+  displayName: Set publishMcrDocs Args
 - script: >
     $(runImageBuilderCmd) publishMcrDocs
     --manifest '$(manifest)'
@@ -14,6 +24,7 @@ steps:
     ${{ parameters.dryRunArg }}
     $(manifestVariables)
     $(imageBuilder.queueArgs)
+    $(additionalPublishMcrDocsArgs)
   name: PublishReadmes
   displayName: Publish Readmes
   condition: ${{ parameters.condition }}

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1076057
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1145787
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
Consumes the `exclude-product-family` option that was added in https://github.com/dotnet/docker-tools/pull/788 in order to avoid publishing the product family repository in the nightly branch.  While this is in the common infra, I chose to reference the `nightly` branch directly even though it's not relevant to the other repositories that consume the common infra.  This decision was based purely on keeping things simple. The alternative is to provide a way to do task injection which would require flowing a parameter value across a bunch of YAML files.

Related to #2361