### PR TITLE
Use any host for dotnet-monitor URLs.

### DIFF
--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -40,4 +40,4 @@ ENV \
 
 RUN chmod 755 dotnet-monitor
 
-ENTRYPOINT ["dotnet-monitor", "collect"]
+ENTRYPOINT [ "dotnet-monitor", "collect", "-urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -40,4 +40,4 @@ ENV \
 
 RUN chmod 755 dotnet-monitor
 
-ENTRYPOINT ["dotnet-monitor", "collect"]
+ENTRYPOINT [ "dotnet-monitor", "collect", "-urls", "https://+:52323", "--metricUrls", "http://+:52325" ]


### PR DESCRIPTION
In this [PR](https://github.com/dotnet/dotnet-monitor/pull/990), dotnet-monitor is removing the heuristic for binding the metrics URL to "any address" from the tool and just binding both sets of URLs to localhost. However, binding to "any address" is desirable in containers since they are frequently run in bridge networking and dotnet-monitor is specifically designed to allow for Prometheus metrics scraping (which scrapes from a separate pod).

This change sets both set of URLs to bind to "any address" to allow access from outside of the pod.

I've tested that:
- The dotnet-monitor URLs are accessible from other pods using the pod IP address.
- Setting the URLs back to localhost using environment variables is respected and prevents access from other hosts.
- Using "kubectl port-forward" works in both "any address" and localhost configurations.

cc @dotnet/dotnet-monitor 