### PR TITLE
Fix urls parameter

### DIFF
--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -40,4 +40,4 @@ ENV \
 
 RUN chmod 755 dotnet-monitor
 
-ENTRYPOINT [ "dotnet-monitor", "collect", "-urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -40,4 +40,4 @@ ENV \
 
 RUN chmod 755 dotnet-monitor
 
-ENTRYPOINT [ "dotnet-monitor", "collect", "-urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]


### PR DESCRIPTION
The urls parameter should be using a double dash since it is the long form of the parameter.