### PR TITLE
Allow arch to be included in monitor tag test data.

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
@@ -24,7 +24,5 @@ namespace Microsoft.DotNet.Docker.Tests
 
             return imageName;
         }
-
-        protected override string GetArchTagSuffix() => string.Empty;
     }
 }


### PR DESCRIPTION
The test code is attempting to use the "6.0-alpine" tag for the dotnet-monitor image. However, this is not a simple tag. The simple tags for dotnet-monitor are "6.0-alpine-amd64" and "6.0.0-preview.8-alpine-amd64".

The problem is that the MonitorImageData class is overriding the arch tag suffix to be empty. The fix is to allow the default arch tag determination behavior.