### PR TITLE
.NET Monitor: Use version variable if product and build are same

### DIFF
--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -14,7 +14,9 @@
     _ All .NET Monitor versions publish to the same storage account, thus use the latest storage account scheme.
       However, the latest 6.0 release still uses dotnetcli storage account. ^
     set urlVersion to when(monitorMajorMinor != "6.0", "7.0", "6.0") ^
-    set url to cat(VARIABLES[cat("base-url|", urlVersion ,"|", VARIABLES["branch"])])
+    set url to cat(VARIABLES[cat("base-url|", urlVersion ,"|", VARIABLES["branch"])]) ^
+    _ Use the $DOTNET_MONITOR_VERSION variable for the version folder if the build and product versions are the same. ^
+    set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$DOTNET_MONITOR_VERSION')
 }}ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
@@ -23,7 +25,7 @@ FROM $SDK_REPO:{{installerBaseTag}} AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION={{monitorVersion}}
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg {{url}}/diagnostics/monitor/{{buildVersion}}/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg {{url}}/diagnostics/monitor/{{versionFolder}}/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='{{monitorSha}}' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework {{targetFrameworkMoniker}} --no-cache \

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:7.0.100-preview.1-alpine3.15-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-preview.1.22109.7
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/7.0.0-preview.1.22109.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='b5f67ef55208bfa10b647d1473abdf663681f5f525abc33da3992b624e011c1cff930495492f455e730716ec5fd0a5d1ce429b4a7a9a459e28bad97942b7ecad' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \


### PR DESCRIPTION
This change makes use of the $DOTNET_MONITOR_VERSION variable in the produce URL if the build and product versions are the same. This allows the Dockerfiles for .NET Monitor to be more consistent with the other dotnet Dockerfiles, especially when shipping from the main branch where the product and build versions are typically the same.