### PR TITLE
Remove apply .NET Fx patch since it exists in base image

### DIFF
--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -2,14 +2,6 @@
 
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
-    && mkdir patch `
-    && expand patch.msu patch -F:* `
-    && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
-    && rmdir /S /Q patch
-
 ENV `
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 `

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
@@ -2,14 +2,6 @@
 
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
-    && mkdir patch `
-    && expand patch.msu patch -F:* `
-    && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
-    && rmdir /S /Q patch
-
 ENV `
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 `

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -2,14 +2,6 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
-    && mkdir patch `
-    && expand patch.msu patch -F:* `
-    && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
-    && rmdir /S /Q patch
-
 ENV `
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 `

--- a/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -2,14 +2,6 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/02/windows10.0-kb4601558-x64_2abd844aa457ecf0cf668fd8c449a1bc3b4da4b4.msu `
-    && mkdir patch `
-    && expand patch.msu patch -F:* `
-    && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4601558-x64.cab `
-    && rmdir /S /Q patch
-
 ENV `
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 `


### PR DESCRIPTION
Removes the application of the .NET Fx patch for the 6B release since the .NET Fx patches will now be applied in the base image.

Related to https://github.com/dotnet/dotnet-docker/issues/2865