### PR TITLE
Add runtime environment variable to dotnet-monitor image

### DIFF
--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -31,6 +31,8 @@ ENV \
     # Default Filter
     DefaultProcess__Filters__0__Key=ProcessId \
     DefaultProcess__Filters__0__Value=1 \
+    # Use the environment variable to determine if we are in a sidecar scenario.
+    DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|build-version"]}} \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)

--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -31,6 +31,8 @@ ENV \
     # Default Filter
     DefaultProcess__Filters__0__Key=ProcessId \
     DefaultProcess__Filters__0__Value=1 \
+    # Use the environment variable to determine if we are in a sidecar scenario.
+    DOTNET_MONITOR_VERSION={{VARIABLES["monitor|7.0|build-version"]}} \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -31,6 +31,8 @@ ENV \
     # Default Filter
     DefaultProcess__Filters__0__Key=ProcessId \
     DefaultProcess__Filters__0__Value=1 \
+    # Use the environment variable to determine if we are in a sidecar scenario.
+    DOTNET_MONITOR_VERSION=6.0.1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -31,6 +31,8 @@ ENV \
     # Default Filter
     DefaultProcess__Filters__0__Key=ProcessId \
     DefaultProcess__Filters__0__Value=1 \
+    # Use the environment variable to determine if we are in a sidecar scenario.
+    DOTNET_MONITOR_VERSION=7.0.0-alpha.1.22055.4 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)


### PR DESCRIPTION
Add an environment variable to dotnet-monitor to simplify detection of sidecar scenarios.

- I am not aware of a way to share ARG's between different bases.
- I can push the inline ENV to top level if it's an issue for subsequent dependency updates.