### PR TITLE
Default to non-root user and port 8080 on .NET 6.0 runtimes

### DIFF
--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.alpine
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+USER root
 
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
@@ -16,3 +17,6 @@ RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.linux
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+USER root
 
 # Installer image
 FROM {{ARCH_VERSIONED}}/buildpack-deps:{{OS_VERSION_BASE}}-curl as installer
@@ -21,3 +22,6 @@ ENV \
     Logging__Console__FormatterName=Json
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+
+# Run as non-root
+USER 1000:3000

--- a/eng/dockerfile-templates/aspnet/6.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/aspnet/6.0/Dockerfile.mariner
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+USER root
 
 ENV \
     # ASP.NET Core version
@@ -13,3 +14,6 @@ RUN curl -SL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspn
     && echo "$dotnet_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \
     && rm aspnetcore.rpm
+
+# Run as non-root
+USER 1000:3000

--- a/eng/dockerfile-templates/runtime-deps/6.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime-deps/6.0/Dockerfile.mariner
@@ -19,10 +19,25 @@ RUN dotnet_version={{VARIABLES["runtime|6.0|build-version"]}} \
     && dotnet_sha512='{{VARIABLES[cat("runtime-deps-cm.1|6.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
     && rpm --install dotnet-runtime-deps.rpm \
-    && rm dotnet-runtime-deps.rpm
+    && rm dotnet-runtime-deps.rpm \
+    \
+    # Non-root user and group
+    && groupadd \
+        --gid 3000 \
+        dotnet \
+    && adduser \
+        --uid 1000 \
+        --gid 3000 \
+        --shell /usr/sbin/nologin \
+        --no-create-home \
+        --system \
+        "dotnet"
 
 ENV \
-    # Configure web servers to bind to port 80 when present
-    ASPNETCORE_URLS=http://+:80 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true
+
+# Run as non-root
+USER 1000:3000

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
@@ -14,3 +14,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
@@ -20,3 +20,6 @@ ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Run as non-root
+USER 1000:3000

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner
@@ -18,3 +18,6 @@ RUN curl -SL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Run
     \
     && rpm --install dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
     && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm
+
+# Run as non-root
+USER 1000:3000

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.linux
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.mariner
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/aspnet/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.0-rc.1-alpine3.14-amd64
+USER root
 
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
@@ -16,3 +17,6 @@ RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.0-rc.1-alpine3.14-arm32v7
+USER root
 
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
@@ -16,3 +17,6 @@ RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/arm64v8/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.0-rc.1-alpine3.14-arm64v8
+USER root
 
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
@@ -16,3 +17,6 @@ RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+USER root
 
 # Installer image
 FROM amd64/buildpack-deps:bullseye-curl as installer
@@ -21,3 +22,6 @@ ENV \
     Logging__Console__FormatterName=Json
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+USER root
 
 # Installer image
 FROM arm32v7/buildpack-deps:bullseye-curl as installer
@@ -21,3 +22,6 @@ ENV \
     Logging__Console__FormatterName=Json
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+USER root
 
 # Installer image
 FROM arm64v8/buildpack-deps:bullseye-curl as installer
@@ -21,3 +22,6 @@ ENV \
     Logging__Console__FormatterName=Json
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.0-rc.1-cbl-mariner1.0-amd64
+USER root
 
 ENV \
     # ASP.NET Core version
@@ -13,3 +14,6 @@ RUN curl -SL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspn
     && echo "$dotnet_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \
     && rm aspnetcore.rpm
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/focal/amd64/Dockerfile
+++ b/src/aspnet/6.0/focal/amd64/Dockerfile
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+USER root
 
 # Installer image
 FROM amd64/buildpack-deps:focal-curl as installer
@@ -21,3 +22,6 @@ ENV \
     Logging__Console__FormatterName=Json
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/focal/arm32v7/Dockerfile
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+USER root
 
 # Installer image
 FROM arm32v7/buildpack-deps:focal-curl as installer
@@ -21,3 +22,6 @@ ENV \
     Logging__Console__FormatterName=Json
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+
+# Run as non-root
+USER 1000:3000

--- a/src/aspnet/6.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/focal/arm64v8/Dockerfile
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+USER root
 
 # Installer image
 FROM arm64v8/buildpack-deps:focal-curl as installer
@@ -21,3 +22,6 @@ ENV \
     Logging__Console__FormatterName=Json
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime-deps/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/bullseye-slim/amd64/Dockerfile
@@ -12,10 +12,25 @@ RUN apt-get update \
         libssl1.1 \
         libstdc++6 \
         zlib1g \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    # Non-root user and group
+    && addgroup \
+        --group dotnet \
+        --gid 3000 \
+    && adduser \
+        --uid 1000 \
+        --gid 3000 \
+        --disabled-login \
+        --no-create-home \
+        --system \
+        "dotnet"
 
 ENV \
-    # Configure web servers to bind to port 80 when present
-    ASPNETCORE_URLS=http://+:80 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime-deps/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -12,10 +12,25 @@ RUN apt-get update \
         libssl1.1 \
         libstdc++6 \
         zlib1g \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    # Non-root user and group
+    && addgroup \
+        --group dotnet \
+        --gid 3000 \
+    && adduser \
+        --uid 1000 \
+        --gid 3000 \
+        --disabled-login \
+        --no-create-home \
+        --system \
+        "dotnet"
 
 ENV \
-    # Configure web servers to bind to port 80 when present
-    ASPNETCORE_URLS=http://+:80 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime-deps/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -12,10 +12,22 @@ RUN apt-get update \
         libssl1.1 \
         libstdc++6 \
         zlib1g \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    # Non-root user and group
+    && addgroup \
+        --group dotnet \
+        --gid 3000 \
+    && adduser \
+        --uid 1000 \
+        --gid 3000 \
+        --disabled-login \
+        --no-create-home \
+        --system \
+        "dotnet"
 
 ENV \
-    # Configure web servers to bind to port 80 when present
-    ASPNETCORE_URLS=http://+:80 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -19,10 +19,25 @@ RUN dotnet_version=6.0.0-rc.1.21451.13 \
     && dotnet_sha512='a73989612d15befcf1ce606c256e05935dac764f543feb254430adf05a35f9b1a0d17aa1930040222449a5f8619d58b9c0f4604c11e8302b538c1d7fcd92daf1' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
     && rpm --install dotnet-runtime-deps.rpm \
-    && rm dotnet-runtime-deps.rpm
+    && rm dotnet-runtime-deps.rpm \
+    \
+    # Non-root user and group
+    && groupadd \
+        --gid 3000 \
+        dotnet \
+    && adduser \
+        --uid 1000 \
+        --gid 3000 \
+        --shell /usr/sbin/nologin \
+        --no-create-home \
+        --system \
+        "dotnet"
 
 ENV \
-    # Configure web servers to bind to port 80 when present
-    ASPNETCORE_URLS=http://+:80 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/amd64/Dockerfile
@@ -14,3 +14,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
@@ -14,3 +14,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
@@ -14,3 +14,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
@@ -20,3 +20,6 @@ ENV DOTNET_VERSION=6.0.0-rc.1.21451.13
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -20,3 +20,6 @@ ENV DOTNET_VERSION=6.0.0-rc.1.21451.13
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -20,3 +20,6 @@ ENV DOTNET_VERSION=6.0.0-rc.1.21451.13
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -18,3 +18,6 @@ RUN curl -SL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Run
     \
     && rpm --install dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
     && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/focal/amd64/Dockerfile
+++ b/src/runtime/6.0/focal/amd64/Dockerfile
@@ -20,3 +20,6 @@ ENV DOTNET_VERSION=6.0.0-rc.1.21451.13
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/6.0/focal/arm32v7/Dockerfile
@@ -20,3 +20,6 @@ ENV DOTNET_VERSION=6.0.0-rc.1.21451.13
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Run as non-root
+USER 1000:3000

--- a/src/runtime/6.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/6.0/focal/arm64v8/Dockerfile
@@ -20,3 +20,6 @@ ENV DOTNET_VERSION=6.0.0-rc.1.21451.13
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Run as non-root
+USER 1000:3000

--- a/src/sdk/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-alpine3.14-amd64
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-alpine3.14-arm32v7
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/arm64v8/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-alpine3.14-arm64v8
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-bullseye-slim-amd64
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-bullseye-slim-arm32v7
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-bullseye-slim-arm64v8
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-cbl-mariner1.0-amd64
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/focal/amd64/Dockerfile
+++ b/src/sdk/6.0/focal/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-focal-amd64
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/6.0/focal/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-focal-arm32v7
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/src/sdk/6.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/6.0/focal/arm64v8/Dockerfile
@@ -1,5 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.0-rc.1-focal-arm64v8
+USER root
 
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -187,11 +187,13 @@ namespace Microsoft.DotNet.Docker.Tests
             string optionalRunArgs = null,
             bool detach = false,
             bool runAsContainerAdministrator = false,
-            bool skipAutoCleanup = false)
+            bool skipAutoCleanup = false,
+            string user = null)
         {
             string cleanupArg = skipAutoCleanup ? string.Empty : " --rm";
             string detachArg = detach ? " -d -t" : string.Empty;
-            string userArg = runAsContainerAdministrator ? " -u ContainerAdministrator" : string.Empty;
+            string linuxUserArg = user != null ? $" -u {user}" : string.Empty;
+            string userArg = runAsContainerAdministrator ? " -u ContainerAdministrator" : linuxUserArg;
             string workdirArg = workdir == null ? string.Empty : $" -w {workdir}";
             return ExecuteWithLogging(
                 $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg} {optionalRunArgs} {image} {command}");

--- a/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
@@ -57,6 +57,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string combinedValues = dockerHelper.Run(
                 image: imageName,
                 name: imageData.GetIdentifier($"env"),
+                user: "root",
                 optionalRunArgs: $"--entrypoint {entrypoint}",
                 command: $"{invokeCommand} \"echo {string.Join($"{delimiterEscape}{delimiter}", echoParts)}\"");
 

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -180,6 +180,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 _dockerHelper.Run(
                     image: _imageData.GetImage(DotNetImageType.SDK, _dockerHelper),
                     name: containerName,
+                    user: "root",
                     command: $"dotnet new {appType} --framework {targetFramework} --no-restore",
                     workdir: "/app",
                     skipAutoCleanup: true);
@@ -227,6 +228,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 _dockerHelper.Run(
                     image: image,
                     name: containerName,
+                    user: "root",
                     detach: _isWeb,
                     optionalRunArgs: _isWeb ? "-p 80" : string.Empty,
                     runAsContainerAdministrator: runAsAdmin,

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -286,6 +286,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 DockerHelper.Run(
                     image: monitorImageName,
                     name: monitorContainerName,
+                    user: "root",
                     command: GetMonitorAdditionalArgs(noAuthentication),
                     detach: true,
                     optionalRunArgs: runArgsBuilder.Build());
@@ -396,6 +397,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 DockerHelper.Run(
                     image: sampleImageName,
                     name: sampleContainerName,
+                    user: "root",
                     detach: true,
                     optionalRunArgs: sampleArgsBuilder.Build());
 
@@ -403,6 +405,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 DockerHelper.Run(
                     image: monitorImageName,
                     name: monitorContainerName,
+                    user: "root",
                     command: GetMonitorAdditionalArgs(noAuthentication),
                     detach: true,
                     optionalRunArgs: monitorArgsBuilder.Build());

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string output = DockerHelper.Run(
                     image: imageData.GetImage(ImageType, DockerHelper),
                     name: imageData.GetIdentifier($"InsecureFiles-{ImageType}"),
+                    user: "root",
                     command: command
                 );
 
@@ -62,7 +63,8 @@ namespace Microsoft.DotNet.Docker.Tests
             string installedPackages = DockerHelper.Run(
                 image: imageData.GetImage(ImageType, DockerHelper),
                 command: command,
-                name: imageData.GetIdentifier("PackageInstallation"));
+                name: imageData.GetIdentifier("PackageInstallation"),
+                user: "root");
 
             return installedPackages.Split(Environment.NewLine);
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -70,6 +70,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     DockerHelper.Run(
                         image: image,
                         name: containerName,
+                        user: "root",
                         detach: true,
                         optionalRunArgs: "-p 80");
 

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -123,7 +123,8 @@ namespace Microsoft.DotNet.Docker.Tests
                 DockerHelper.Run(
                     image: imageData.GetImage(DotNetImageType.SDK, DockerHelper),
                     command: verifyCacheCommand,
-                    name: imageData.GetIdentifier("PackageCache"));
+                    name: imageData.GetIdentifier("PackageCache"),
+                    user: "root");
             }
         }
 
@@ -266,7 +267,8 @@ namespace Microsoft.DotNet.Docker.Tests
             string containerFileList = DockerHelper.Run(
                 image: imageData.GetImage(ImageType, DockerHelper),
                 command: command,
-                name: imageData.GetIdentifier("DotnetFolder"));
+                name: imageData.GetIdentifier("DotnetFolder"),
+                user: "root");
 
             IEnumerable<SdkContentFileInfo> actualDotnetFiles = containerFileList
                 .Replace("\r\n", "\n")


### PR DESCRIPTION
This PR includes hardenings instructed on https://techcommunity.microsoft.com/t5/azure-developer-community-blog/hardening-an-asp-net-container-running-on-kubernetes/ba-p/2542224 to .NET 6.0.0 runtimes and runtime-deps with one minor difference:
* I used UID 1000 and GID 3000 to match with Kyverno [Add Default securityContext](https://kyverno.io/policies/other/add-default-securitycontext/) policy.
~~* Using `DOTNET_` prefix on EnableDiagnostics environment variable like described on https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling~~

~~File system permission changed should be also done to samples but that must be done after #3103 is merged.~~

Closes #2249