### PR TITLE
Update .NET Monitor featured tags

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -4,12 +4,10 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 
 # Featured Tags
 
-* `7.0` (Preview)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7.0`
-* `6.1` (Preview)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6.1`
-* `6.0` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6.0`
+* `7` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
+* `6` (Current)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 # About This Image
 
@@ -50,13 +48,13 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+6.1.0-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.0-alpine, 6.1-alpine, 6-alpine, 6.1.0, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.15
 6.0.2-alpine-amd64, 6.0-alpine-amd64, 6.0.2-alpine, 6.0-alpine, 6.0.2, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile) | Alpine 3.14
 
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.0.0-preview.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-preview.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-preview.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.15
-6.1.0-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.0-alpine, 6.1-alpine, 6-alpine, 6.1.0, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.15
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -2,5 +2,4 @@ $(McrTagsYmlRepo:monitor)
 $(McrTagsYmlTagGroup:7.0-alpine-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:6.1-alpine-amd64)
-    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:6.0-alpine-amd64)

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -10,12 +10,10 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
   * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
 * `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`
-^elif match(SHORT_REPO, "monitor"):* `7.0` (Preview)
-  * `docker pull {{FULL_REPO}}:7.0`
-* `6.1` (Preview)
-  * `docker pull {{FULL_REPO}}:6.1`
-* `6.0` (Current)
-  * `docker pull {{FULL_REPO}}:6.0`
+^elif match(SHORT_REPO, "monitor"):* `7` (Preview)
+  * `docker pull {{FULL_REPO}}:7`
+* `6` (Current)
+  * `docker pull {{FULL_REPO}}:6`
 ^else: * `7.0` (Preview)
   * `docker pull {{FULL_REPO}}:7.0`
 * `6.0` (Current, LTS)


### PR DESCRIPTION
Remove sub table title for 6.1

cc @dotnet/dotnet-monitor 