### PR TITLE
Include test for published WS 2022 sample images

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -97,10 +97,10 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static readonly SampleImageData[] s_windowsSampleTestData =
         {
-            new SampleImageData { OS = OS.NanoServer1809, Arch = Arch.Amd64, IsPublished = true },
-            new SampleImageData { OS = OS.NanoServer2004, Arch = Arch.Amd64, IsPublished = true },
-            new SampleImageData { OS = OS.NanoServer20H2, Arch = Arch.Amd64, IsPublished = true },
-            // TODO: Add NanoServerLtsc2022 once the sample image has been published.
+            new SampleImageData { OS = OS.NanoServer1809,     Arch = Arch.Amd64, IsPublished = true },
+            new SampleImageData { OS = OS.NanoServer2004,     Arch = Arch.Amd64, IsPublished = true },
+            new SampleImageData { OS = OS.NanoServer20H2,     Arch = Arch.Amd64, IsPublished = true },
+            new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, IsPublished = true },
 
             new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "nanoserver-x64" },
             new SampleImageData { OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64, DockerfileSuffix = "nanoserver-x64-slim" },


### PR DESCRIPTION
Now that the Nano Server 2022 sample images have been published, we can enable testing of those images.