### PR TITLE
Use consistent templates for targeting pack RPM URLs

### DIFF
--- a/eng/dockerfile-templates/sdk/7.0/Dockerfile.mariner
+++ b/eng/dockerfile-templates/sdk/7.0/Dockerfile.mariner
@@ -30,15 +30,15 @@ RUN curl -fSL --output dotnet.rpm {{VARIABLES[cat("base-url|7.0|", VARIABLES["br
     && dotnet_sha512='{{VARIABLES[cat("runtime-apphost-pack|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  apphost.rpm" | sha512sum -c - \
     \
-    && curl -fSL --output targeting-pack.rpm {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/$DOTNET_VERSION/dotnet-targeting-pack-$DOTNET_VERSION-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output targeting-pack.rpm {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/Runtime/{{VARIABLES["runtime|7.0|targeting-pack-version"]}}/dotnet-targeting-pack-{{VARIABLES["runtime|7.0|targeting-pack-version"]}}-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("runtime-targeting-pack|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  targeting-pack.rpm" | sha512sum -c - \
     \
-    && curl -fSL --output aspnetcore-targeting-pack.rpm {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-targeting-pack-$ASPNET_VERSION.rpm \
+    && curl -fSL --output aspnetcore-targeting-pack.rpm {{VARIABLES[cat("base-url|7.0|", VARIABLES["branch"])]}}/aspnetcore/Runtime/{{VARIABLES["aspnet|7.0|targeting-pack-version"]}}/aspnetcore-targeting-pack-{{VARIABLES["aspnet|7.0|targeting-pack-version"]}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("aspnet-runtime-targeting-pack|7.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
     \
-    && curl -fSL --output netstandard-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-{{ARCH_SHORT}}.rpm \
+    && curl -fSL --output netstandard-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/{{VARIABLES["runtime|3.1|targeting-pack-version"]}}/netstandard-targeting-pack-2.1.0-{{ARCH_SHORT}}.rpm \
     && dotnet_sha512='{{VARIABLES[cat("netstandard-targeting-pack-2.1.0|linux-rpm|", ARCH_SHORT, "|sha")]}}' \
     && echo "$dotnet_sha512  netstandard-targeting-pack.rpm" | sha512sum -c - \
     \

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -36,6 +36,7 @@
     "aspnet-runtime-targeting-pack|6.0|linux-rpm|x64|sha": "1fc26f04cdb5509c6d02b9a628d0c7a9543af3c1971d02beff9ce52df9a367c54f82042a83db8355a7ed349ce187c914cf02983755257720b682589a1c6ff354",
 
     "aspnet|7.0|build-version": "7.0.0-preview.1.22081.6",
+    "aspnet|7.0|targeting-pack-version": "$(aspnet|7.0|build-version)",
     "aspnet|7.0|linux-musl|x64|sha": "ef72a8a547f81197a29e28a11b633c3f7b97ed780f339554b9ce8af8157cc7e3cdcbb51de8bc3070d888888b02eeb87d4d6942e3bbbfefab9b59e753a36a13f5",
     "aspnet|7.0|linux-musl|arm|sha": "9ebb4679e08b3d2f50cfa9c006a8f0f394e0529915fe5d775e11273da79b6f45a60133b8bc12d780d2166c644d553f763ab336993369a85413ca1b3e19188b19",
     "aspnet|7.0|linux-musl|arm64|sha": "e1834f562d1a715c27afe65185bf966288dffc1a8428c96b91e3032ad8b8564d6cd85aace1ccae6e38989b26519acdc01a39f82e5400857cd14ec30dbde67b7a",
@@ -155,6 +156,7 @@
     "runtime-targeting-pack|6.0|linux-rpm|x64|sha": "928e3c0c1a08d9150709fb821e04bd57445a0482c46c16ad4146b8ed21dad3340ce9bbd9fb2243763b3c463aa0119320e5faf44299e11895e68f46fcc1d490ed",
 
     "runtime|7.0|build-version": "7.0.0-preview.1.22076.8",
+    "runtime|7.0|targeting-pack-version": "$(runtime|7.0|build-version)",
     "runtime|7.0|linux-musl|x64|sha": "74cdf90223f293adc5fc884910be9f8c26f8d476269df5d86ad022c6449a9376f3bf2a8c251ddd3bda7f11a8be1ae6a0876e988ed445e0baeeaff8d4e9456948",
     "runtime|7.0|linux-musl|arm|sha": "db3a841fcebe667144a62c3e15347da2ab826e908fa5da7c693371645900df2a533af7bc36e6792466c65556938827baaa16a570988848fad06ae3aba5245f56",
     "runtime|7.0|linux-musl|arm64|sha": "642bee46020fc51b4710d542570cae2facbecddcd7ed36919ee11cd419fd1a933bbf489870594182ff40ed6fc273d6ee8721f40f4ab8ca447e21909e902b6f99",

--- a/src/sdk/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/sdk/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -30,11 +30,11 @@ RUN curl -fSL --output dotnet.rpm https://dotnetbuilds.azureedge.net/public/Sdk/
     && dotnet_sha512='07208f773a734f7428c7c128314cd8c7f6b6b5f1e078b7e202ba9d2343f50a4428207de595dd267d35d968edff91b666efa3b75f1676f2b7a6dbce7c2b9beba5' \
     && echo "$dotnet_sha512  apphost.rpm" | sha512sum -c - \
     \
-    && curl -fSL --output targeting-pack.rpm https://dotnetbuilds.azureedge.net/public/Runtime/$DOTNET_VERSION/dotnet-targeting-pack-$DOTNET_VERSION-x64.rpm \
+    && curl -fSL --output targeting-pack.rpm https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-preview.1.22076.8/dotnet-targeting-pack-7.0.0-preview.1.22076.8-x64.rpm \
     && dotnet_sha512='0e0d8bdf92494e6c7d74faaa6a78017b4658fba5d15f78316393ced4df188df67dbec62fd465b53314294145d15b9f2fea4f6a6f8b734971a12ef9eaac6db42f' \
     && echo "$dotnet_sha512  targeting-pack.rpm" | sha512sum -c - \
     \
-    && curl -fSL --output aspnetcore-targeting-pack.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-targeting-pack-$ASPNET_VERSION.rpm \
+    && curl -fSL --output aspnetcore-targeting-pack.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/7.0.0-preview.1.22081.6/aspnetcore-targeting-pack-7.0.0-preview.1.22081.6.rpm \
     && dotnet_sha512='0229222c24e24a1eae07a3697f0d450363a70fbd2095293d69091262fb4f6ecaf52ecfe30184bf47768a78af9945e25cb5bd2beb5f1673876671a3df193563d7' \
     && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
     \


### PR DESCRIPTION
Currently the 7.0 sdk Dockerfile template differs from the other .NET versions when it comes to constructing the URL of targeting packs. This is because 7.0 is in active development and targeting packs get produced with each new product build. So the version of the targeting pack matches the version of the respective runtime. For past released versions, however, the targeting pack releases stabilize, having a version that differs from the runtime version.

To handle this, the 7.0 sdk Dockerfile uses the runtime version environment variable in the URL path because the version of the targeting pack always matches the version of the runtime. There's a better way to do this that provides a consistent Dockerfile template across .NET versions. Templates for past released versions reference a variable named `runtime|<dotnet-version>|targeting-pack-version`. We can do the same thing for 7.0 and allow it to automatically reference the latest build version by using a nested variable reference: `"runtime|7.0|targeting-pack-version": "$(runtime|7.0|build-version)"`. This allows all these Dockerfile templates to use the same pattern of referencing a variable named `runtime|<dotnet-version>|targeting-pack-version`; no special case needed for 7.0.