### PR TITLE
Fix test matrix generation of samples

### DIFF
--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -118,7 +118,7 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
+                  "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
                     "$(Repo:samples):dotnetapp-buster-slim-amd64"
@@ -141,7 +141,7 @@
               "variant": "v7",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
+                  "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
                     "$(Repo:samples):dotnetapp-buster-slim-arm32v7"
@@ -164,7 +164,7 @@
               "variant": "v8",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
+                  "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
                     "$(Repo:samples):dotnetapp-buster-slim-arm64v8"
@@ -185,7 +185,7 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
+                  "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
                     "$(Repo:samples):dotnetapp-nanoserver-1809"
@@ -206,7 +206,7 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
+                  "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
                     "$(Repo:samples):dotnetapp-nanoserver-20H2"
@@ -223,7 +223,7 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
+                  "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
                     "$(Repo:samples):dotnetapp-nanoserver-ltsc2022"


### PR DESCRIPTION
The samples build is currently broken due to the validation introduced by https://github.com/dotnet/docker-tools/pull/941. It's causing duplicate test leg names because there are two separate leaves of the dependency tree (dotnetapp, aspnetapp) that are being placed in separate test legs. But because everything about them is the same, except for their Dockerfile path, it causes the test leg name to be identical between the two.

In this case, we don't actually want the test legs to be distinct. That would just cause duplication in the testing being done across two legs. What we want is for them to be combined into one test leg.

The manifest is already configured to at least enable this combined test job scenario, but only for PR builds. The fix is to just change the customBuildLegGroup name to be `test-dependencies` which is in scope for both official and PR builds. That allows Image Builder to combine both dotnetapp and aspnetapp paths into one test leg for either scenario.