### PR TITLE
Revert "Ensure Alpine images have their packages upgraded (#3074)"

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime-deps/3.1/Dockerfile.alpine
@@ -9,8 +9,7 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib \
-    && apk upgrade
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.13/amd64/Dockerfile
@@ -9,8 +9,7 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib \
-    && apk upgrade
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/3.1/alpine3.13/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.13/arm64v8/Dockerfile
@@ -9,8 +9,7 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib \
-    && apk upgrade
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present

--- a/src/runtime-deps/5.0/alpine3.13/arm32v7/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.13/arm32v7/Dockerfile
@@ -9,8 +9,7 @@ RUN apk add --no-cache \
         libintl \
         libssl1.1 \
         libstdc++ \
-        zlib \
-    && apk upgrade
+        zlib
 
 ENV \
     # Configure web servers to bind to port 80 when present


### PR DESCRIPTION
This reverts commit ae7fe5d2624954633a0fe684ec85fc1710b95878.

Reverting #3074 now that images for Alpine 3.13.6 have been released that contain the updated apk-tools and libssl1.1 packages.