### PR TITLE
Disable PowerShell-related tests on Alpine for Arm arch

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 return;
             }
 
-            // Disable this test for Arm-based Alpine on 6.0 until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
+            // Disable this test for Arm-based Alpine until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
             if (imageData.OS.Contains("alpine") && imageData.IsArm)
             {
                 return;
@@ -324,7 +324,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private void PowerShellScenario_Execute(ProductImageData imageData, string optionalArgs)
         {
-            // Disable this test for Arm-based Alpine on 6.0 until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
+            // Disable this test for Arm-based Alpine until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
             if (imageData.OS.Contains("alpine") && imageData.IsArm)
             {
                 OutputHelper.WriteLine("PowerShell does not have Alpine arm images, skip testing");

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
 
             // Disable this test for Arm-based Alpine on 6.0 until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
-            if (imageData.Version.Major == 6 && imageData.OS.Contains("alpine") && imageData.IsArm)
+            if (imageData.OS.Contains("alpine") && imageData.IsArm)
             {
                 return;
             }
@@ -325,7 +325,7 @@ namespace Microsoft.DotNet.Docker.Tests
         private void PowerShellScenario_Execute(ProductImageData imageData, string optionalArgs)
         {
             // Disable this test for Arm-based Alpine on 6.0 until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
-            if (imageData.Version.Major == 6 && imageData.OS.Contains("alpine") && imageData.IsArm)
+            if (imageData.OS.Contains("alpine") && imageData.IsArm)
             {
                 OutputHelper.WriteLine("PowerShell does not have Alpine arm images, skip testing");
                 return;


### PR DESCRIPTION
Changes were made in https://github.com/dotnet/dotnet-docker/commit/c2b14dc92c29fb8d60c7aae49cd4895de59c687e#diff-374c24707f197ad0b90b129473a517046626f7148c795b21c9155a978d83b2ad that removed the disable of PowerShell tests for Alpine 3.15. This should only be done for AMD64 but not for Arm32/Arm64 because PowerShell doesn't support musl-based Arm. There was an existing check for this that was incorrectly specific to 6.0 so I've generalized it to be broader.