### PR TITLE
Update .NET Monitor 7.0 baseline sizes

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -235,7 +235,7 @@
     "src/monitor/6.2/alpine/amd64": 107698176,
     "src/monitor/6.2/alpine/arm64v8": 118521282,
     "src/monitor/6.2/cbl-mariner/amd64": 350489871,
-    "src/monitor/7.0/alpine/amd64": 114588203,
-    "src/monitor/7.0/cbl-mariner/amd64": 351879133
+    "src/monitor/7.0/alpine/amd64": 109210745,
+    "src/monitor/7.0/cbl-mariner/amd64": 365444937
   }
 }


### PR DESCRIPTION
We've removed a handful of files from the .NET Monitor package in the latest build, so I'm updating the baseline sizes to account for the change.

cc @dotnet/dotnet-monitor 