### PR TITLE
Fix Dockerfile inconsistencies

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux
@@ -27,7 +27,7 @@
 {{InsertTemplate("Dockerfile.env-vars")}}
 }}
 # Install ASP.NET Core
-{{InsertTemplate("Dockerfile.linux.install-aspnet")}}^else:
+{{InsertTemplate("Dockerfile.linux.install-aspnet", ["use-local-version-var": dotnetVersion = "3.1"])}}^else:
 {{
 
     _ MULTI STAGE
@@ -40,7 +40,7 @@ RUN tdnf install -y ca-certificates-microsoft \
     && tdnf clean all
 }}
 # Retrieve ASP.NET Core
-{{InsertTemplate("Dockerfile.linux.install-aspnet")}}
+{{InsertTemplate("Dockerfile.linux.install-aspnet", ["use-local-version-var": "true"])}}
 
 
 # ASP.NET Core image

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
@@ -7,12 +7,8 @@
     set varPlatform to when(isAlpine, "linux-musl", when(isFullMariner, "linux-rpm", "linux")) ^
     set fileExt to when(isFullMariner, "rpm", "tar.gz") ^
     set tarballDestDir to when(isAlpine || dotnetVersion = "3.1", "/usr/share/dotnet", when(isDistroless, "/dotnet", "")) ^
-    set useLocalVersionVar to (dotnetVersion = "3.1" || isDistroless) ^
-    set aspnetVersion to when(useLocalVersionVar,
-        "$aspnetcore_version",
-        when(isAlpine || isFullMariner,
-            "$ASPNET_VERSION",
-            VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")])) ^
+    set useLocalVersionVar to (dotnetVersion = "3.1" || !isAlpine || isDistroless) ^
+    set aspnetVersion to when(useLocalVersionVar, "$aspnetcore_version", "$ASPNET_VERSION") ^
     set url to cat(
         VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])],
         "/aspnetcore/Runtime/", aspnetVersion, "/aspnetcore-runtime-", aspnetVersion, filePlatform, "-", ARCH_SHORT, ".", fileExt)

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
@@ -1,4 +1,8 @@
 {{
+    _ ARGS:
+        - use-local-version-var (optional): Whether to define a local variable for the ASP.NET Core runtime version
+            instead of referencing the environment variable. ^
+
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isFullMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
     set isDistroless to find(OS_VERSION, "-distroless") >= 0 ^
@@ -7,12 +11,11 @@
     set varPlatform to when(isAlpine, "linux-musl", when(isFullMariner, "linux-rpm", "linux")) ^
     set fileExt to when(isFullMariner, "rpm", "tar.gz") ^
     set tarballDestDir to when(isAlpine || dotnetVersion = "3.1", "/usr/share/dotnet", when(isDistroless, "/dotnet", "")) ^
-    set useLocalVersionVar to (dotnetVersion = "3.1" || !isAlpine || isDistroless) ^
-    set aspnetVersion to when(useLocalVersionVar, "$aspnetcore_version", "$ASPNET_VERSION") ^
+    set aspnetVersion to when(ARGS["use-local-version-var"], "$aspnetcore_version", "$ASPNET_VERSION") ^
     set url to cat(
         VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])],
         "/aspnetcore/Runtime/", aspnetVersion, "/aspnetcore-runtime-", aspnetVersion, filePlatform, "-", ARCH_SHORT, ".", fileExt)
-}}RUN {{if useLocalVersionVar:aspnetcore_version={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}} \
+}}RUN {{if ARGS["use-local-version-var"]:aspnetcore_version={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}} \
     && }}{{InsertTemplate("../Dockerfile.linux.download-file", ["out-file": cat("aspnetcore.", fileExt), "url": url])}} \
     && aspnetcore_sha512='{{VARIABLES[join(["aspnet", dotnetVersion, varPlatform, ARCH_SHORT, "sha"], "|")]}}' \
     && echo "$aspnetcore_sha512  aspnetcore.{{fileExt}}" | sha512sum -c - \{{if isDistroless:

--- a/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
@@ -22,5 +22,5 @@ RUN powershell -Command `
         }; `
         `
         {{if isNanoServer:mkdir {{dotnetDir}}/shared/Microsoft.AspNetCore.App; `
-        }}tar -C {{dotnetDir}} -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        }}tar -oxzf aspnetcore.zip -C {{dotnetDir}} ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
@@ -1,5 +1,6 @@
 {{
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set isServerCore to find(OS_VERSION, "windowsservercore") >= 0 ^
     set isNanoServer to find(OS_VERSION, "nanoserver") >= 0 ^
     set dotnetDir to when(isServerCore, "$Env:ProgramFiles\dotnet", "dotnet") ^
     set useLocalVersionVar to (dotnetVersion = "3.1" || isNanoServer) ^

--- a/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
@@ -1,12 +1,9 @@
 {{
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
-    set isServerCore to find(OS_VERSION, "windowsservercore") >= 0 ^
+    set isNanoServer to find(OS_VERSION, "nanoserver") >= 0 ^
     set dotnetDir to when(isServerCore, "$Env:ProgramFiles\dotnet", "dotnet") ^
-    set aspnetVersion to when(dotnetVersion = "3.1",
-        "$aspnetcore_version",
-        when(isServerCore,
-            "$Env:ASPNET_VERSION",
-            VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")])) ^
+    set useLocalVersionVar to (dotnetVersion = "3.1" || isNanoServer) ^
+    set aspnetVersion to when(useLocalVersionVar, "$aspnetcore_version", "$Env:ASPNET_VERSION") ^
     set url to cat(
         VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])],
         "/aspnetcore/Runtime/", aspnetVersion, "/aspnetcore-runtime-", aspnetVersion, "-win-x64.zip")
@@ -15,7 +12,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        {{if eq(dotnetVersion "3.1"):$aspnetcore_version = '{{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}}'; `
+        {{if useLocalVersionVar:$aspnetcore_version = '{{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}}'; `
         }}Invoke-WebRequest -OutFile aspnetcore.zip {{url}}; `
         $aspnetcore_sha512 = '{{VARIABLES[cat("aspnet|", dotnetVersion, "|win|x64|sha")]}}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
@@ -23,6 +20,6 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        {{if not(isServerCore):mkdir {{dotnetDir}}/shared/Microsoft.AspNetCore.App; `
+        {{if isNanoServer:mkdir {{dotnetDir}}/shared/Microsoft.AspNetCore.App; `
         }}tar -C {{dotnetDir}} -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.alpine
@@ -4,12 +4,12 @@ FROM $REPO:{{VARIABLES["dotnet|3.1|product-version"]}}-{{OS_VERSION}}{{if ARCH_V
 # .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version={{VARIABLES["runtime|3.1|build-version"]}} \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|3.1|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.linux
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version={{VARIABLES["runtime|3.1|build-version"]}} \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|3.1|linux|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.mariner
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:{{VARIABLES["dotnet|3.1|product-version"]}}-{{OS_VERSION}}{{if ARCH_VERSIONED != "amd64":{{ARCH_TAG_SUFFIX}}}}
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version={{VARIABLES["runtime|3.1|build-version"]}} \
     && curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-host-$dotnet_version-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime-host|3.1|linux-rpm|", ARCH_SHORT, "|sha")]}}' \

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf -C dotnet dotnet.zip; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf -C dotnet dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='{{VARIABLES[cat("runtime|5.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -4,7 +4,9 @@ FROM $REPO:{{VARIABLES["dotnet|5.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.alpine
@@ -4,9 +4,8 @@ FROM $REPO:{{VARIABLES["dotnet|5.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -16,7 +16,9 @@ RUN dotnet_version={{VARIABLES["runtime|5.0|build-version"]}} \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|5.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -16,9 +16,8 @@ RUN dotnet_version={{VARIABLES["runtime|5.0|build-version"]}} \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|5.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM {{ARCH_VERSIONED}}/buildpack-deps:{{OS_VERSION_BASE}}-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/{{VARIABLES["runtime|5.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|5.0|build-version"]}}-linux-{{ARCH_SHORT}}.tar.gz \
+RUN dotnet_version={{VARIABLES["runtime|5.0|build-version"]}} \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|5.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.mariner
@@ -1,9 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:{{VARIABLES["dotnet|5.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.mariner
@@ -1,7 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:{{VARIABLES["dotnet|5.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|5.0|build-version"]}}
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/{{VARIABLES["runtime|5.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|5.0|build-version"]}}-win-x64.zip; `
+        $dotnet_version = '{{VARIABLES["runtime|5.0|build-version"]}}'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '{{VARIABLES["runtime|5.0|win|x64|sha"]}}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.windowsservercore
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='{{VARIABLES[cat("runtime|6.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
@@ -4,7 +4,9 @@ FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.alpine
@@ -4,9 +4,8 @@ FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
@@ -16,9 +16,8 @@ RUN dotnet_version={{VARIABLES["runtime|6.0|build-version"]}} \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
@@ -16,7 +16,9 @@ RUN dotnet_version={{VARIABLES["runtime|6.0|build-version"]}} \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM {{ARCH_VERSIONED}}/buildpack-deps:{{OS_VERSION_BASE}}-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/{{VARIABLES["runtime|6.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|6.0|build-version"]}}-linux-{{ARCH_SHORT}}.tar.gz \
+RUN dotnet_version={{VARIABLES["runtime|6.0|build-version"]}} \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|6.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner
@@ -1,7 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner
@@ -1,9 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
@@ -12,7 +12,7 @@ RUN dotnet_version='{{VARIABLES["runtime|6.0|build-version"]}}' \
     && dotnet_sha512='{{VARIABLES[cat("runtime|6.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz
 
 RUN mkdir /dotnet-symlink \

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
@@ -22,7 +22,9 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
@@ -22,9 +22,8 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|6.0|build-version"]}}
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.nanoserver
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/{{VARIABLES["runtime|6.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|6.0|build-version"]}}-win-x64.zip; `
+        $dotnet_version = '{{VARIABLES["runtime|6.0|build-version"]}}'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '{{VARIABLES["runtime|6.0|win|x64|sha"]}}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.windowsservercore
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.alpine
@@ -4,7 +4,9 @@ FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.alpine
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]
     && dotnet_sha512='{{VARIABLES[cat("runtime|7.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.alpine
@@ -4,9 +4,8 @@ FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-{{ARCH_SHORT}}.tar.gz \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
@@ -16,7 +16,9 @@ RUN dotnet_version={{VARIABLES["runtime|7.0|build-version"]}} \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
@@ -16,9 +16,8 @@ RUN dotnet_version={{VARIABLES["runtime|7.0|build-version"]}} \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM {{ARCH_VERSIONED}}/buildpack-deps:{{OS_VERSION_BASE}}-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/{{VARIABLES["runtime|7.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|7.0|build-version"]}}-linux-{{ARCH_SHORT}}.tar.gz \
+RUN dotnet_version={{VARIABLES["runtime|7.0|build-version"]}} \
+    && curl -fSL --output dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner
@@ -1,7 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner
@@ -1,9 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
@@ -22,7 +22,9 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
@@ -12,7 +12,7 @@ RUN dotnet_version='{{VARIABLES["runtime|7.0|build-version"]}}' \
     && dotnet_sha512='{{VARIABLES[cat("runtime|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz
 
 RUN mkdir /dotnet-symlink \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
@@ -22,9 +22,8 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
+# .NET Runtime version
+ENV DOTNET_VERSION={{VARIABLES["runtime|7.0|build-version"]}}
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.nanoserver
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/{{VARIABLES["runtime|7.0|build-version"]}}/dotnet-runtime-{{VARIABLES["runtime|7.0|build-version"]}}-win-x64.zip; `
+        $dotnet_version = '{{VARIABLES["runtime|7.0|build-version"]}}'; `
+        Invoke-WebRequest -OutFile dotnet.zip {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '{{VARIABLES["runtime|7.0|win|x64|sha"]}}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.windowsservercore
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/eng/dockerfile-templates/sdk/3.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/3.1/Dockerfile.alpine
@@ -26,7 +26,7 @@ RUN dotnet_sdk_version={{VARIABLES["sdk|3.1|build-version"]}} \
     && dotnet_sha512='{{VARIABLES["sdk|3.1|linux-musl|x64|sha"]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -oxzf dotnet.zip -C dotnet ; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "    ")}} `

--- a/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/3.1/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet ; `
     Remove-Item -Force dotnet.zip; `
     `
     {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "    ")}} `

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.alpine
@@ -27,7 +27,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='{{VARIABLES["sdk|5.0|linux-musl|x64|sha"]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.linux
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='{{VARIABLES[cat("sdk|5.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "    ")}} `

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.nanoserver
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/{{VARIABLES["sdk|5.0|build-version"]}}/dotnet-sdk-{{VARIABLES["sdk|5.0|build-version"]}}-win-x64.zip; `
+    $sdk_version = '{{VARIABLES["sdk|5.0|build-version"]}}'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '{{VARIABLES["sdk|5.0|win|x64|sha"]}}'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/sdk/5.0/Dockerfile.windowsservercore
@@ -28,7 +28,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "        ")}}"

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.alpine
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='{{VARIABLES[cat("sdk|6.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help{{if ARCH_VERSIONED = "amd64":

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.linux
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='{{VARIABLES[cat("sdk|6.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "    ")}} `

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.nanoserver
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/{{VARIABLES["sdk|6.0|build-version"]}}/dotnet-sdk-{{VARIABLES["sdk|6.0|build-version"]}}-win-x64.zip; `
+    $sdk_version = '{{VARIABLES["sdk|6.0|build-version"]}}'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '{{VARIABLES["sdk|6.0|win|x64|sha"]}}'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/eng/dockerfile-templates/sdk/6.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/sdk/6.0/Dockerfile.windowsservercore
@@ -32,7 +32,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "        ")}}"

--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.alpine
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]
     && dotnet_sha512='{{VARIABLES[cat("sdk|7.0|linux-musl|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help{{if ARCH_VERSIONED = "amd64":

--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.linux
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES[
     && dotnet_sha512='{{VARIABLES[cat("sdk|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.nanoserver
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "    ")}} `

--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.nanoserver
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.nanoserver
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Sdk/{{VARIABLES["sdk|7.0|build-version"]}}/dotnet-sdk-{{VARIABLES["sdk|7.0|build-version"]}}-win-x64.zip; `
+    $sdk_version = '{{VARIABLES["sdk|7.0|build-version"]}}'; `
+    Invoke-WebRequest -OutFile dotnet.zip {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '{{VARIABLES["sdk|7.0|win|x64|sha"]}}'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.windowsservercore
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.windowsservercore
@@ -32,7 +32,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         {{InsertTemplate("../Dockerfile.windows.install-powershell", [], "        ")}}"

--- a/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/3.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-20H2/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/3.1/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/3.1/nanoserver-ltsc2022/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-x64.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='d3014d473b3bef0a9645908c768f1c458c53ebfd3ed6f2fd259b2921a6d7401f3c0403e99c0d80a6457ecc229dcf828a4031e17868538d831ae1394bb8aa0ad4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-arm.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='4b92e7a686c852149e228c777f899d2426d81691b2cbc0a2a8708b9c8ab5b504dd544c1c291c848339c7c59d139d9e91e8914059326b0e84e662bcf32d3fb472' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-arm64.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='757ccf8a453d8cc9075a438d02bf95bb6d3738651100de8d4ae842a97dc10d8d7507597ec9d2806a3140d8000faec602748b4585b0a644816c74ebbf7ab98719' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:buster-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-x64.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='d3014d473b3bef0a9645908c768f1c458c53ebfd3ed6f2fd259b2921a6d7401f3c0403e99c0d80a6457ecc229dcf828a4031e17868538d831ae1394bb8aa0ad4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:buster-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-arm.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='4b92e7a686c852149e228c777f899d2426d81691b2cbc0a2a8708b9c8ab5b504dd544c1c291c848339c7c59d139d9e91e8914059326b0e84e662bcf32d3fb472' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:buster-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-arm64.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='757ccf8a453d8cc9075a438d02bf95bb6d3738651100de8d4ae842a97dc10d8d7507597ec9d2806a3140d8000faec602748b4585b0a644816c74ebbf7ab98719' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/5.0/cbl-mariner1.0/amd64/Dockerfile
@@ -4,8 +4,7 @@ FROM $REPO:5.0.13-cbl-mariner1.0-amd64
 ENV ASPNET_VERSION=5.0.13
 
 # Install ASP.NET Core
-RUN aspnetcore_version=5.0.13 \
-    && curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-x64.rpm \
+RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
     && aspnetcore_sha512='1b5e9a990459ec69341171021e8cbf20e875a5d6b98204bdd6baf96e956ff3dfe350269eb9086734dd07465372d56dadb779c0e2db4566d67345084f5572c899' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/src/aspnet/5.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/5.0/cbl-mariner1.0/amd64/Dockerfile
@@ -4,7 +4,8 @@ FROM $REPO:5.0.13-cbl-mariner1.0-amd64
 ENV ASPNET_VERSION=5.0.13
 
 # Install ASP.NET Core
-RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-x64.rpm \
     && aspnetcore_sha512='1b5e9a990459ec69341171021e8cbf20e875a5d6b98204bdd6baf96e956ff3dfe350269eb9086734dd07465372d56dadb779c0e2db4566d67345084f5572c899' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/src/aspnet/5.0/focal/amd64/Dockerfile
+++ b/src/aspnet/5.0/focal/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-x64.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='d3014d473b3bef0a9645908c768f1c458c53ebfd3ed6f2fd259b2921a6d7401f3c0403e99c0d80a6457ecc229dcf828a4031e17868538d831ae1394bb8aa0ad4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-arm.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='4b92e7a686c852149e228c777f899d2426d81691b2cbc0a2a8708b9c8ab5b504dd544c1c291c848339c7c59d139d9e91e8914059326b0e84e662bcf32d3fb472' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-linux-arm64.tar.gz \
+RUN aspnetcore_version=5.0.13 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='757ccf8a453d8cc9075a438d02bf95bb6d3738651100de8d4ae842a97dc10d8d7507597ec9d2806a3140d8000faec602748b4585b0a644816c74ebbf7ab98719' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-win-x64.zip; `
+        $aspnetcore_version = '5.0.13'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = '480baa6a03e1b6a2d25afdd8da9cb0387a9be91a0d7c4ddda6cd7725a6d5805dcb35b65cd872871140da3442efae1ae53a0bf7b39c133049082ee6a3dffe627d'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-win-x64.zip; `
+        $aspnetcore_version = '5.0.13'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = '480baa6a03e1b6a2d25afdd8da9cb0387a9be91a0d7c4ddda6cd7725a6d5805dcb35b65cd872871140da3442efae1ae53a0bf7b39c133049082ee6a3dffe627d'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/5.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/5.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/5.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/5.0.13/aspnetcore-runtime-5.0.13-win-x64.zip; `
+        $aspnetcore_version = '5.0.13'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = '480baa6a03e1b6a2d25afdd8da9cb0387a9be91a0d7c4ddda6cd7725a6d5805dcb35b65cd872871140da3442efae1ae53a0bf7b39c133049082ee6a3dffe627d'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -17,5 +17,5 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C $Env:ProgramFiles\dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/src/aspnet/5.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/5.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -17,5 +17,5 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C $Env:ProgramFiles\dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-linux-x64.tar.gz \
+RUN aspnetcore_version=6.0.1 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='9e42c4ac282d3ed099203b9a8a06b4f1baf1267b4d51c9d505ca7127930534b60d4e94022036719133b30c1b503f66d7d4571bc24059d735e510f5e455ec6c51' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-linux-arm.tar.gz \
+RUN aspnetcore_version=6.0.1 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='e1d9f0b2357ba637ee33bc8f8428b9ff0b3656ac28d1f7727693444191cc8a0a078c2e864547d58668cf3767f0b6df5b804e2743b6fb0906106d2877cdb687dc' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-linux-arm64.tar.gz \
+RUN aspnetcore_version=6.0.1 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='c1cab4bc800bd507ca6046ed1af900a7f1a7d28fa564615b8b93803139affc7f5fe6824c2b161ce635047862d644d724181424b44281b30a77f7159d6769c83c' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -8,8 +8,7 @@ ENV \
     Logging__Console__FormatterName=Json
 
 # Install ASP.NET Core
-RUN aspnetcore_version=6.0.1 \
-    && curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-x64.rpm \
+RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
     && aspnetcore_sha512='1c9e5bb3e578af73b8eda17dbb8e098cead7c9e3e8adbb7582c51fa98746856e8ffd4889ca3b5e7f9fe6337e6ca1a1f783bfced401848653b4dbfa142ad815b5' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -8,7 +8,8 @@ ENV \
     Logging__Console__FormatterName=Json
 
 # Install ASP.NET Core
-RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
+RUN aspnetcore_version=6.0.1 \
+    && curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-x64.rpm \
     && aspnetcore_sha512='1c9e5bb3e578af73b8eda17dbb8e098cead7c9e3e8adbb7582c51fa98746856e8ffd4889ca3b5e7f9fe6337e6ca1a1f783bfced401848653b4dbfa142ad815b5' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/src/aspnet/6.0/focal/amd64/Dockerfile
+++ b/src/aspnet/6.0/focal/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-linux-x64.tar.gz \
+RUN aspnetcore_version=6.0.1 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='9e42c4ac282d3ed099203b9a8a06b4f1baf1267b4d51c9d505ca7127930534b60d4e94022036719133b30c1b503f66d7d4571bc24059d735e510f5e455ec6c51' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/6.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-linux-arm.tar.gz \
+RUN aspnetcore_version=6.0.1 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='e1d9f0b2357ba637ee33bc8f8428b9ff0b3656ac28d1f7727693444191cc8a0a078c2e864547d58668cf3767f0b6df5b804e2743b6fb0906106d2877cdb687dc' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/6.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-linux-arm64.tar.gz \
+RUN aspnetcore_version=6.0.1 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='c1cab4bc800bd507ca6046ed1af900a7f1a7d28fa564615b8b93803139affc7f5fe6824c2b161ce635047862d644d724181424b44281b30a77f7159d6769c83c' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-win-x64.zip; `
+        $aspnetcore_version = '6.0.1'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = 'a5c5e6b7249101bb3cf309255ee0c33e509783406e64bd3c132afffc7895061a83c4760a1c15297ba0153beca53196b28f81eacb4552481f53d5d7c21b21a30b'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-win-x64.zip; `
+        $aspnetcore_version = '6.0.1'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = 'a5c5e6b7249101bb3cf309255ee0c33e509783406e64bd3c132afffc7895061a83c4760a1c15297ba0153beca53196b28f81eacb4552481f53d5d7c21b21a30b'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.1/aspnetcore-runtime-6.0.1-win-x64.zip; `
+        $aspnetcore_version = '6.0.1'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = 'a5c5e6b7249101bb3cf309255ee0c33e509783406e64bd3c132afffc7895061a83c4760a1c15297ba0153beca53196b28f81eacb4552481f53d5d7c21b21a30b'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -21,5 +21,5 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C $Env:ProgramFiles\dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/src/aspnet/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -21,5 +21,5 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C $Env:ProgramFiles\dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-linux-x64.tar.gz \
+RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='2eba23aa5ec34f1891d52fadfabfd07e59678fdf01fdfa88e17d16da9468314eebf32e4235ddb182431b218d1feda241ce409012eadd55890d1b16515be660db' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-linux-arm.tar.gz \
+RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='dc6b68fa15dc4be7b4cc0e064ec2f9f4001a0282feea06e8ee32a2a4d787c14cc049d35a519a8488aac6284d1a9d1d69c6e2263790b213c22bfe7f956989d5d9' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-linux-arm64.tar.gz \
+RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='3e1b86ab10baa9902c20575dcc06a59c672f264177b9d24de2af1d6ff0b29734951bd460b2d0fb149f29d77bf43feff27c50401773b7dc6f0b40b0894e8b7f26' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -8,8 +8,7 @@ ENV \
     Logging__Console__FormatterName=Json
 
 # Install ASP.NET Core
-RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
-    && curl -fSL --output aspnetcore.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-x64.rpm \
+RUN curl -fSL --output aspnetcore.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
     && aspnetcore_sha512='21f50c95baad94eca71aaaa15309054813834add8ae4f091d3a7cae307fe4f1b42db0486be19d46771a6497bd0a59f339eb9cf621edea01996fcbc7fd12996e6' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/src/aspnet/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -8,7 +8,8 @@ ENV \
     Logging__Console__FormatterName=Json
 
 # Install ASP.NET Core
-RUN curl -fSL --output aspnetcore.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
+RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
+    && curl -fSL --output aspnetcore.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-x64.rpm \
     && aspnetcore_sha512='21f50c95baad94eca71aaaa15309054813834add8ae4f091d3a7cae307fe4f1b42db0486be19d46771a6497bd0a59f339eb9cf621edea01996fcbc7fd12996e6' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
     && rpm --install aspnetcore.rpm \

--- a/src/aspnet/7.0/focal/amd64/Dockerfile
+++ b/src/aspnet/7.0/focal/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM amd64/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-linux-x64.tar.gz \
+RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='2eba23aa5ec34f1891d52fadfabfd07e59678fdf01fdfa88e17d16da9468314eebf32e4235ddb182431b218d1feda241ce409012eadd55890d1b16515be660db' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/7.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm32v7/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-linux-arm.tar.gz \
+RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='dc6b68fa15dc4be7b4cc0e064ec2f9f4001a0282feea06e8ee32a2a4d787c14cc049d35a519a8488aac6284d1a9d1d69c6e2263790b213c22bfe7f956989d5d9' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM arm64v8/buildpack-deps:focal-curl AS installer
 
 # Retrieve ASP.NET Core
-RUN curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-linux-arm64.tar.gz \
+RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='3e1b86ab10baa9902c20575dcc06a59c672f264177b9d24de2af1d6ff0b29734951bd460b2d0fb149f29d77bf43feff27c50401773b7dc6f0b40b0894e8b7f26' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \

--- a/src/aspnet/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/7.0/nanoserver-1809/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/7.0/nanoserver-1809/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-win-x64.zip; `
+        $aspnetcore_version = '7.0.0-alpha.1.22067.2'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = '72d5a173bd9afc39cda44af78a51436b9e9a387e9bbfbbe8460ff0f92c8ad0fb9aeb7efd02a0502a6b921704c4548e96d21935eb8b3dc87cab45208399281db5'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet/shared/Microsoft.AspNetCore.App; `
-        tar -C dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip
 
 

--- a/src/aspnet/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -10,7 +10,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-alpha.1.22067.2/aspnetcore-runtime-7.0.0-alpha.1.22067.2-win-x64.zip; `
+        $aspnetcore_version = '7.0.0-alpha.1.22067.2'; `
+        Invoke-WebRequest -OutFile aspnetcore.zip https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip; `
         $aspnetcore_sha512 = '72d5a173bd9afc39cda44af78a51436b9e9a387e9bbfbbe8460ff0f92c8ad0fb9aeb7efd02a0502a6b921704c4548e96d21935eb8b3dc87cab45208399281db5'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -21,5 +21,5 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C $Env:ProgramFiles\dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/src/aspnet/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -21,5 +21,5 @@ RUN powershell -Command `
             exit 1; `
         }; `
         `
-        tar -C $Env:ProgramFiles\dotnet -oxzf aspnetcore.zip ./shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C $Env:ProgramFiles\dotnet ./shared/Microsoft.AspNetCore.App; `
         Remove-Item -Force aspnetcore.zip

--- a/src/runtime/3.1/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/3.1/alpine3.14/amd64/Dockerfile
@@ -4,12 +4,12 @@ FROM $REPO:3.1.22-alpine3.14
 # .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
     && dotnet_sha512='708d17a4f3fc0bb866343f359e88543c99c70511d1d90fa3c889ce126bd2625f2ce3118552dbea52b3410b70586ad5f551453de41c6cb88ec77e131854979955' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/3.1/alpine3.14/arm64v8/Dockerfile
@@ -4,12 +4,12 @@ FROM $REPO:3.1.22-alpine3.14-arm64v8
 # .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
     && dotnet_sha512='3145597fe5fb4d8d08839e744a2c517591a03c6d287c02390a65eb99d4559a9ee593568a09044fe1d583f44f4a398cf0c309b7f6c5bea0d6ed5d63c57bdae650' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/3.1/alpine3.15/amd64/Dockerfile
@@ -4,12 +4,12 @@ FROM $REPO:3.1.22-alpine3.15
 # .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
     && dotnet_sha512='708d17a4f3fc0bb866343f359e88543c99c70511d1d90fa3c889ce126bd2625f2ce3118552dbea52b3410b70586ad5f551453de41c6cb88ec77e131854979955' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/3.1/alpine3.15/arm64v8/Dockerfile
@@ -4,12 +4,12 @@ FROM $REPO:3.1.22-alpine3.15-arm64v8
 # .NET Core globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
     && dotnet_sha512='3145597fe5fb4d8d08839e744a2c517591a03c6d287c02390a65eb99d4559a9ee593568a09044fe1d583f44f4a398cf0c309b7f6c5bea0d6ed5d63c57bdae650' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/bionic/amd64/Dockerfile
+++ b/src/runtime/3.1/bionic/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \

--- a/src/runtime/3.1/bionic/arm32v7/Dockerfile
+++ b/src/runtime/3.1/bionic/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \

--- a/src/runtime/3.1/bionic/arm64v8/Dockerfile
+++ b/src/runtime/3.1/bionic/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \

--- a/src/runtime/3.1/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/3.1/bullseye-slim/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \

--- a/src/runtime/3.1/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/3.1/bullseye-slim/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \

--- a/src/runtime/3.1/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/3.1/bullseye-slim/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \

--- a/src/runtime/3.1/buster-slim/amd64/Dockerfile
+++ b/src/runtime/3.1/buster-slim/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \

--- a/src/runtime/3.1/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/3.1/buster-slim/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \

--- a/src/runtime/3.1/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/3.1/buster-slim/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \

--- a/src/runtime/3.1/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/3.1/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:3.1.22-cbl-mariner1.0
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-host-$dotnet_version-x64.rpm \
     && dotnet_sha512='752fae0cb7f8f0c117c544de86560873c5250995dd897153cb9c01b9bfbf64bf84ec0fb0833dcabea5cdd6ffa295e7d1eb7ff3dcaf8e6148e3baddfff5c575ee' \

--- a/src/runtime/3.1/focal/amd64/Dockerfile
+++ b/src/runtime/3.1/focal/amd64/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \

--- a/src/runtime/3.1/focal/arm32v7/Dockerfile
+++ b/src/runtime/3.1/focal/arm32v7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \

--- a/src/runtime/3.1/focal/arm64v8/Dockerfile
+++ b/src/runtime/3.1/focal/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
+# Install .NET Core Runtime
 RUN dotnet_version=3.1.22 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \

--- a/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf -C dotnet dotnet.zip; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf -C dotnet dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf -C dotnet dotnet.zip; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf -C dotnet dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf -C dotnet dotnet.zip; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/3.1/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/3.1/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf -C dotnet dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/amd64/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:5.0.13-alpine3.14-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/5.0/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/amd64/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='86132e578da8f4a964ce10e9cf63e3acc982bdd3822d89225a938b915c441992e023803547f8bb852c70ea61b7a76e65733f64ae3e171bdd290d73f2705a0b71' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/5.0/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/amd64/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:5.0.13-alpine3.14-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/5.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/arm32v7/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:5.0.13-alpine3.14-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/5.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/arm32v7/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:5.0.13-alpine3.14-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/5.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/arm32v7/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='1cd50bb756d17251f277005e3824cab36b3b6c3c5e62383fc05fbca4d0e346cd9ec7e93a528f413f47a11dc5c64a6d0689bc99fc1a25377fa79875023c93d03d' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/5.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/arm64v8/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:5.0.13-alpine3.14-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/5.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/arm64v8/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='bc44e529db137a4df4f244de92bf6ff773be24ef1611a2648ed9119784fd77a202f64be21a269ddb2521c54797c217211271620fb7bf0ab62b51715ca1342371' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/5.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.14/arm64v8/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:5.0.13-alpine3.14-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/5.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/amd64/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:5.0.13-alpine3.15-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/5.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/amd64/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='86132e578da8f4a964ce10e9cf63e3acc982bdd3822d89225a938b915c441992e023803547f8bb852c70ea61b7a76e65733f64ae3e171bdd290d73f2705a0b71' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/5.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/amd64/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:5.0.13-alpine3.15-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/5.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/arm32v7/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:5.0.13-alpine3.15-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/5.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/arm32v7/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:5.0.13-alpine3.15-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/5.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/arm32v7/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='1cd50bb756d17251f277005e3824cab36b3b6c3c5e62383fc05fbca4d0e346cd9ec7e93a528f413f47a11dc5c64a6d0689bc99fc1a25377fa79875023c93d03d' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/5.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/arm64v8/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:5.0.13-alpine3.15-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/5.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/arm64v8/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:5.0.13-alpine3.15-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/5.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/5.0/alpine3.15/arm64v8/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='bc44e529db137a4df4f244de92bf6ff773be24ef1611a2648ed9119784fd77a202f64be21a269ddb2521c54797c217211271620fb7bf0ab62b51715ca1342371' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-bullseye-slim-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-bullseye-slim-amd64
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-x64.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='32f574369975606da5e67ca7f8e709e73b67a98fa1a175f49c979f582be658132375663e6ad944a3a89d1186322a7a04cead043cf1d4526fdb7ff195ead6f317' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-arm.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='3d0a10b51e89d5716ab284e499e0927835d7944d7a4c15a9294679a8c4af3ca99f51cad25c0d19fa4a91b8b76a832a9bb81afb67bcdc2385730b061d135644f6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-bullseye-slim-arm32v7
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-bullseye-slim-arm32v7
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-arm64.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='428adbb6cd564b919333cf18b7245784b6a2e93740e31fb85c4344690519eb88038b220621f199ba2524eef0f4d0fd2e17bbea0851de0d0ec7dec4c092311d10' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-bullseye-slim-arm64v8
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-bullseye-slim-arm64v8
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:buster-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-x64.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='32f574369975606da5e67ca7f8e709e73b67a98fa1a175f49c979f582be658132375663e6ad944a3a89d1186322a7a04cead043cf1d4526fdb7ff195ead6f317' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-buster-slim-amd64
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-buster-slim-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-buster-slim-arm32v7
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-buster-slim-arm32v7
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:buster-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-arm.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='3d0a10b51e89d5716ab284e499e0927835d7944d7a4c15a9294679a8c4af3ca99f51cad25c0d19fa4a91b8b76a832a9bb81afb67bcdc2385730b061d135644f6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-buster-slim-arm64v8
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-buster-slim-arm64v8
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:buster-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-arm64.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='428adbb6cd564b919333cf18b7245784b6a2e93740e31fb85c4344690519eb88038b220621f199ba2524eef0f4d0fd2e17bbea0851de0d0ec7dec4c092311d10' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/5.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0.13-cbl-mariner1.0-amd64
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \

--- a/src/runtime/5.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/5.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,9 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:5.0.13-cbl-mariner1.0-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-x64.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='32f574369975606da5e67ca7f8e709e73b67a98fa1a175f49c979f582be658132375663e6ad944a3a89d1186322a7a04cead043cf1d4526fdb7ff195ead6f317' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-focal-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-focal-amd64
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/5.0/focal/arm32v7/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-focal-arm32v7
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/5.0/focal/arm32v7/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-focal-arm32v7
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/5.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-arm.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='3d0a10b51e89d5716ab284e499e0927835d7944d7a4c15a9294679a8c4af3ca99f51cad25c0d19fa4a91b8b76a832a9bb81afb67bcdc2385730b061d135644f6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/5.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-linux-arm64.tar.gz \
+RUN dotnet_version=5.0.13 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='428adbb6cd564b919333cf18b7245784b6a2e93740e31fb85c4344690519eb88038b220621f199ba2524eef0f4d0fd2e17bbea0851de0d0ec7dec4c092311d10' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/5.0/focal/arm64v8/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-focal-arm64v8
 
-ENV DOTNET_VERSION=5.0.13
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/5.0/focal/arm64v8/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=5.0.13 \
 # .NET runtime image
 FROM $REPO:5.0.13-focal-arm64v8
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=5.0.13
+# .NET Runtime version
+ENV DOTNET_VERSION=5.0.13
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-win-x64.zip; `
+        $dotnet_version = '5.0.13'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '53dc994202801aca3b6f23b6489a10803224325ab723ecd47f560296f08e33813474708701115418c8b34239b53868a5a0e87fc3dccf86f4483598de98ea8981'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-win-x64.zip; `
+        $dotnet_version = '5.0.13'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '53dc994202801aca3b6f23b6489a10803224325ab723ecd47f560296f08e33813474708701115418c8b34239b53868a5a0e87fc3dccf86f4483598de98ea8981'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/5.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/5.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/5.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/5.0.13/dotnet-runtime-5.0.13-win-x64.zip; `
+        $dotnet_version = '5.0.13'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '53dc994202801aca3b6f23b6489a10803224325ab723ecd47f560296f08e33813474708701115418c8b34239b53868a5a0e87fc3dccf86f4483598de98ea8981'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/5.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/5.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/amd64/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:6.0.1-alpine3.14-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/amd64/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='bcb328eb00ad53ae2f8ebce8802dda1329de68cbba120311d69a5f235f81ee59316728289f7797f23f657102d50751e3cff641538d4670ac8fd85da1d57feb97' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/amd64/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:6.0.1-alpine3.14-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:6.0.1-alpine3.14-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:6.0.1-alpine3.14-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm32v7/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='97d011df17d97db5ac6f5b5ab541f8a0428bc699a8a04ac92da5cb3865f200031cde07a34430ff492a5a54af41ee4fd4c5628093c2b7a0f4895a8326f4f63d35' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='d18a059cabe2581054d9e9a2ef83c7b11159954726e2bc15e7e6b8f01cb5d7eacd34ca28dd12701286810bb52712129927471933fcd77bc062b7c892e46bca83' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:6.0.1-alpine3.14-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.14/arm64v8/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:6.0.1-alpine3.14-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/amd64/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:6.0.1-alpine3.15-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/amd64/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='bcb328eb00ad53ae2f8ebce8802dda1329de68cbba120311d69a5f235f81ee59316728289f7797f23f657102d50751e3cff641538d4670ac8fd85da1d57feb97' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/amd64/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:6.0.1-alpine3.15-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/arm32v7/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:6.0.1-alpine3.15-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/arm32v7/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:6.0.1-alpine3.15-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/arm32v7/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='97d011df17d97db5ac6f5b5ab541f8a0428bc699a8a04ac92da5cb3865f200031cde07a34430ff492a5a54af41ee4fd4c5628093c2b7a0f4895a8326f4f63d35' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/arm64v8/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET
     && dotnet_sha512='d18a059cabe2581054d9e9a2ef83c7b11159954726e2bc15e7e6b8f01cb5d7eacd34ca28dd12701286810bb52712129927471933fcd77bc062b7c892e46bca83' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/arm64v8/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:6.0.1-alpine3.15-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.15/arm64v8/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:6.0.1-alpine3.15-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-linux-x64.tar.gz \
+RUN dotnet_version=6.0.1 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='2a316e8cba20778b409b8f2a3810348e2805f35afad8aba77a67c4e6bb2c2091e60bc369df22554bb145a5fad0c50e20b39d350b98a85bd33566034a11230da7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-bullseye-slim-amd64
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-bullseye-slim-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-bullseye-slim-arm32v7
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-bullseye-slim-arm32v7
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-linux-arm.tar.gz \
+RUN dotnet_version=6.0.1 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='a6bea3289279ddfaeda4c46bc2cae82c662e2b2cfa13abefa18baa8db747bd1be9fabdd8c0103310f89d4c9e356235551af5354742117d2cd58abf5727883609' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-linux-arm64.tar.gz \
+RUN dotnet_version=6.0.1 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='10b8775d44088ddc1ae193ce41f456d1bbaad21f2dc993de75c2b076b6ffcb07bca446f52180c9a175715a1e47ad42a4862c43ef11b5cbc1023cb4da3c426146' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-bullseye-slim-arm64v8
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-bullseye-slim-arm64v8
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -22,7 +22,9 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:6.0.1-cbl-mariner1.0-distroless-amd64
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -22,9 +22,8 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:6.0.1-cbl-mariner1.0-distroless-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet_version='6.0.1' \
     && dotnet_sha512='2a316e8cba20778b409b8f2a3810348e2805f35afad8aba77a67c4e6bb2c2091e60bc369df22554bb145a5fad0c50e20b39d350b98a85bd33566034a11230da7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz
 
 RUN mkdir /dotnet-symlink \

--- a/src/runtime/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,9 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0.1-cbl-mariner1.0-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \

--- a/src/runtime/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:6.0.1-cbl-mariner1.0-amd64
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \

--- a/src/runtime/6.0/focal/amd64/Dockerfile
+++ b/src/runtime/6.0/focal/amd64/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-focal-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/amd64/Dockerfile
+++ b/src/runtime/6.0/focal/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-linux-x64.tar.gz \
+RUN dotnet_version=6.0.1 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='2a316e8cba20778b409b8f2a3810348e2805f35afad8aba77a67c4e6bb2c2091e60bc369df22554bb145a5fad0c50e20b39d350b98a85bd33566034a11230da7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/6.0/focal/amd64/Dockerfile
+++ b/src/runtime/6.0/focal/amd64/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-focal-amd64
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/6.0/focal/arm32v7/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-focal-arm32v7
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/6.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-linux-arm.tar.gz \
+RUN dotnet_version=6.0.1 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='a6bea3289279ddfaeda4c46bc2cae82c662e2b2cfa13abefa18baa8db747bd1be9fabdd8c0103310f89d4c9e356235551af5354742117d2cd58abf5727883609' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/6.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/6.0/focal/arm32v7/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-focal-arm32v7
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/6.0/focal/arm64v8/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-focal-arm64v8
 
-ENV DOTNET_VERSION=6.0.1
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/6.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-linux-arm64.tar.gz \
+RUN dotnet_version=6.0.1 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='10b8775d44088ddc1ae193ce41f456d1bbaad21f2dc993de75c2b076b6ffcb07bca446f52180c9a175715a1e47ad42a4862c43ef11b5cbc1023cb4da3c426146' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/6.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/6.0/focal/arm64v8/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=6.0.1 \
 # .NET runtime image
 FROM $REPO:6.0.1-focal-arm64v8
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=6.0.1
+# .NET Runtime version
+ENV DOTNET_VERSION=6.0.1
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-1809/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-win-x64.zip; `
+        $dotnet_version = '6.0.1'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '059ef7dffb1e421a764779f1e75eb804fb61e32a75855964e426d7e0e8d7dd171b26861b8655738bf887efcd17657cde1b6386cf844c55e63d9822527e83411d'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-win-x64.zip; `
+        $dotnet_version = '6.0.1'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '059ef7dffb1e421a764779f1e75eb804fb61e32a75855964e426d7e0e8d7dd171b26861b8655738bf887efcd17657cde1b6386cf844c55e63d9822527e83411d'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/dotnet-runtime-6.0.1-win-x64.zip; `
+        $dotnet_version = '6.0.1'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '059ef7dffb1e421a764779f1e75eb804fb61e32a75855964e426d7e0e8d7dd171b26861b8655738bf887efcd17657cde1b6386cf844c55e63d9822527e83411d'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/7.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/amd64/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:7.0.0-alpha.1-alpine3.15-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/7.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/amd64/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOT
     && dotnet_sha512='4f96754d9e0679ef9968aca754552e5d1873eab6c9330499e2bc2e13a495d96a2f53df3bbde28df5b5fcd9b957bd2b180236e6e288a828e25bd3d6938be159fa' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/7.0/alpine3.15/amd64/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/amd64/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:7.0.0-alpha.1-alpine3.15-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/7.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/arm32v7/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOT
     && dotnet_sha512='19e00b0257efb9ca692fbeaf7fc6c67bd0c5e8d998662144b3f4117132313480c13becface5a91b76a850c112d34ab5ba2b0ff996793a554c65c3a7f18399b31' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/7.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/arm32v7/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:7.0.0-alpha.1-alpine3.15-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/7.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/arm32v7/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:7.0.0-alpha.1-alpine3.15-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/7.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/arm64v8/Dockerfile
@@ -4,7 +4,9 @@ FROM $REPO:7.0.0-alpha.1-alpine3.15-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/7.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/arm64v8/Dockerfile
@@ -13,6 +13,6 @@ RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOT
     && dotnet_sha512='05cf85e5eb37b9b5242b00822f6aab9cc4fe898e64dafe15237514dffaa23f8a344707d2e64af8b323b4e43737ac915c1bbdf0bc9d62dd3ab0546190571292e8' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/7.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime/7.0/alpine3.15/arm64v8/Dockerfile
@@ -4,9 +4,8 @@ FROM $REPO:7.0.0-alpha.1-alpine3.15-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-linux-x64.tar.gz \
+RUN dotnet_version=7.0.0-alpha.1.22066.4 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='54035da58611ad409fa12026aabc3b1eb1ace645e2f4409762968d2197d6d288856425d0433eabc564a69906a08fe9dbab8ce730d5f7d649c9b09ddeb94a2477' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-bullseye-slim-amd64
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-bullseye-slim-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-bullseye-slim-arm32v7
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-bullseye-slim-arm32v7
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-linux-arm.tar.gz \
+RUN dotnet_version=7.0.0-alpha.1.22066.4 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='83198698b68e439c210ae141b278da6140196f6a06a070c259f36bb2d36cecb43c660b83817258c4f7643655e846fff8b9a742d1b4788bb95de965a40bd91d67' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-bullseye-slim-arm64v8
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-bullseye-slim-arm64v8
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:bullseye-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-linux-arm64.tar.gz \
+RUN dotnet_version=7.0.0-alpha.1.22066.4 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='a4ee9743cbe4bc49b18b5630fb8ee383f3cca9ebc954b401af2561f7c79579c0e83686d89b7af60058b46c20f1d3ec3c71fecce23339dbc92171ca82422b2587' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -22,9 +22,8 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-cbl-mariner1.0-distroless-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -22,7 +22,9 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-cbl-mariner1.0-distroless-amd64
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet_version='7.0.0-alpha.1.22066.4' \
     && dotnet_sha512='54035da58611ad409fa12026aabc3b1eb1ace645e2f4409762968d2197d6d288856425d0433eabc564a69906a08fe9dbab8ce730d5f7d649c9b09ddeb94a2477' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz
 
 RUN mkdir /dotnet-symlink \

--- a/src/runtime/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,9 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:7.0.0-alpha.1-cbl-mariner1.0-amd64
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \

--- a/src/runtime/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,9 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:7.0.0-alpha.1-cbl-mariner1.0-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 # Install .NET Runtime
 RUN curl -fSL --output dotnet-host.rpm https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \

--- a/src/runtime/7.0/focal/amd64/Dockerfile
+++ b/src/runtime/7.0/focal/amd64/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-focal-amd64
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/focal/amd64/Dockerfile
+++ b/src/runtime/7.0/focal/amd64/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM amd64/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-linux-x64.tar.gz \
+RUN dotnet_version=7.0.0-alpha.1.22066.4 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='54035da58611ad409fa12026aabc3b1eb1ace645e2f4409762968d2197d6d288856425d0433eabc564a69906a08fe9dbab8ce730d5f7d649c9b09ddeb94a2477' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/focal/amd64/Dockerfile
+++ b/src/runtime/7.0/focal/amd64/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-focal-amd64
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/7.0/focal/arm32v7/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm32v7/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-linux-arm.tar.gz \
+RUN dotnet_version=7.0.0-alpha.1.22066.4 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
     && dotnet_sha512='83198698b68e439c210ae141b278da6140196f6a06a070c259f36bb2d36cecb43c660b83817258c4f7643655e846fff8b9a742d1b4788bb95de965a40bd91d67' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/7.0/focal/arm32v7/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-focal-arm32v7
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/7.0/focal/arm32v7/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-focal-arm32v7
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/7.0/focal/arm64v8/Dockerfile
@@ -4,7 +4,8 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM arm64v8/buildpack-deps:focal-curl AS installer
 
 # Retrieve .NET Runtime
-RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-linux-arm64.tar.gz \
+RUN dotnet_version=7.0.0-alpha.1.22066.4 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
     && dotnet_sha512='a4ee9743cbe4bc49b18b5630fb8ee383f3cca9ebc954b401af2561f7c79579c0e83686d89b7af60058b46c20f1d3ec3c71fecce23339dbc92171ca82422b2587' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/src/runtime/7.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/7.0/focal/arm64v8/Dockerfile
@@ -16,9 +16,8 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-focal-arm64v8
 
-ENV \
-    # .NET Runtime version
-    DOTNET_VERSION=7.0.0-alpha.1.22066.4
+# .NET Runtime version
+ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/7.0/focal/arm64v8/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
 # .NET runtime image
 FROM $REPO:7.0.0-alpha.1-focal-arm64v8
 
-ENV DOTNET_VERSION=7.0.0-alpha.1.22066.4
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=7.0.0-alpha.1.22066.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-win-x64.zip; `
+        $dotnet_version = '7.0.0-alpha.1.22066.4'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '31b94eb1da036e0cd1ccee4d5e4d91ab2f516b5d5aeb70e0239037c99862b76216660a70ce855269d1b38cab2efa5eba7807515b5acc61f31382c92b1ae80596'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -oxzf dotnet.zip -C dotnet ; `
+        tar -oxzf dotnet.zip -C dotnet; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -8,7 +8,8 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.22066.4/dotnet-runtime-7.0.0-alpha.1.22066.4-win-x64.zip; `
+        $dotnet_version = '7.0.0-alpha.1.22066.4'; `
+        Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip; `
         $dotnet_sha512 = '31b94eb1da036e0cd1ccee4d5e4d91ab2f516b5d5aeb70e0239037c99862b76216660a70ce855269d1b38cab2efa5eba7807515b5acc61f31382c92b1ae80596'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir dotnet; `
-        tar -C dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C dotnet ; `
         Remove-Item -Force dotnet.zip
 
 

--- a/src/runtime/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/runtime/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/runtime/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/runtime/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command `
         }; `
         `
         mkdir $Env:ProgramFiles\dotnet; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet; `
         Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/src/sdk/3.1/alpine3.14/amd64/Dockerfile
+++ b/src/sdk/3.1/alpine3.14/amd64/Dockerfile
@@ -26,7 +26,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='252837690f099ee756705559a030715dd19836c8f7b2d0364beb9998fc78596586d045e2a7f23e16143be2dbccf19470eec1818486790bf8d9160c166eeb72dc' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/3.1/alpine3.15/amd64/Dockerfile
+++ b/src/sdk/3.1/alpine3.15/amd64/Dockerfile
@@ -26,7 +26,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='252837690f099ee756705559a030715dd19836c8f7b2d0364beb9998fc78596586d045e2a7f23e16143be2dbccf19470eec1818486790bf8d9160c166eeb72dc' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet ; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -oxzf dotnet.zip -C dotnet ; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet ; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -oxzf dotnet.zip -C dotnet ; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet ; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -oxzf dotnet.zip -C dotnet ; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/alpine3.14/amd64/Dockerfile
+++ b/src/sdk/5.0/alpine3.14/amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='f165e381f9496af0368573db7f4559041c53c0a00cf6c1a9fb104ca62b4f079014c26b2d4787d206ae6594f3969a24f90d90f81c876c8b5ded4122b651d95587' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/alpine3.15/amd64/Dockerfile
+++ b/src/sdk/5.0/alpine3.15/amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='f165e381f9496af0368573db7f4559041c53c0a00cf6c1a9fb104ca62b4f079014c26b2d4787d206ae6594f3969a24f90d90f81c876c8b5ded4122b651d95587' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/5.0/bullseye-slim/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='6f9b83b2b661ce3b033a04d4c50ff3a435efa288de1a48f58be1150e64c5dd9d6bd2a4bf40f697dcd7d64ffaac24f14cc4a874e738544c5d0e8113c474fd2ee0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/5.0/bullseye-slim/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='39e56d5966edfbb8e4e343c3bc97f71e809713f61d12afb0a6901a1dff6e29df8de0288c99246c638bb76582cd9523b529dacd981c37c2365e4d724738950851' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/5.0/bullseye-slim/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='d35abcfacb3da88eed82f9f7a0a9d3f8680d4c85839c8b348c247ddc9b3b99e7a3417d406976e3ac91d8d4bd31e0efb685ebaf4c33bb59586d00cdc731b59893' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/buster-slim/amd64/Dockerfile
+++ b/src/sdk/5.0/buster-slim/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='6f9b83b2b661ce3b033a04d4c50ff3a435efa288de1a48f58be1150e64c5dd9d6bd2a4bf40f697dcd7d64ffaac24f14cc4a874e738544c5d0e8113c474fd2ee0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='39e56d5966edfbb8e4e343c3bc97f71e809713f61d12afb0a6901a1dff6e29df8de0288c99246c638bb76582cd9523b529dacd981c37c2365e4d724738950851' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/sdk/5.0/buster-slim/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='d35abcfacb3da88eed82f9f7a0a9d3f8680d4c85839c8b348c247ddc9b3b99e7a3417d406976e3ac91d8d4bd31e0efb685ebaf4c33bb59586d00cdc731b59893' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/focal/amd64/Dockerfile
+++ b/src/sdk/5.0/focal/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='6f9b83b2b661ce3b033a04d4c50ff3a435efa288de1a48f58be1150e64c5dd9d6bd2a4bf40f697dcd7d64ffaac24f14cc4a874e738544c5d0e8113c474fd2ee0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/5.0/focal/arm32v7/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='39e56d5966edfbb8e4e343c3bc97f71e809713f61d12afb0a6901a1dff6e29df8de0288c99246c638bb76582cd9523b529dacd981c37c2365e4d724738950851' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/5.0/focal/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='d35abcfacb3da88eed82f9f7a0a9d3f8680d4c85839c8b348c247ddc9b3b99e7a3417d406976e3ac91d8d4bd31e0efb685ebaf4c33bb59586d00cdc731b59893' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet  ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.404/dotnet-sdk-5.0.404-win-x64.zip; `
+    $sdk_version = '5.0.404'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = 'a6d254a46e93a41bf41df34c941503cfc5f61af20ffc0abc571bbaf238fd66f0fcc879e7181e1e1af788e96912b31012e817bf1202e55b8f27c17352f3f5528d'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-20H2/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.404/dotnet-sdk-5.0.404-win-x64.zip; `
+    $sdk_version = '5.0.404'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = 'a6d254a46e93a41bf41df34c941503cfc5f61af20ffc0abc571bbaf238fd66f0fcc879e7181e1e1af788e96912b31012e817bf1202e55b8f27c17352f3f5528d'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/5.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/5.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/5.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/5.0.404/dotnet-sdk-5.0.404-win-x64.zip; `
+    $sdk_version = '5.0.404'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = 'a6d254a46e93a41bf41df34c941503cfc5f61af20ffc0abc571bbaf238fd66f0fcc879e7181e1e1af788e96912b31012e817bf1202e55b8f27c17352f3f5528d'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool

--- a/src/sdk/5.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/5.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool

--- a/src/sdk/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='113428f918514d9be657e18ec454281d1f86b7e6a3214b4327379b4ab679dc60569149e943e894a169c0523f9513f3aed02ddc252daef66b67e514d3501f17a5' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='9f6ca3c29ce1ec948b69e1bfa0f40f30451d6e998b59bea8ad96701bb0815800e7f44aa91259805e9294f903e9f6264966e76a9e8918e5593d69a417385e999a' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='4d1ef2a941f7be3c73fddda9a129707e1f71c50a7df99cf67dca2310eb7775e98898fa18e017950df39cee2600a87c8c546b1dbb9bb6c2d0550e56cf5ce9e764' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='113428f918514d9be657e18ec454281d1f86b7e6a3214b4327379b4ab679dc60569149e943e894a169c0523f9513f3aed02ddc252daef66b67e514d3501f17a5' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='9f6ca3c29ce1ec948b69e1bfa0f40f30451d6e998b59bea8ad96701bb0815800e7f44aa91259805e9294f903e9f6264966e76a9e8918e5593d69a417385e999a' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK
     && dotnet_sha512='4d1ef2a941f7be3c73fddda9a129707e1f71c50a7df99cf67dca2310eb7775e98898fa18e017950df39cee2600a87c8c546b1dbb9bb6c2d0550e56cf5ce9e764' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='ca21345400bcaceadad6327345f5364e858059cfcbc1759f05d7df7701fec26f1ead297b6928afa01e46db6f84e50770c673146a10b9ff71e4c7f7bc76fbf709' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='f9e212dc4cccbe665d9aac23da6bdddce4957ae4e4d407cf3f1d6da7e79784ebd408c3a59b3ecc6ceaa930b37cf01a4a91c6b38517970d49227e96e50658cc46' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='04cd89279f412ae6b11170d1724c6ac42bb5d4fae8352020a1f28511086dd6d6af2106dd48ebe3b39d312a21ee8925115de51979687a9161819a3a29e270a954' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/focal/amd64/Dockerfile
+++ b/src/sdk/6.0/focal/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='ca21345400bcaceadad6327345f5364e858059cfcbc1759f05d7df7701fec26f1ead297b6928afa01e46db6f84e50770c673146a10b9ff71e4c7f7bc76fbf709' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/6.0/focal/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='f9e212dc4cccbe665d9aac23da6bdddce4957ae4e4d407cf3f1d6da7e79784ebd408c3a59b3ecc6ceaa930b37cf01a4a91c6b38517970d49227e96e50658cc46' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/6.0/focal/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && dotnet_sha512='04cd89279f412ae6b11170d1724c6ac42bb5d4fae8352020a1f28511086dd6d6af2106dd48ebe3b39d312a21ee8925115de51979687a9161819a3a29e270a954' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.101/dotnet-sdk-6.0.101-win-x64.zip; `
+    $sdk_version = '6.0.101'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '7259dc349861d68878f19ba1f4f72ee47403adda2e8814882c5096a44bfd42e475fc2b9eb16d819bbc61c166e13b9b5b97cfc16a36190faa88eeb6eb61693f12'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.101/dotnet-sdk-6.0.101-win-x64.zip; `
+    $sdk_version = '6.0.101'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '7259dc349861d68878f19ba1f4f72ee47403adda2e8814882c5096a44bfd42e475fc2b9eb16d819bbc61c166e13b9b5b97cfc16a36190faa88eeb6eb61693f12'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.101/dotnet-sdk-6.0.101-win-x64.zip; `
+    $sdk_version = '6.0.101'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '7259dc349861d68878f19ba1f4f72ee47403adda2e8814882c5096a44bfd42e475fc2b9eb16d819bbc61c166e13b9b5b97cfc16a36190faa88eeb6eb61693f12'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool

--- a/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool

--- a/src/sdk/7.0/alpine3.15/amd64/Dockerfile
+++ b/src/sdk/7.0/alpine3.15/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Sdk/$DOTNET_
     && dotnet_sha512='3b2ccf888d43718f406302836ff176f41a4b1230ac66b9ccd95bddced5f0d7c65fc2304641a3978f89b93c04d3b8b0273e91deda91c9c5b312fde1057c90a110' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/sdk/7.0/alpine3.15/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Sdk/$DOTNET_
     && dotnet_sha512='eafffb09965e73f0345143b040f53d0bd66cb67e9377b2c728901688d24b1618b8f64579edebaaa4ecec996e1dae99fa303b74258fd40eda5284c2292a13704d' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/sdk/7.0/alpine3.15/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Sdk/$DOTNET_
     && dotnet_sha512='c551bbfd0e86d851e2475f49e03728cf9d420e562d34554bb6b9649632dd3c796abcefeed36e7e2905bc99fbd80e4151133b3373842d918d0fb5364583031d83' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/7.0/bullseye-slim/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet_sha512='85b41a5c8896de02920208b6f3b419ac09dd23562f40907409180b1dc2586345af2e60689bfa2079202d3c543a5bee740f61ac6b984f6fbe0a6c670d7b838613' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet_sha512='110dfd32df180ee8c2a9aef9e62eb610253ff36b257703aa33b80a2150cda6572de60870f1d43e1d5d16502993807774e9631b29a7ae6315b41601e4f4be7bc3' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet_sha512='4066f9da8eee8a3afecca229566bcb2a61f69ef32d1f0874a1eb31f5be25f8275be42a282d65afc7ff700a9c2f75e905896a0859f2915439987812722b691f1c' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/focal/amd64/Dockerfile
+++ b/src/sdk/7.0/focal/amd64/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet_sha512='85b41a5c8896de02920208b6f3b419ac09dd23562f40907409180b1dc2586345af2e60689bfa2079202d3c543a5bee740f61ac6b984f6fbe0a6c670d7b838613' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/7.0/focal/arm32v7/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet_sha512='110dfd32df180ee8c2a9aef9e62eb610253ff36b257703aa33b80a2150cda6572de60870f1d43e1d5d16502993807774e9631b29a7ae6315b41601e4f4be7bc3' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/7.0/focal/arm64v8/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet_sha512='4066f9da8eee8a3afecca229566bcb2a61f69ef32d1f0874a1eb31f5be25f8275be42a282d65afc7ff700a9c2f75e905896a0859f2915439987812722b691f1c' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Sdk/7.0.100-alpha.1.22069.1/dotnet-sdk-7.0.100-alpha.1.22069.1-win-x64.zip; `
+    $sdk_version = '7.0.100-alpha.1.22069.1'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '5baa534026cdf1020afd0187ec264fb347c1dc8abcc0a0e66829bb75dd70cef7c9315e21f21f2086cef59a0e2240bf85c7f8d4c0f5fd2c06f8d83b4a1c1cef26'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -17,7 +17,7 @@ RUN `
         exit 1; `
     }; `
     mkdir dotnet; `
-    tar -C dotnet -oxzf dotnet.zip; `
+    tar -oxzf dotnet.zip -C dotnet; `
     Remove-Item -Force dotnet.zip; `
     `
     # Install PowerShell global tool

--- a/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -9,7 +9,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN `
     # Retrieve .NET SDK
-    Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Sdk/7.0.100-alpha.1.22069.1/dotnet-sdk-7.0.100-alpha.1.22069.1-win-x64.zip; `
+    $sdk_version = '7.0.100-alpha.1.22069.1'; `
+    Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.azureedge.net/public/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip; `
     $dotnet_sha512 = '5baa534026cdf1020afd0187ec264fb347c1dc8abcc0a0e66829bb75dd70cef7c9315e21f21f2086cef59a0e2240bf85c7f8d4c0f5fd2c06f8d83b4a1c1cef26'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool

--- a/src/sdk/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN powershell -Command "`
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `
         }; `
-        tar -C $Env:ProgramFiles\dotnet -oxzf dotnet.zip ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
+        tar -oxzf dotnet.zip -C $Env:ProgramFiles\dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt ./shared/Microsoft.WindowsDesktop.App; `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool


### PR DESCRIPTION
Addresses the following inconsistencies:
* Refer to ".NET Core Runtime" instead of just ".NET Core".
* Use consistent ordering of `tar` command options.
* Deletion of tarball should occur immediately after extracting it, before any other commands.
* Set build version to a local shell variable if it doesn't exist as an environment variable instead of inlining the version in a URL.