### PR TITLE
Split 5.0 runtime-deps Buster tags to have separate product version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -213,13 +213,11 @@
           "productVersion": "$(dotnet|3.1|product-version)",
           "sharedTags": {
             "$(dotnet|3.1|product-version)": {
-              "documentationGroup": "3.1",
               "syndication": {
                 "repo": "$(syndicatedRuntimeDepsRepo)"
               }
             },
             "3.1": {
-              "documentationGroup": "3.1",
               "syndication": {
                 "repo": "$(syndicatedRuntimeDepsRepo)",
                 "destinationTags": [
@@ -227,18 +225,6 @@
                   "latest"
                 ]
               }
-            },
-            "$(dotnet|5.0|product-version)": {
-              "documentationGroup": "5.0"
-            },
-            "$(dotnet|5.0|product-version)-buster-slim": {
-              "documentationGroup": "5.0"
-            },
-            "5.0": {
-              "documentationGroup": "5.0"
-            },
-            "5.0-buster-slim": {
-              "documentationGroup": "5.0"
             }
           },
           "platforms": [
@@ -249,22 +235,14 @@
               "osVersion": "buster-slim",
               "tags": {
                 "$(dotnet|3.1|product-version)-buster-slim": {
-                  "documentationGroup": "3.1",
                   "syndication": {
                     "repo": "$(syndicatedRuntimeDepsRepo)"
                   }
                 },
                 "3.1-buster-slim": {
-                  "documentationGroup": "3.1",
                   "syndication": {
                     "repo": "$(syndicatedRuntimeDepsRepo)"
                   }
-                },
-                "$(dotnet|5.0|product-version)-buster-slim-amd64": {
-                  "documentationGroup": "5.0"
-                },
-                "5.0-buster-slim-amd64": {
-                  "documentationGroup": "5.0"
                 }
               }
             },
@@ -276,22 +254,14 @@
               "osVersion": "buster-slim",
               "tags": {
                 "$(dotnet|3.1|product-version)-buster-slim-arm32v7": {
-                  "documentationGroup": "3.1",
                   "syndication": {
                     "repo": "$(syndicatedRuntimeDepsRepo)"
                   }
                 },
                 "3.1-buster-slim-arm32v7": {
-                  "documentationGroup": "3.1",
                   "syndication": {
                     "repo": "$(syndicatedRuntimeDepsRepo)"
                   }
-                },
-                "$(dotnet|5.0|product-version)-buster-slim-arm32v7": {
-                  "documentationGroup": "5.0"
-                },
-                "5.0-buster-slim-arm32v7": {
-                  "documentationGroup": "5.0"
                 }
               },
               "variant": "v7"
@@ -304,22 +274,14 @@
               "osVersion": "buster-slim",
               "tags": {
                 "$(dotnet|3.1|product-version)-buster-slim-arm64v8": {
-                  "documentationGroup": "3.1",
                   "syndication": {
                     "repo": "$(syndicatedRuntimeDepsRepo)"
                   }
                 },
                 "3.1-buster-slim-arm64v8": {
-                  "documentationGroup": "3.1",
                   "syndication": {
                     "repo": "$(syndicatedRuntimeDepsRepo)"
                   }
-                },
-                "$(dotnet|5.0|product-version)-buster-slim-arm64v8": {
-                  "documentationGroup": "5.0"
-                },
-                "5.0-buster-slim-arm64v8": {
-                  "documentationGroup": "5.0"
                 }
               },
               "variant": "v8"
@@ -557,6 +519,51 @@
                     "repo": "$(syndicatedRuntimeDepsRepo)"
                   }
                 }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(dotnet|5.0|product-version)",
+          "sharedTags": {
+            "$(dotnet|5.0|product-version)": {},
+            "$(dotnet|5.0|product-version)-buster-slim": {},
+            "5.0": {},
+            "5.0-buster-slim": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/runtime-deps/3.1/buster-slim/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {
+                "$(dotnet|5.0|product-version)-buster-slim-amd64": {},
+                "5.0-buster-slim-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "src/runtime-deps/3.1/buster-slim/arm32v7",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {
+                "$(dotnet|5.0|product-version)-buster-slim-arm32v7": {},
+                "5.0-buster-slim-arm32v7": {}
+              },
+              "variant": "v7"
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/runtime-deps/3.1/buster-slim/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "buster-slim",
+              "tags": {
+                "$(dotnet|5.0|product-version)-buster-slim-arm64v8": {},
+                "5.0-buster-slim-arm64v8": {}
               },
               "variant": "v8"
             }


### PR DESCRIPTION
Fixes #2858