### PR TITLE
Updated 6.0 images to use latest PowerShell Preview build 7.2.0-preview.6

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -57,12 +57,12 @@
     "powershell|5.0|Linux|x64|sha": "537d885b79dd1cd183d14b5f5e71046558fb015f562bb817ee90fbabaa9b1039c822949b7e1a5c9b69a976eae09786e3b2c0f0586c01c822868cc48ea7e36620",
     "powershell|5.0|Windows|x64|sha": "6a390cddbc88fe9a645363ccec9819603cfb754b5dead3161197f45c4b248b6bd4176b369ded139d7f9d485105351395de07cd8e61ed4f22a9cdd34bfaff9fc5",
 
-    "powershell|6.0|build-version": "7.2.0-preview.5",
-    "powershell|6.0|Linux.Alpine|sha": "5caa0c0c710740078df0dd6b02912bdf101006bd449642dec08e39730fa45c787988252d0667a438e03a8fd7c4e68d1692d8c259f54d4a3a83687fcaeb268394",
-    "powershell|6.0|Linux|arm32|sha": "3e143afe24cca7adcbdc37de4109acdd520ea46d052983a0dae672e7f99326aa2637af2beb42f4dcb65bd725f5bf8d3297e7b21eb23b725e775c5e0a600271e7",
-    "powershell|6.0|Linux|arm64|sha": "c18386b717567ec7aa52d161713225cd9fa782a77601b4fe829faece49ba3ceed7b8297e8be1dc8f8ac98e2bec1e92bce49c5f191ee90391bbb0c419453021b8",
-    "powershell|6.0|Linux|x64|sha": "2766efbeaba81f3fa47b3de57ae606b34f00eb6f63a7d58d678c52ce8ac9e6cdba3d89e964b149f7f58db7bbefc07e49a0d91d4957da1c04ca1d77714b27c767",
-    "powershell|6.0|Windows|x64|sha": "76fec0e3160bb9d19531cb95f7bd1fce07074f990bc2e2e35fe67b00460e034a24079d52aef0353070cecb8261721f1bb314bdd8919f52f788e6c48cadedbecd",
+    "powershell|6.0|build-version": "7.2.0-preview.6",
+    "powershell|6.0|Linux.Alpine|sha": "ec3b6d18778b16b96b6735f53e8ab3c7ada2f5a1df26cfae699a902a0ecc9c4bd03aaf60ec0bdca919a4d6d2333144cb9e59a63dbdd38cabc900c7a0bedc527b",
+    "powershell|6.0|Linux|arm32|sha": "789185f4a44d45270d9fc8fbaa56009985ca93144f190bc9a7220aeac6247d8582503257fe3668f0113879897a43dc876d19926d4c0ece61240cbff3c443b718",
+    "powershell|6.0|Linux|arm64|sha": "87b1d51125f8c492fa806c90ec52be013fb52e7d56d3a67b2a0dbb203715ea2f9ac514b95074e4f5d058c40ac4fbb0f83eba1ff862d10b0adb5e6cb22f76dc09",
+    "powershell|6.0|Linux|x64|sha": "f241505d1dd976faefa3a8a14bb57f43be057fcbf2f199551d9abb589f64436d28a69978baaa51f91e840da5dc36f7218cbc670bbcd0810c3b8e5fdefae88142",
+    "powershell|6.0|Windows|x64|sha": "ee6684bf0d8ed26116e26205a8c2e041aca96d28dd2de0fd6401c14185e351c2daca82009f7ec46ecf12e9e30b860e0216a64c436d18f213ad269236d7359094",
 
     "runtime|2.1|build-version": "2.1.28",
     "runtime|2.1|linux-musl|x64|sha": "a8e6f3e20b6ecc9bb8501ae61caadeecfcf7cb61343b1f4008138f2dcf15f23bad4c228d61f334b1dec5afb635d6bfb5aae01e82bc95a70af5509b51d2d40efe",

--- a/src/sdk/6.0/alpine3.13/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.13/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.2.0-preview.5 \
+RUN powershell_version=7.2.0-preview.6 \
     && wget -O PowerShell.Linux.Alpine.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='5caa0c0c710740078df0dd6b02912bdf101006bd449642dec08e39730fa45c787988252d0667a438e03a8fd7c4e68d1692d8c259f54d4a3a83687fcaeb268394' \
+    && powershell_sha512='ec3b6d18778b16b96b6735f53e8ab3c7ada2f5a1df26cfae699a902a0ecc9c4bd03aaf60ec0bdca919a4d6d2333144cb9e59a63dbdd38cabc900c7a0bedc527b' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \

--- a/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.2.0-preview.5 \
+RUN powershell_version=7.2.0-preview.6 \
     && curl -SL --output PowerShell.Linux.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='2766efbeaba81f3fa47b3de57ae606b34f00eb6f63a7d58d678c52ce8ac9e6cdba3d89e964b149f7f58db7bbefc07e49a0d91d4957da1c04ca1d77714b27c767' \
+    && powershell_sha512='f241505d1dd976faefa3a8a14bb57f43be057fcbf2f199551d9abb589f64436d28a69978baaa51f91e840da5dc36f7218cbc670bbcd0810c3b8e5fdefae88142' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -37,9 +37,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.2.0-preview.5 \
+RUN powershell_version=7.2.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='3e143afe24cca7adcbdc37de4109acdd520ea46d052983a0dae672e7f99326aa2637af2beb42f4dcb65bd725f5bf8d3297e7b21eb23b725e775c5e0a600271e7' \
+    && powershell_sha512='789185f4a44d45270d9fc8fbaa56009985ca93144f190bc9a7220aeac6247d8582503257fe3668f0113879897a43dc876d19926d4c0ece61240cbff3c443b718' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -37,9 +37,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.2.0-preview.5 \
+RUN powershell_version=7.2.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='c18386b717567ec7aa52d161713225cd9fa782a77601b4fe829faece49ba3ceed7b8297e8be1dc8f8ac98e2bec1e92bce49c5f191ee90391bbb0c419453021b8' \
+    && powershell_sha512='87b1d51125f8c492fa806c90ec52be013fb52e7d56d3a67b2a0dbb203715ea2f9ac514b95074e4f5d058c40ac4fbb0f83eba1ff862d10b0adb5e6cb22f76dc09' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/6.0/focal/amd64/Dockerfile
+++ b/src/sdk/6.0/focal/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.2.0-preview.5 \
+RUN powershell_version=7.2.0-preview.6 \
     && curl -SL --output PowerShell.Linux.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='2766efbeaba81f3fa47b3de57ae606b34f00eb6f63a7d58d678c52ce8ac9e6cdba3d89e964b149f7f58db7bbefc07e49a0d91d4957da1c04ca1d77714b27c767' \
+    && powershell_sha512='f241505d1dd976faefa3a8a14bb57f43be057fcbf2f199551d9abb589f64436d28a69978baaa51f91e840da5dc36f7218cbc670bbcd0810c3b8e5fdefae88142' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/6.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/6.0/focal/arm32v7/Dockerfile
@@ -37,9 +37,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.2.0-preview.5 \
+RUN powershell_version=7.2.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='3e143afe24cca7adcbdc37de4109acdd520ea46d052983a0dae672e7f99326aa2637af2beb42f4dcb65bd725f5bf8d3297e7b21eb23b725e775c5e0a600271e7' \
+    && powershell_sha512='789185f4a44d45270d9fc8fbaa56009985ca93144f190bc9a7220aeac6247d8582503257fe3668f0113879897a43dc876d19926d4c0ece61240cbff3c443b718' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/6.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/6.0/focal/arm64v8/Dockerfile
@@ -37,9 +37,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.2.0-preview.5 \
+RUN powershell_version=7.2.0-preview.6 \
     && curl -SL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='c18386b717567ec7aa52d161713225cd9fa782a77601b4fe829faece49ba3ceed7b8297e8be1dc8f8ac98e2bec1e92bce49c5f191ee90391bbb0c419453021b8' \
+    && powershell_sha512='87b1d51125f8c492fa806c90ec52be013fb52e7d56d3a67b2a0dbb203715ea2f9ac514b95074e4f5d058c40ac4fbb0f83eba1ff862d10b0adb5e6cb22f76dc09' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
@@ -22,9 +22,9 @@ RUN `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool
-    $powershell_version = '7.2.0-preview.5'; `
+    $powershell_version = '7.2.0-preview.6'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-    $powershell_sha512 = '76fec0e3160bb9d19531cb95f7bd1fce07074f990bc2e2e35fe67b00460e034a24079d52aef0353070cecb8261721f1bb314bdd8919f52f788e6c48cadedbecd'; `
+    $powershell_sha512 = 'ee6684bf0d8ed26116e26205a8c2e041aca96d28dd2de0fd6401c14185e351c2daca82009f7ec46ecf12e9e30b860e0216a64c436d18f213ad269236d7359094'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/src/sdk/6.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-2004/amd64/Dockerfile
@@ -22,9 +22,9 @@ RUN `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool
-    $powershell_version = '7.2.0-preview.5'; `
+    $powershell_version = '7.2.0-preview.6'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-    $powershell_sha512 = '76fec0e3160bb9d19531cb95f7bd1fce07074f990bc2e2e35fe67b00460e034a24079d52aef0353070cecb8261721f1bb314bdd8919f52f788e6c48cadedbecd'; `
+    $powershell_sha512 = 'ee6684bf0d8ed26116e26205a8c2e041aca96d28dd2de0fd6401c14185e351c2daca82009f7ec46ecf12e9e30b860e0216a64c436d18f213ad269236d7359094'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -22,9 +22,9 @@ RUN `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool
-    $powershell_version = '7.2.0-preview.5'; `
+    $powershell_version = '7.2.0-preview.6'; `
     Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-    $powershell_sha512 = '76fec0e3160bb9d19531cb95f7bd1fce07074f990bc2e2e35fe67b00460e034a24079d52aef0353070cecb8261721f1bb314bdd8919f52f788e6c48cadedbecd'; `
+    $powershell_sha512 = 'ee6684bf0d8ed26116e26205a8c2e041aca96d28dd2de0fd6401c14185e351c2daca82009f7ec46ecf12e9e30b860e0216a64c436d18f213ad269236d7359094'; `
     if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `

--- a/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -36,9 +36,9 @@ RUN powershell -Command "`
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.2.0-preview.5'; `
+        $powershell_version = '7.2.0-preview.6'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '76fec0e3160bb9d19531cb95f7bd1fce07074f990bc2e2e35fe67b00460e034a24079d52aef0353070cecb8261721f1bb314bdd8919f52f788e6c48cadedbecd'; `
+        $powershell_sha512 = 'ee6684bf0d8ed26116e26205a8c2e041aca96d28dd2de0fd6401c14185e351c2daca82009f7ec46ecf12e9e30b860e0216a64c436d18f213ad269236d7359094'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `


### PR DESCRIPTION
This PR is a result of running `dotnet run --project .\eng\update-dependencies\ -- 6.0 --product-version powershell=7.2.0-preview.6 --compute-shas` with Docker in Linux container mode.