### PR TITLE
Update image size baseline for .NET Monitor

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -233,7 +233,7 @@
     "src/monitor/6.1/alpine/amd64": 107919731,
     "src/monitor/6.1/cbl-mariner/amd64": 329811976,
     "src/monitor/6.2/alpine/amd64": 107698176,
-    "src/monitor/7.0/alpine/amd64": 108759306,
+    "src/monitor/7.0/alpine/amd64": 114588203,
     "src/monitor/7.0/cbl-mariner/amd64": 351879133
   }
 }


### PR DESCRIPTION
New assemblies exist within the version introduced by https://github.com/dotnet/dotnet-docker/pull/3580 which increased the size.