### PR TITLE
Use build versions in .NET Monitor URLs and stable branding.

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -50,13 +50,13 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-6.0.1-alpine-amd64, 6.0-alpine-amd64, 6.0.1-alpine, 6.0-alpine, 6.0.1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile) | Alpine 3.14
+6.0.2-alpine-amd64, 6.0-alpine-amd64, 6.0.2-alpine, 6.0-alpine, 6.0.2, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile) | Alpine 3.14
 
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.0.0-alpha.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-alpha.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-alpha.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.15
-6.1.0-alpha.1-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.0-alpha.1-alpine, 6.1-alpine, 6-alpine, 6.1.0-alpha.1, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.15
+6.1.0-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.0-alpine, 6.1-alpine, 6-alpine, 6.1.0, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.15
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -5,8 +5,8 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:{{VARIABLES["sdk|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}} AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|build-version"]}}
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://www.nuget.org/api/v2/package/dotnet-monitor/$DOTNET_MONITOR_VERSION \
+ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.0|product-version"]}}
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/{{VARIABLES["monitor|6.0|build-version"]}}/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|6.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/eng/dockerfile-templates/monitor/6.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.1/Dockerfile.alpine
@@ -5,8 +5,8 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:{{VARIABLES["sdk|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG_SUFFIX}} AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.1|build-version"]}}
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|6.1|product-version"]}}
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/{{VARIABLES["monitor|6.1|build-version"]}}/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|6.1|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/7.0/Dockerfile.alpine
@@ -6,7 +6,7 @@ FROM $SDK_REPO:{{VARIABLES["sdk|6.0|product-version"]}}-{{OS_VERSION}}{{ARCH_TAG
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{VARIABLES["monitor|7.0|build-version"]}}
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/{{VARIABLES["monitor|7.0|build-version"]}}/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='{{VARIABLES["monitor|7.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -65,13 +65,13 @@
     "libicu|buster-slim": 63,
     "libicu|focal": 66,
 
-    "monitor|6.0|build-version": "6.0.1",
-    "monitor|6.0|product-version": "6.0.1",
-    "monitor|6.0|sha": "469f2ffc9f6cc350e1487a3186abcde64fe80994205664e85a1f021ae731155c04a669bd25d657982a726fd1cfde668663f1db21061926c442ae1f655395a144",
+    "monitor|6.0|build-version": "6.0.2-servicing.22077.7",
+    "monitor|6.0|product-version": "6.0.2",
+    "monitor|6.0|sha": "3203e455fe4fa9e7b251ba957ddf286a3a3fcf1c88663315547d5f4f7df9ee1c1f164dfcc42edeebaf786bf1b893753c5a5339377b259798208d5f07c48f9a10",
 
-    "monitor|6.1|build-version": "6.1.0-alpha.1.22070.5",
-    "monitor|6.1|product-version": "6.1.0-alpha.1",
-    "monitor|6.1|sha": "e0bf14f4280c50ce4c3b2d58d08bd4c1c4106b9044046e35b6b002a1bd3f09a742f5bca2bc2a3dd6745fe593670b5ee29222d126ee38b7117b28f2159a8bff8d",
+    "monitor|6.1|build-version": "6.1.0-rtm.22077.8",
+    "monitor|6.1|product-version": "6.1.0",
+    "monitor|6.1|sha": "2d1d10e75be400e6ebab707731daa2ca2723a055b60129247504b6b0d28e63fbc2a23e4d9a7ba7b597d48d1438389acd29c475dda2796920816c7fe63214b1d7",
 
     "monitor|7.0|build-version": "7.0.0-alpha.1.22076.3",
     "monitor|7.0|product-version": "7.0.0-alpha.1",

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:6.0.101-alpine3.14-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=6.0.1
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://www.nuget.org/api/v2/package/dotnet-monitor/$DOTNET_MONITOR_VERSION \
-    && dotnetmonitor_sha512='469f2ffc9f6cc350e1487a3186abcde64fe80994205664e85a1f021ae731155c04a669bd25d657982a726fd1cfde668663f1db21061926c442ae1f655395a144' \
+ENV DOTNET_MONITOR_VERSION=6.0.2
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/6.0.2-servicing.22077.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='3203e455fe4fa9e7b251ba957ddf286a3a3fcf1c88663315547d5f4f7df9ee1c1f164dfcc42edeebaf786bf1b893753c5a5339377b259798208d5f07c48f9a10' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.

--- a/src/monitor/6.1/alpine/amd64/Dockerfile
+++ b/src/monitor/6.1/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:6.0.101-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=6.1.0-alpha.1.22070.5
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='e0bf14f4280c50ce4c3b2d58d08bd4c1c4106b9044046e35b6b002a1bd3f09a742f5bca2bc2a3dd6745fe593670b5ee29222d126ee38b7117b28f2159a8bff8d' \
+ENV DOTNET_MONITOR_VERSION=6.1.0
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/6.1.0-rtm.22077.8/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='2d1d10e75be400e6ebab707731daa2ca2723a055b60129247504b6b0d28e63fbc2a23e4d9a7ba7b597d48d1438389acd29c475dda2796920816c7fe63214b1d7' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove the copy of the nupkg under the tools.

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.101-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-alpha.1.22076.3
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/7.0.0-alpha.1.22076.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='a237e5338bd0e57df655787ef8381b2387623f9b1bde979e57e9e685d2748134c8d128969a5b6255baea63bb184a47d6647bb5673510cbf08cb6ee53e25935dc' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \


### PR DESCRIPTION
This change updates the .NET Monitor templates to use the product version for the package version and the build version as part of the blob container name for release and servicing builds. The builds of .NET Monitor publish their nupkg files under a blob container that has the build version as one of its folders to allow stable version builds to not collide. Prerelease builds produce package versions that are unique for every build, hence why the 7.0 template still uses the build version for its package version.

The 6.0 and 6.1 lines have been updated to the latest builds using stable branding.

cc @dotnet/dotnet-monitor 