### PR TITLE
Move the .NET Monitor 6 and 6-* tags back to the 6.1 image

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -48,14 +48,14 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-6.1.1-alpine-amd64, 6.1-alpine-amd64, 6.1.1-alpine, 6.1-alpine, 6.1.1, 6.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.14
+6.1.1-alpine-amd64, 6.1-alpine-amd64, 6-alpine-amd64, 6.1.1-alpine, 6.1-alpine, 6-alpine, 6.1.1, 6.1, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.1/alpine/amd64/Dockerfile) | Alpine 3.14
 6.0.2-alpine-amd64, 6.0-alpine-amd64, 6.0.2-alpine, 6.0-alpine, 6.0.2, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.0/alpine/amd64/Dockerfile) | Alpine 3.14
 
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.0.0-preview.3-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-preview.3-alpine, 7.0-alpine, 7-alpine, 7.0.0-preview.3, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.15
-6.2.0-alpha.1-alpine-amd64, 6.2-alpine-amd64, 6-alpine-amd64, 6.2.0-alpha.1-alpine, 6.2-alpine, 6-alpine, 6.2.0-alpha.1, 6.2, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/amd64/Dockerfile) | Alpine 3.15
+6.2.0-alpha.1-alpine-amd64, 6.2-alpine-amd64, 6.2.0-alpha.1-alpine, 6.2-alpine, 6.2.0-alpha.1, 6.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/amd64/Dockerfile) | Alpine 3.15
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/manifest.json
+++ b/manifest.json
@@ -6708,8 +6708,10 @@
           "sharedTags": {
             "$(monitor|6.1|product-version)-alpine": {},
             "6.1-alpine": {},
+            "6-alpine": {},
             "$(monitor|6.1|product-version)": {},
-            "6.1": {}
+            "6.1": {},
+            "6": {}
           },
           "platforms": [
             {
@@ -6723,7 +6725,8 @@
               "osVersion": "alpine3.14",
               "tags": {
                 "$(monitor|6.1|product-version)-alpine-amd64": {},
-                "6.1-alpine-amd64": {}
+                "6.1-alpine-amd64": {},
+                "6-alpine-amd64": {}
               }
             }
           ]
@@ -6733,10 +6736,8 @@
           "sharedTags": {
             "$(monitor|6.2|product-version)-alpine": {},
             "6.2-alpine": {},
-            "6-alpine": {},
             "$(monitor|6.2|product-version)": {},
-            "6.2": {},
-            "6": {}
+            "6.2": {}
           },
           "platforms": [
             {
@@ -6750,8 +6751,7 @@
               "osVersion": "alpine3.15",
               "tags": {
                 "$(monitor|6.2|product-version)-alpine-amd64": {},
-                "6.2-alpine-amd64": {},
-                "6-alpine-amd64": {}
+                "6.2-alpine-amd64": {}
               }
             }
           ]


### PR DESCRIPTION
The major version only tags should remain on the image that will be shipping next to ease the update process in the main branch until the next version is ready to be shipped. We anticipate that 6.2 will NOT ship in April, thus the 6 and 6-* tags should remain on the 6.1 image.

cc @dotnet/dotnet-monitor 