### PR TITLE
Fix pipelines to have project name parameters

### DIFF
--- a/eng/pipelines/dotnet-core-samples.yml
+++ b/eng/pipelines/dotnet-core-samples.yml
@@ -12,3 +12,6 @@ variables:
 
 stages:
 - template: stages/build-test-publish-repo.yml
+  parameters:
+    internalProjectName: ${{ variables.internalProjectName }}
+    publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -12,3 +12,6 @@ variables:
 
 stages:
 - template: stages/build-test-publish-repo.yml
+  parameters:
+    internalProjectName: ${{ variables.internalProjectName }}
+    publicProjectName: ${{ variables.publicProjectName }}


### PR DESCRIPTION
Builds for main branch are failing due to missing project name parameters from infrastructure updates.