### PR TITLE
Remove single quotes from var assignment

### DIFF
--- a/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/6.0/Dockerfile.mariner-distroless
@@ -7,7 +7,7 @@ RUN tdnf install -y ca-certificates-microsoft \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version='{{VARIABLES["runtime|6.0|build-version"]}}' \
+RUN dotnet_version={{VARIABLES["runtime|6.0|build-version"]}} \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|6.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \

--- a/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
+++ b/eng/dockerfile-templates/runtime/7.0/Dockerfile.mariner-distroless
@@ -7,7 +7,7 @@ RUN tdnf install -y ca-certificates-microsoft \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version='{{VARIABLES["runtime|7.0|build-version"]}}' \
+RUN dotnet_version={{VARIABLES["runtime|7.0|build-version"]}} \
     && curl -fSL --output dotnet.tar.gz {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-{{ARCH_SHORT}}.tar.gz \
     && dotnet_sha512='{{VARIABLES[cat("runtime|7.0|linux|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \

--- a/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN tdnf install -y ca-certificates-microsoft \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version='6.0.1' \
+RUN dotnet_version=6.0.1 \
     && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='2a316e8cba20778b409b8f2a3810348e2805f35afad8aba77a67c4e6bb2c2091e60bc369df22554bb145a5fad0c50e20b39d350b98a85bd33566034a11230da7' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \

--- a/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN tdnf install -y ca-certificates-microsoft \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version='7.0.0-alpha.1.22066.4' \
+RUN dotnet_version=7.0.0-alpha.1.22066.4 \
     && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
     && dotnet_sha512='54035da58611ad409fa12026aabc3b1eb1ace645e2f4409762968d2197d6d288856425d0433eabc564a69906a08fe9dbab8ce730d5f7d649c9b09ddeb94a2477' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \


### PR DESCRIPTION
This variable assignment pattern used in the distroless Mariner Dockerfile templates is unnecessary and inconsistent with the other templates.