### PR TITLE
Fix conditional pipeline logic

### DIFF
--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -1,5 +1,4 @@
 parameters:
-  isPullRequestPipeline: false
   noCache: false
   internalProjectName: null
   publicProjectName: null
@@ -12,12 +11,11 @@ stages:
     publicProjectName: ${{ parameters.publicProjectName }}
     internalVersionsRepoRef: InternalVersionsRepo
     publicVersionsRepoRef: PublicVersionsRepo
-    ${{ if parameters.isPullRequestPipeline }}:
+    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
       buildMatrixType: platformVersionedOs
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies
-    ${{ if not(parameters.isPullRequestPipeline) }}:
-      buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
     ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
       customPublishVariables:
       - group: DotNet-AllOrgs-Darc-Pats
 


### PR DESCRIPTION
Builds in the nightly branch aren't working correctly due to incorrect settings for generating the build matrix.  This is a regression due to https://github.com/dotnet/dotnet-docker/pull/3088.  There were actually a couples issues with those:
1. Pipelines that made use of the eng/pipelines/stages/build-test-publish-repo.yml template never passed in a value for the `isPullRequestPipeline` parameter so it always defaulted to false.
2. The conditional logic that references the `isPullRequestPipeline` parameter was incorrectly defined, causing it to always return true. It needs to use an equality comparison rather than strictly basing it on the boolean value:

https://github.com/dotnet/dotnet-docker/blob/5aee0db4b68855b66f2bf9c683c3d6db4a2cb198/eng/pipelines/stages/build-test-publish-repo.yml#L15

When fixing this, I realized this can be simplified to not require a parameter to be passed in at all.  We can just base the condition on whether the pipeline is internal or public on which matrix type to use.  