### PR TITLE
Clarify globalization invariant mode in Alpine

### DIFF
--- a/eng/dockerfile-templates/aspnet/2.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/2.1/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-{{OS_VERSION}}
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 ENV ASPNETCORE_VERSION={{VARIABLES["aspnet|2.1|build-version"]}}
 

--- a/eng/dockerfile-templates/aspnet/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/3.1/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:3.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 RUN aspnetcore_version={{VARIABLES["aspnet|3.1|build-version"]}} \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/5.0/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 ENV ASPNET_VERSION={{VARIABLES["aspnet|5.0|build-version"]}}
 

--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 ENV \
     # ASP.NET Core version
     ASPNET_VERSION={{VARIABLES["aspnet|6.0|build-version"]}} \

--- a/eng/dockerfile-templates/runtime-deps/2.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime-deps/2.1/Dockerfile.alpine
@@ -19,5 +19,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/eng/dockerfile-templates/runtime/2.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/2.1/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-{{OS_VERSION}}
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET Core
 ENV DOTNET_VERSION={{VARIABLES["runtime|2.1|build-version"]}}
 

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:3.1-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET Core
 RUN dotnet_version={{VARIABLES["runtime|3.1|build-version"]}} \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 

--- a/samples/aspnetapp/Dockerfile.alpine-arm32
+++ b/samples/aspnetapp/Dockerfile.alpine-arm32
@@ -19,9 +19,10 @@ COPY --from=build /app ./
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.alpine-arm64
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64
@@ -19,9 +19,10 @@ COPY --from=build /app ./
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL=en_US.UTF-8
-#ENV LANG=en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -19,9 +19,10 @@ COPY --from=build /app ./
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL=en_US.UTF-8
-#ENV LANG=en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-x64-slim
@@ -19,9 +19,10 @@ COPY --from=build /app ./
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL=en_US.UTF-8
-#ENV LANG=en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/dotnetapp/Dockerfile.alpine-arm32
+++ b/samples/dotnetapp/Dockerfile.alpine-arm32
@@ -17,9 +17,10 @@ COPY --from=build /app .
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL en_US.UTF-8
-#ENV LANG en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.alpine-arm64
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64
@@ -17,9 +17,10 @@ COPY --from=build /app .
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL=en_US.UTF-8
-#ENV LANG=en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.alpine-x64
@@ -17,9 +17,10 @@ COPY --from=build /app .
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL=en_US.UTF-8
-#ENV LANG=en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-x64-slim
@@ -17,9 +17,10 @@ COPY --from=build /app .
 
 # See: https://github.com/dotnet/announcements/issues/20
 # Uncomment to enable globalization APIs (or delete)
-#ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-#RUN apk add --no-cache icu-libs
-#ENV LC_ALL=en_US.UTF-8
-#ENV LANG=en_US.UTF-8
+# ENV \
+#     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+#     LC_ALL=en_US.UTF-8 \
+#     LANG=en_US.UTF-8
+# RUN apk add --no-cache icu-libs
 
 ENTRYPOINT ["./dotnetapp"]

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -60,21 +60,21 @@ docker pull mcr.microsoft.com/dotnet/runtime:5.0-alpine
 
 ### Linux
 
-#### Debian
+#### [Debian](https://www.debian.org)
 
 * When targeting Linux containers, Debian is the default Linux distro for all tags that do not specify an OS. For example, `latest`, `5.0`, and `5.0.0` will all provide a Debian image.
 * Very stable.
 
-#### Ubuntu
+#### [Ubuntu](https://ubuntu.com)
 
 * Shares Debian's codebase.
 * Feature-rich.
 * Less stable compared to Debain.
 
-#### Alpine
+#### [Alpine](https://www.alpinelinux.org)
 
 * Security-oriented and lightweight.
-* Uses [musl instead of glibc](https://wiki.musl-libc.org/functional-differences-from-glibc.html) which may have incompatibility with your existing software.
+* Uses [musl instead of glibc](https://wiki.musl-libc.org/functional-differences-from-glibc.html) which may have incompatibility with your software.
 
 <a name="alpine-globalization">Globalization Support</a>:
 
@@ -82,17 +82,20 @@ By default, the `icu-libs` package is not included and the [globalization invari
 
 ### Windows
 
-#### Nano Server
+#### [Nano Server](https://docs.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images)
 
 * When targeting Windows containers, Nano Server is the default OS for all tags that do not specify an OS. For example, `latest`, `5.0`, and `5.0.0` will all provide a Nano Server image.
 * Small, minimalistic version of Windows.
+* Good option for new application development.
 
-#### Windows Server Core
+#### [Windows Server Core](https://docs.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images)
 
 * Significantly larger than Nano Server.
-* Contains additional components that are missing from Nano Server.
-* Capable of running IIS.
-* Supports running .NET Framework.
+* Feature-rich; contains additional components that are missing from Nano Server.
+* Supports:
+  * IIS
+  * .NET Framework
+* Good option for "lifting and shifting" Windows Server apps.
 
 ## Targeting a specific processor type
 

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -40,12 +40,12 @@ This will work on all operating systems and on all supported chips, but building
 
 ## Targeting a specific operating system
 
-If you want a specific operating system image, you should use a specific operating system tag. We publish images for Alpine, Debian, Ubuntu and Windows Nano Server.
+If you want a specific operating system image, you should use a specific operating system tag. We publish images for [Alpine](#alpine), [Debian](#debian), [Ubuntu](#ubuntu), [Windows Nano Server](#nano-server), and [Windows Server Core](#windows-server-core).
 
 The following tags demonstrate the pattern used to describe each operating system (using .NET 5.0 as the example):
 
 * `5.0-alpine` (Latest Alpine)
-* `5.0-bionic` (Ubuntu 18.04)
+* `5.0-focal` (Ubuntu 20.04)
 * `5.0-buster-slim` (Debian 10)
 * `5.0-nanoserver-20H2` (Nano Server, version 20H2)
 * `5.0-nanoserver-2004` (Nano Server, version 2004)
@@ -57,6 +57,42 @@ For example, the following command will pull an x64 Alpine image:
 ```console
 docker pull mcr.microsoft.com/dotnet/runtime:5.0-alpine
 ```
+
+### Linux
+
+#### Debian
+
+* When targeting Linux containers, Debian is the default Linux distro for all tags that do not specify an OS. For example, `latest`, `5.0`, and `5.0.0` will all provide a Debian image.
+* Very stable.
+
+#### Ubuntu
+
+* Shares Debian's codebase.
+* Feature-rich.
+* Less stable compared to Debain.
+
+#### Alpine
+
+* Security-oriented and lightweight.
+* Uses [musl instead of glibc](https://wiki.musl-libc.org/functional-differences-from-glibc.html) which may have incompatibility with your existing software.
+
+<a name="alpine-globalization">Globalization Support</a>:
+
+By default, the `icu-libs` package is not included and the [globalization invariant mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md) is enabled. You can opt into globalization support by [following the pattern shown in the sample Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.alpine-x64#L19).
+
+### Windows
+
+#### Nano Server
+
+* When targeting Windows containers, Nano Server is the default OS for all tags that do not specify an OS. For example, `latest`, `5.0`, and `5.0.0` will all provide a Nano Server image.
+* Small, minimalistic version of Windows.
+
+#### Windows Server Core
+
+* Significantly larger than Nano Server.
+* Contains additional components that are missing from Nano Server.
+* Capable of running IIS.
+* Supports running .NET Framework.
 
 ## Targeting a specific processor type
 

--- a/src/aspnet/2.1/alpine3.13/amd64/Dockerfile
+++ b/src/aspnet/2.1/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-alpine3.13
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 ENV ASPNETCORE_VERSION=2.1.28
 

--- a/src/aspnet/3.1/alpine3.13/amd64/Dockerfile
+++ b/src/aspnet/3.1/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:3.1-alpine3.13
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 RUN aspnetcore_version=3.1.17 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \

--- a/src/aspnet/3.1/alpine3.13/arm64v8/Dockerfile
+++ b/src/aspnet/3.1/alpine3.13/arm64v8/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:3.1-alpine3.13-arm64v8
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 RUN aspnetcore_version=3.1.17 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \

--- a/src/aspnet/5.0/alpine3.13/amd64/Dockerfile
+++ b/src/aspnet/5.0/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-alpine3.13-amd64
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 ENV ASPNET_VERSION=5.0.8
 

--- a/src/aspnet/5.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/alpine3.13/arm32v7/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-alpine3.13-arm32v7
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 ENV ASPNET_VERSION=5.0.8
 

--- a/src/aspnet/5.0/alpine3.13/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/alpine3.13/arm64v8/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:5.0-alpine3.13-arm64v8
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install ASP.NET Core
 ENV ASPNET_VERSION=5.0.8
 

--- a/src/aspnet/6.0/alpine3.13/amd64/Dockerfile
+++ b/src/aspnet/6.0/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-alpine3.13-amd64
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 ENV \
     # ASP.NET Core version
     ASPNET_VERSION=6.0.0-preview.6.21355.2 \

--- a/src/aspnet/6.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/alpine3.13/arm32v7/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-alpine3.13-arm32v7
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 ENV \
     # ASP.NET Core version
     ASPNET_VERSION=6.0.0-preview.6.21355.2 \

--- a/src/aspnet/6.0/alpine3.13/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/alpine3.13/arm64v8/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0-alpine3.13-arm64v8
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 ENV \
     # ASP.NET Core version
     ASPNET_VERSION=6.0.0-preview.6.21355.2 \

--- a/src/runtime-deps/2.1/alpine3.13/amd64/Dockerfile
+++ b/src/runtime-deps/2.1/alpine3.13/amd64/Dockerfile
@@ -19,5 +19,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/3.1/alpine3.13/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.13/arm64v8/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/5.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.13/arm32v7/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu_libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime/2.1/alpine3.13/amd64/Dockerfile
+++ b/src/runtime/2.1/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:2.1-alpine3.13
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET Core
 ENV DOTNET_VERSION=2.1.28
 

--- a/src/runtime/3.1/alpine3.13/amd64/Dockerfile
+++ b/src/runtime/3.1/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:3.1-alpine3.13
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET Core
 RUN dotnet_version=3.1.17 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \

--- a/src/runtime/3.1/alpine3.13/arm64v8/Dockerfile
+++ b/src/runtime/3.1/alpine3.13/arm64v8/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:3.1-alpine3.13-arm64v8
 
+# .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET Core
 RUN dotnet_version=3.1.17 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \

--- a/src/runtime/5.0/alpine3.13/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-alpine3.13-amd64
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION=5.0.8
 

--- a/src/runtime/5.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/runtime/5.0/alpine3.13/arm32v7/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-alpine3.13-arm32v7
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION=5.0.8
 

--- a/src/runtime/5.0/alpine3.13/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.13/arm64v8/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0-alpine3.13-arm64v8
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION=5.0.8
 

--- a/src/runtime/6.0/alpine3.13/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.13/amd64/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0-alpine3.13-amd64
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION=6.0.0-preview.6.21352.12
 

--- a/src/runtime/6.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.13/arm32v7/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0-alpine3.13-arm32v7
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION=6.0.0-preview.6.21352.12
 

--- a/src/runtime/6.0/alpine3.13/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.13/arm64v8/Dockerfile
@@ -1,6 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0-alpine3.13-arm64v8
 
+# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
+# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
+
 # Install .NET
 ENV DOTNET_VERSION=6.0.0-preview.6.21352.12
 


### PR DESCRIPTION
* Adds a comment to runtime and aspnet Dockerfiles indicating that globalization invariant mode is enabled.
* Updated the formatting of the commented out globalization-related instructions in the sample Dockerfiles.
* Updated the selecting-tags doc to contain more details on the differences between operating systems. This includes information about invariant mode being enabled in Alpine.

Related to #2798