### PR TITLE
Ensure Alpine images have their packages upgraded

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib
+        zlib \
+    && apk upgrade
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib
+        zlib \
+    && apk upgrade
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/alpine3.13/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.13/arm64v8/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib
+        zlib \
+    && apk upgrade
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/5.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.13/arm32v7/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib
+        zlib \
+    && apk upgrade
 
 ENV \
     # Configure web servers to bind to port 80 when present


### PR DESCRIPTION
Ensures that packages from the base alpine:3.13 image, including apk-tools and libssl1.1, have been upgraded to latest available version.  This addresses the following CVEs:

* CVE-2021-36159
* CVE-2021-3711
* CVE-2021-3712