### PR TITLE
Add CBL Mariner 2.0 images in Arm64v8 for Monitor 6.2 and 7.0 images

### DIFF
--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -6,10 +6,6 @@ $(McrTagsYmlTagGroup:7.0-alpine-arm64v8)
 $(McrTagsYmlTagGroup:6.2-alpine-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:6.2-alpine-arm64v8)
-    customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:7.0-cbl-mariner-arm64v8)
-    customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:6.2-cbl-mariner-arm64v8)
-    customSubTableTitle: .NET Monitor Preview Tags
+    customSubTableTitle: .NET Monitor Preview Tags10
 $(McrTagsYmlTagGroup:6.1-alpine-amd64)
 $(McrTagsYmlTagGroup:6.0-alpine-amd64)

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -7,5 +7,9 @@ $(McrTagsYmlTagGroup:6.2-alpine-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:6.2-alpine-arm64v8)
     customSubTableTitle: .NET Monitor Preview Tags
+$(McrTagsYmlTagGroup:7.0-cbl-mariner-arm64v8)
+    customSubTableTitle: .NET Monitor Preview Tags
+$(McrTagsYmlTagGroup:6.2-cbl-mariner-arm64v8)
+    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:6.1-alpine-amd64)
 $(McrTagsYmlTagGroup:6.0-alpine-amd64)

--- a/manifest.json
+++ b/manifest.json
@@ -7054,7 +7054,8 @@
                 "6.2-cbl-mariner-arm64v8": {
                   "docType": "Undocumented"
                 }
-              }
+              },
+              "variant": "v8"
             }
           ]
         },
@@ -7159,7 +7160,8 @@
                 "7-cbl-mariner-arm64v8": {
                   "docType": "Undocumented"
                 }
-              }
+              },
+              "variant": "v8"
             }
           ]
         }

--- a/manifest.json
+++ b/manifest.json
@@ -7036,6 +7036,25 @@
                   "docType": "Undocumented"
                 }
               }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/6.2/cbl-mariner/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "$(monitor|6.2|product-version)-cbl-mariner-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "6.2-cbl-mariner-arm64v8": {
+                  "docType": "Undocumented"
+                }
+              }
             }
           ]
         },
@@ -7116,6 +7135,28 @@
                   "docType": "Undocumented"
                 },
                 "7-cbl-mariner-amd64": {
+                  "docType": "Undocumented"
+                }
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/7.0/cbl-mariner/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "$(monitor|7.0|product-version)-cbl-mariner-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "7.0-cbl-mariner-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "7-cbl-mariner-arm64v8": {
                   "docType": "Undocumented"
                 }
               }

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -1,0 +1,53 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:6.0.201-cbl-mariner2.0-arm64v8 AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION=6.2.0-alpha.1.22168.1
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='a72a176ccac58c055033dbe67a6de5e2be6d6bdb65700fea68e6eaf7c7d07f9219ead6660fcf3b1f4a6bf49b82d770bb94a77359485b53602c2a38fbcfb20508' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
+    # To reduce image size, remove all non-net6.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net6.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:6.0.3-cbl-mariner2.0-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+RUN chmod 755 dotnet-monitor
+
+ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
@@ -1,0 +1,54 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:7.0.100-preview.3-cbl-mariner2.0-arm64v8 AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION=7.0.0-preview.3.22181.5
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='aa1d723635c881f7e1adb2c80e0c65dca5b3d00dff1d17e9679a43ed059d651a1d776e8d36aae2f809eef826b97d8b69481eaf262e295fc93be24762cfdc8307' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
+    # To reduce image size, remove all non-net7.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:7.0.0-preview.3-cbl-mariner2.0-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+RUN chmod 755 dotnet-monitor
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -148,9 +148,11 @@ namespace Microsoft.DotNet.Docker.Tests
             new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Alpine315, OSTag = OS.Alpine, Arch = Arch.Amd64 },
             new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Alpine315, OSTag = OS.Alpine, Arch = Arch.Arm64 },
             new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Arm64 },
             new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Alpine315, OSTag = OS.Alpine, Arch = Arch.Amd64 },
             new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Alpine315, OSTag = OS.Alpine, Arch = Arch.Arm64 },
             new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Arm64 },
         };
 
         private static readonly MonitorImageData[] s_windowsMonitorTestData =

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -235,8 +235,10 @@
     "src/monitor/6.2/alpine/amd64": 107698176,
     "src/monitor/6.2/alpine/arm64v8": 118521282,
     "src/monitor/6.2/cbl-mariner/amd64": 350489871,
+    "src/monitor/6.2/cbl-mariner/arm64v8": 360000000,
     "src/monitor/7.0/alpine/amd64": 109210745,
     "src/monitor/7.0/alpine/arm64v8": 119985095,
-    "src/monitor/7.0/cbl-mariner/amd64": 365444937
+    "src/monitor/7.0/cbl-mariner/amd64": 365444937,
+    "src/monitor/7.0/cbl-mariner/arm64v8": 370000000
   }
 }


### PR DESCRIPTION
Adds dotnet-monitor images:
- 6.2 dotnet-monitor, CBL Mariner 2.0, Arm64v8
- 7.0 dotnet-monitor, CBL Mariner 2.0, Arm64v8