### PR TITLE
Samples: Scan dependencies with Trivy

### DIFF
--- a/samples/aspnetapp/Dockerfile
+++ b/samples/aspnetapp/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app --no-restore

--- a/samples/aspnetapp/Dockerfile.alpine-arm64
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-musl-arm64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-musl-arm64 --self-contained false --no-restore

--- a/samples/aspnetapp/Dockerfile.alpine-arm64
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-musl-arm64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-musl-x64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-musl-x64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained false --no-restore

--- a/samples/aspnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-x64-slim
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-x64-slim
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true

--- a/samples/aspnetapp/Dockerfile.debian-arm64
+++ b/samples/aspnetapp/Dockerfile.debian-arm64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-arm64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-arm64 --self-contained false --no-restore

--- a/samples/aspnetapp/Dockerfile.debian-arm64
+++ b/samples/aspnetapp/Dockerfile.debian-arm64
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-arm64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.debian-x64
+++ b/samples/aspnetapp/Dockerfile.debian-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained false --no-restore

--- a/samples/aspnetapp/Dockerfile.debian-x64
+++ b/samples/aspnetapp/Dockerfile.debian-x64
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.debian-x64-slim
+++ b/samples/aspnetapp/Dockerfile.debian-x64-slim
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true

--- a/samples/aspnetapp/Dockerfile.debian-x64-slim
+++ b/samples/aspnetapp/Dockerfile.debian-x64-slim
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r win-x64
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -1,7 +1,7 @@
 # escape=`
 
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -9,7 +9,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r win-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained false --no-restore

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
@@ -8,7 +8,7 @@ COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
@@ -1,7 +1,7 @@
 # escape=`
 
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -9,7 +9,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs `
+    --exit-code 1 `
+    --no-progress `
+    --ignore-unfixed `
+    --severity "HIGH,CRITICAL" `
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app --no-restore

--- a/samples/aspnetapp/Dockerfile.windowsservercore-x64
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-x64
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r win-x64
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs `
+    --exit-code 1 `
+    --no-progress `
+    --ignore-unfixed `
+    --severity "HIGH,CRITICAL" `
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore

--- a/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
@@ -1,7 +1,7 @@
 # escape=`
 
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -9,7 +9,18 @@ COPY *.sln .
 COPY aspnetapp/*.csproj ./aspnetapp/
 RUN dotnet restore -r win-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs `
+    --exit-code 1 `
+    --no-progress `
+    --ignore-unfixed `
+    --severity "HIGH,CRITICAL" `
+    --security-checks vuln /source
+
 # copy everything else and build app
+FROM restore AS build
 COPY aspnetapp/. ./aspnetapp/
 WORKDIR /source/aspnetapp
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true

--- a/samples/aspnetapp/aspnetapp/aspnetapp.csproj
+++ b/samples/aspnetapp/aspnetapp/aspnetapp.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>57393389627611478466</UserSecretsId>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
 </Project>

--- a/samples/complexapp/Dockerfile
+++ b/samples/complexapp/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -8,7 +8,18 @@ COPY libfoo/*.csproj libfoo/
 COPY libbar/*.csproj libbar/
 RUN dotnet restore complexapp/complexapp.csproj
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and build app and libraries
+FROM restore AS build
 COPY complexapp/ complexapp/
 COPY libfoo/ libfoo/
 COPY libbar/ libbar/

--- a/samples/complexapp/complexapp/complexapp.csproj
+++ b/samples/complexapp/complexapp/complexapp.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dotnetapp/Dockerfile
+++ b/samples/dotnetapp/Dockerfile
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app --no-restore
 

--- a/samples/dotnetapp/Dockerfile.alpine-arm64
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-musl-arm64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-musl-arm64 --self-contained false --no-restore
 

--- a/samples/dotnetapp/Dockerfile.alpine-arm64
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-musl-arm64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.alpine-x64
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-musl-x64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.alpine-x64
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-musl-x64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained false --no-restore
 

--- a/samples/dotnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-x64-slim
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-x64-slim
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 

--- a/samples/dotnetapp/Dockerfile.debian-arm64
+++ b/samples/dotnetapp/Dockerfile.debian-arm64
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-arm64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.debian-arm64
+++ b/samples/dotnetapp/Dockerfile.debian-arm64
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-arm64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-arm64 --self-contained false --no-restore
 

--- a/samples/dotnetapp/Dockerfile.debian-x64
+++ b/samples/dotnetapp/Dockerfile.debian-x64
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-x64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.debian-x64
+++ b/samples/dotnetapp/Dockerfile.debian-x64
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-x64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained false --no-restore
 

--- a/samples/dotnetapp/Dockerfile.debian-x64-slim
+++ b/samples/dotnetapp/Dockerfile.debian-x64-slim
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 

--- a/samples/dotnetapp/Dockerfile.debian-x64-slim
+++ b/samples/dotnetapp/Dockerfile.debian-x64-slim
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r win-x64
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained false --no-restore
 

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r win-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 

--- a/samples/dotnetapp/Dockerfile.ubuntu-arm64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-arm64
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-arm64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-arm64 --self-contained false --no-restore
 

--- a/samples/dotnetapp/Dockerfile.ubuntu-arm64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-arm64
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-arm64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-x64
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-x64
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained false --no-restore
 

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
@@ -7,7 +7,7 @@ COPY *.csproj .
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
 # dependencies vulnerability scan
-FROM aquasec/trivy AS trivy
+FROM ollijanatuinen/trivy AS trivy
 COPY --from=restore /source /source
 RUN trivy fs \
     --exit-code 1 \

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM aquasec/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 

--- a/samples/dotnetapp/Dockerfile.windowsservercore-x64
+++ b/samples/dotnetapp/Dockerfile.windowsservercore-x64
@@ -1,8 +1,19 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS restore
 WORKDIR /source
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy csproj and restore as distinct layers
+FROM restore AS build
 COPY *.csproj .
 RUN dotnet restore -r win-x64
 

--- a/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
@@ -1,12 +1,23 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2022 AS restore
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY *.csproj .
 RUN dotnet restore -r win-x64 /p:PublishReadyToRun=true
 
+# dependencies vulnerability scan
+FROM ollijanatuinen/trivy AS trivy
+COPY --from=restore /source /source
+RUN trivy fs \
+    --exit-code 1 \
+    --no-progress \
+    --ignore-unfixed \
+    --severity "HIGH,CRITICAL" \
+    --security-checks vuln /source
+
 # copy and publish app and libraries
+FROM restore AS build
 COPY . .
 RUN dotnet publish -c release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 

--- a/samples/dotnetapp/dotnetapp.csproj
+++ b/samples/dotnetapp/dotnetapp.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Now when everyone is trying to figure out if/where their applications use `log4j2` it is probably good time to propose that samples on here should contain security scan.

This PR enables `RestorePackagesWithLockFile` to samples which will instruct `dotnet restore` to generate `packages.lock.json` (like described on [here](https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/)) and add new stage where Trivy does security scan based on it as have been supported over year now https://github.com/aquasecurity/trivy/pull/686

Current it is done only for Linux with *amd64* and arm64* as Trivy docker image for *arm32* or Windows does not exist.

~To make sure that scan works correctly I also added **latest version** of `Microsoft.AspNetCore.Diagnostics` which it selves is not vulnerable but one of it's dependencies (`System.Text.Encodings.Web` version `4.5.0`) is to aspnetapp and that same package to complexapp and dotnetapp as separate commit which why this PR is currently marked as WIP. I will remove that commit after first CI run.~
CI failed as expected. Here is log file [Linux_amd64 buster.log](https://github.com/dotnet/dotnet-docker/files/7698695/Linux_amd64.buster.log) and here the relevant part of it:
```
2021-12-12T11:40:09.9754419Z  ---> Running in 6d8f1734c7f1
2021-12-12T11:40:09.9755159Z 2021-12-12T11:40:09.453Z	[34mINFO[0m	Need to update DB
2021-12-12T11:40:09.9755914Z 2021-12-12T11:40:09.453Z	[34mINFO[0m	Downloading DB...
2021-12-12T11:40:11.5711243Z 2021-12-12T11:40:11.569Z	[34mINFO[0m	Number of language-specific files: 1
2021-12-12T11:40:11.5713059Z 2021-12-12T11:40:11.569Z	[34mINFO[0m	Detecting nuget vulnerabilities...
2021-12-12T11:40:11.5723190Z 
2021-12-12T11:40:11.5723737Z packages.lock.json (nuget)
2021-12-12T11:40:11.5724105Z ==========================
2021-12-12T11:40:11.5724493Z Total: 1 (HIGH: 0, CRITICAL: 1)
2021-12-12T11:40:11.5724712Z 
2021-12-12T11:40:11.5725540Z +---------------------------+------------------+----------+-------------------+---------------------+---------------------------------------+
2021-12-12T11:40:11.5726385Z |          LIBRARY          | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |    FIXED VERSION    |                 TITLE                 |
2021-12-12T11:40:11.5727226Z +---------------------------+------------------+----------+-------------------+---------------------+---------------------------------------+
2021-12-12T11:40:11.5735239Z | System.Text.Encodings.Web | CVE-2021-26701   | CRITICAL | 4.5.0             | 5.0.1, 4.7.2, 4.5.1 | dotnet: System.Text.Encodings.Web     |
2021-12-12T11:40:11.5736411Z |                           |                  |          |                   |                     | Remote Code Execution                 |
2021-12-12T11:40:11.5741160Z |                           |                  |          |                   |                     | -->avd.aquasec.com/nvd/cve-2021-26701 |
2021-12-12T11:40:11.5742552Z +---------------------------+------------------+----------+-------------------+---------------------+---------------------------------------+
2021-12-12T11:40:12.8080677Z -- EXECUTION ELAPSED TIME: 00:13:26.4639683
2021-12-12T11:40:12.8082013Z The command '/bin/sh -c trivy fs     --exit-code 1     --no-progress     --ignore-unfixed     --severity "HIGH,CRITICAL"     --security-checks vuln /source' returned a non-zero code: 1
```

Additionally I needed to leave this test out from generic Dockerfile now as it applies to Windows too. Will start working on Trivy side to trying get Windows support included.


EDIT: Converted back to draft because looks that I will get Trivy working on Windows containers too so will implement that first.