### PR TITLE
Update support policy docs

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -182,20 +182,22 @@ You can retrieve a list of all available tags for dotnet/aspnet at https://mcr.m
 
 For tags contained in the old dotnet/core/aspnet repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/aspnet/tags/list.
 
-*Tags not listed in the table above should be considered unsupported.*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -182,9 +182,13 @@ You can retrieve a list of all available tags for dotnet/aspnet at https://mcr.m
 
 For tags contained in the old dotnet/core/aspnet repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/aspnet/tags/list.
 
+*Tags not listed in the table above should be considered unsupported.*
+
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/README.md
+++ b/README.md
@@ -71,16 +71,18 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -60,9 +60,13 @@ Tags | Dockerfile | OS Version
 You can retrieve a list of all available tags for dotnet/monitor at https://mcr.microsoft.com/v2/dotnet/monitor/tags/list.
 <!--End of generated tags-->
 
+*Tags not listed in the table above should be considered unsupported.*
+
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -60,20 +60,22 @@ Tags | Dockerfile | OS Version
 You can retrieve a list of all available tags for dotnet/monitor at https://mcr.microsoft.com/v2/dotnet/monitor/tags/list.
 <!--End of generated tags-->
 
-*Tags not listed in the table above should be considered unsupported.*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -117,20 +117,22 @@ You can retrieve a list of all available tags for dotnet/runtime-deps at https:/
 
 For tags contained in the old dotnet/core/runtime-deps repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/runtime-deps/tags/list.
 
-*Tags not listed in the table above should be considered unsupported.*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -117,9 +117,13 @@ You can retrieve a list of all available tags for dotnet/runtime-deps at https:/
 
 For tags contained in the old dotnet/core/runtime-deps repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/runtime-deps/tags/list.
 
+*Tags not listed in the table above should be considered unsupported.*
+
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -178,20 +178,22 @@ You can retrieve a list of all available tags for dotnet/runtime at https://mcr.
 
 For tags contained in the old dotnet/core/runtime repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/runtime/tags/list.
 
-*Tags not listed in the table above should be considered unsupported.*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -178,9 +178,13 @@ You can retrieve a list of all available tags for dotnet/runtime at https://mcr.
 
 For tags contained in the old dotnet/core/runtime repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/runtime/tags/list.
 
+*Tags not listed in the table above should be considered unsupported.*
+
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -98,9 +98,13 @@ You can retrieve a list of all available tags for dotnet/samples at https://mcr.
 
 For tags contained in the old dotnet/core/samples repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/samples/tags/list.
 
+*Tags not listed in the table above should be considered unsupported.*
+
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -98,20 +98,22 @@ You can retrieve a list of all available tags for dotnet/samples at https://mcr.
 
 For tags contained in the old dotnet/core/samples repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/samples/tags/list.
 
-*Tags not listed in the table above should be considered unsupported.*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -181,9 +181,13 @@ You can retrieve a list of all available tags for dotnet/sdk at https://mcr.micr
 
 For tags contained in the old dotnet/core/sdk repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/sdk/tags/list.
 
+*Tags not listed in the table above should be considered unsupported.*
+
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -181,20 +181,22 @@ You can retrieve a list of all available tags for dotnet/sdk at https://mcr.micr
 
 For tags contained in the old dotnet/core/sdk repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/sdk/tags/list.
 
-*Tags not listed in the table above should be considered unsupported.*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)

--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -117,9 +117,9 @@ Each tag will be supported for the lifetime of the .NET and OS version reference
 
 When an OS version reaches EOL, its tags will no longer be maintained.
 
-When a .NET version reaches EOL, its tags will continue to be maintained until the next .NET servicing date (.NET servicing dates are on ["Patch Tuesday"](https://www.microsoft.com/msrc/faqs-security-update-guide)). The maintenance consists of rebuilds due to base image updates or security fixes to Linux packages installed by .NET.
+When a .NET version reaches EOL, its tags will continue to be maintained until the next .NET servicing date (typically on "Update Tuesday", the 2nd Tuesday of the month). The maintenance consists of rebuilds due to base image updates or security fixes to Linux packages installed by .NET.
 
-> Example: The last .NET patch update for .NET 5 is on May 10, 2022. Tags for .NET 5 will continue to be maintained until the next .NET servicing date on June 14, 2022. Within that time period, an update to the Debian 10 base image, for example, will cause the .NET 5 Debian 10 tags to be updated with rebuilt images. Any update to a dependent base image after June 14, 2022 will not result in the .NET 5 tags to be updated.
+> Example: The last .NET patch update for .NET 5 is on May 10, 2022. Maintenance of .NET 5 tags would continue until the next .NET servicing date on June 14, 2022. Within that time period, an update to the Debian 10 base image, for example, would cause the .NET 5 Debian 10 tags to be updated with rebuilt images. Any update to a dependent base image after June 14, 2022 would not result in the .NET 5 tags being updated.
 
 Once a tag is no longer maintained, it will be considered unsupported, will no longer be updated and will be removed from the [Tag Listing](#tag-listing).
 

--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -134,4 +134,4 @@ Unsupported tags will be preserved to prevent breaking any references to it. See
 
 ## Policy Changes
 
-In the event that a change is needed to the tagging patterns used, all tags for the previous pattern will continue to be supported for their original lifetime. They will however be removed from the documentation. [Announcements](https://github.com/dotnet/dotnet-docker/labels/announcement) will be posted when any tagging policy changes are made.
+In the event that a change is needed to the tagging patterns used, all tags for the previous pattern will continue to be supported for their original lifetime. They will however be removed from the documentation. [Announcements](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) will be posted when any tagging policy changes are made.

--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -105,7 +105,7 @@ _Shared Tags_ reference images for [multiple platforms](https://blog.docker.com/
 
 ## Tag Listing
 
-Each [Docker Hub repository](https://hub.docker.com/_/microsoft-dotnet) contains a detailed listing of all supported tags. The listing is broken apart by OS platform (e.g. `Linux amd64 Tags` or `Nano Server 2022 amd64 Tags`). Each row represents a single image and contains all of the tags that reference it. For example the following entry represents the 6.0 runtime Bullseye image which is referenced by seven tags:
+Each [Docker Hub repository](https://hub.docker.com/_/microsoft-dotnet) contains a detailed listing of all supported tags. Any tag not included in the listing should be considered unsupported. The listing is broken apart by OS platform (e.g. `Linux amd64 Tags` or `Nano Server 2022 amd64 Tags`). Each row represents a single image and contains all of the tags that reference it. For example the following entry represents the 6.0 runtime Bullseye image which is referenced by seven tags:
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
@@ -113,7 +113,17 @@ Tags | Dockerfile | OS Version
 
 ## Tag Lifecycle
 
-Each tag will be supported for the lifetime of the .NET and OS version referenced by the tag. Once either either of these reaches EOL, the tag will be considered unsupported, will no longer be updated and will be removed from the [Tag Listing](#tag-listing). Unsupported tags will be preserved to prevent breaking any references to it. See [Microsoft support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for additional details.
+Each tag will be supported for the lifetime of the .NET and OS version referenced by the tag, unless further restricted according to [platform support policy](supported-platforms.md).
+
+When an OS version reaches EOL, its tags will no longer be maintained.
+
+When a .NET version reaches EOL, its tags will continue to be maintained until the next .NET servicing date (.NET servicing dates are on ["Patch Tuesday"](https://www.microsoft.com/msrc/faqs-security-update-guide)). The maintenance consists of rebuilds due to base image updates or security fixes to Linux packages installed by .NET.
+
+> Example: The last .NET patch update for .NET 5 is on May 10, 2022. Tags for .NET 5 will continue to be maintained until the next .NET servicing date on June 14, 2022. Within that time period, an update to the Debian 10 base image, for example, will cause the .NET 5 Debian 10 tags to be updated with rebuilt images. Any update to a dependent base image after June 14, 2022 will not result in the .NET 5 tags to be updated.
+
+Once a tag is no longer maintained, it will be considered unsupported, will no longer be updated and will be removed from the [Tag Listing](#tag-listing).
+
+Unsupported tags will be preserved to prevent breaking any references to it. See [Microsoft support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for additional details.
 
 ### Examples
 

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -87,9 +87,13 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 {{if SHORT_REPO != "monitor":For tags contained in the old dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}} repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}}/tags/list.
 
-}}}}# Support
+}}*Tags not listed in the table above should be considered unsupported.*
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/microsoft-support.md) for the support lifecycle.
+}}# Support
+
+See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+
+See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
 
 # Image Update Policy
 

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -87,20 +87,22 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 {{if SHORT_REPO != "monitor":For tags contained in the old dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}} repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}}/tags/list.
 
-}}*Tags not listed in the table above should be considered unsupported.*
+}}*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 }}# Support
 
-See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md) for the support lifecycle.
+## Lifecycle
 
-See detailed support information for .NET containers on [OS platforms](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md) and [tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
 
-# Image Update Policy
+## Image Update Policy
 
 * We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
 * We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
 
-# Feedback
+## Feedback
 
 * [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)


### PR DESCRIPTION
* Clarified the documentation to explicitly state that unlisted tags are not supported.
* Added links to the Supported Platforms and Supported Tags docs in the support section of the readmes.
* Expanded the Tag Lifecycle section in Supported Tags to describe how tags are maintained after a .NET version reaches EOL.