### PR TITLE
Reenables test for 5.0 on Alpine arm

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -24,12 +24,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
-            // Skip test for .NET 5 on Arm32 Alpine 3.13 due to https://github.com/dotnet/runtime/issues/47423
-            if (imageData.Version.Major == 5 && imageData.OS == "alpine3.13" && imageData.Arch == Arch.Arm)
-            {
-                return;
-            }
-            
             ImageScenarioVerifier verifier = new ImageScenarioVerifier(imageData, DockerHelper, OutputHelper, isWeb: true);
             await verifier.Execute();
         }


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-docker/pull/2878 had missed removing the workaround for the ASP.NET Core tests.

Fixes https://github.com/dotnet/dotnet-docker/issues/2539