### PR TITLE
Package version updates for Ubuntu 22.04

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -32,7 +32,7 @@
                 "libgcc1",
                 "libgssapi-krb5-2",
                 cat("libicu", VARIABLES[cat("libicu|", OS_VERSION_BASE)]),
-                "libssl1.1",
+                cat("libssl", VARIABLES[cat("libssl|", OS_VERSION_BASE)]),
                 "libstdc++6",
                 "zlib1g"
             ])) ^

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -65,7 +65,13 @@
     "libicu|bullseye": 67,
     "libicu|buster": 63,
     "libicu|focal": 66,
-    "libicu|jammy": 67,
+    "libicu|jammy": 70,
+
+    "libssl|bionic": "1.1",
+    "libssl|bullseye": "1.1",
+    "libssl|buster": "1.1",
+    "libssl|focal": "1.1",
+    "libssl|jammy": "3",
 
     "monitor|6.0|build-version": "6.0.2-servicing.22077.7",
     "monitor|6.0|product-version": "6.0.2",

--- a/src/runtime-deps/6.0/jammy/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy/amd64/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu67 \
-        libssl1.1 \
+        libicu70 \
+        libssl3 \
         libstdc++6 \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*

--- a/src/runtime-deps/6.0/jammy/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy/arm32v7/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu67 \
-        libssl1.1 \
+        libicu70 \
+        libssl3 \
         libstdc++6 \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*

--- a/src/runtime-deps/6.0/jammy/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy/arm64v8/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu67 \
-        libssl1.1 \
+        libicu70 \
+        libssl3 \
         libstdc++6 \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Nightly build is currently broken due to a change in the package names for Ubuntu 22.04. I've updated the package names for the runtime-deps Dockerfiles to reflect the new available versions of those packages: libicu70 and libssl3.

Related to #3350 
