### PR TITLE
Set correct matrix type for PR builds

### DIFF
--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -13,6 +13,7 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
     ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+      buildMatrixType: platformVersionedOs
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies
     ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config.nightly
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config.nightly
@@ -5,7 +5,7 @@
     <add key="dotnet3.1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/7.0.0/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
PR builds in dotnet-docker have not been executing correctly, using the wrong matrix type. This has resulted in builds being executed but the tests haven't been running anything (all tests were skipped). This became broken as a result of https://github.com/dotnet/dotnet-docker/pull/3241 which requires the matrix type to explicitly be set by the template consumer.

As a result of this, I'm also updating a feed change to fix the .NET 7 tests due to a change in the feed name.

I will cherry-pick this to main once it's confirmed to be working.