### PR TITLE
Handle empty simpleTags field in tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     imageExistsInStaging = repoInfo.Value<JArray>("images")
                         .SelectMany(imageInfo => imageInfo.Value<JArray>("platforms"))
                         .Cast<JObject>()
-                        .Any(platformInfo => platformInfo.Value<JArray>("simpleTags").Any(imageTag => imageTag.ToString() == tag));
+                        .Any(platformInfo => platformInfo.Value<JArray>("simpleTags")?.Any(imageTag => imageTag.ToString() == tag) == true);
                 }
                 else
                 {


### PR DESCRIPTION
Due to changes in https://github.com/dotnet/docker-tools/pull/861, empty lists are no longer being serialized in the image info JSON.  When the test code attempts to read the JSON file, it expects the simpleTags field to be there and is leading to a NRE.

This fixes the code to check that simpleTags exists.