### PR TITLE
Use test dependencies for test matrix

### DIFF
--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -17,6 +17,7 @@ stages:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies
     ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
+    testMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
 
     # Template paths must be relative to the YAML job that executes them
     customBuildInitSteps:


### PR DESCRIPTION
The changes from https://github.com/dotnet/docker-tools/pull/941 exposed an issue in the test matrix generation related to .NET Core 3.1 sdk images for Debian/Ubuntu. Those Dockerfiles are based on buildpack-deps and so they don't have a direct dependency on the runtime-related Dockerfiles. However, for testing purposes we want them tested together. To accomplish this, the manifest defines a customBuildLegGroup named `test-dependencies` that causes the matrix generation to integrate these platforms for testing:

https://github.com/dotnet/dotnet-docker/blob/69758fdf9d02311de1247964a2c0d9621c3bb911/manifest.json#L3151-L3159

However, in the test stage of the build, this `test-dependencies` customBuildLegGroup was not enabled. This led the matrix generation to include two separate test legs: one for the runtime-related Dockerfiles and one for the sdk Dockerfile. The test legs had the same name. Because of the changes in https://github.com/dotnet/docker-tools/pull/941, this is now causing an exception.

In reality, having the duplicate test legs names was not causing any tests from being excluded. We were still testing everything that should have been tested before. That's because the `--path` parameters of the test leg, which are different between the two test legs, aren't actually used by the test code; it's driven off the contents of the image info file that is passed as input. However, we still want to address the issue of duplicate leg names to ensure correctness.

I've fixed this by setting the `testMatrixCustomBuildLegGroupArgs` pipeline parameter so that `test-dependencies` is included.

