### PR TITLE
Remove net7.0 folders from .NET monitor.

### DIFF
--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -13,7 +13,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    && find /app -print | grep -i '.*/net7[.]0$' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -13,7 +13,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    && find /app -print | grep -i '.*/net7[.]0$' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 


### PR DESCRIPTION
The dotnet-monitor package has removed the netcoreapp3.1 TFM and added the net7.0 TFM. This caused the image size to increase due to the filter only removing netcoreapp3.1 from the filesystem. After correcting this, the size baseline is correct again.

closes #3429 