### PR TITLE
Disable sample test for Windows

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -90,6 +90,12 @@ namespace Microsoft.DotNet.Docker.Tests
         [Fact]
         public void VerifyComplexAppSample()
         {
+            if (Config.Os.StartsWith(OS.NanoServer20H2))
+            {
+                OutputHelper.WriteLine("Disable this test for 20H2 due to https://github.com/dotnet/dotnet-docker/issues/3510. Reenable when fixed.");
+                return;
+            }
+
             string appTag = SampleImageData.GetImageName("complexapp-local-app");
             string testTag = SampleImageData.GetImageName("complexapp-local-test");
             string sampleFolder = Path.Combine(s_samplesPath, "complexapp");

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -90,9 +90,9 @@ namespace Microsoft.DotNet.Docker.Tests
         [Fact]
         public void VerifyComplexAppSample()
         {
-            if (Config.Os.StartsWith(OS.NanoServer20H2))
+            if (!DockerHelper.IsLinuxContainerModeEnabled)
             {
-                OutputHelper.WriteLine("Disable this test for 20H2 due to https://github.com/dotnet/dotnet-docker/issues/3510. Reenable when fixed.");
+                OutputHelper.WriteLine("Disable this test for Windows due to https://github.com/dotnet/dotnet-docker/issues/3510. Reenable when fixed.");
                 return;
             }
 


### PR DESCRIPTION
Disable sample test for Windows Server version 20H2 due to a `dotnet restore` issue: https://github.com/dotnet/dotnet-docker/issues/3510.