### PR TITLE
Add major-only version tags for .NET Monitor

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -55,8 +55,8 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-7.0.0-alpha.1-alpine-amd64, 7.0-alpine-amd64, 7.0.0-alpha.1-alpine, 7.0-alpine, 7.0.0-alpha.1, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.15
-6.1.0-alpha.1-alpine-amd64, 6.1-alpine-amd64, 6.1.0-alpha.1-alpine, 6.1-alpine, 6.1.0-alpha.1, 6.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.15
+7.0.0-alpha.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-alpha.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-alpha.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.15
+6.1.0-alpha.1-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.0-alpha.1-alpine, 6.1-alpine, 6-alpine, 6.1.0-alpha.1, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.15
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/manifest.json
+++ b/manifest.json
@@ -6007,8 +6007,10 @@
           "sharedTags": {
             "$(monitor|6.1|product-version)-alpine": {},
             "6.1-alpine": {},
+            "6-alpine": {},
             "$(monitor|6.1|product-version)": {},
-            "6.1": {}
+            "6.1": {},
+            "6": {}
           },
           "platforms": [
             {
@@ -6022,7 +6024,8 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "$(monitor|6.1|product-version)-alpine-amd64": {},
-                "6.1-alpine-amd64": {}
+                "6.1-alpine-amd64": {},
+                "6-alpine-amd64": {}
               }
             }
           ]
@@ -6032,8 +6035,10 @@
           "sharedTags": {
             "$(monitor|7.0|product-version)-alpine": {},
             "7.0-alpine": {},
+            "7-alpine": {},
             "$(monitor|7.0|product-version)": {},
             "7.0": {},
+            "7": {},
             "latest": {}
           },
           "platforms": [
@@ -6048,7 +6053,8 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "$(monitor|7.0|product-version)-alpine-amd64": {},
-                "7.0-alpine-amd64": {}
+                "7.0-alpine-amd64": {},
+                "7-alpine-amd64": {}
               }
             }
           ]


### PR DESCRIPTION
.NET Monitor now has multiple versions for 6.x images. It would be useful to add major-only version tags to allows customers to pull the latest 6.x image. All 6.x images are backward compatible with lower minor versions.

I've applied the same for the 7.x image line so that customers can use the 7 major tags from the beginning of the 7.x development.

cc @dotnet/dotnet-monitor