### PR TITLE
Update Baseline for dotnet-monitor 7.0 cbl-mariner arm64v8

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -239,6 +239,6 @@
     "src/monitor/7.0/alpine/amd64": 109210745,
     "src/monitor/7.0/alpine/arm64v8": 119985095,
     "src/monitor/7.0/cbl-mariner/amd64": 365444937,
-    "src/monitor/7.0/cbl-mariner/arm64v8": 370000000
+    "src/monitor/7.0/cbl-mariner/arm64v8": 352262165
   }
 }


### PR DESCRIPTION
This updates the baseline for `src/monitor/7.0/cbl-mariner/arm64v8` to the real value generated by the validate build.