### PR TITLE
Fix typo in build-server shutdown

### DIFF
--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.nanoserver
@@ -35,7 +35,7 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Workaround for https://github.com/dotnet/sdk/issues/18410
-    \dotnet\dotnet build-server shutdown `
+    \dotnet\dotnet build-server shutdown; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
     Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `

--- a/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
@@ -35,7 +35,7 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Workaround for https://github.com/dotnet/sdk/issues/18410
-    \dotnet\dotnet build-server shutdown `
+    \dotnet\dotnet build-server shutdown; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
     Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `

--- a/src/sdk/6.0/nanoserver-2004/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-2004/amd64/Dockerfile
@@ -35,7 +35,7 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Workaround for https://github.com/dotnet/sdk/issues/18410
-    \dotnet\dotnet build-server shutdown `
+    \dotnet\dotnet build-server shutdown; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
     Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `

--- a/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -35,7 +35,7 @@ RUN `
     Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
     `
     # Workaround for https://github.com/dotnet/sdk/issues/18410
-    \dotnet\dotnet build-server shutdown `
+    \dotnet\dotnet build-server shutdown; `
     `
     # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
     Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `


### PR DESCRIPTION
The build results from https://github.com/dotnet/dotnet-docker/pull/2911 lied to me.  I don't think the build got run or didn't show up in GitHub or something with the change to shutdown build-server.  I'm fixing the syntax here because it's incorrect and causing a build failure.