### PR TITLE
Only keep net6.0 TFM in dotnet-monitor

### DIFF
--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -9,9 +9,11 @@ ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|build-version"]}}
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|6.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
-    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # To reduce image size, remove all non-net6.0 TFMs
+    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -9,9 +9,11 @@ ENV DOTNET_MONITOR_VERSION=6.0.0-rtm.21551.11
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
     && dotnetmonitor_sha512='9500e8a408e38d11a68b6bc76a1d90be603db77c4558cb79eb115f165b4cc503db6bc0e8e6b9dcb4ca367d4a5f06b04923fcf8afe426672a4dab94dd653180b5' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
-    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --no-cache \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # To reduce image size, remove all non-net6.0 TFMs
+    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 


### PR DESCRIPTION
The `dotnet monitor` tool now ships with two TFMs (netcoreapp3.1 and net6.0) within the tool package. However, since this image only has the ASP.NET 6 and .NET 6 frameworks, it's not necessary to keep the netcoreapp3.1 bits. This will save a few megabytes on the image and not give anyone the illusion that the netcoreapp3.1 version is runnable from this image.