### PR TITLE
Dotnet-Monitor reduce image size

### DIFF
--- a/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.0/Dockerfile.alpine
@@ -10,10 +10,18 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnetmonitor_sha512='{{VARIABLES["monitor|6.0|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
-    # To reduce image size, remove the copy of the nupkg under the tools.
-    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net6.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/eng/dockerfile-templates/monitor/6.1/Dockerfile.alpine
+++ b/eng/dockerfile-templates/monitor/6.1/Dockerfile.alpine
@@ -10,10 +10,18 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnetmonitor_sha512='{{VARIABLES["monitor|6.1|sha"]}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
-    # To reduce image size, remove the copy of the nupkg under the tools.
-    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net6.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/src/monitor/6.0/alpine/amd64/Dockerfile
+++ b/src/monitor/6.0/alpine/amd64/Dockerfile
@@ -10,10 +10,18 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnetmonitor_sha512='3203e455fe4fa9e7b251ba957ddf286a3a3fcf1c88663315547d5f4f7df9ee1c1f164dfcc42edeebaf786bf1b893753c5a5339377b259798208d5f07c48f9a10' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
-    # To reduce image size, remove the copy of the nupkg under the tools.
-    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net6.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/src/monitor/6.1/alpine/amd64/Dockerfile
+++ b/src/monitor/6.1/alpine/amd64/Dockerfile
@@ -10,10 +10,18 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azure
     && dotnetmonitor_sha512='2d1d10e75be400e6ebab707731daa2ca2723a055b60129247504b6b0d28e63fbc2a23e4d9a7ba7b597d48d1438389acd29c475dda2796920816c7fe63214b1d7' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
-    # To reduce image size, remove the copy of the nupkg under the tools.
-    && find /app -print | grep -i '.*[.]nupkg$' | xargs rm \
     # To reduce image size, remove all non-net6.0 TFMs
-    && find /app -print | grep -i '.*/netcoreapp3[.]1$' | xargs rm -rf \
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net6.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -197,8 +197,8 @@
     "src/sdk/7.0/cbl-mariner1.0/amd64": 874993672
   },
   "dotnet/nightly/monitor": {
-    "src/monitor/6.0/alpine/amd64": 109543092,
-    "src/monitor/6.1/alpine/amd64": 108128663,
-    "src/monitor/7.0/alpine/amd64": 108783168
+    "src/monitor/6.0/alpine/amd64": 107934342,
+    "src/monitor/6.1/alpine/amd64": 107919731,
+    "src/monitor/7.0/alpine/amd64": 108759306
   }
 }


### PR DESCRIPTION
Applies image stripping done for `7.0` image to `6.0` and `6.1` images.

Update image size for all dotnet-monitor images.

`src/monitor/6.0/alpine/amd64` Image contents:
```
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/
-rwxr--r-- 0/0          146816 2020-08-18 10:46 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Azure.Core.dll
-rwxr--r-- 0/0          871800 2020-08-31 15:39 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Azure.Storage.Blobs.dll
-rwxr--r-- 0/0           73592 2020-08-31 15:39 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Azure.Storage.Common.dll
-rwxr--r-- 0/0           59024 2018-02-22 21:52 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Dia2Lib.dll
-rwxr--r-- 0/0             204 2022-01-27 21:20 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/DotnetToolSettings.xml
-rwxr--r-- 0/0           37752 2021-06-18 11:38 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.AspNetCore.Authentication.JwtBearer.dll
-rwxr--r-- 0/0           41344 2020-10-20 17:11 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.AspNetCore.Authentication.Negotiate.dll
-rwxr--r-- 0/0           14920 2019-11-15 00:38 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Bcl.AsyncInterfaces.dll
-rwxr--r-- 0/0           52616 2021-01-05 14:25 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.FastSerialization.dll
-rwxr--r-- 0/0          163760 2021-11-23 17:04 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.EventPipe.dll
-rwxr--r-- 0/0           84872 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.Options.dll
-rwxr--r-- 0/0           19328 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.Options.pdb
-rwxr--r-- 0/0          140680 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.WebApi.dll
-rwxr--r-- 0/0           56048 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.WebApi.pdb
-rwxr--r-- 0/0           26897 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.WebApi.xml
-rwxr--r-- 0/0           27048 2021-11-23 17:03 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.dll
-rwxr--r-- 0/0          132520 2021-11-23 17:03 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.NETCore.Client.dll
-rwxr--r-- 0/0         3053448 2021-01-05 14:28 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.Diagnostics.Tracing.TraceEvent.dll
-rwxr--r-- 0/0           62840 2021-05-21 15:23 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.IdentityModel.JsonWebTokens.dll
-rwxr--r-- 0/0           29560 2021-05-21 15:25 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.IdentityModel.Logging.dll
-rwxr--r-- 0/0          109096 2019-06-24 12:59 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
-rwxr--r-- 0/0           37416 2019-06-24 12:54 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.IdentityModel.Protocols.dll
-rwxr--r-- 0/0          889216 2021-05-21 15:30 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Microsoft.IdentityModel.Tokens.dll
-rwxr--r-- 0/0          648600 2017-03-20 13:03 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/Newtonsoft.Json.dll
-rwxr--r-- 0/0           32000 2019-01-04 08:24 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/OSExtensions.dll
-rwxr--r-- 0/0          194432 2020-09-18 15:17 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/System.CommandLine.dll
-rwxr--r-- 0/0           81784 2021-05-21 15:22 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/System.IdentityModel.Tokens.Jwt.dll
-rwxr--r-- 0/0           23216 2018-02-22 21:52 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/TraceReloggerLib.dll
-rwxr--r-- 0/0             146 2022-01-27 20:53 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/appsettings.Development.json
-rwxr--r-- 0/0             636 2022-01-27 20:53 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/appsettings.json
-rwxr--r-- 0/0           61413 2022-01-27 21:20 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/dotnet-monitor.deps.json
-rwxr--r-- 0/0          256904 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/dotnet-monitor.dll
-rwxr--r-- 0/0           91820 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/dotnet-monitor.pdb
-rwxr--r-- 0/0             517 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/dotnet-monitor.runtimeconfig.json
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/shims/
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/shims/linux-musl-x64/
-rwxr--r-- 0/0           85448 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/shims/linux-musl-x64/dotnet-monitor
drwxr-xr-x 0/0               0 2022-02-04 11:42 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/shims/linux-x64/
-rwxr--r-- 0/0          142840 2022-01-27 20:57 app/.store/dotnet-monitor/6.0.2/dotnet-monitor/6.0.2/tools/net6.0/any/shims/linux-x64/dotnet-monitor
-rwxr-xr-x 0/0           85448 2022-01-27 20:57 app/dotnet-monitor
```
`src/monitor/6.1/alpine/amd64` Image contents:
```
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/
-rwxr--r-- 0/0          146816 2020-08-18 10:46 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Azure.Core.dll
-rwxr--r-- 0/0          871800 2020-08-31 15:39 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Azure.Storage.Blobs.dll
-rwxr--r-- 0/0           73592 2020-08-31 15:39 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Azure.Storage.Common.dll
-rwxr--r-- 0/0           59024 2018-02-22 21:52 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Dia2Lib.dll
-rwxr--r-- 0/0             204 2022-01-27 21:21 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/DotnetToolSettings.xml
-rwxr--r-- 0/0           37752 2021-06-18 11:38 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.AspNetCore.Authentication.JwtBearer.dll
-rwxr--r-- 0/0           41344 2020-10-20 17:11 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.AspNetCore.Authentication.Negotiate.dll
-rwxr--r-- 0/0           14920 2019-11-15 00:38 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Bcl.AsyncInterfaces.dll
-rwxr--r-- 0/0           52616 2021-01-05 14:25 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.FastSerialization.dll
-rwxr--r-- 0/0          163760 2021-11-23 17:04 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.EventPipe.dll
-rwxr--r-- 0/0           87952 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.Options.dll
-rwxr--r-- 0/0           19468 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.Options.pdb
-rwxr--r-- 0/0          141712 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.WebApi.dll
-rwxr--r-- 0/0           56048 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.WebApi.pdb
-rwxr--r-- 0/0           26897 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.WebApi.xml
-rwxr--r-- 0/0           27048 2021-11-23 17:03 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Monitoring.dll
-rwxr--r-- 0/0          132520 2021-11-23 17:03 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.NETCore.Client.dll
-rwxr--r-- 0/0         3053448 2021-01-05 14:28 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.Diagnostics.Tracing.TraceEvent.dll
-rwxr--r-- 0/0           62840 2021-05-21 15:23 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.IdentityModel.JsonWebTokens.dll
-rwxr--r-- 0/0           29560 2021-05-21 15:25 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.IdentityModel.Logging.dll
-rwxr--r-- 0/0          109096 2019-06-24 12:59 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
-rwxr--r-- 0/0           37416 2019-06-24 12:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.IdentityModel.Protocols.dll
-rwxr--r-- 0/0          889216 2021-05-21 15:30 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Microsoft.IdentityModel.Tokens.dll
-rwxr--r-- 0/0          649640 2017-03-20 13:03 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/Newtonsoft.Json.dll
-rwxr--r-- 0/0           32000 2019-01-04 08:24 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/OSExtensions.dll
-rwxr--r-- 0/0          194432 2020-09-18 15:17 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/System.CommandLine.dll
-rwxr--r-- 0/0           81784 2021-05-21 15:22 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/System.IdentityModel.Tokens.Jwt.dll
-rwxr--r-- 0/0           23216 2018-02-22 21:52 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/TraceReloggerLib.dll
-rwxr--r-- 0/0             146 2022-01-27 20:53 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/appsettings.Development.json
-rwxr--r-- 0/0             636 2022-01-27 20:53 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/appsettings.json
-rwxr--r-- 0/0           61371 2022-01-27 21:21 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/dotnet-monitor.deps.json
-rwxr--r-- 0/0          267152 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/dotnet-monitor.dll
-rwxr--r-- 0/0           94252 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/dotnet-monitor.pdb
-rwxr--r-- 0/0             517 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/dotnet-monitor.runtimeconfig.json
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/shims/
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/shims/linux-musl-x64/
-rwxr--r-- 0/0           85448 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/shims/linux-musl-x64/dotnet-monitor
drwxr-xr-x 0/0               0 2022-02-04 11:54 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/shims/linux-x64/
-rwxr--r-- 0/0          142840 2022-01-27 20:58 app/.store/dotnet-monitor/6.1.0/dotnet-monitor/6.1.0/tools/net6.0/any/shims/linux-x64/dotnet-monitor
-rwxr-xr-x 0/0           85448 2022-01-27 20:58 app/dotnet-monitor
```

Testing done: Setup both `6.1` and `6.0` containers and did `docker container start` and hit the `{server}/info` endpoint, verifying process started. 