### PR TITLE
Fix samples for WS 2022

### DIFF
--- a/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
@@ -1,7 +1,7 @@
 # escape=`
 
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2019 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -15,7 +15,7 @@ WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-windowsservercore-ltsc2022
 
 # Only needed for this sample because the sample project is targeting .NET 5
 ENV DOTNET_ROLL_FORWARD=LatestMajor

--- a/samples/aspnetapp/Dockerfile.windowsservercore-x64
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2019 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2022 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -13,7 +13,7 @@ WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-windowsservercore-ltsc2019 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-windowsservercore-ltsc2022 AS runtime
 WORKDIR /app
 COPY --from=build /app ./
 ENTRYPOINT ["aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
@@ -1,7 +1,7 @@
 # escape=`
 
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2019 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2022 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/samples/dotnetapp/Dockerfile.windowsservercore-x64
+++ b/samples/dotnetapp/Dockerfile.windowsservercore-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2019 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2022 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/runtime:5.0-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/runtime:5.0-windowsservercore-ltsc2022
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnetapp"]

--- a/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2019 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-windowsservercore-ltsc2022 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -109,8 +109,6 @@ namespace Microsoft.DotNet.Docker.Tests
             // needs to match the filter set by the build/test job. We only produce builds jobs based on what's in the manifest
             // and the manifest only defines Nano Server-based Dockerfiles. So we just need to piggyback on the Nano Server
             // jobs in order to test the Windows Server Core samples.
-            new SampleImageData { OS = OS.NanoServer1809, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-x64" },
-            new SampleImageData { OS = OS.NanoServer1809, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-iis-x64" },
             new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-x64" },
             new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-iis-x64" },
 

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -100,9 +100,10 @@ namespace Microsoft.DotNet.Docker.Tests
             new SampleImageData { OS = OS.NanoServer1809, Arch = Arch.Amd64, IsPublished = true },
             new SampleImageData { OS = OS.NanoServer2004, Arch = Arch.Amd64, IsPublished = true },
             new SampleImageData { OS = OS.NanoServer20H2, Arch = Arch.Amd64, IsPublished = true },
+            // TODO: Add NanoServerLtsc2022 once the sample image has been published.
 
-            new SampleImageData { OS = OS.NanoServer20H2, Arch = Arch.Amd64, DockerfileSuffix = "nanoserver-x64" },
-            new SampleImageData { OS = OS.NanoServer20H2, Arch = Arch.Amd64, DockerfileSuffix = "nanoserver-x64-slim" },
+            new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "nanoserver-x64" },
+            new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "nanoserver-x64-slim" },
 
             // Use Nano Server as the OS even though the Dockerfiles are for Windows Server Core. This is because the OS value
             // needs to match the filter set by the build/test job. We only produce builds jobs based on what's in the manifest
@@ -110,9 +111,12 @@ namespace Microsoft.DotNet.Docker.Tests
             // jobs in order to test the Windows Server Core samples.
             new SampleImageData { OS = OS.NanoServer1809, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-x64" },
             new SampleImageData { OS = OS.NanoServer1809, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-iis-x64" },
+            new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-x64" },
+            new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-iis-x64" },
 
             // Disabling the slim sample due to https://github.com/dotnet/dotnet-docker/issues/2938
             //new SampleImageData { OS = OS.NanoServer1809, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-x64-slim" },
+            new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "windowsservercore-x64-slim" },
         };
 
         private static readonly MonitorImageData[] s_linuxMonitorTestData =


### PR DESCRIPTION
The nanoserver-x64-slim sample Dockerfile had been updated to reference nanoserver:ltsc2022 for the WS 2022 update. But the test code was still configured to test that Dockerfile on a 20H2 machine.  This obviously caused a failure due to Windows container version incompatibility.

I've updated the test code to configure the tests to run on 2022 machines.  Also updated to include windowsservercore-x64-slim testing on WS 2022.  