### PR TITLE
Update image size baselines

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -22,7 +22,7 @@
     "src/runtime-deps/5.0/cbl-mariner1.0/amd64": 230996191,
     "src/runtime-deps/6.0/cbl-mariner1.0/amd64": 229251169,
     "src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64": 63825551,
-    "src/runtime-deps/7.0/cbl-mariner1.0/amd64": 231275701
+    "src/runtime-deps/7.0/cbl-mariner1.0/amd64": 219315628
   },
   "dotnet/nightly/runtime": {
     "src/runtime/3.1/bullseye-slim/amd64": 198162495,
@@ -185,15 +185,15 @@
     "src/sdk/6.0/focal/arm32v7": 665193304,
     "src/sdk/6.0/focal/arm64v8": 738493120,
     "src/sdk/6.0/cbl-mariner1.0/amd64": 888550600,
-    "src/sdk/7.0/bullseye-slim/amd64": 683653828,
-    "src/sdk/7.0/bullseye-slim/arm32v7": 630396582,
-    "src/sdk/7.0/bullseye-slim/arm64v8": 705643751,
-    "src/sdk/7.0/alpine3.15/amd64": 547757128,
+    "src/sdk/7.0/bullseye-slim/amd64": 726571989,
+    "src/sdk/7.0/bullseye-slim/arm32v7": 671608341,
+    "src/sdk/7.0/bullseye-slim/arm64v8": 747202299,
+    "src/sdk/7.0/alpine3.15/amd64": 590311239,
     "src/sdk/7.0/alpine3.15/arm32v7": 529991390,
     "src/sdk/7.0/alpine3.15/arm64v8": 577467676,
-    "src/sdk/7.0/focal/amd64": 696023061,
-    "src/sdk/7.0/focal/arm32v7": 636616624,
-    "src/sdk/7.0/focal/arm64v8": 715255004,
+    "src/sdk/7.0/focal/amd64": 738914594,
+    "src/sdk/7.0/focal/arm32v7": 677818259,
+    "src/sdk/7.0/focal/arm64v8": 756811624,
     "src/sdk/7.0/cbl-mariner1.0/amd64": 874993672
   },
   "dotnet/nightly/monitor": {

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -38,7 +38,7 @@
     "src/aspnet/7.0/windowsservercore-ltsc2022/amd64": 5034052450
   },
   "dotnet/nightly/sdk": {
-    "src/sdk/3.1/nanoserver-1809/amd64": 730951559,
+    "src/sdk/3.1/nanoserver-1809/amd64": 769444420,
     "src/sdk/3.1/nanoserver-20H2/amd64": 764063867,
     "src/sdk/3.1/nanoserver-ltsc2022/amd64": 800304552,
     "src/sdk/5.0/nanoserver-1809/amd64": 831969504,
@@ -51,8 +51,8 @@
     "src/sdk/6.0/nanoserver-ltsc2022/amd64": 1006844828,
     "src/sdk/6.0/windowsservercore-ltsc2019/amd64": 6286084693,
     "src/sdk/6.0/windowsservercore-ltsc2022/amd64": 5556352529,
-    "src/sdk/7.0/nanoserver-1809/amd64": 916862436,
-    "src/sdk/7.0/nanoserver-ltsc2022/amd64": 957134936,
+    "src/sdk/7.0/nanoserver-1809/amd64": 975012837,
+    "src/sdk/7.0/nanoserver-ltsc2022/amd64": 1005128696,
     "src/sdk/7.0/windowsservercore-ltsc2019/amd64": 6429570443,
     "src/sdk/7.0/windowsservercore-ltsc2022/amd64": 5629364231
   }


### PR DESCRIPTION
The increase in .NET 7 images is due to the inclusion of PowerShell.