### PR TITLE
Update curl option for .NET 7 Dockerfiles

### DIFF
--- a/eng/dockerfile-templates/aspnet/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/7.0/Dockerfile.linux
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM {{ARCH_VERSIONED}}/buildpack-deps:{{OS_VERSION_BASE}}-curl as installer
 
 # Retrieve ASP.NET Core
-RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/{{VARIABLES["aspnet|7.0|build-version"]}}/aspnetcore-runtime-{{VARIABLES["aspnet|7.0|build-version"]}}-linux-{{ARCH_SHORT}}.tar.gz \
+RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/{{VARIABLES["aspnet|7.0|build-version"]}}/aspnetcore-runtime-{{VARIABLES["aspnet|7.0|build-version"]}}-linux-{{ARCH_SHORT}}.tar.gz \
     && aspnetcore_sha512='{{VARIABLES[cat("aspnet|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/eng/dockerfile-templates/aspnet/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/aspnet/7.0/Dockerfile.mariner
@@ -8,7 +8,7 @@ ENV \
     Logging__Console__FormatterName=Json
 
 # Install ASP.NET Core
-RUN curl -SL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-{{ARCH_SHORT}}.rpm \
+RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("aspnet|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/eng/dockerfile-templates/runtime-deps/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime-deps/7.0/Dockerfile.mariner
@@ -15,7 +15,7 @@ RUN tdnf install -y \
 
 # Install dotnet-runtime-deps package
 RUN dotnet_version={{VARIABLES["runtime|7.0|build-version"]}} \
-    && curl -SL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.1-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.1-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime-deps-cm.1|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
     && rpm --install dotnet-runtime-deps.rpm \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM {{ARCH_VERSIONED}}/buildpack-deps:{{OS_VERSION_BASE}}-curl as installer
 
 # Retrieve .NET
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/{{VARIABLES["runtime|7.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|7.0|build-version"]}}-linux-{{ARCH_SHORT}}.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/{{VARIABLES["runtime|7.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|7.0|build-version"]}}-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner
@@ -4,15 +4,15 @@ FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_
 # Install .NET
 ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
-RUN curl -SL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
+RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime-host|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet-host.rpm" | sha512sum -c - \
     \
-    && curl -SL --output dotnet-hostfxr.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-hostfxr-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output dotnet-hostfxr.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-hostfxr-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime-hostfxr|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet-hostfxr.rpm" | sha512sum -c - \
     \
-    && curl -SL --output dotnet-runtime.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output dotnet-runtime.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
     \

--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.linux
@@ -27,7 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-{{ARCH_SHORT}}.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("sdk|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.mariner
@@ -24,23 +24,23 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-{{ARCH_SHORT}}.rpm \
+RUN curl -fSL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("sdk|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.rpm" | sha512sum -c - \
     \
-    && curl -SL --output apphost.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-apphost-pack-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output apphost.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-apphost-pack-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime-apphost-pack|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  apphost.rpm" | sha512sum -c - \
     \
-    && curl -SL --output targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-targeting-pack-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-targeting-pack-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime-targeting-pack|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  targeting-pack.rpm" | sha512sum -c - \
     \
-    && curl -SL --output aspnetcore-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-targeting-pack-$ASPNET_VERSION.rpm \
+    && curl -fSL --output aspnetcore-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-targeting-pack-$ASPNET_VERSION.rpm \
     && dotnet_sha512='{{VARIABLES[cat("aspnet-runtime-targeting-pack|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
     \
-    && curl -SL --output netstandard-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output netstandard-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("netstandard-targeting-pack-2.1.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  netstandard-targeting-pack.rpm" | sha512sum -c - \
     \

--- a/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:bullseye-curl as installer
 
 # Retrieve ASP.NET Core
-RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-x64.tar.gz \
+RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-x64.tar.gz \
     && aspnetcore_sha512='89fa917fa391f96412ae7691749208d185cc26c9e3e5aadf23950a10de9dc9d8e1af0cd03a3640a2f7050d74925dab002e31b1b6e3bc7ac48a4afc5120db6574' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:bullseye-curl as installer
 
 # Retrieve ASP.NET Core
-RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm.tar.gz \
+RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm.tar.gz \
     && aspnetcore_sha512='bd8c96bc27f3ed83c7aa056eee41e0785f03d3d632714de8b00c2753ba9eb3982218676bbc1bd317cda16248ef979b52d1472f0811a668f05589e45cda1db180' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:bullseye-curl as installer
 
 # Retrieve ASP.NET Core
-RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm64.tar.gz \
+RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm64.tar.gz \
     && aspnetcore_sha512='addf88a0fc1bc45207662bac846de18843a21d53d9da619e81f115a32dba5b1e7744d3bb2e8faa3b80b7ad38b5527fd666a8540d42339170e0c55f80f1d7347f' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     Logging__Console__FormatterName=Json
 
 # Install ASP.NET Core
-RUN curl -SL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
+RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
     && dotnet_sha512='af489a5701c3e0a911b2079adf169cf888cd460428bf219b0682a3be56ca92bf47ad2d43359cd38621ebd625bb5e9676af99fda4e67bb4bf846ebdf179521a3d' \
     && echo "$dotnet_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/src/aspnet/7.0/focal/amd64/Dockerfile
+++ b/src/aspnet/7.0/focal/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:focal-curl as installer
 
 # Retrieve ASP.NET Core
-RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-x64.tar.gz \
+RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-x64.tar.gz \
     && aspnetcore_sha512='89fa917fa391f96412ae7691749208d185cc26c9e3e5aadf23950a10de9dc9d8e1af0cd03a3640a2f7050d74925dab002e31b1b6e3bc7ac48a4afc5120db6574' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/7.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:focal-curl as installer
 
 # Retrieve ASP.NET Core
-RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm.tar.gz \
+RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm.tar.gz \
     && aspnetcore_sha512='bd8c96bc27f3ed83c7aa056eee41e0785f03d3d632714de8b00c2753ba9eb3982218676bbc1bd317cda16248ef979b52d1472f0811a668f05589e45cda1db180' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:focal-curl as installer
 
 # Retrieve ASP.NET Core
-RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm64.tar.gz \
+RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-alpha.1.21567.15/aspnetcore-runtime-7.0.0-alpha.1.21567.15-linux-arm64.tar.gz \
     && aspnetcore_sha512='addf88a0fc1bc45207662bac846de18843a21d53d9da619e81f115a32dba5b1e7744d3bb2e8faa3b80b7ad38b5527fd666a8540d42339170e0c55f80f1d7347f' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/runtime-deps/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN tdnf install -y \
 
 # Install dotnet-runtime-deps package
 RUN dotnet_version=7.0.0-alpha.1.21567.1 \
-    && curl -SL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.1-x64.rpm \
+    && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.1-x64.rpm \
     && dotnet_sha512='4c4baf75e72130a8d0385bc7c94e7a4f2b9720fde96eb9a7bd32482591ac884115415cd4735fdb847a7b50fa42fd0a5799bd26bee358028647476dbc6a8bf972' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
     && rpm --install dotnet-runtime-deps.rpm \

--- a/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:bullseye-curl as installer
 
 # Retrieve .NET
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-x64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-x64.tar.gz \
     && dotnet_sha512='67a1451c805d07afb26e902be2f88cb9fd831c38ff865795b78534f12af952d252bdd34aaaa3fe98550067eebe91dc776abdf154dce196e8376c43beaafc1a78' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:bullseye-curl as installer
 
 # Retrieve .NET
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm.tar.gz \
     && dotnet_sha512='ad6bbcdca2c79fd247c8eed877d4165ab39502c20b75f42f6d0febafb3ef2bba73edce07bb128ca88735b70e14a025b1d4b3f49cbae1463ab0cc1c4a897054b9' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:bullseye-curl as installer
 
 # Retrieve .NET
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm64.tar.gz \
     && dotnet_sha512='dd2e94cc310c2546c3c694684a518860195ee35634921e46b0743d17601a500dcfc11e4ff51fd3858ed30db70b40f8f0f15a80a5244781649ae2cb8fcf4d8251' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -4,15 +4,15 @@ FROM $REPO:7.0.0-alpha.1-cbl-mariner1.0-amd64
 # Install .NET
 ENV DOTNET_VERSION=7.0.0-alpha.1.21567.1
 
-RUN curl -SL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \
+RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \
     && dotnet_sha512='bc1537240c31d4353dc1ff92e72e88d1f5fb0266245add09fa2f7294887737a4f64fca3a8944642520ed152327b99d9e885a5e0b189b5500475a51cada781d3d' \
     && echo "$dotnet_sha512  dotnet-host.rpm" | sha512sum -c - \
     \
-    && curl -SL --output dotnet-hostfxr.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-hostfxr-$DOTNET_VERSION-x64.rpm \
+    && curl -fSL --output dotnet-hostfxr.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-hostfxr-$DOTNET_VERSION-x64.rpm \
     && dotnet_sha512='f6d1958247b9b68acdb84c0f6c18bac17d820bed2b8a1c581d38ed80026dbce98eef693fc87bc70566a4829a387cb5f6d0c913d53c8e5934c6029fce4648028b' \
     && echo "$dotnet_sha512  dotnet-hostfxr.rpm" | sha512sum -c - \
     \
-    && curl -SL --output dotnet-runtime.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-x64.rpm \
+    && curl -fSL --output dotnet-runtime.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-x64.rpm \
     && dotnet_sha512='99a279a150c926127927c8e9f7be084820b8f523a3ba52810c94d1adcbe23eb12acdb8be9c21d0c2c98493a991a87415404e3d2b82261c51cf4991690eac2d62' \
     && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
     \

--- a/src/runtime/7.0/focal/amd64/Dockerfile
+++ b/src/runtime/7.0/focal/amd64/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:focal-curl as installer
 
 # Retrieve .NET
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-x64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-x64.tar.gz \
     && dotnet_sha512='67a1451c805d07afb26e902be2f88cb9fd831c38ff865795b78534f12af952d252bdd34aaaa3fe98550067eebe91dc776abdf154dce196e8376c43beaafc1a78' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/7.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:focal-curl as installer
 
 # Retrieve .NET
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm.tar.gz \
     && dotnet_sha512='ad6bbcdca2c79fd247c8eed877d4165ab39502c20b75f42f6d0febafb3ef2bba73edce07bb128ca88735b70e14a025b1d4b3f49cbae1463ab0cc1c4a897054b9' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/7.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:focal-curl as installer
 
 # Retrieve .NET
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-alpha.1.21567.1/dotnet-runtime-7.0.0-alpha.1.21567.1-linux-arm64.tar.gz \
     && dotnet_sha512='dd2e94cc310c2546c3c694684a518860195ee35634921e46b0743d17601a500dcfc11e4ff51fd3858ed30db70b40f8f0f15a80a5244781649ae2cb8fcf4d8251' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/sdk/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/7.0/bullseye-slim/amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='9bc4e7b7ee6d2897af99b473cf50980022bf47b9ea5d8c7024eebdc116b2f49d32b570fee04194594d3b29173c863946a11f6fc3c3882ad138ae075e944cc4df' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/src/sdk/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='e26e7693ca0a602a55b1cd285c89b77086104f02b9df95175686e00ffc97a9e965b3db45f01ebbc8bf336df233d21564266e8bb640dd3b2dd2e43eb9e2bc8210' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/src/sdk/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz \
     && dotnet_sha512='7aa8d2a3ef2681cdb80b120c09ac7b964b229cdbf7857c84490e23dca58e2847b91be9fddca499c61d2e3f451fed2eaa2966f05f5b53b1d3a0674ad5d47d687b' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/src/sdk/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/sdk/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -24,23 +24,23 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-x64.rpm \
+RUN curl -fSL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-x64.rpm \
     && dotnet_sha512='8b779090a7b79d55ff508aa9b81e48080bbbcf1fdd4906a37a1bfe66991b068b5f8adaceb9561b925f1f448f327ab8f37839df410b2b1a29810e0bef2939c5d5' \
     && echo "$dotnet_sha512  dotnet.rpm" | sha512sum -c - \
     \
-    && curl -SL --output apphost.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-apphost-pack-$DOTNET_VERSION-x64.rpm \
+    && curl -fSL --output apphost.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-apphost-pack-$DOTNET_VERSION-x64.rpm \
     && dotnet_sha512='d280d5ffc1e9b7e6dd4a9059abd09d6e4f01afdf481bda140de180fbde7eeb08153ca3626e9bb83b8284207d6b10e4de7d4d3b55f1f6e29ec2e429eae2ef0973' \
     && echo "$dotnet_sha512  apphost.rpm" | sha512sum -c - \
     \
-    && curl -SL --output targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-targeting-pack-$DOTNET_VERSION-x64.rpm \
+    && curl -fSL --output targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-targeting-pack-$DOTNET_VERSION-x64.rpm \
     && dotnet_sha512='1c282148ed878c2dfeead287b455fe57d3fec3d7508b869ac165e20c334a91bb3813ff452339df51fc09e3df93bc74f9e1370c5fb115ea477e31f8d00131b0b2' \
     && echo "$dotnet_sha512  targeting-pack.rpm" | sha512sum -c - \
     \
-    && curl -SL --output aspnetcore-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-targeting-pack-$ASPNET_VERSION.rpm \
+    && curl -fSL --output aspnetcore-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-targeting-pack-$ASPNET_VERSION.rpm \
     && dotnet_sha512='32b30311bc81976bb84afd03dfe5695bd2747834188195f012de944fc9a4b2fee9282b1f2471a4e9f336520ddcad7c3cc79bf4cacd7cf85ba399096fef2046bb' \
     && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
     \
-    && curl -SL --output netstandard-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.rpm \
+    && curl -fSL --output netstandard-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.rpm \
     && dotnet_sha512='fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880' \
     && echo "$dotnet_sha512  netstandard-targeting-pack.rpm" | sha512sum -c - \
     \

--- a/src/sdk/7.0/focal/amd64/Dockerfile
+++ b/src/sdk/7.0/focal/amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && dotnet_sha512='9bc4e7b7ee6d2897af99b473cf50980022bf47b9ea5d8c7024eebdc116b2f49d32b570fee04194594d3b29173c863946a11f6fc3c3882ad138ae075e944cc4df' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/src/sdk/7.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/7.0/focal/arm32v7/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz \
     && dotnet_sha512='e26e7693ca0a602a55b1cd285c89b77086104f02b9df95175686e00ffc97a9e965b3db45f01ebbc8bf336df233d21564266e8bb640dd3b2dd2e43eb9e2bc8210' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/src/sdk/7.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/7.0/focal/arm64v8/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz \
     && dotnet_sha512='7aa8d2a3ef2681cdb80b120c09ac7b964b229cdbf7857c84490e23dca58e2847b91be9fddca499c61d2e3f451fed2eaa2966f05f5b53b1d3a0674ad5d47d687b' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \


### PR DESCRIPTION
Fixing the .NET 7 Dockerfiles because the changes in https://github.com/dotnet/dotnet-docker/pull/3287 were never applied to them.