### PR TITLE
Use default process environment variable with lower precedence.

### DIFF
--- a/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine
@@ -27,8 +27,8 @@ ENV \
     # Disable debugger and profiler diagnostics to avoid diagnosing self.
     COMPlus_EnableDiagnostics=0 \
     # Default Filter
-    DotnetMonitor_DefaultProcess__Filters__0__Key=ProcessId \
-    DotnetMonitor_DefaultProcess__Filters__0__Value=1 \
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)

--- a/src/monitor/5.0/alpine/amd64/Dockerfile
+++ b/src/monitor/5.0/alpine/amd64/Dockerfile
@@ -27,8 +27,8 @@ ENV \
     # Disable debugger and profiler diagnostics to avoid diagnosing self.
     COMPlus_EnableDiagnostics=0 \
     # Default Filter
-    DotnetMonitor_DefaultProcess__Filters__0__Key=ProcessId \
-    DotnetMonitor_DefaultProcess__Filters__0__Value=1 \
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -92,8 +92,8 @@ namespace Microsoft.DotNet.Docker.Tests
             // Diagnostics should be disabled
             variables.Add(new EnvironmentVariableInfo("COMPlus_EnableDiagnostics", "0"));
             // DefaultProcess filter should select a process with a process ID of 1
-            variables.Add(new EnvironmentVariableInfo("DotnetMonitor_DefaultProcess__Filters__0__Key", "ProcessId"));
-            variables.Add(new EnvironmentVariableInfo("DotnetMonitor_DefaultProcess__Filters__0__Value", "1"));
+            variables.Add(new EnvironmentVariableInfo("DefaultProcess__Filters__0__Key", "ProcessId"));
+            variables.Add(new EnvironmentVariableInfo("DefaultProcess__Filters__0__Value", "1"));
             // Console logger format should be JSON and output UTC timestamps without timezone information
             variables.Add(new EnvironmentVariableInfo("Logging__Console__FormatterName", "json"));
             variables.Add(new EnvironmentVariableInfo("Logging__Console__FormatterOptions__TimestampFormat", "yyyy-MM-ddTHH:mm:ss.fffffffZ"));


### PR DESCRIPTION
The current images use `DotnetMonitor_`* environment variables to set the default process selection. This causes an issue where no other means of configuration (settings.json, key-per-file, non-`DotnetMonitor_` environment variables) is able to override the first default process filter and forces the user to use the `DotnetMonitor_DefaultProcess__Filters__0__`* environment variables for configuring the first default process filter.

This change uses an environment variable with a lower precedence such that all other means of configuration may override its values.

This fixes https://github.com/dotnet/dotnet-monitor/issues/568