### PR TITLE
Enable 5.0 tests for Alpine on Arm

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -61,13 +61,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
                 if (DockerHelper.IsLinuxContainerModeEnabled)
                 {
-                    // Skip test until end-to-end scenario works for self-contained publishing on Alpine arm32
-                    if ((_imageData.Version.Major == 5) &&
-                        _imageData.Arch == Arch.Arm && _imageData.OS.Contains("alpine"))
-                    {
-                        return;
-                    }
-
                     // Use `sdk` image to publish self contained app and run with `runtime-deps` image
                     string selfContainedTag = BuildTestAppImage("self_contained_app", appDir, customBuildArgs: $"rid={_imageData.Rid}");
                     tags.Add(selfContainedTag);

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -23,12 +23,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
-            // Skip test for .NET 5 on Arm32 Alpine 3.13 due to https://github.com/dotnet/runtime/issues/47423
-            if (imageData.Version.Major == 5 && imageData.OS == "alpine3.13" && imageData.Arch == Arch.Arm)
-            {
-                return;
-            }
-
             ImageScenarioVerifier verifier = new ImageScenarioVerifier(imageData, DockerHelper, OutputHelper);
             await verifier.Execute();
         }


### PR DESCRIPTION
With the release of 5.0.7, Alpine on Arm32 is working.  Re-enabling the tests.

Related to https://github.com/dotnet/dotnet-docker/issues/2353