### PR TITLE
Move dotnet-monitor to .NET 6 and version 6.0.0

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -4,8 +4,8 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 
 # Featured Tags
 
-* `5.0` (Preview)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:5.0`
+* `6.0` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6.0`
 
 # About This Image
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -46,7 +46,7 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-5.0.0-preview.8-alpine-amd64, 5.0-alpine-amd64, 5.0.0-preview.8-alpine, 5.0-alpine, 5.0.0-preview.8, 5.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/5.0/alpine/amd64/Dockerfile) | Alpine 3.14
+6.0.0-preview.8-alpine-amd64, 6.0-alpine-amd64, 6.0.0-preview.8-alpine, 6.0-alpine, 6.0.0-preview.8, 6.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile) | Alpine 3.14
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -2,12 +2,12 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:3.1-alpine3.14 AS installer
+FROM $SDK_REPO:6.0-alpine{{OS_VERSION_NUMBER}} AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=5.0.0-preview.8.21477.3
+ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|build-version"]}}
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
-    && dotnetmonitor_sha512='7e8890dd81dab08f1033b57e6eb6e338a3ddc42767f8f4586294494733477da0935a073733c2b167c48da967f0e49d05308f4f5dca2565a1bfcb6b8405002df3' \
+    && dotnetmonitor_sha512='{{VARIABLES["monitor|6.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
@@ -16,7 +16,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.
 
 
 # Monitor image
-FROM $ASPNET_REPO:3.1-alpine3.14
+FROM $ASPNET_REPO:6.0-alpine{{OS_VERSION_NUMBER}}
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-alpine{{OS_VERSION_NUMBER}}-amd64 AS installer
+FROM $SDK_REPO:{{VARIABLES["sdk|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}} AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|build-version"]}}
@@ -16,7 +16,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.
 
 
 # Monitor image
-FROM $ASPNET_REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-alpine{{OS_VERSION_NUMBER}}-amd64
+FROM $ASPNET_REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0-alpine{{OS_VERSION_NUMBER}}-amd64 AS installer
+FROM $SDK_REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-alpine{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|build-version"]}}
@@ -16,7 +16,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0-alpine{{OS_VERSION_NUMBER}}-amd64
+FROM $ASPNET_REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-alpine{{OS_VERSION_NUMBER}}-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0-alpine{{OS_VERSION_NUMBER}} AS installer
+FROM $SDK_REPO:6.0-alpine{{OS_VERSION_NUMBER}}-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|build-version"]}}
@@ -16,7 +16,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0-alpine{{OS_VERSION_NUMBER}}
+FROM $ASPNET_REPO:6.0-alpine{{OS_VERSION_NUMBER}}-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -1,2 +1,2 @@
 $(McrTagsYmlRepo:monitor)
-$(McrTagsYmlTagGroup:5.0-alpine-amd64)
+$(McrTagsYmlTagGroup:6.0-alpine-amd64)

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -10,8 +10,8 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
   * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
 * `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`
-^elif match(SHORT_REPO, "monitor"):* `5.0` (Preview)
-  * `docker pull {{FULL_REPO}}:5.0`
+^elif match(SHORT_REPO, "monitor"):* `6.0` (Preview)
+  * `docker pull {{FULL_REPO}}:6.0`
 ^else:* `5.0` (Current)
   * `docker pull {{FULL_REPO}}:5.0`
 * `3.1` (LTS)

--- a/manifest.json
+++ b/manifest.json
@@ -4629,12 +4629,12 @@
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/monitor-tags.yml",
       "images": [
         {
-          "productVersion": "$(monitor|5.0|product-version)",
+          "productVersion": "$(monitor|6.0|product-version)",
           "sharedTags": {
-            "$(monitor|5.0|product-version)-alpine": {},
-            "5.0-alpine": {},
-            "$(monitor|5.0|product-version)": {},
-            "5.0": {},
+            "$(monitor|6.0|product-version)-alpine": {},
+            "6.0-alpine": {},
+            "$(monitor|6.0|product-version)": {},
+            "6.0": {},
             "latest": {}
           },
           "platforms": [
@@ -4643,13 +4643,13 @@
                 "ASPNET_REPO": "$(Repo:aspnet)",
                 "SDK_REPO": "$(Repo:sdk)"
               },
-              "dockerfile": "src/monitor/5.0/alpine/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/monitor/5.0/Dockerfile.alpine",
+              "dockerfile": "src/monitor/6.0/alpine/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine",
               "os": "linux",
               "osVersion": "alpine3.14",
               "tags": {
-                "$(monitor|5.0|product-version)-alpine-amd64": {},
-                "5.0-alpine-amd64": {}
+                "$(monitor|6.0|product-version)-alpine-amd64": {},
+                "6.0-alpine-amd64": {}
               }
             }
           ]

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -36,9 +36,9 @@
     "dotnet|5.0|product-version": "5.0.10",
     "dotnet|6.0|product-version": "6.0.0-rc.2",
 
-    "monitor|5.0|build-version": "5.0.0-preview.8.21477.3",
-    "monitor|5.0|product-version": "5.0.0-preview.8",
-    "monitor|5.0|sha": "7e8890dd81dab08f1033b57e6eb6e338a3ddc42767f8f4586294494733477da0935a073733c2b167c48da967f0e49d05308f4f5dca2565a1bfcb6b8405002df3",
+    "monitor|6.0|build-version": "6.0.0-preview.8.21478.3",
+    "monitor|6.0|product-version": "6.0.0-preview.8",
+    "monitor|6.0|sha": "6d6899e907cd05238801b49a60b41c6a0c4bf591b7dea5c416b5b4524992dc347c65ca0f99f1b71db58e10f9b8cf951922711a441e9fe4efe8d8ea8f08bd8db3",
 
     "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha": "fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880",
 

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.0-rc.2-alpine3.14-amd64 AS installer
+FROM $SDK_REPO:6.0.100-rc.2-alpine3.14-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.0.0-preview.8.21478.3

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0-alpine3.14-amd64 AS installer
+FROM $SDK_REPO:6.0.0-rc.2-alpine3.14-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.0.0-preview.8.21478.3
@@ -16,7 +16,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0-alpine3.14-amd64
+FROM $ASPNET_REPO:6.0.0-rc.2-alpine3.14-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -2,12 +2,12 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:3.1-alpine{{OS_VERSION_NUMBER}} AS installer
+FROM $SDK_REPO:6.0-alpine3.14 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|5.0|build-version"]}}
+ENV DOTNET_MONITOR_VERSION=6.0.0-preview.8.21478.3
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
-    && dotnetmonitor_sha512='{{VARIABLES["monitor|5.0|sha"]}}' \
+    && dotnetmonitor_sha512='6d6899e907cd05238801b49a60b41c6a0c4bf591b7dea5c416b5b4524992dc347c65ca0f99f1b71db58e10f9b8cf951922711a441e9fe4efe8d8ea8f08bd8db3' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
@@ -16,7 +16,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.
 
 
 # Monitor image
-FROM $ASPNET_REPO:3.1-alpine{{OS_VERSION_NUMBER}}
+FROM $ASPNET_REPO:6.0-alpine3.14
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0-alpine3.14 AS installer
+FROM $SDK_REPO:6.0-alpine3.14-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.0.0-preview.8.21478.3
@@ -16,7 +16,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0-alpine3.14
+FROM $ASPNET_REPO:6.0-alpine3.14-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static readonly MonitorImageData[] s_linuxMonitorTestData =
         {
-            new MonitorImageData { Version = V5_0, RuntimeVersion = V3_1, OS = OS.Alpine314, OSTag = OS.Alpine, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V6_0, RuntimeVersion = V6_0, OS = OS.Alpine314, OSTag = OS.Alpine, Arch = Arch.Amd64 },
         };
 
         private static readonly MonitorImageData[] s_windowsMonitorTestData =

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -152,6 +152,6 @@
     "src/sdk/6.0/cbl-mariner1.0/amd64": 888550600
   },
   "dotnet/nightly/monitor": {
-    "src/monitor/5.0/alpine/amd64": 112576244
+    "src/monitor/6.0/alpine/amd64": 112576244
   }
 }


### PR DESCRIPTION
Dotnet-monitor is aligning its versioning to the runtime and building for that same runtime version. At this time, the tool is aligning to the 6.0.0 version and using the ASP.NET 6.0 image.

cc @dotnet/dotnet-monitor