### PR TITLE
Support parameterized agent pools

### DIFF
--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -1,12 +1,12 @@
 parameters:
   name: null
+  pool: {}
   additionalOptions: null
   publicProjectName: null
   
 jobs:
 - job: ${{ parameters.name }}
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  pool: ${{ parameters.pool }}
   steps:
   - template: ../steps/init-docker-linux.yml
   - ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -1,14 +1,14 @@
 parameters:
   matrixType: null
   name: null
+  pool: {}
   customBuildLegGroupArgs: ""
   isTestStage: false
   internalProjectName: null
 
 jobs:
 - job: ${{ parameters.name }}
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  pool: ${{ parameters.pool }}
   steps:
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/validate-branch.yml

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -15,9 +15,6 @@ parameters:
   linuxArmTestJobTimeout: 60
   windowsAmdTestJobTimeout: 60
 
-  linuxAmd64BuildPool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
-
   noCache: false
 
   internalProjectName: null
@@ -25,6 +22,23 @@ parameters:
 
   internalVersionsRepoRef: null
   publicVersionsRepoRef: null
+
+  linuxAmd64Pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
+  linuxArm32Pool:
+    vmImage: $(defaultLinuxArm32PoolImage)
+  linuxArm64Pool:
+    vmImage: $(defaultLinuxArm64PoolImage)
+  windows2016Pool:
+    vmImage: $(defaultWindows2016PoolImage)
+  windows1809Pool:
+    vmImage: $(defaultWindows1809PoolImage)
+  windows2004Pool:
+    vmImage: $(defaultWindows2004PoolImage)
+  windows20H2Pool:
+    vmImage: $(defaultWindows20H2PoolImage)
+  windows2022Pool:
+    vmImage: $(defaultWindows2022PoolImage)
 
 stages:
 
@@ -37,20 +51,21 @@ stages:
   - template: ../jobs/test-images-linux-client.yml
     parameters:
       name: PreBuildValidation
-      pool:
-        vmImage: $(defaultLinuxAmd64PoolImage)
+      pool: ${{ parameters.linuxAmd64Pool }}
       testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
       preBuildValidation: true
       internalProjectName: ${{ parameters.internalProjectName }}
   - template: ../jobs/copy-base-images.yml
     parameters:
       name: CopyBaseImages
+      pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
   - template: ../jobs/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
       name: GenerateBuildMatrix
+      pool: ${{ parameters.linuxAmd64Pool }}
       customBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
       internalProjectName: ${{ parameters.internalProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
@@ -58,7 +73,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Linux_amd64
-      pool: ${{ parameters.linuxAmd64BuildPool }}
+      pool: ${{ parameters.linuxAmd64Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxAmd64']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
@@ -71,14 +86,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Linux_arm64v8
-      pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      pool: ${{ parameters.linuxArm64Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64v8']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
@@ -91,14 +99,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Linux_arm32v7
-      pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      pool: ${{ parameters.linuxArm32Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v7']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
@@ -111,7 +112,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows1809_amd64
-      pool: Docker-1809-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows1809Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -124,7 +125,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows2004_amd64
-      pool: Docker-2004-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows2004Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -137,7 +138,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows20H2_amd64
-      pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows20H2Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows20H2Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -150,7 +151,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows2022_amd64
-      pool: Docker-2022-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows2022Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2022Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -163,7 +164,7 @@ stages:
   - template: ../jobs/build-images.yml
     parameters:
       name: WindowsLtsc2016_amd64
-      pool: Docker-2016-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows2016Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2016Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
@@ -204,6 +205,7 @@ stages:
       parameters:
         matrixType: ${{ parameters.testMatrixType }}
         name: GenerateTestMatrix
+        pool: ${{ parameters.linuxAmd64Pool }}
         customBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
         isTestStage: true
         internalProjectName: ${{ parameters.internalProjectName }}
@@ -212,65 +214,56 @@ stages:
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_amd64
-        pool:
-          vmImage: $(defaultLinuxAmd64PoolImage)
+        pool: ${{ parameters.linuxAmd64Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxAmd64']
         testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_arm64v8
-        pool:
-          name: DotNetCore-Docker
-          demands:
-          - Agent.OS -equals linux
-          - Agent.OSArchitecture -equals ARM64
+        pool: ${{ parameters.linuxArm64Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64v8']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_arm32v7
-        pool:
-          name: DotNetCore-Docker
-          demands:
-          - Agent.OS -equals linux
-          - Agent.OSArchitecture -equals ARM64
+        pool: ${{ parameters.linuxArm32Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32v7']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows1809_amd64
-        pool: Docker-1809-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows1809Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2004_amd64
-        pool: Docker-2004-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows2004Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows20H2_amd64
-        pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows20H2Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2022_amd64
-        pool: Docker-2022-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows2022Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2022Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: WindowsLtsc2016_amd64
-        pool: Docker-2016-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows2016Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
@@ -313,8 +306,7 @@ stages:
   jobs:
   - template: ../jobs/publish.yml
     parameters:
-      pool:
-        vmImage: $(defaultLinuxAmd64PoolImage)
+      pool: ${{ parameters.linuxAmd64Pool }}
       internalProjectName: ${{ parameters.internalProjectName }}
       customPublishVariables: ${{ parameters.customPublishVariables }}
       customInitSteps: ${{ parameters.customPublishInitSteps }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -1,0 +1,51 @@
+# A wrapper template around the common build-test-publish-repo template with settings
+# specific to the .NET team's infrastructure.
+
+parameters:
+  noCache: false
+  internalProjectName: null
+  publicProjectName: null
+  buildMatrixType: null
+  buildMatrixCustomBuildLegGroupArgs: null
+  customBuildInitSteps: []
+  customPublishInitSteps: []
+
+stages:
+- template: ../build-test-publish-repo.yml
+  parameters:
+    noCache: ${{ parameters.noCache }}
+    internalProjectName: ${{ parameters.internalProjectName }}
+    publicProjectName: ${{ parameters.publicProjectName }}
+    buildMatrixType: ${{ parameters.buildMatrixType }}
+    buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
+    customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
+    customPublishInitSteps: ${{ parameters.customPublishInitSteps }}
+
+    internalVersionsRepoRef: InternalVersionsRepo
+    publicVersionsRepoRef: PublicVersionsRepo
+    
+    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      customPublishVariables:
+      - group: DotNet-AllOrgs-Darc-Pats
+    
+    linuxArm64Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+          name: DotNetCore-Docker
+        demands:
+        - Agent.OS -equals linux
+        - Agent.OSArchitecture -equals ARM64
+    linuxArm32Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+          name: DotNetCore-Docker
+        demands:
+        - Agent.OS -equals linux
+        - Agent.OSArchitecture -equals ARM64
+    windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
+    windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+    windows2004Pool: Docker-2004-${{ variables['System.TeamProject'] }}
+    windows20H2Pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+    windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -19,8 +19,6 @@ variables:
   value: true
 - name: manifestVariables
   value: ""
-- name: defaultLinuxAmd64PoolImage
-  value: ubuntu-latest
 - name: mcrImageIngestionTimeout
   value: "00:20:00"
 - name: mcrDocIngestionTimeout
@@ -32,3 +30,20 @@ variables:
   value: 'mirror/'
 - name: cgBuildGrepArgs
   value: "''"
+
+- name: defaultLinuxAmd64PoolImage
+  value: ubuntu-latest
+- name: defaultLinuxArm32PoolImage
+  value: null
+- name: defaultLinuxArm64PoolImage
+  value: null
+- name: defaultWindows2016PoolImage
+  value: vs2017-win2016
+- name: defaultWindows1809PoolImage
+  value: windows-2019
+- name: defaultWindows2004PoolImage
+  value: null
+- name: defaultWindows20H2PoolImage
+  value: null
+- name: defaultWindows2022PoolImage
+  value: windows-2022

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -1,3 +1,5 @@
+# Common variables for building/testing/publishing in the .NET team's pipelines
+
 variables:
 - template: common.yml
 

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -1,3 +1,6 @@
+# A wrapper template around the common .NET build-test-publish-repo template with settings
+# specific to the Dockerfiles in this repo.
+
 parameters:
   isPullRequestPipeline: false
   noCache: false
@@ -5,21 +8,16 @@ parameters:
   publicProjectName: null
 
 stages:
-- template: ../../common/templates/stages/build-test-publish-repo.yml
+- template: ../../common/templates/stages/dotnet/build-test-publish-repo.yml
   parameters:
     noCache: ${{ parameters.noCache }}
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
-    internalVersionsRepoRef: InternalVersionsRepo
-    publicVersionsRepoRef: PublicVersionsRepo
     ${{ if parameters.isPullRequestPipeline }}:
       buildMatrixType: platformVersionedOs
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies
     ${{ if not(parameters.isPullRequestPipeline) }}:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
-    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-      customPublishVariables:
-      - group: DotNet-AllOrgs-Darc-Pats
 
     # Template paths must be relative to the YAML job that executes them
     customBuildInitSteps:
@@ -27,4 +25,3 @@ stages:
     customPublishInitSteps:
     - template: ../../../pipelines/steps/set-public-source-branch-var.yml
     - template: ../../../pipelines/steps/set-publish-mcrdocs-args-var.yml
-    


### PR DESCRIPTION
This removes hard-coded pools in the common build-test-publish-repo template in order for it to be easily reusable by other products. Pools can be defined using template parameters but also have defaults configured.

In order for the pools, and other settings, to be used by the other .NET team-owned repositories, such as dotnet-framework-docker, I've created a wrapper template at `eng/common/stages/dotnet/build-test-publish-repo.yml` which consolidates these settings.

Related to dotnet/docker-tools#843