### PR TITLE
.NET Monitor: Get package from dotnetcli if stable product version

### DIFF
--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -14,7 +14,10 @@
     _ All .NET Monitor versions publish to the same storage account, thus use the latest storage account scheme.
       However, the latest 6.0 release still uses dotnetcli storage account. ^
     set urlVersion to when(monitorMajorMinor != "6.0", "7.0", "6.0") ^
-    set url to cat(VARIABLES[cat("base-url|", urlVersion ,"|", VARIABLES["branch"])]) ^
+    _ When build and product versions are the same and they are stable versions, use account from main branch e.g. dotnetcli
+      Otherwise, use the account that is associated with the current branch. ^
+    set urlBranch to when(find(monitorVersion, "-") >= 0 || buildVersion != monitorVersion, VARIABLES["branch"], "main") ^
+    set url to cat(VARIABLES[cat("base-url|", urlVersion ,"|", urlBranch)]) ^
     _ Use the $DOTNET_MONITOR_VERSION variable for the version folder if the build and product versions are the same. ^
     set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$DOTNET_MONITOR_VERSION')
 }}ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet


### PR DESCRIPTION
This change allows acquisition of the .NET Monitor package from the dotnetcli storage account regardless of the branch in which the Dockerfiles are generated if (1) the product and build versions are the same and (2) the product version is a stable version (doesn't have -* label). This allows merges back from main to nightly without accidentally regenerating the Dockerfiles to use dotnetstage storage account if the above conditions hold.

This currently does not cause changes in the nightly branch because the 6.0.* and 6.1.* lines have product versions different from their build versions and the 7.0.* line is not a stable version.

cc @dotnet/dotnet-monitor