### PR TITLE
Fix update-dependencies to handle PowerShell shas

### DIFF
--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -198,12 +198,12 @@ namespace Dotnet.Docker
 
         private static string GetOs(string[] variableParts)
         {
-            if (variableParts.Length == 4)
+            if (variableParts.Length == 4 && !Version.TryParse(variableParts[1], out _))
             {
                 // Handles the case of "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha".
                 return variableParts[1];
             }
-            else if (variableParts.Length >= 5)
+            else if (variableParts.Length >= 4)
             {
                 return variableParts[2];
             }
@@ -213,7 +213,7 @@ namespace Dotnet.Docker
 
         private static string GetArch(string[] variableParts)
         {
-            if (variableParts.Length == 4)
+            if (variableParts.Length == 4 && !Version.TryParse(variableParts[1], out _))
             {
                 // Handles the case of "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha".
                 return variableParts[2];


### PR DESCRIPTION
Changes from https://github.com/dotnet/dotnet-docker/pull/2841 broke the ability to update the checksum for `powershell|<version>|Linux.Alpine|sha` because it doesn't contain an architecture value. This was discovered in https://github.com/dotnet/dotnet-docker/pull/2903#issuecomment-863552655. This is fixed by properly distinguishing the differences of `powershell|<version>|Linux.Alpine|sha` and `netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha` by checking whether a version number exists in the 2nd position.