### PR TITLE
Split image scanning into arch-specific jobs

### DIFF
--- a/eng/pipelines/cg-images.yml
+++ b/eng/pipelines/cg-images.yml
@@ -15,13 +15,22 @@ variables:
 
 jobs:
 - job: ScanImages
+  displayName: Scan Images
   pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
+  strategy:
+      matrix:
+        amd64:
+          arch: amd64
+        arm32:
+          arch: arm
+        arm64:
+          arch: arm64
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
   - script: >
       $(runImageBuilderCmd) pullImages
-      --architecture '*'
+      --architecture '$(arch)'
       --manifest 'manifest.json'
       --output-var 'pulledImages'
     displayName: Pull Images


### PR DESCRIPTION
Component detection of container images had been broken for a while and just fixed by https://github.com/dotnet/docker-tools/pull/968. However, now that scanning is running again we're running into disk space issues on the agent. The agent is running out of space when it attempts to scan the images because it saves each image to a tarball for scanning.

To workaround this, I'm splitting the scanning into arch-specific jobs so that each agent has to deal with less images.