### PR TITLE
Add authentication validation for .NET Monitor images

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
@@ -27,6 +27,15 @@ namespace Microsoft.DotNet.Docker.Tests
         }
 
         /// <summary>
+        /// Sets the entrypoint of the container.
+        /// </summary>
+        public DockerRunArgsBuilder Entrypoint(string entrypoint)
+        {
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "--entrypoint {0} ", entrypoint);
+            return this;
+        }
+
+        /// <summary>
         /// Sets the named environment variable with the specified value.
         /// </summary>
         public DockerRunArgsBuilder EnvironmentVariable(string name, string value)

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -242,7 +243,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        public static async Task<HttpResponseMessage> GetHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null, Action<HttpResponseMessage> validateCallback = null)
+        public static async Task<HttpResponseMessage> GetHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null, Action<HttpResponseMessage> validateCallback = null, AuthenticationHeaderValue authorizationHeader = null)
         {
             int retries = 30;
 
@@ -253,6 +254,11 @@ namespace Microsoft.DotNet.Docker.Tests
 
             using (HttpClient client = new HttpClient())
             {
+                if (null != authorizationHeader)
+                {
+                    client.DefaultRequestHeaders.Authorization = authorizationHeader;
+                }
+
                 while (retries > 0)
                 {
                     retries--;

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -298,14 +298,15 @@ namespace Microsoft.DotNet.Docker.Tests
             throw new TimeoutException($"Timed out attempting to access the endpoint {url} on container {containerName}");
         }
 
-        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null)
+        public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort = 80, string pathAndQuery = null, Action<HttpResponseMessage> validateCallback = null)
         {
             (await GetHttpResponseFromContainerAsync(
                 containerName,
                 dockerHelper,
                 outputHelper,
                 containerPort,
-                pathAndQuery)).Dispose();
+                pathAndQuery,
+                validateCallback)).Dispose();
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -150,13 +150,13 @@ namespace Microsoft.DotNet.Docker.Tests
                     if (!Config.IsHttpVerificationDisabled)
                     {
                         // Verify processes returns 401 (Unauthorized) since authentication was not configured.
-                        (await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                        await ImageScenarioVerifier.VerifyHttpResponseFromContainerAsync(
                             containerName,
                             DockerHelper,
                             OutputHelper,
                             DefaultArtifactsPort,
                             UrlPath_Processes,
-                            m => VerifyStatusCode(m, HttpStatusCode.Unauthorized))).Dispose();
+                            m => VerifyStatusCode(m, HttpStatusCode.Unauthorized));
                     }
                 },
                 builder =>
@@ -223,13 +223,13 @@ namespace Microsoft.DotNet.Docker.Tests
                     if (!Config.IsHttpVerificationDisabled)
                     {
                         // Verify processes returns 401 (Unauthorized) since authentication was not provided.
-                        (await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                        await ImageScenarioVerifier.VerifyHttpResponseFromContainerAsync(
                             containerName,
                             DockerHelper,
                             OutputHelper,
                             DefaultArtifactsPort,
                             UrlPath_Processes,
-                            m => VerifyStatusCode(m, HttpStatusCode.Unauthorized))).Dispose();
+                            m => VerifyStatusCode(m, HttpStatusCode.Unauthorized));
 
                         // Verify processes is accessible using authorization header
                         using HttpResponseMessage processesMessage =

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -150,14 +150,13 @@ namespace Microsoft.DotNet.Docker.Tests
                     if (!Config.IsHttpVerificationDisabled)
                     {
                         // Verify processes returns 401 (Unauthorized) since authentication was not configured.
-                        using HttpResponseMessage processesMessage =
-                            await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
-                                containerName,
-                                DockerHelper,
-                                OutputHelper,
-                                DefaultArtifactsPort,
-                                UrlPath_Processes,
-                                m => VerifyStatusCode(m, HttpStatusCode.Unauthorized));
+                        (await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                            containerName,
+                            DockerHelper,
+                            OutputHelper,
+                            DefaultArtifactsPort,
+                            UrlPath_Processes,
+                            m => VerifyStatusCode(m, HttpStatusCode.Unauthorized))).Dispose();
                     }
                 },
                 builder =>
@@ -224,17 +223,16 @@ namespace Microsoft.DotNet.Docker.Tests
                     if (!Config.IsHttpVerificationDisabled)
                     {
                         // Verify processes returns 401 (Unauthorized) since authentication was not provided.
-                        using HttpResponseMessage processesMessageUnauthorized =
-                            await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
-                                containerName,
-                                DockerHelper,
-                                OutputHelper,
-                                DefaultArtifactsPort,
-                                UrlPath_Processes,
-                                m => VerifyStatusCode(m, HttpStatusCode.Unauthorized));
+                        (await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
+                            containerName,
+                            DockerHelper,
+                            OutputHelper,
+                            DefaultArtifactsPort,
+                            UrlPath_Processes,
+                            m => VerifyStatusCode(m, HttpStatusCode.Unauthorized))).Dispose();
 
                         // Verify processes is accessible using authorization header
-                        using HttpResponseMessage processesMessageSuccess =
+                        using HttpResponseMessage processesMessage =
                             await ImageScenarioVerifier.GetHttpResponseFromContainerAsync(
                                 containerName,
                                 DockerHelper,
@@ -242,6 +240,12 @@ namespace Microsoft.DotNet.Docker.Tests
                                 DefaultArtifactsPort,
                                 UrlPath_Processes,
                                 authorizationHeader: authorizationHeader);
+
+                        JsonElement rootElement = GetContentAsJsonElement(processesMessage);
+
+                        // Verify returns an empty array (should not detect any processes)
+                        Assert.Equal(JsonValueKind.Array, rootElement.ValueKind);
+                        Assert.Equal(0, rootElement.GetArrayLength());
                     }
                 },
                 builder =>


### PR DESCRIPTION
Only applies to .NET Monitor 6.1 and later, which have the `machinejson` output option for API key generation.

cc @dotnet/dotnet-monitor

closes #3209