### PR TITLE
Remove ICU package from distroless version of Mariner 2.0

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.common-dotnet-envs
+++ b/eng/dockerfile-templates/Dockerfile.common-dotnet-envs
@@ -1,10 +1,12 @@
 {{
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isWindows to find(OS_VERSION, "nanoserver") >= 0 || find(OS_VERSION, "windowsservercore") >= 0 ^
+    set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
     set lineContinuation to when(isWindows, "`", "\")
 }}ENV {{lineContinuation}}
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 {{lineContinuation}}
-    {{InsertTemplate("Dockerfile.env.container")}}{{if isAlpine: {{lineContinuation}}
-    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    {{InsertTemplate("Dockerfile.env.container")}}{{if isAlpine || (isDistrolessMariner && find(OS_VERSION, "1.0") < 0): {{lineContinuation}}
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true}}

--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -18,15 +18,24 @@
             "zlib"
         ],
         when(isMariner,
-            [
-                "glibc",
-                "icu",
-                "krb5",
-                "libgcc",
-                "libstdc++",
-                "openssl-libs",
-                "zlib"
-            ],
+            when(isDistrolessMariner && find(OS_VERSION, "1.0") < 0,
+                [
+                    "glibc",
+                    "krb5",
+                    "libgcc",
+                    "libstdc++",
+                    "openssl-libs",
+                    "zlib"
+                ],
+                [
+                    "glibc",
+                    "icu",
+                    "krb5",
+                    "libgcc",
+                    "libstdc++",
+                    "openssl-libs",
+                    "zlib"
+                ]),
             [
                 "libc6",
                 "libgcc1",

--- a/src/runtime-deps/3.1/alpine3.14/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.14/amd64/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/3.1/alpine3.14/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.14/arm64v8/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/3.1/alpine3.15/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.15/amd64/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/3.1/alpine3.15/arm64v8/Dockerfile
+++ b/src/runtime-deps/3.1/alpine3.15/arm64v8/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/5.0/alpine3.14/arm32v7/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.14/arm32v7/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/5.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/runtime-deps/5.0/alpine3.15/arm32v7/Dockerfile
@@ -16,5 +16,5 @@ ENV \
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true \
-    # Set the invariant mode since icu-libs isn't included (see https://github.com/dotnet/announcements/issues/20)
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -12,7 +12,6 @@ RUN mkdir /staging \
         \
         # .NET dependencies
         glibc \
-        icu \
         krb5 \
         libgcc \
         libstdc++ \
@@ -52,6 +51,8 @@ ENV \
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 USER app

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -12,7 +12,6 @@ RUN mkdir /staging \
         \
         # .NET dependencies
         glibc \
-        icu \
         krb5 \
         libgcc \
         libstdc++ \
@@ -52,6 +51,8 @@ ENV \
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 \
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 USER app

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -35,7 +35,8 @@ namespace Microsoft.DotNet.Docker.Tests
                 variables.AddRange(customVariables);
             }
 
-            if (imageData.OS.StartsWith(OS.AlpinePrefix))
+            if (imageData.OS.StartsWith(OS.AlpinePrefix) ||
+                (imageData.IsDistroless && imageData.OS != OS.Mariner10Distroless))
             {
                 variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true"));
             }


### PR DESCRIPTION
This removes the ICU package from distroless Mariner 2.0 for both .NET 6 and 7.

Alpine Dockerfiles ended up having some comments updated in order to have a consistent comment that isn't specific to the name of the ICU package.

Fixes #3394