### PR TITLE
Update Baseline for dotnet-monitor 6.2 cbl-mariner arm64v8

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -235,7 +235,7 @@
     "src/monitor/6.2/alpine/amd64": 107698176,
     "src/monitor/6.2/alpine/arm64v8": 118521282,
     "src/monitor/6.2/cbl-mariner/amd64": 350489871,
-    "src/monitor/6.2/cbl-mariner/arm64v8": 360000000,
+    "src/monitor/6.2/cbl-mariner/arm64v8": 350873324,
     "src/monitor/7.0/alpine/amd64": 109210745,
     "src/monitor/7.0/alpine/arm64v8": 119985095,
     "src/monitor/7.0/cbl-mariner/amd64": 365444937,


### PR DESCRIPTION
This updates the baseline for `src/monitor/6.2/cbl-mariner/arm64v8` to the real value generated by the validate build.