### PR TITLE
Rollback to Alpine 3.14 for .NET Monitor

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -55,8 +55,8 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-7.0.0-preview.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-preview.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-preview.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.15
-6.1.0-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.0-alpine, 6.1-alpine, 6-alpine, 6.1.0, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.15
+7.0.0-preview.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-preview.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-preview.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.14
+6.1.0-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.0-alpine, 6.1-alpine, 6-alpine, 6.1.0, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.14
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/manifest.json
+++ b/manifest.json
@@ -6021,7 +6021,7 @@
               "dockerfile": "src/monitor/6.1/alpine/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
               "os": "linux",
-              "osVersion": "alpine3.15",
+              "osVersion": "alpine3.14",
               "tags": {
                 "$(monitor|6.1|product-version)-alpine-amd64": {},
                 "6.1-alpine-amd64": {},
@@ -6050,7 +6050,7 @@
               "dockerfile": "src/monitor/7.0/alpine/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
               "os": "linux",
-              "osVersion": "alpine3.15",
+              "osVersion": "alpine3.14",
               "tags": {
                 "$(monitor|7.0|product-version)-alpine-amd64": {},
                 "7.0-alpine-amd64": {},

--- a/src/monitor/6.1/alpine/amd64/Dockerfile
+++ b/src/monitor/6.1/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.102-alpine3.15-amd64 AS installer
+FROM $SDK_REPO:6.0.102-alpine3.14-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.1.0
@@ -26,7 +26,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0.2-alpine3.15-amd64
+FROM $ASPNET_REPO:6.0.2-alpine3.14-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:7.0.100-preview.1-alpine3.15-amd64 AS installer
+FROM $SDK_REPO:7.0.100-preview.1-alpine3.14-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-preview.1.22107.5
@@ -26,7 +26,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
 
 
 # Monitor image
-FROM $ASPNET_REPO:7.0.0-preview.1-alpine3.15-amd64
+FROM $ASPNET_REPO:7.0.0-preview.1-alpine3.14-amd64
 
 WORKDIR /app
 COPY --from=installer /app .


### PR DESCRIPTION
This change rolls back the version of Alpine to 3.14 for the .NET Monitor images. These images have not been released yet so there is no breaking change.

cc @dotnet/dotnet-monitor 