### PR TITLE
Remove Json as default console logging formatter in aspnet images for 6.0

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.envs
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.envs
@@ -2,10 +2,5 @@
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isWindows to find(OS_VERSION, "nanoserver") >= 0 || find(OS_VERSION, "windowsservercore") >= 0 ^
     set lineContinuation to when(isWindows, "`", "\")
-}}{{if dotnetVersion = "6.0":ENV {{lineContinuation}}
-    # ASP.NET Core version
-    ASPNET_VERSION={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}} {{lineContinuation}}
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json^
-else:# ASP.NET Core version
-ENV ASPNET_VERSION={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}}}}
+}}# ASP.NET Core version
+ENV ASPNET_VERSION={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}}

--- a/eng/dockerfile-templates/sdk/Dockerfile.envs
+++ b/eng/dockerfile-templates/sdk/Dockerfile.envs
@@ -20,9 +20,7 @@
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false {{lineContinuation}}}}{{if ARGS["based-on-buildpack-deps"]:
     {{InsertTemplate("../Dockerfile.env.container")}} {{lineContinuation}}}}
     # Enable correct mode for dotnet watch (only mode supported in a container)
-    DOTNET_USE_POLLING_FILE_WATCHER=true {{lineContinuation}}{{if dotnetVersion = "6.0":
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= {{lineContinuation}}}}{{if isAlpine && dotnetVersion = "3.1":
+    DOTNET_USE_POLLING_FILE_WATCHER=true {{lineContinuation}}{{if isAlpine && dotnetVersion = "3.1":
     LC_ALL=en_US.UTF-8 {{lineContinuation}}
     LANG=en_US.UTF-8 {{lineContinuation}}}}
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/src/aspnet/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/amd64/Dockerfile
@@ -4,11 +4,8 @@ FROM $REPO:6.0.4-alpine3.14-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/aspnet/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/arm32v7/Dockerfile
@@ -4,11 +4,8 @@ FROM $REPO:6.0.4-alpine3.14-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/aspnet/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/alpine3.14/arm64v8/Dockerfile
@@ -4,11 +4,8 @@ FROM $REPO:6.0.4-alpine3.14-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/aspnet/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/aspnet/6.0/alpine3.15/amd64/Dockerfile
@@ -4,11 +4,8 @@ FROM $REPO:6.0.4-alpine3.15-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/aspnet/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/alpine3.15/arm32v7/Dockerfile
@@ -4,11 +4,8 @@ FROM $REPO:6.0.4-alpine3.15-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/aspnet/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/alpine3.15/arm64v8/Dockerfile
@@ -4,11 +4,8 @@ FROM $REPO:6.0.4-alpine3.15-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN wget -O aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \

--- a/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-bullseye-slim-amd64
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-bullseye-slim-arm32v7
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-bullseye-slim-arm64v8
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -19,10 +19,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-cbl-mariner1.0-distroless-amd64
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,11 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.4-cbl-mariner1.0-amd64
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \

--- a/src/aspnet/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -19,10 +19,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-cbl-mariner2.0-distroless-amd64
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/src/aspnet/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -19,10 +19,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-cbl-mariner2.0-distroless-arm64v8
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/src/aspnet/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -1,11 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.4-cbl-mariner2.0-amd64
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \

--- a/src/aspnet/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -1,11 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.4-cbl-mariner2.0-arm64v8
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core
 RUN curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-arm64.tar.gz \

--- a/src/aspnet/6.0/focal/amd64/Dockerfile
+++ b/src/aspnet/6.0/focal/amd64/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-focal-amd64
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/focal/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/focal/arm32v7/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-focal-arm32v7
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/focal/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/focal/arm64v8/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-focal-arm64v8
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/jammy/amd64/Dockerfile
+++ b/src/aspnet/6.0/jammy/amd64/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-jammy-amd64
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/jammy/arm32v7/Dockerfile
+++ b/src/aspnet/6.0/jammy/arm32v7/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-jammy-arm32v7
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/jammy/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/jammy/arm64v8/Dockerfile
@@ -15,10 +15,7 @@ RUN aspnetcore_version=6.0.4 \
 # ASP.NET Core image
 FROM $REPO:6.0.4-jammy-arm64v8
 
-ENV \
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 \
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
@@ -26,10 +26,7 @@ RUN powershell -Command `
 # ASP.NET Core image
 FROM $REPO:6.0.4-nanoserver-1809
 
-ENV `
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 `
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -26,10 +26,7 @@ RUN powershell -Command `
 # ASP.NET Core image
 FROM $REPO:6.0.4-nanoserver-20H2
 
-ENV `
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 `
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -26,10 +26,7 @@ RUN powershell -Command `
 # ASP.NET Core image
 FROM $REPO:6.0.4-nanoserver-ltsc2022
 
-ENV `
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 `
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -3,11 +3,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.4-windowsservercore-ltsc2019
 
-ENV `
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 `
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core Runtime
 RUN powershell -Command `

--- a/src/aspnet/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/aspnet/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -3,11 +3,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 FROM $REPO:6.0.4-windowsservercore-ltsc2022
 
-ENV `
-    # ASP.NET Core version
-    ASPNET_VERSION=6.0.4 `
-    # Set the default console formatter to JSON
-    Logging__Console__FormatterName=Json
+# ASP.NET Core version
+ENV ASPNET_VERSION=6.0.4
 
 # Install ASP.NET Core Runtime
 RUN powershell -Command `

--- a/src/sdk/6.0/alpine3.14/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/amd64/Dockerfile
@@ -14,8 +14,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/arm32v7/Dockerfile
@@ -14,8 +14,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/alpine3.14/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.14/arm64v8/Dockerfile
@@ -14,8 +14,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/amd64/Dockerfile
@@ -14,8 +14,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
@@ -14,8 +14,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
@@ -14,8 +14,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/focal/amd64/Dockerfile
+++ b/src/sdk/6.0/focal/amd64/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/6.0/focal/arm32v7/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/6.0/focal/arm64v8/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/jammy/amd64/Dockerfile
+++ b/src/sdk/6.0/jammy/amd64/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/6.0/jammy/arm32v7/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/6.0/jammy/arm64v8/Dockerfile
@@ -12,8 +12,6 @@ ENV \
     DOTNET_SDK_VERSION=6.0.202 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
@@ -57,8 +57,6 @@ ENV `
     DOTNET_SDK_VERSION=6.0.202 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -57,8 +57,6 @@ ENV `
     DOTNET_SDK_VERSION=6.0.202 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -57,8 +57,6 @@ ENV `
     DOTNET_SDK_VERSION=6.0.202 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -14,8 +14,6 @@ ENV `
     DOTNET_SDK_VERSION=6.0.202 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage

--- a/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -14,8 +14,6 @@ ENV `
     DOTNET_SDK_VERSION=6.0.202 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
-    # Unset Logging__Console__FormatterName from aspnet base image
-    Logging__Console__FormatterName= `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -59,11 +59,6 @@ namespace Microsoft.DotNet.Docker.Tests
                 variables.Add(RuntimeImageTests.GetRuntimeVersionVariableInfo(imageData, DockerHelper));
             }
 
-            if (imageData.Version.Major == 6)
-            {
-                variables.Add(new EnvironmentVariableInfo("Logging__Console__FormatterName", "Json"));
-            }
-
             base.VerifyCommonEnvironmentVariables(imageData, variables);
         }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -81,11 +81,6 @@ namespace Microsoft.DotNet.Docker.Tests
                 variables.Add(new EnvironmentVariableInfo("DOTNET_NOLOGO", "true"));
             }
 
-            if (imageData.Version.Major == 6)
-            {
-                variables.Add(new EnvironmentVariableInfo("Logging__Console__FormatterName", string.Empty));
-            }
-
             if (imageData.SdkOS.StartsWith(OS.AlpinePrefix))
             {
                 variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "false"));


### PR DESCRIPTION
The change to default this to Json in 6.0 has been problematic for some customers as evidenced by the thread in https://github.com/dotnet/dotnet-docker/issues/2725. We're making a breaking change to revert this back to the original behavior as announced in https://github.com/dotnet/dotnet-docker/issues/3642. This leaves the `Logging__Console__FormatterName` environment variable unset.