### PR TITLE
Mariner reference to prebuilt-ca-certificates pkg

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime-deps/7.0/Dockerfile.mariner
@@ -1,7 +1,7 @@
 FROM cblmariner.azurecr.io/base/core:{{OS_VERSION_NUMBER}}
 
 RUN tdnf install -y \
-        ca-certificates-microsoft \
+        prebuilt-ca-certificates \
         \
         # .NET dependencies
         glibc \

--- a/src/runtime-deps/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM cblmariner.azurecr.io/base/core:1.0
 
 RUN tdnf install -y \
-        ca-certificates-microsoft \
+        prebuilt-ca-certificates \
         \
         # .NET dependencies
         glibc \


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-docker/pull/3271 never got applied to the 7.0 runtime-deps Dockerfile.