### PR TITLE
Update distroless Mariner to reference prebuilt-ca-certificates package

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/6.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime-deps/6.0/Dockerfile.mariner
@@ -1,7 +1,7 @@
 FROM cblmariner.azurecr.io/base/core:{{OS_VERSION_NUMBER}}
 
 RUN tdnf install -y \
-        ca-certificates-microsoft \
+        prebuilt-ca-certificates \
         \
         # .NET dependencies
         glibc \

--- a/eng/dockerfile-templates/runtime-deps/6.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime-deps/6.0/Dockerfile.mariner-distroless
@@ -6,7 +6,7 @@ RUN tdnf install -y dnf
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
     && dnf install -y --releasever={{OS_VERSION_NUMBER}} --installroot /staging \
-        ca-certificates-microsoft \
+        prebuilt-ca-certificates \
         glibc \
         icu \
         krb5 \

--- a/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN tdnf install -y dnf
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
     && dnf install -y --releasever=1.0 --installroot /staging \
-        ca-certificates-microsoft \
+        prebuilt-ca-certificates \
         glibc \
         icu \
         krb5 \

--- a/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM cblmariner.azurecr.io/base/core:1.0
 
 RUN tdnf install -y \
-        ca-certificates-microsoft \
+        prebuilt-ca-certificates \
         \
         # .NET dependencies
         glibc \


### PR DESCRIPTION
Fixes #3236