### PR TITLE
Add dotnet-monitor 7.0 image

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -4,6 +4,8 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 
 # Featured Tags
 
+* `7.0` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7.0`
 * `6.0` (Current)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6.0`
 
@@ -46,7 +48,12 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-6.0.0-alpine-amd64, 6.0-alpine-amd64, 6.0.0-alpine, 6.0-alpine, 6.0.0, 6.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile) | Alpine 3.14
+6.0.0-alpine-amd64, 6.0-alpine-amd64, 6.0.0-alpine, 6.0-alpine, 6.0.0, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile) | Alpine 3.14
+
+##### .NET Monitor 7.0 Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+7.0.0-alpha.1-alpine-amd64, 7.0-alpine-amd64, 7.0.0-alpha.1-alpine, 7.0-alpine, 7.0.0-alpha.1, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.14
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -1,0 +1,45 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:{{VARIABLES["sdk|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}} AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|7.0|build-version"]}}
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
+    && dotnetmonitor_sha512='{{VARIABLES["monitor|7.0|sha"]}}' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
+    # To reduce image size, remove the copy of the nupkg under the tools.
+    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # To reduce image size, remove all non-net6.0 TFMs
+    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+RUN chmod 755 dotnet-monitor
+
+ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/eng/get-drop-versions-monitor.sh
+++ b/eng/get-drop-versions-monitor.sh
@@ -7,10 +7,10 @@ set -u
 
 channel=$1
 
-curl -SLo dotnet-monitor.nupkg.version https://aka.ms/dotnet/diagnostics/monitor$channel/dotnet-monitor.nupkg.version
+curl -SLo dotnet-monitor.nupkg.buildversion https://aka.ms/dotnet/diagnostics/monitor$channel/dotnet-monitor.nupkg.buildversion
 
 # Read version file and remove newlines
-monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.version)
+monitorVer=$(tr -d '\r\n' < dotnet-monitor.nupkg.buildversion)
 
 rm dotnet-monitor.nupkg.version
 

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -1,2 +1,4 @@
 $(McrTagsYmlRepo:monitor)
 $(McrTagsYmlTagGroup:6.0-alpine-amd64)
+$(McrTagsYmlTagGroup:7.0-alpine-amd64)
+    customSubTableTitle: .NET Monitor 7.0 Preview Tags

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -1,4 +1,4 @@
 $(McrTagsYmlRepo:monitor)
-$(McrTagsYmlTagGroup:6.0-alpine-amd64)
 $(McrTagsYmlTagGroup:7.0-alpine-amd64)
     customSubTableTitle: .NET Monitor 7.0 Preview Tags
+$(McrTagsYmlTagGroup:6.0-alpine-amd64)

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -10,7 +10,9 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
   * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
 * `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`
-^elif match(SHORT_REPO, "monitor"):* `6.0` (Current)
+^elif match(SHORT_REPO, "monitor"):* `7.0` (Preview)
+  * `docker pull {{FULL_REPO}}:7.0`
+* `6.0` (Current)
   * `docker pull {{FULL_REPO}}:6.0`
 ^else:* `6.0` (Current, LTS)
   * `docker pull {{FULL_REPO}}:6.0`

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -39,7 +39,7 @@ namespace Dotnet.Docker
         private static readonly Dictionary<string, string[]> s_urls = new() {
             {"powershell", new string[] { "https://pwshtool.blob.core.windows.net/tool/$VERSION_DIR/PowerShell.$OS.$ARCH.$VERSION_FILE.nupkg" }},
 
-            {"monitor", new string[] { $"{DotnetBaseUrl}/diagnostics/monitor$CHANNEL_NAME/dotnet-monitor.$VERSION_FILE.nupkg" }},
+            {"monitor", new string[] { $"{DotnetBaseUrl}/diagnostics/monitor/$VERSION_DIR/dotnet-monitor.$VERSION_FILE.nupkg" }},
 
             {"runtime", new string[] { $"{DotnetBaseUrl}/Runtime/$VERSION_DIR/dotnet-runtime-$VERSION_FILE$OPTIONAL_OS-$ARCH.$ARCHIVE_EXT" }},
             {"runtime-host", new string[] { $"{DotnetBaseUrl}/Runtime/$VERSION_DIR/dotnet-host-$VERSION_FILE-$ARCH.$ARCHIVE_EXT" }},

--- a/manifest.json
+++ b/manifest.json
@@ -4712,8 +4712,7 @@
             "$(monitor|6.0|product-version)-alpine": {},
             "6.0-alpine": {},
             "$(monitor|6.0|product-version)": {},
-            "6.0": {},
-            "latest": {}
+            "6.0": {}
           },
           "platforms": [
             {
@@ -4728,6 +4727,32 @@
               "tags": {
                 "$(monitor|6.0|product-version)-alpine-amd64": {},
                 "6.0-alpine-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|7.0|product-version)",
+          "sharedTags": {
+            "$(monitor|7.0|product-version)-alpine": {},
+            "7.0-alpine": {},
+            "$(monitor|7.0|product-version)": {},
+            "7.0": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/7.0/alpine/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine",
+              "os": "linux",
+              "osVersion": "alpine3.14",
+              "tags": {
+                "$(monitor|7.0|product-version)-alpine-amd64": {},
+                "7.0-alpine-amd64": {}
               }
             }
           ]

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -40,6 +40,10 @@
     "monitor|6.0|product-version": "6.0.0",
     "monitor|6.0|sha": "ce7b9332555220ff415699a138b3b25eb781634d361de19d9795829c132fd2bea371dc1201bc1cfd38cc4f07bd018eb459d3e87d7d020c5d0e75e910f13f31e0",
 
+    "monitor|7.0|build-version": "7.0.0-alpha.1.21560.7",
+    "monitor|7.0|product-version": "7.0.0-alpha.1",
+    "monitor|7.0|sha": "56bf82e10f926ba880ef495af0d42dceea41fd510d6906202dca6e21bc1e23c363da310cc4b1a24b61c4315fd2f9a1940eab9b1aa593bcff0ba9785f1566969f",
+
     "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha": "fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880",
 
     "powershell|3.1|build-version": "7.0.8",

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -1,0 +1,45 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:6.0.100-alpine3.14-amd64 AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.21560.7
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
+    && dotnetmonitor_sha512='56bf82e10f926ba880ef495af0d42dceea41fd510d6906202dca6e21bc1e23c363da310cc4b1a24b61c4315fd2f9a1940eab9b1aa593bcff0ba9785f1566969f' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
+    # To reduce image size, remove the copy of the nupkg under the tools.
+    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # To reduce image size, remove all non-net6.0 TFMs
+    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:6.0.0-alpine3.14-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+RUN chmod 755 dotnet-monitor
+
+ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
@@ -11,5 +11,6 @@ namespace Microsoft.DotNet.Docker.Tests
         public static readonly Version V3_1 = new Version(3, 1);
         public static readonly Version V5_0 = new Version(5, 0);
         public static readonly Version V6_0 = new Version(6, 0);
+        public static readonly Version V7_0 = new Version(7, 0);
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -121,6 +121,7 @@ namespace Microsoft.DotNet.Docker.Tests
         private static readonly MonitorImageData[] s_linuxMonitorTestData =
         {
             new MonitorImageData { Version = V6_0, RuntimeVersion = V6_0, OS = OS.Alpine314, OSTag = OS.Alpine, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V6_0, OS = OS.Alpine314, OSTag = OS.Alpine, Arch = Arch.Amd64 },
         };
 
         private static readonly MonitorImageData[] s_windowsMonitorTestData =

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -155,6 +155,7 @@
     "src/sdk/6.0/cbl-mariner1.0/amd64": 888550600
   },
   "dotnet/nightly/monitor": {
-    "src/monitor/6.0/alpine/amd64": 112576244
+    "src/monitor/6.0/alpine/amd64": 109543092,
+    "src/monitor/7.0/alpine/amd64": 108132591
   }
 }


### PR DESCRIPTION
The 7.0 builds of the tool are based on .NET 6 at this time, so the Dockerfile is effectively the same as the 6.0 version but with 7.0 branding.

closes #3277