### PR TITLE
Use correct ca-certs pkg for full Mariner

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -38,7 +38,9 @@
             ])) ^
         set certsPkgPrefix to when(isMariner,
             [
-                when(dotnetVersion = "3.1" || dotnetVersion = "5.0", "ca-certificates", "prebuilt-ca-certificates"),
+                when(dotnetVersion = "3.1" || dotnetVersion = "5.0",
+                    "ca-certificates",
+                    when(isDistrolessMariner, "prebuilt-ca-certificates", "ca-certificates-microsoft")),
                 "",
                 dotnetDepsComment
             ],

--- a/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM cblmariner.azurecr.io/base/core:1.0
 
 RUN tdnf install -y \
-        prebuilt-ca-certificates \
+        ca-certificates-microsoft \
         \
         # .NET dependencies
         glibc \

--- a/src/runtime-deps/7.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,7 +1,7 @@
 FROM cblmariner.azurecr.io/base/core:1.0
 
 RUN tdnf install -y \
-        prebuilt-ca-certificates \
+        ca-certificates-microsoft \
         \
         # .NET dependencies
         glibc \


### PR DESCRIPTION
The `prebuilt-ca-certificates` package should only be used for distroless implementations of CBL-Mariner. Otherwise, it can lead to conflicts with the existing cert packages that are installed in full Mariner. See https://dev.azure.com/microsoft/OS/_workitems/edit/38162114. Instead, the non-prebuilt version of the package should be used: `ca-certificates-microsoft`.