### PR TITLE
Get dotnet monitor from blob storage.

### DIFF
--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -6,7 +6,7 @@ FROM $SDK_REPO:{{VARIABLES["sdk|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|7.0|build-version"]}}
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|7.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -55,9 +55,9 @@
     "monitor|6.0|product-version": "6.0.1",
     "monitor|6.0|sha": "469f2ffc9f6cc350e1487a3186abcde64fe80994205664e85a1f021ae731155c04a669bd25d657982a726fd1cfde668663f1db21061926c442ae1f655395a144",
 
-    "monitor|7.0|build-version": "7.0.0-alpha.1.21615.2",
+    "monitor|7.0|build-version": "7.0.0-alpha.1.21620.4",
     "monitor|7.0|product-version": "7.0.0-alpha.1",
-    "monitor|7.0|sha": "c31c6ec244da6629e22279ee8d70313d96126c10eacae871a1aa778718b2365776caaa6a426560f9c542cacb136d24595f1304436bcbd7242f29d39df892f586",
+    "monitor|7.0|sha": "dbc2e178b01e660bcf7698deb7aa6da682fde22eb4fe787885dac9e69f9c3c05b41760d8803dba9fbfae17e998e2b1fa99f3a29e574e05073a4ff76fdac0fcba",
 
     "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha": "fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880",
 

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:6.0.101-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.21615.2
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools/nuget/packages/dotnet-monitor/versions/$DOTNET_MONITOR_VERSION/content \
-    && dotnetmonitor_sha512='c31c6ec244da6629e22279ee8d70313d96126c10eacae871a1aa778718b2365776caaa6a426560f9c542cacb136d24595f1304436bcbd7242f29d39df892f586' \
+ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.21620.4
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='dbc2e178b01e660bcf7698deb7aa6da682fde22eb4fe787885dac9e69f9c3c05b41760d8803dba9fbfae17e998e2b1fa99f3a29e574e05073a4ff76fdac0fcba' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.


### PR DESCRIPTION
The dotnet-monitor repo can now publish its nupkg file to blob storage in addition to the dotnet-tools feed. This change switches the Dockerfiles to pull from blob storage. This will be especially useful when shipping the final versions of 7.0+ such that the package can be provided using the same mechanism as the rest of the dotnet packages and the checksum file value will match the package (as compared to the 6.0 releases, where the package had to be published to nuget.org, which changes the signing of the package and thus the checksum file doesn't match).