### PR TITLE
Fix update-dependencies checksum resolution logic

### DIFF
--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -230,9 +230,10 @@ namespace Dotnet.Docker
         {
             if (!s_shaCache.TryGetValue(downloadUrl, out string? sha))
             {
-                sha = await GetDotNetCliChecksumsShaAsync(downloadUrl)
-                    ?? await GetDotNetReleaseChecksumsShaFromRuntimeVersionAsync(downloadUrl)
+                sha = await GetDotNetReleaseChecksumsShaFromRuntimeVersionAsync(downloadUrl)
                     ?? await GetDotNetReleaseChecksumsShaFromBuildVersionAsync(downloadUrl)
+                    ?? await GetDotNetReleaseChecksumsShaFromPreviewVersionAsync(downloadUrl)
+                    ?? await GetDotNetCliChecksumsShaAsync(downloadUrl)
                     ?? await ComputeChecksumShaAsync(downloadUrl);
 
                 if (sha != null)
@@ -321,8 +322,10 @@ namespace Dotnet.Docker
             return sha;
         }
 
-        private Task<string?> GetDotNetReleaseChecksumsShaFromRuntimeVersionAsync(
-            string productDownloadUrl)
+        private Task<string?> GetDotNetReleaseChecksumsShaFromRuntimeVersionAsync(string productDownloadUrl) =>
+            GetDotNetReleaseChecksumsShaAsync(productDownloadUrl, GetRuntimeVersion());
+
+        private string? GetRuntimeVersion()
         {
             string? version = _buildVersion;
             // The release checksum file contains content for all products in the release (runtime, sdk, etc.)
@@ -333,13 +336,24 @@ namespace Dotnet.Docker
                 version = GetBuildVersion("runtime", _dockerfileVersion, _versions, _options);
             }
 
-            return GetDotNetReleaseChecksumsShaAsync(productDownloadUrl, version);
+            return version;
         }
 
         private Task<string?> GetDotNetReleaseChecksumsShaFromBuildVersionAsync(string productDownloadUrl) =>
             GetDotNetReleaseChecksumsShaAsync(productDownloadUrl, _buildVersion);
 
-        private async Task<string?> GetDotNetReleaseChecksumsShaAsync(
+        private Task<string?> GetDotNetReleaseChecksumsShaFromPreviewVersionAsync(string productDownloadUrl)
+        {
+            string? runtimeVersion = GetRuntimeVersion();
+            if (runtimeVersion is not null && TryParsePreviewVersion(runtimeVersion, out string? previewVersion))
+            {
+                return GetDotNetReleaseChecksumsShaAsync(productDownloadUrl, previewVersion);
+            }
+
+            return Task.FromResult<string?>(null);
+        }
+
+        private static async Task<string?> GetDotNetReleaseChecksumsShaAsync(
             string productDownloadUrl, string? version)
         {
             IDictionary<string, string> checksumEntries = await GetDotnetReleaseChecksums(version);
@@ -352,6 +366,26 @@ namespace Dotnet.Docker
             }
 
             return sha;
+        }
+
+        private static bool TryParsePreviewVersion(string version, out string? previewVersion)
+        {
+            // Example format: 6.0.0-preview.5.21301.5
+            // This method returns the 6.0.0-preview.5 segment of that value.
+
+            const string PreviewGroup = "Preview";
+            string PreviewVersionRegex = @$"(?<{PreviewGroup}>\d+\.\d+\.\d+-[\w-]+\.\d+)\.[\d\.]+";
+            Match match = Regex.Match(version, PreviewVersionRegex);
+            if (match.Success)
+            {
+                previewVersion = match.Groups[PreviewGroup].Value;
+                return true;
+            }
+            else
+            {
+                previewVersion = null;
+                return false;
+            }
         }
 
         private static async Task<IDictionary<string, string>> GetDotnetReleaseChecksums(string? version)


### PR DESCRIPTION
Given that the binaries stored in blob storage for preview bits are not immutable (some get signed just prior to release and overwrite the original non-signed files), we need to adjust what the update-dependencies tool uses for its checksum source.

The best authority for checksum values on release day is `https://dotnetcli.blob.core.windows.net/dotnet/checksums/<product-version>-sha.txt`.  This file aggregates all the checksums and is updated with final checksum values even before the final files have been copied to blog storage.  So I moved this checksum source to be the first one that is checked.

But there is an existing issue in the logic which prevents that checksum source from being used for preview releases.  A preview release version has a value like `6.0.0-preview.5.21301.5` (it contains the build number).  But the actual release checksum file for this is `https://dotnetcli.blob.core.windows.net/dotnet/checksums/6.0.0-preview.5-sha.txt` (without the build number). So the logic is broken today because it will attempt to look for the file at `https://dotnetcli.blob.core.windows.net/dotnet/checksums/6.0.0-preview.5.21301.5-sha.txt` and get a 404.  I've fixed this by checking for whether the version is a preview version and trimming the build version off.