### PR TITLE
Update UID of non-root user for Mariner 2.0

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -50,10 +50,10 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 # Create a non-root user and group
 RUN groupadd \
         --system \
-        --gid=1000 \
+        --gid={{if find(OS_VERSION, "1.0") >= 0:1000^else:101}} \
         app \
     && adduser \
-        --uid 1000 \
+        --uid {{if find(OS_VERSION, "1.0") >= 0:1000^else:101}} \
         --gid app \
         --shell /bin/false \
         --no-create-home \

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -23,10 +23,10 @@ RUN mkdir /staging \
 # Create a non-root user and group
 RUN groupadd \
         --system \
-        --gid=1000 \
+        --gid=101 \
         app \
     && adduser \
-        --uid 1000 \
+        --uid 101 \
         --gid app \
         --shell /bin/false \
         --no-create-home \

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -23,10 +23,10 @@ RUN mkdir /staging \
 # Create a non-root user and group
 RUN groupadd \
         --system \
-        --gid=1000 \
+        --gid=101 \
         app \
     && adduser \
-        --uid 1000 \
+        --uid 101 \
         --gid app \
         --shell /bin/false \
         --no-create-home \


### PR DESCRIPTION
When building the runtime-deps Dockerfile for the distroless version of Mariner 1.0, a warning shows up in the output:

```
adduser warning: app's uid 1000 outside of the SYS_UID_MIN 101 and SYS_UID_MAX 999 range.
```

This happens because `adduser` is called to create a system user with an ID of 1000. The 1000 value was used initially because that's the min value for a normal user (UID_MIN). This was mistakenly used because we're actually creating a system user which have a different range of IDs (101 - 999). (System groups have the same range but, for whatever reason, `groupadd` doesn't show such an error even though we're also setting it to 1000.) Functionally, the user still works. There may be some undiscovered issues with having such an ID though.

These changes update to use the min ID for system users (101), starting with Mariner 2.0. This change is only applied to Mariner 2.0 to get rid of the warning. Given that there's been no feedback on usability issues with the `app` user in Mariner 1.0 and that it'll be EOL later this year anyway, I don't see a need to update it for that version, especially since it would technically be a breaking change.