### PR TITLE
Convert dotnet-monitor 7.0 image to using 7.0 TFM

### DIFF
--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -10,8 +10,6 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnetmonitor_sha512='{{VARIABLES["monitor|7.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
-    # To reduce image size, remove the copy of the nupkg under the tools.
-    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net7.0 TFMs
     # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
     # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
@@ -20,8 +18,10 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
-    && find /app -type d -empty -print | xargs rm -rf \
+    && find /app -type d -empty -delete \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -8,7 +8,7 @@ FROM $SDK_REPO:{{VARIABLES["sdk|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|7.0|build-version"]}}
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|7.0|sha"]}}' \
-    && echo "$dotnetmonitor_sha512 dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \

--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -2,23 +2,23 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:{{VARIABLES["sdk|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}} AS installer
+FROM $SDK_REPO:{{VARIABLES["sdk|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}} AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|7.0|build-version"]}}
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|7.0|sha"]}}' \
-    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
-    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
+    && echo "$dotnetmonitor_sha512 dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
-    # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    # To reduce image size, remove all non-net7.0 TFMs (currently only net6.0 exists)
+    && find /app -print | grep -i '.*/net6[.]0' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
 # Monitor image
-FROM $ASPNET_REPO:{{VARIABLES["dotnet|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
+FROM $ASPNET_REPO:{{VARIABLES["dotnet|7.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}}
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -12,8 +12,14 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
-    # To reduce image size, remove all non-net7.0 TFMs (currently only net6.0 exists)
-    && find /app -print | grep -i '.*/net6[.]0' | xargs rm -rf \
+    # To reduce image size, remove all non-net7.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find anything in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -15,11 +15,13 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     # To reduce image size, remove all non-net7.0 TFMs
     # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
     # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
-    # 1. Find anything in /app
+    # 1. Find any files in /app
     # 2. Match anything that is under a *folder* called 'dotnet-monitor'
     # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
     # 4. Delete everything from step 3
-    && find /app -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -print | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -2,14 +2,14 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:7.0.100-alpha.1-alpine3.15-amd64 AS installer
+FROM $SDK_REPO:7.0.100-preview.1-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.22076.3
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='a237e5338bd0e57df655787ef8381b2387623f9b1bde979e57e9e685d2748134c8d128969a5b6255baea63bb184a47d6647bb5673510cbf08cb6ee53e25935dc' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
-    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -24,7 +24,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
 
 
 # Monitor image
-FROM $ASPNET_REPO:7.0.0-alpha.1-alpine3.15-amd64
+FROM $ASPNET_REPO:7.0.0-preview.1-alpine3.15-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:7.0.100-preview.1-alpine3.15-amd64 AS installer
+FROM $SDK_REPO:7.0.100-alpha.1-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.22076.3
@@ -15,16 +15,18 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     # To reduce image size, remove all non-net7.0 TFMs
     # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
     # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
-    # 1. Find anything in /app
+    # 1. Find any files in /app
     # 2. Match anything that is under a *folder* called 'dotnet-monitor'
     # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
     # 4. Delete everything from step 3
-    && find /app -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -print | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
 # Monitor image
-FROM $ASPNET_REPO:7.0.0-preview.1-alpine3.15-amd64
+FROM $ASPNET_REPO:7.0.0-alpha.1-alpine3.15-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:7.0.100-alpha.1-alpine3.15-amd64 AS installer
+FROM $SDK_REPO:7.0.100-preview.1-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.22076.3
@@ -10,8 +10,6 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnetmonitor_sha512='a237e5338bd0e57df655787ef8381b2387623f9b1bde979e57e9e685d2748134c8d128969a5b6255baea63bb184a47d6647bb5673510cbf08cb6ee53e25935dc' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
-    # To reduce image size, remove the copy of the nupkg under the tools.
-    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net7.0 TFMs
     # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
     # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
@@ -20,13 +18,15 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
-    && find /app -type d -empty -print | xargs rm -rf \
+    && find /app -type d -empty -delete \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
 # Monitor image
-FROM $ASPNET_REPO:7.0.0-alpha.1-alpine3.15-amd64
+FROM $ASPNET_REPO:7.0.0-preview.1-alpine3.15-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.101-alpine3.15-amd64 AS installer
+FROM $SDK_REPO:7.0.100-alpha.1-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.22076.3
@@ -12,13 +12,13 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
-    # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    # To reduce image size, remove all non-net7.0 TFMs (currently only net6.0 exists)
+    && find /app -print | grep -i '.*/net6[.]0' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0.1-alpine3.15-amd64
+FROM $ASPNET_REPO:7.0.0-alpha.1-alpine3.15-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -12,8 +12,14 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.
     && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
-    # To reduce image size, remove all non-net7.0 TFMs (currently only net6.0 exists)
-    && find /app -print | grep -i '.*/net6[.]0' | xargs rm -rf \
+    # To reduce image size, remove all non-net7.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find anything in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Docker.Tests
             new ProductImageData { Version = V7_0, OS = OS.ServerCoreLtsc2019, Arch = Arch.Amd64 },
             new ProductImageData { Version = V7_0, OS = OS.ServerCoreLtsc2022, Arch = Arch.Amd64 },
         };
-        
+
         private static readonly SampleImageData[] s_linuxSampleTestData =
         {
             new SampleImageData { OS = OS.BusterSlim, Arch = Arch.Amd64, IsPublished = true },
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             new MonitorImageData { Version = V6_0, RuntimeVersion = V6_0, OS = OS.Alpine314, OSTag = OS.Alpine, Arch = Arch.Amd64 },
             new MonitorImageData { Version = V6_1, RuntimeVersion = V6_0, OS = OS.Alpine315, OSTag = OS.Alpine, Arch = Arch.Amd64 },
-            new MonitorImageData { Version = V7_0, RuntimeVersion = V6_0, OS = OS.Alpine315, OSTag = OS.Alpine, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Alpine315, OSTag = OS.Alpine, Arch = Arch.Amd64 },
         };
 
         private static readonly MonitorImageData[] s_windowsMonitorTestData =

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -199,6 +199,6 @@
   "dotnet/nightly/monitor": {
     "src/monitor/6.0/alpine/amd64": 109543092,
     "src/monitor/6.1/alpine/amd64": 108128663,
-    "src/monitor/7.0/alpine/amd64": 108132591
+    "src/monitor/7.0/alpine/amd64": 115718294
   }
 }

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -199,6 +199,6 @@
   "dotnet/nightly/monitor": {
     "src/monitor/6.0/alpine/amd64": 109543092,
     "src/monitor/6.1/alpine/amd64": 108128663,
-    "src/monitor/7.0/alpine/amd64": 115718294
+    "src/monitor/7.0/alpine/amd64": 108783168
   }
 }


### PR DESCRIPTION
Applies following changes to `dotnet-monitor`s 7.0 image:
- Change over to using 7.0 SDK image (image used for `dotnet tool install`)
- Removes `net6.0` compiled version of `dotnet-monitor` from image
- Changes base image that we ship on to `aspnet 7.0`