### PR TITLE
Update image size baselines

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -25,7 +25,7 @@
     "src/runtime-deps/6.0/cbl-mariner2.0/amd64": 249765784,
     "src/runtime-deps/6.0/cbl-mariner2.0/arm64v8": 235008327,
     "src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64": 60790443,
-    "src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8": 73578539,
+    "src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8": 58349137,
     "src/runtime-deps/6.0/jammy/amd64": 118850628,
     "src/runtime-deps/6.0/jammy/arm32v7": 92396848,
     "src/runtime-deps/6.0/jammy/arm64v8": 109539947,
@@ -86,7 +86,7 @@
     "src/runtime/6.0/cbl-mariner2.0/amd64": 324144610,
     "src/runtime/6.0/cbl-mariner2.0/arm64v8": 312795102,
     "src/runtime/6.0/cbl-mariner2.0-distroless/amd64": 131421721,
-    "src/runtime/6.0/cbl-mariner2.0-distroless/arm64v8": 151365314,
+    "src/runtime/6.0/cbl-mariner2.0-distroless/arm64v8": 136153608,
     "src/runtime/7.0/bullseye-slim/amd64": 188948418,
     "src/runtime/7.0/bullseye-slim/arm32v7": 156704885,
     "src/runtime/7.0/bullseye-slim/arm64v8": 190089155,
@@ -99,7 +99,7 @@
     "src/runtime/7.0/cbl-mariner2.0/amd64": 325127948,
     "src/runtime/7.0/cbl-mariner2.0/arm64v8": 313628766,
     "src/runtime/7.0/cbl-mariner2.0-distroless/amd64": 132456468,
-    "src/runtime/7.0/cbl-mariner2.0-distroless/arm64v8": 152198978
+    "src/runtime/7.0/cbl-mariner2.0-distroless/arm64v8": 137028148
   },
   "dotnet/nightly/aspnet": {
     "src/aspnet/3.1/bullseye-slim/amd64": 216031293,
@@ -155,7 +155,7 @@
     "src/aspnet/6.0/cbl-mariner2.0/amd64": 348192131,
     "src/aspnet/6.0/cbl-mariner2.0/arm64v8": 335534473,
     "src/aspnet/6.0/cbl-mariner2.0-distroless/amd64": 151682585,
-    "src/aspnet/6.0/cbl-mariner2.0-distroless/arm64v8": 174104685,
+    "src/aspnet/6.0/cbl-mariner2.0-distroless/arm64v8": 158901778,
     "src/aspnet/7.0/bullseye-slim/amd64": 209108403,
     "src/aspnet/7.0/bullseye-slim/arm32v7": 178193510,
     "src/aspnet/7.0/bullseye-slim/arm64v8": 212762558,
@@ -168,7 +168,7 @@
     "src/aspnet/7.0/cbl-mariner2.0/amd64": 349399815,
     "src/aspnet/7.0/cbl-mariner2.0/arm64v8": 336633443,
     "src/aspnet/7.0/cbl-mariner2.0-distroless/amd64": 153017871,
-    "src/aspnet/7.0/cbl-mariner2.0-distroless/arm64v8": 175203655
+    "src/aspnet/7.0/cbl-mariner2.0-distroless/arm64v8": 160116281
   },
   "dotnet/nightly/sdk": {
     "src/sdk/3.1/bullseye/amd64": 723914836,
@@ -217,14 +217,14 @@
     "src/sdk/6.0/cbl-mariner2.0/amd64": 1147000560,
     "src/sdk/6.0/cbl-mariner2.0/arm64v8": 1118137587,
     "src/sdk/7.0/bullseye-slim/amd64": 776238295,
-    "src/sdk/7.0/bullseye-slim/arm32v7": 671608341,
-    "src/sdk/7.0/bullseye-slim/arm64v8": 747202299,
+    "src/sdk/7.0/bullseye-slim/arm32v7": 719341335,
+    "src/sdk/7.0/bullseye-slim/arm64v8": 798856900,
     "src/sdk/7.0/alpine3.15/amd64": 640681481,
-    "src/sdk/7.0/alpine3.15/arm32v7": 529991390,
-    "src/sdk/7.0/alpine3.15/arm64v8": 577467676,
+    "src/sdk/7.0/alpine3.15/arm32v7": 581284782,
+    "src/sdk/7.0/alpine3.15/arm64v8": 632896582,
     "src/sdk/7.0/jammy/amd64": 773149049,
-    "src/sdk/7.0/jammy/arm32v7": 679229148,
-    "src/sdk/7.0/jammy/arm64v8": 740582000,
+    "src/sdk/7.0/jammy/arm32v7": 722423439,
+    "src/sdk/7.0/jammy/arm64v8": 786777942,
     "src/sdk/7.0/cbl-mariner2.0/amd64": 1153542224,
     "src/sdk/7.0/cbl-mariner2.0/arm64v8": 1122410785
   },

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -52,7 +52,7 @@
     "src/sdk/6.0/windowsservercore-ltsc2019/amd64": 6286084693,
     "src/sdk/6.0/windowsservercore-ltsc2022/amd64": 5556352529,
     "src/sdk/7.0/nanoserver-1809/amd64": 975012837,
-    "src/sdk/7.0/nanoserver-ltsc2022/amd64": 1005128696,
+    "src/sdk/7.0/nanoserver-ltsc2022/amd64": 1058152303,
     "src/sdk/7.0/windowsservercore-ltsc2019/amd64": 6429570443,
     "src/sdk/7.0/windowsservercore-ltsc2022/amd64": 5629364231
   }


### PR DESCRIPTION
This is a continuation of the changes made in https://github.com/dotnet/dotnet-docker/pull/3614 which missed the updates for Windows and Linux on Arm.