### PR TITLE
Use consistent order for tar options

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
@@ -22,5 +22,5 @@
     && mkdir -p /dotnet \}}
     && {{
         if isFullMariner:rpm --install aspnetcore.{{fileExt}}^
-        else:tar -ozxf aspnetcore.{{fileExt}} {{if tarballDestDir != "":-C {{tarballDestDir}} }}./shared/Microsoft.AspNetCore.App}} \
+        else:tar -oxzf aspnetcore.{{fileExt}} {{if tarballDestDir != "":-C {{tarballDestDir}} }}./shared/Microsoft.AspNetCore.App}} \
     && rm aspnetcore.{{fileExt}}

--- a/eng/dockerfile-templates/runtime/3.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/3.1/Dockerfile.linux
@@ -12,6 +12,6 @@ RUN dotnet_version={{VARIABLES["runtime|3.1|build-version"]}} \
     && dotnet_sha512='{{VARIABLES[cat("runtime|3.1|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/5.0/Dockerfile.linux
@@ -9,7 +9,7 @@ RUN dotnet_version={{VARIABLES["runtime|5.0|build-version"]}} \
     && dotnet_sha512='{{VARIABLES[cat("runtime|5.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.linux
@@ -9,7 +9,7 @@ RUN dotnet_version={{VARIABLES["runtime|6.0|build-version"]}} \
     && dotnet_sha512='{{VARIABLES[cat("runtime|6.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.linux
@@ -9,7 +9,7 @@ RUN dotnet_version={{VARIABLES["runtime|7.0|build-version"]}} \
     && dotnet_sha512='{{VARIABLES[cat("runtime|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/eng/dockerfile-templates/sdk/3.1/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/3.1/Dockerfile.linux
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version={{VARIABLES["sdk|3.1|build-version"]}} \
     && dotnet_sha512='{{VARIABLES[cat("sdk|3.1|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/aspnet/3.1/alpine3.14/amd64/Dockerfile
+++ b/src/aspnet/3.1/alpine3.14/amd64/Dockerfile
@@ -9,5 +9,5 @@ RUN aspnetcore_version=3.1.22 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='36fd0f7d1922f3da4eb5b6624a4c58aee01c7a74c9727e27f1efcb39459ca9cf9cbcbdbb8253ae9bb713f84448622dc2e8d7e1a7bf6b86cf602be41aa325feb4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/alpine3.14/arm64v8/Dockerfile
+++ b/src/aspnet/3.1/alpine3.14/arm64v8/Dockerfile
@@ -9,5 +9,5 @@ RUN aspnetcore_version=3.1.22 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='137758a409afffdb6bfc9a696e35dd78717222c8585cf2ea2f5a24bcc2f3b1dd23bd1413b8d854265511ca37054cb9ed022faa19b6a2b30e20000c719f7cf7b7' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/alpine3.15/amd64/Dockerfile
+++ b/src/aspnet/3.1/alpine3.15/amd64/Dockerfile
@@ -9,5 +9,5 @@ RUN aspnetcore_version=3.1.22 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='36fd0f7d1922f3da4eb5b6624a4c58aee01c7a74c9727e27f1efcb39459ca9cf9cbcbdbb8253ae9bb713f84448622dc2e8d7e1a7bf6b86cf602be41aa325feb4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/alpine3.15/arm64v8/Dockerfile
+++ b/src/aspnet/3.1/alpine3.15/arm64v8/Dockerfile
@@ -9,5 +9,5 @@ RUN aspnetcore_version=3.1.22 \
     && wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='137758a409afffdb6bfc9a696e35dd78717222c8585cf2ea2f5a24bcc2f3b1dd23bd1413b8d854265511ca37054cb9ed022faa19b6a2b30e20000c719f7cf7b7' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/bionic/amd64/Dockerfile
+++ b/src/aspnet/3.1/bionic/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='32332a09a2f05e56ca66fff2a27e988dc35dc12dcc312b62c99c2a7b2532fb02bab0fa7f49f73938999488c0463a0c79c151b020e01104b8e9cfab80a877b5f3' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/bionic/arm32v7/Dockerfile
+++ b/src/aspnet/3.1/bionic/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='ff4490c739ba6e86bdd1106d4832759c152a03af3866068cf9e48e9bbabbbd81f2af9842cdcd36610aa221ee894f50952b93f237a2c4e1e1bfa183b5c6119e28' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/bionic/arm64v8/Dockerfile
+++ b/src/aspnet/3.1/bionic/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='b60afc6277fbf256c6c8ff17cb644d0e893054d0f017d7fe68ed3acc5bc1276636cdf11e89148bd2bea8cee35acee688224d64cc3a468152ee8c84a9a33b4a2e' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/3.1/bullseye-slim/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='32332a09a2f05e56ca66fff2a27e988dc35dc12dcc312b62c99c2a7b2532fb02bab0fa7f49f73938999488c0463a0c79c151b020e01104b8e9cfab80a877b5f3' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/3.1/bullseye-slim/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='ff4490c739ba6e86bdd1106d4832759c152a03af3866068cf9e48e9bbabbbd81f2af9842cdcd36610aa221ee894f50952b93f237a2c4e1e1bfa183b5c6119e28' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/3.1/bullseye-slim/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='b60afc6277fbf256c6c8ff17cb644d0e893054d0f017d7fe68ed3acc5bc1276636cdf11e89148bd2bea8cee35acee688224d64cc3a468152ee8c84a9a33b4a2e' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/3.1/buster-slim/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='32332a09a2f05e56ca66fff2a27e988dc35dc12dcc312b62c99c2a7b2532fb02bab0fa7f49f73938999488c0463a0c79c151b020e01104b8e9cfab80a877b5f3' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/buster-slim/arm32v7/Dockerfile
+++ b/src/aspnet/3.1/buster-slim/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='ff4490c739ba6e86bdd1106d4832759c152a03af3866068cf9e48e9bbabbbd81f2af9842cdcd36610aa221ee894f50952b93f237a2c4e1e1bfa183b5c6119e28' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/buster-slim/arm64v8/Dockerfile
+++ b/src/aspnet/3.1/buster-slim/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='b60afc6277fbf256c6c8ff17cb644d0e893054d0f017d7fe68ed3acc5bc1276636cdf11e89148bd2bea8cee35acee688224d64cc3a468152ee8c84a9a33b4a2e' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/focal/amd64/Dockerfile
+++ b/src/aspnet/3.1/focal/amd64/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='32332a09a2f05e56ca66fff2a27e988dc35dc12dcc312b62c99c2a7b2532fb02bab0fa7f49f73938999488c0463a0c79c151b020e01104b8e9cfab80a877b5f3' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/focal/arm32v7/Dockerfile
+++ b/src/aspnet/3.1/focal/arm32v7/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='ff4490c739ba6e86bdd1106d4832759c152a03af3866068cf9e48e9bbabbbd81f2af9842cdcd36610aa221ee894f50952b93f237a2c4e1e1bfa183b5c6119e28' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/3.1/focal/arm64v8/Dockerfile
+++ b/src/aspnet/3.1/focal/arm64v8/Dockerfile
@@ -6,5 +6,5 @@ RUN aspnetcore_version=3.1.22 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='b60afc6277fbf256c6c8ff17cb644d0e893054d0f017d7fe68ed3acc5bc1276636cdf11e89148bd2bea8cee35acee688224d64cc3a468152ee8c84a9a33b4a2e' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/5.0/alpine3.14/amd64/Dockerfile
+++ b/src/aspnet/5.0/alpine3.14/amd64/Dockerfile
@@ -10,5 +10,5 @@ ENV ASPNET_VERSION=5.0.13
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='0ea8a945bb1b663b8bf65708d6cfd6411aaf6ac8cc2ade34dfda160c331230694620b8b0abf80c4266fc9a2444300bf9b58906e40c30e7aff7a27291240ca583' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/5.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/alpine3.14/arm32v7/Dockerfile
@@ -10,5 +10,5 @@ ENV ASPNET_VERSION=5.0.13
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \
     && aspnetcore_sha512='f081b9f59119508d21e5dff3e6adc7f69f037620b90614b8ac71fc6c7fa7293d6092a727789d6f6fc26b54c7dc543d427ee044d7b1909c0d13c3d3fe495609a4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/5.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/alpine3.14/arm64v8/Dockerfile
@@ -10,5 +10,5 @@ ENV ASPNET_VERSION=5.0.13
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='2c45e5b4c6d4cbaaf95e616ee04662ec87f4fcc81d5710cb94063447fb2b3de1a120beea6c6e2784a83a6d2703f2ad2a3c3cad7dfdb28bde1f7d3761d3216e89' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/5.0/alpine3.15/amd64/Dockerfile
+++ b/src/aspnet/5.0/alpine3.15/amd64/Dockerfile
@@ -10,5 +10,5 @@ ENV ASPNET_VERSION=5.0.13
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='0ea8a945bb1b663b8bf65708d6cfd6411aaf6ac8cc2ade34dfda160c331230694620b8b0abf80c4266fc9a2444300bf9b58906e40c30e7aff7a27291240ca583' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/5.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/alpine3.15/arm32v7/Dockerfile
@@ -10,5 +10,5 @@ ENV ASPNET_VERSION=5.0.13
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \
     && aspnetcore_sha512='f081b9f59119508d21e5dff3e6adc7f69f037620b90614b8ac71fc6c7fa7293d6092a727789d6f6fc26b54c7dc543d427ee044d7b1909c0d13c3d3fe495609a4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/5.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/alpine3.15/arm64v8/Dockerfile
@@ -10,5 +10,5 @@ ENV ASPNET_VERSION=5.0.13
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='2c45e5b4c6d4cbaaf95e616ee04662ec87f4fcc81d5710cb94063447fb2b3de1a120beea6c6e2784a83a6d2703f2ad2a3c3cad7dfdb28bde1f7d3761d3216e89' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/5.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/bullseye-slim/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='d3014d473b3bef0a9645908c768f1c458c53ebfd3ed6f2fd259b2921a6d7401f3c0403e99c0d80a6457ecc229dcf828a4031e17868538d831ae1394bb8aa0ad4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/bullseye-slim/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='4b92e7a686c852149e228c777f899d2426d81691b2cbc0a2a8708b9c8ab5b504dd544c1c291c848339c7c59d139d9e91e8914059326b0e84e662bcf32d3fb472' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/bullseye-slim/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='757ccf8a453d8cc9075a438d02bf95bb6d3738651100de8d4ae842a97dc10d8d7507597ec9d2806a3140d8000faec602748b4585b0a644816c74ebbf7ab98719' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/buster-slim/amd64/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='d3014d473b3bef0a9645908c768f1c458c53ebfd3ed6f2fd259b2921a6d7401f3c0403e99c0d80a6457ecc229dcf828a4031e17868538d831ae1394bb8aa0ad4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='4b92e7a686c852149e228c777f899d2426d81691b2cbc0a2a8708b9c8ab5b504dd544c1c291c848339c7c59d139d9e91e8914059326b0e84e662bcf32d3fb472' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='757ccf8a453d8cc9075a438d02bf95bb6d3738651100de8d4ae842a97dc10d8d7507597ec9d2806a3140d8000faec602748b4585b0a644816c74ebbf7ab98719' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/focal/amd64/Dockerfile
+++ b/src/aspnet/5.0/focal/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='d3014d473b3bef0a9645908c768f1c458c53ebfd3ed6f2fd259b2921a6d7401f3c0403e99c0d80a6457ecc229dcf828a4031e17868538d831ae1394bb8aa0ad4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/5.0/focal/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='4b92e7a686c852149e228c777f899d2426d81691b2cbc0a2a8708b9c8ab5b504dd544c1c291c848339c7c59d139d9e91e8914059326b0e84e662bcf32d3fb472' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/5.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/5.0/focal/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=5.0.13 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='757ccf8a453d8cc9075a438d02bf95bb6d3738651100de8d4ae842a97dc10d8d7507597ec9d2806a3140d8000faec602748b4585b0a644816c74ebbf7ab98719' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/amd64/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='763a9895e20ac19012b6fb6489be45a25879c3717e47b7c8f13e38e5c8a33e9ccdf5fe0a90896bd4719324cc24397c62f06426e9dd43c9cdf42296fcb08a1f26' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/arm32v7/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \
     && aspnetcore_sha512='f613fb9f30ff2f0693aeeceaf1160f925467f33a2c2308f39c198a128713ef19c1d743aad63b381159a420689d06a60a65f8b99fbeab1220f27463e8c112a92b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/arm64v8/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='7624ae6b63475c4861e1d48aa85151a8f1e506513fe3dfd3fb95ae9a1067a77ad8ddd3e44bf8d27baca62c9c2b3cb425dbaa8d8de346f45aecb5b40870f3334c' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/aspnet/6.0/alpine3.15/amd64/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='763a9895e20ac19012b6fb6489be45a25879c3717e47b7c8f13e38e5c8a33e9ccdf5fe0a90896bd4719324cc24397c62f06426e9dd43c9cdf42296fcb08a1f26' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/alpine3.15/arm32v7/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \
     && aspnetcore_sha512='f613fb9f30ff2f0693aeeceaf1160f925467f33a2c2308f39c198a128713ef19c1d743aad63b381159a420689d06a60a65f8b99fbeab1220f27463e8c112a92b' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/alpine3.15/arm64v8/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='7624ae6b63475c4861e1d48aa85151a8f1e506513fe3dfd3fb95ae9a1067a77ad8ddd3e44bf8d27baca62c9c2b3cb425dbaa8d8de346f45aecb5b40870f3334c' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=6.0.1 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='9e42c4ac282d3ed099203b9a8a06b4f1baf1267b4d51c9d505ca7127930534b60d4e94022036719133b30c1b503f66d7d4571bc24059d735e510f5e455ec6c51' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=6.0.1 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='e1d9f0b2357ba637ee33bc8f8428b9ff0b3656ac28d1f7727693444191cc8a0a078c2e864547d58668cf3767f0b6df5b804e2743b6fb0906106d2877cdb687dc' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=6.0.1 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='c1cab4bc800bd507ca6046ed1af900a7f1a7d28fa564615b8b93803139affc7f5fe6824c2b161ce635047862d644d724181424b44281b30a77f7159d6769c83c' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN aspnetcore_version=6.0.1 \
     && aspnetcore_sha512='9e42c4ac282d3ed099203b9a8a06b4f1baf1267b4d51c9d505ca7127930534b60d4e94022036719133b30c1b503f66d7d4571bc24059d735e510f5e455ec6c51' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/6.0/focal/amd64/Dockerfile
+++ b/src/aspnet/6.0/focal/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=6.0.1 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='9e42c4ac282d3ed099203b9a8a06b4f1baf1267b4d51c9d505ca7127930534b60d4e94022036719133b30c1b503f66d7d4571bc24059d735e510f5e455ec6c51' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/6.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/focal/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=6.0.1 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='e1d9f0b2357ba637ee33bc8f8428b9ff0b3656ac28d1f7727693444191cc8a0a078c2e864547d58668cf3767f0b6df5b804e2743b6fb0906106d2877cdb687dc' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/6.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/focal/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=6.0.1 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='c1cab4bc800bd507ca6046ed1af900a7f1a7d28fa564615b8b93803139affc7f5fe6824c2b161ce635047862d644d724181424b44281b30a77f7159d6769c83c' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/7.0/alpine3.15/amd64/Dockerfile
+++ b/src/aspnet/7.0/alpine3.15/amd64/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
     && aspnetcore_sha512='0bc5b5dc7555c51f7f09735ae928667809643a9c6bb7ebb70b3fa8eb0373da79a98471077e75f506492c303ef9555ea1b0d029aa633fa3bc105d23f131e01fd3' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/7.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/aspnet/7.0/alpine3.15/arm32v7/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \
     && aspnetcore_sha512='779778061006754ce86c7e6354c8e315e3d87f385178c961ff0dccac537c7857adacc564580b698aaa2baf3b84a7dfa8e72bc9f28c34ec90f569add56ebd2c42' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/7.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/alpine3.15/arm64v8/Dockerfile
@@ -14,5 +14,5 @@ ENV \
 RUN wget -O aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
     && aspnetcore_sha512='c41d4e9f86ad4bcf0739f7bd735ca86dd2f77db1de5e94de4c1883529018f42da4f095373d395c4e359786575356cc2ca140ccc2fadd72eeffe1d824fc9717a4' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz

--- a/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='2eba23aa5ec34f1891d52fadfabfd07e59678fdf01fdfa88e17d16da9468314eebf32e4235ddb182431b218d1feda241ce409012eadd55890d1b16515be660db' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='dc6b68fa15dc4be7b4cc0e064ec2f9f4001a0282feea06e8ee32a2a4d787c14cc049d35a519a8488aac6284d1a9d1d69c6e2263790b213c22bfe7f956989d5d9' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='3e1b86ab10baa9902c20575dcc06a59c672f264177b9d24de2af1d6ff0b29734951bd460b2d0fb149f29d77bf43feff27c50401773b7dc6f0b40b0894e8b7f26' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -12,7 +12,7 @@ RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
     && aspnetcore_sha512='2eba23aa5ec34f1891d52fadfabfd07e59678fdf01fdfa88e17d16da9468314eebf32e4235ddb182431b218d1feda241ce409012eadd55890d1b16515be660db' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/7.0/focal/amd64/Dockerfile
+++ b/src/aspnet/7.0/focal/amd64/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
     && aspnetcore_sha512='2eba23aa5ec34f1891d52fadfabfd07e59678fdf01fdfa88e17d16da9468314eebf32e4235ddb182431b218d1feda241ce409012eadd55890d1b16515be660db' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/7.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/7.0/focal/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
     && aspnetcore_sha512='dc6b68fa15dc4be7b4cc0e064ec2f9f4001a0282feea06e8ee32a2a4d787c14cc049d35a519a8488aac6284d1a9d1d69c6e2263790b213c22bfe7f956989d5d9' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/aspnet/7.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/focal/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ RUN aspnetcore_version=7.0.0-alpha.1.22067.2 \
     && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
     && aspnetcore_sha512='3e1b86ab10baa9902c20575dcc06a59c672f264177b9d24de2af1d6ff0b29734951bd460b2d0fb149f29d77bf43feff27c50401773b7dc6f0b40b0894e8b7f26' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -ozxf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
     && rm aspnetcore.tar.gz
 
 

--- a/src/runtime/3.1/bionic/amd64/Dockerfile
+++ b/src/runtime/3.1/bionic/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/bionic/arm32v7/Dockerfile
+++ b/src/runtime/3.1/bionic/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/bionic/arm64v8/Dockerfile
+++ b/src/runtime/3.1/bionic/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/3.1/bullseye-slim/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/3.1/bullseye-slim/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/3.1/bullseye-slim/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/buster-slim/amd64/Dockerfile
+++ b/src/runtime/3.1/buster-slim/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/3.1/buster-slim/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/3.1/buster-slim/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/focal/amd64/Dockerfile
+++ b/src/runtime/3.1/focal/amd64/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='4e32b45086fbd630622d20b0b2316d0c9bd66647b38ef1475c9bf8ef755bd60ec7eb8055a8de2bf89ed96e0460abc9e68f500189dd5437e21f2dfbd4fc71693e' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/focal/arm32v7/Dockerfile
+++ b/src/runtime/3.1/focal/arm32v7/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='2b189ab7fa7c2a42c155a270c59ec149b78194aa4c84c2e35b236e757ae73b7d0055bcade6d45e208f00e391fecb04fa5f71ef51a6a0851f29949517d33086fa' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/3.1/focal/arm64v8/Dockerfile
+++ b/src/runtime/3.1/focal/arm64v8/Dockerfile
@@ -12,6 +12,6 @@ RUN dotnet_version=3.1.22 \
     && dotnet_sha512='ac7abb9273d1446ecacf536d2c59b01f23de81a21db035c98e53f63f64f8c3d252b613c24b7f9ea9e559f9c75385d93528ae0207aa7b734dba421c8871f312ed' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='32f574369975606da5e67ca7f8e709e73b67a98fa1a175f49c979f582be658132375663e6ad944a3a89d1186322a7a04cead043cf1d4526fdb7ff195ead6f317' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm32v7/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='3d0a10b51e89d5716ab284e499e0927835d7944d7a4c15a9294679a8c4af3ca99f51cad25c0d19fa4a91b8b76a832a9bb81afb67bcdc2385730b061d135644f6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/bullseye-slim/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='428adbb6cd564b919333cf18b7245784b6a2e93740e31fb85c4344690519eb88038b220621f199ba2524eef0f4d0fd2e17bbea0851de0d0ec7dec4c092311d10' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/buster-slim/amd64/Dockerfile
+++ b/src/runtime/5.0/buster-slim/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='32f574369975606da5e67ca7f8e709e73b67a98fa1a175f49c979f582be658132375663e6ad944a3a89d1186322a7a04cead043cf1d4526fdb7ff195ead6f317' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm32v7/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='3d0a10b51e89d5716ab284e499e0927835d7944d7a4c15a9294679a8c4af3ca99f51cad25c0d19fa4a91b8b76a832a9bb81afb67bcdc2385730b061d135644f6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
+++ b/src/runtime/5.0/buster-slim/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='428adbb6cd564b919333cf18b7245784b6a2e93740e31fb85c4344690519eb88038b220621f199ba2524eef0f4d0fd2e17bbea0851de0d0ec7dec4c092311d10' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/focal/amd64/Dockerfile
+++ b/src/runtime/5.0/focal/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='32f574369975606da5e67ca7f8e709e73b67a98fa1a175f49c979f582be658132375663e6ad944a3a89d1186322a7a04cead043cf1d4526fdb7ff195ead6f317' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/5.0/focal/arm32v7/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='3d0a10b51e89d5716ab284e499e0927835d7944d7a4c15a9294679a8c4af3ca99f51cad25c0d19fa4a91b8b76a832a9bb81afb67bcdc2385730b061d135644f6' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/5.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/5.0/focal/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=5.0.13 \
     && dotnet_sha512='428adbb6cd564b919333cf18b7245784b6a2e93740e31fb85c4344690519eb88038b220621f199ba2524eef0f4d0fd2e17bbea0851de0d0ec7dec4c092311d10' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=6.0.1 \
     && dotnet_sha512='2a316e8cba20778b409b8f2a3810348e2805f35afad8aba77a67c4e6bb2c2091e60bc369df22554bb145a5fad0c50e20b39d350b98a85bd33566034a11230da7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=6.0.1 \
     && dotnet_sha512='a6bea3289279ddfaeda4c46bc2cae82c662e2b2cfa13abefa18baa8db747bd1be9fabdd8c0103310f89d4c9e356235551af5354742117d2cd58abf5727883609' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=6.0.1 \
     && dotnet_sha512='10b8775d44088ddc1ae193ce41f456d1bbaad21f2dc993de75c2b076b6ffcb07bca446f52180c9a175715a1e47ad42a4862c43ef11b5cbc1023cb4da3c426146' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/6.0/focal/amd64/Dockerfile
+++ b/src/runtime/6.0/focal/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=6.0.1 \
     && dotnet_sha512='2a316e8cba20778b409b8f2a3810348e2805f35afad8aba77a67c4e6bb2c2091e60bc369df22554bb145a5fad0c50e20b39d350b98a85bd33566034a11230da7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/6.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/6.0/focal/arm32v7/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=6.0.1 \
     && dotnet_sha512='a6bea3289279ddfaeda4c46bc2cae82c662e2b2cfa13abefa18baa8db747bd1be9fabdd8c0103310f89d4c9e356235551af5354742117d2cd58abf5727883609' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/6.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/6.0/focal/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=6.0.1 \
     && dotnet_sha512='10b8775d44088ddc1ae193ce41f456d1bbaad21f2dc993de75c2b076b6ffcb07bca446f52180c9a175715a1e47ad42a4862c43ef11b5cbc1023cb4da3c426146' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
     && dotnet_sha512='54035da58611ad409fa12026aabc3b1eb1ace645e2f4409762968d2197d6d288856425d0433eabc564a69906a08fe9dbab8ce730d5f7d649c9b09ddeb94a2477' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
     && dotnet_sha512='83198698b68e439c210ae141b278da6140196f6a06a070c259f36bb2d36cecb43c660b83817258c4f7643655e846fff8b9a742d1b4788bb95de965a40bd91d67' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
     && dotnet_sha512='a4ee9743cbe4bc49b18b5630fb8ee383f3cca9ebc954b401af2561f7c79579c0e83686d89b7af60058b46c20f1d3ec3c71fecce23339dbc92171ca82422b2587' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/7.0/focal/amd64/Dockerfile
+++ b/src/runtime/7.0/focal/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
     && dotnet_sha512='54035da58611ad409fa12026aabc3b1eb1ace645e2f4409762968d2197d6d288856425d0433eabc564a69906a08fe9dbab8ce730d5f7d649c9b09ddeb94a2477' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/7.0/focal/arm32v7/Dockerfile
+++ b/src/runtime/7.0/focal/arm32v7/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
     && dotnet_sha512='83198698b68e439c210ae141b278da6140196f6a06a070c259f36bb2d36cecb43c660b83817258c4f7643655e846fff8b9a742d1b4788bb95de965a40bd91d67' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/runtime/7.0/focal/arm64v8/Dockerfile
+++ b/src/runtime/7.0/focal/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet_version=7.0.0-alpha.1.22066.4 \
     && dotnet_sha512='a4ee9743cbe4bc49b18b5630fb8ee383f3cca9ebc954b401af2561f7c79579c0e83686d89b7af60058b46c20f1d3ec3c71fecce23339dbc92171ca82422b2587' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \
-    && tar -ozxf dotnet.tar.gz -C /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
     && rm dotnet.tar.gz
 
 

--- a/src/sdk/3.1/bionic/amd64/Dockerfile
+++ b/src/sdk/3.1/bionic/amd64/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='dec1dcf326487031c45dec0849a046a0d034d6cbb43ab591da6d94c2faf72da8e31deeaf4d2165049181546d5296bb874a039ccc2f618cf95e68a26399da5e7f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/bionic/arm32v7/Dockerfile
+++ b/src/sdk/3.1/bionic/arm32v7/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='33a6d64f466839cc30adef87909a2ff98ecdf6bb763b82a7951314ee8eded7dc210297f914d4aa0b9c0b101aa0c33da97cb15ff64c5f83f08b212b885d662e90' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/bionic/arm64v8/Dockerfile
+++ b/src/sdk/3.1/bionic/arm64v8/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='0065c7afb129b1a0e0c11703309f3b45cf9a3c0ea156247f7cc61555f21c37054f215eb77add509dad77b1d388a4e6c585f8a8016109f31c5b64184b25e2c407' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/bullseye/amd64/Dockerfile
+++ b/src/sdk/3.1/bullseye/amd64/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='dec1dcf326487031c45dec0849a046a0d034d6cbb43ab591da6d94c2faf72da8e31deeaf4d2165049181546d5296bb874a039ccc2f618cf95e68a26399da5e7f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/bullseye/arm32v7/Dockerfile
+++ b/src/sdk/3.1/bullseye/arm32v7/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='33a6d64f466839cc30adef87909a2ff98ecdf6bb763b82a7951314ee8eded7dc210297f914d4aa0b9c0b101aa0c33da97cb15ff64c5f83f08b212b885d662e90' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/bullseye/arm64v8/Dockerfile
+++ b/src/sdk/3.1/bullseye/arm64v8/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='0065c7afb129b1a0e0c11703309f3b45cf9a3c0ea156247f7cc61555f21c37054f215eb77add509dad77b1d388a4e6c585f8a8016109f31c5b64184b25e2c407' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/buster/amd64/Dockerfile
+++ b/src/sdk/3.1/buster/amd64/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='dec1dcf326487031c45dec0849a046a0d034d6cbb43ab591da6d94c2faf72da8e31deeaf4d2165049181546d5296bb874a039ccc2f618cf95e68a26399da5e7f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/buster/arm32v7/Dockerfile
+++ b/src/sdk/3.1/buster/arm32v7/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='33a6d64f466839cc30adef87909a2ff98ecdf6bb763b82a7951314ee8eded7dc210297f914d4aa0b9c0b101aa0c33da97cb15ff64c5f83f08b212b885d662e90' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/buster/arm64v8/Dockerfile
+++ b/src/sdk/3.1/buster/arm64v8/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='0065c7afb129b1a0e0c11703309f3b45cf9a3c0ea156247f7cc61555f21c37054f215eb77add509dad77b1d388a4e6c585f8a8016109f31c5b64184b25e2c407' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/focal/amd64/Dockerfile
+++ b/src/sdk/3.1/focal/amd64/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='dec1dcf326487031c45dec0849a046a0d034d6cbb43ab591da6d94c2faf72da8e31deeaf4d2165049181546d5296bb874a039ccc2f618cf95e68a26399da5e7f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/focal/arm32v7/Dockerfile
+++ b/src/sdk/3.1/focal/arm32v7/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='33a6d64f466839cc30adef87909a2ff98ecdf6bb763b82a7951314ee8eded7dc210297f914d4aa0b9c0b101aa0c33da97cb15ff64c5f83f08b212b885d662e90' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/focal/arm64v8/Dockerfile
+++ b/src/sdk/3.1/focal/arm64v8/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet_sdk_version=3.1.416 \
     && dotnet_sha512='0065c7afb129b1a0e0c11703309f3b45cf9a3c0ea156247f7cc61555f21c37054f215eb77add509dad77b1d388a4e6c585f8a8016109f31c5b64184b25e2c407' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd


### PR DESCRIPTION
There's a mix of the ordering of `tar` options amongst the Dockerfiles. They either use `tar -ozxf` or `tar -oxzf` (the `x` and `z` are swapped). I chose to standardize them all on the latter because there were more Dockerfiles using that pattern.