### PR TITLE
Update-dependencies support for internal .NET builds

### DIFF
--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -37,7 +37,15 @@ param(
 
     # When set, only prints out an Azure DevOps variable with the value of the args to pass to update-dependencies.
     [Switch]
-    $PrintArgsVariableOnly
+    $PrintArgsVariableOnly,
+
+    # SAS query string used to access files in the binary blob container
+    [string]
+    $BinarySasQueryString,
+
+    # SAS query string used to access files in the checksum blob container
+    [string]
+    $ChecksumSasQueryString
 )
 
 $updateDepsArgs = @($ProductVersion)
@@ -60,6 +68,14 @@ if ($MonitorVersion) {
 
 if ($ComputeShas) {
     $updateDepsArgs += "--compute-shas"
+}
+
+if ($BinarySasQueryString) {
+    $updateDepsArgs += "--binary-sas=$BinarySasQueryString"
+}
+
+if ($ChecksumSasQueryString) {
+    $updateDepsArgs += "--checksum-sas=$ChecksumSasQueryString"
 }
 
 if ($UseStableBranding) {

--- a/eng/update-dependencies/BaseUrlUpdater.cs
+++ b/eng/update-dependencies/BaseUrlUpdater.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.VersionTools.Dependencies;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+/// <summary>
+/// Updates the baseUrl variables in the manifest.versions.json file.
+/// </summary>
+internal class BaseUrlUpdater : FileRegexUpdater
+{
+    private const string BaseUrlGroupName = "BaseUrlValue";
+    private readonly Options _options;
+    private readonly JObject _manifestVariables;
+
+    public BaseUrlUpdater(string repoRoot, Options options)
+    {
+        Path = System.IO.Path.Combine(repoRoot, UpdateDependencies.VersionsFilename);
+        VersionGroupName = BaseUrlGroupName;
+        Regex = ManifestHelper.GetManifestVariableRegex(
+            ManifestHelper.GetBaseUrlVariableName(options.DockerfileVersion, options.Branch),
+            $"(?<{BaseUrlGroupName}>.+)");
+        _options = options;
+
+        _manifestVariables = (JObject)ManifestHelper.LoadManifest(UpdateDependencies.VersionsFilename)["variables"];
+    }
+
+    protected override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)
+    {
+        usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
+
+        string baseUrlVersionVarName = ManifestHelper.GetBaseUrlVariableName(_options.DockerfileVersion, _options.Branch);
+        string unresolvedBaseUrl = _manifestVariables[baseUrlVersionVarName].ToString();
+
+        if (_options.IsInternal)
+        {
+            unresolvedBaseUrl = unresolvedBaseUrl.Replace("public", "internal");
+        }
+        else
+        {
+            unresolvedBaseUrl = unresolvedBaseUrl.Replace("internal", "public");
+        }
+
+        return unresolvedBaseUrl;
+    }
+}
+#nullable disable

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.DotNet.VersionTools.Dependencies;
+using Newtonsoft.Json.Linq;
 
 #nullable enable
 namespace Dotnet.Docker
@@ -22,10 +23,7 @@ namespace Dotnet.Docker
     /// </summary>
     public class DockerfileShaUpdater : FileRegexUpdater
     {
-        private const string ReleaseDotnetBaseUrl = "https://dotnetcli.blob.core.windows.net/dotnet";
-        private const string ReleaseChecksumsBaseUrl = "https://dotnetclichecksums.blob.core.windows.net/dotnet";
-        private const string BuildsDotnetBaseUrl = "https://dotnetbuilds.blob.core.windows.net/public";
-        private const string BuildsChecksumsBaseUrl = "https://dotnetbuilds.blob.core.windows.net/public-checksums";
+        private const string ReleaseDotnetBaseUrl = $"https://dotnetcli.blob.core.windows.net/dotnet";
 
         private const string ShaVariableGroupName = "shaVariable";
         private const string ShaValueGroupName = "shaValue";
@@ -33,8 +31,7 @@ namespace Dotnet.Docker
 
         private static readonly Dictionary<string, string> s_shaCache = new();
         private static readonly Dictionary<string, Dictionary<string, string>> s_releaseChecksumCache = new();
-
-        private static HttpClient s_httpClient { get; } = new();
+        private static readonly HttpClient s_httpClient = new();
 
         private readonly string _productName;
         private readonly Version _dockerfileVersion;
@@ -44,6 +41,7 @@ namespace Dotnet.Docker
         private readonly Options _options;
         private readonly string _versions;
         private readonly Dictionary<string, string[]> _urls;
+        private readonly JObject _manifestVariables;
 
         public DockerfileShaUpdater(
             string productName, string dockerfileVersion, string? buildVersion, string arch, string os, string versions, Options options)
@@ -79,7 +77,7 @@ namespace Dotnet.Docker
                     }
                 },
                 { "runtime-apphost-pack", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-apphost-pack-$VERSION_FILE-$ARCH.$ARCHIVE_EXT" } },
-                { NetStandard21TargetingPack, new string[] { $"{ReleaseChecksumsBaseUrl}/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-$ARCH.$ARCHIVE_EXT" } },
+                { NetStandard21TargetingPack, new string[] { $"{ReleaseDotnetBaseUrl}/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-$ARCH.$ARCHIVE_EXT" } },
                 { "runtime-deps-cm.1", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-runtime-deps-$VERSION_FILE-cm.1-$ARCH.$ARCHIVE_EXT" } },
 
                 { "aspnet", new string[] { $"$DOTNET_BASE_URL/aspnetcore/Runtime/$VERSION_DIR/aspnetcore-runtime-$VERSION_FILE$OPTIONAL_OS-$ARCH.$ARCHIVE_EXT" } },
@@ -95,6 +93,8 @@ namespace Dotnet.Docker
                 { "sdk", new string[] { $"$DOTNET_BASE_URL/Sdk/$VERSION_DIR/dotnet-sdk-$VERSION_FILE$OPTIONAL_OS-$ARCH.$ARCHIVE_EXT" } },
                 { "lzma", new string[] { $"$DOTNET_BASE_URL/Sdk/$VERSION_DIR/nuGetPackagesArchive.lzma" } }
             };
+
+            _manifestVariables = (JObject)ManifestHelper.LoadManifest(UpdateDependencies.VersionsFilename)["variables"];
         }
 
         private string GetAspnetTargetingPackArchFormat() => _dockerfileVersion.Major <= 5 ? string.Empty : "-$ARCH";
@@ -180,33 +180,28 @@ namespace Dotnet.Docker
             // should be listed in priority order. Each subsequent URL listed is treated as a fallback.
             string[] candidateUrls = _urls[_productName];
 
-            string[] baseUrls = new[] { BuildsDotnetBaseUrl, ReleaseDotnetBaseUrl };
-
             for (int candidateUrlIndex = 0; candidateUrlIndex < candidateUrls.Length; candidateUrlIndex++)
             {
-                for (int baseUrlIndex = 0; baseUrlIndex < baseUrls.Length; baseUrlIndex++)
+                string baseUrl = ManifestHelper.GetBaseUrl(_manifestVariables, _options);
+                string downloadUrl = candidateUrls[candidateUrlIndex]
+                    .Replace("$DOTNET_BASE_URL", baseUrl)
+                    .Replace("$ARCHIVE_EXT", archiveExt)
+                    .Replace("$VERSION_DIR", versionDir)
+                    .Replace("$VERSION_FILE", versionFile)
+                    .Replace("$CHANNEL_NAME", _options.ChannelName)
+                    .Replace("$OS", _os)
+                    .Replace("$OPTIONAL_OS", optionalOs)
+                    .Replace("$ARCH", _arch)
+                    .Replace("$DF_VERSION", _options.DockerfileVersion)
+                    .Replace("..", ".");
+
+                bool isLastUrlToCheck =
+                    candidateUrlIndex == candidateUrls.Length - 1;
+
+                string? result = GetArtifactShaAsync(downloadUrl, errorOnNotFound: isLastUrlToCheck).Result;
+                if (result is not null)
                 {
-                    string downloadUrl = candidateUrls[candidateUrlIndex]
-                        .Replace("$DOTNET_BASE_URL", baseUrls[baseUrlIndex])
-                        .Replace("$ARCHIVE_EXT", archiveExt)
-                        .Replace("$VERSION_DIR", versionDir)
-                        .Replace("$VERSION_FILE", versionFile)
-                        .Replace("$CHANNEL_NAME", _options.ChannelName)
-                        .Replace("$OS", _os)
-                        .Replace("$OPTIONAL_OS", optionalOs)
-                        .Replace("$ARCH", _arch)
-                        .Replace("$DF_VERSION", _options.DockerfileVersion)
-                        .Replace("..", ".");
-
-                    bool isLastUrlToCheck =
-                        candidateUrlIndex == candidateUrls.Length - 1 &&
-                        baseUrlIndex == baseUrls.Length - 1;
-
-                    string? result = GetArtifactShaAsync(downloadUrl, errorOnNotFound: isLastUrlToCheck).Result;
-                    if (result is not null)
-                    {
-                        return result;
-                    }
+                    return result;
                 }
             }
 
@@ -286,7 +281,7 @@ namespace Dotnet.Docker
             string? sha = null;
 
             Trace.TraceInformation($"Downloading '{downloadUrl}'.");
-            using (HttpResponseMessage response = await s_httpClient.GetAsync(downloadUrl))
+            using (HttpResponseMessage response = await s_httpClient.GetAsync(ApplySasQueryStringIfNecessary(downloadUrl, _options.BinarySasQueryString)))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -312,17 +307,34 @@ namespace Dotnet.Docker
             return sha;
         }
 
+        private static bool IsInternalUrl(string url)
+        {
+            return url.Contains("msrc") || url.Contains("/internal");
+        }
+
+        private static string ApplySasQueryStringIfNecessary(string url, string sasQueryString)
+        {
+            if (IsInternalUrl(url))
+            {
+                return url + sasQueryString;
+            }
+
+            return url;
+        }
+
         private async Task<string?> GetDotNetBinaryStorageChecksumsShaAsync(string productDownloadUrl)
         {
             string? sha = null;
             string shaExt = _productName.Contains("sdk", StringComparison.OrdinalIgnoreCase) ? ".sha" : ".sha512";
+
             string shaUrl = productDownloadUrl
-                .Replace(ReleaseDotnetBaseUrl, ReleaseChecksumsBaseUrl)
-                .Replace(BuildsDotnetBaseUrl, BuildsChecksumsBaseUrl)
+                .Replace("/dotnetcli", "/dotnetclichecksums")
+                .Replace("/internal/", "/internal-checksums/")
+                .Replace("/public/", "/public-checksums/")
                 + shaExt;
 
             Trace.TraceInformation($"Downloading '{shaUrl}'.");
-            using (HttpResponseMessage response = await s_httpClient.GetAsync(shaUrl))
+            using (HttpResponseMessage response = await s_httpClient.GetAsync(ApplySasQueryStringIfNecessary(shaUrl, _options.ChecksumSasQueryString)))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -413,7 +425,7 @@ namespace Dotnet.Docker
             }
         }
 
-        private static async Task<IDictionary<string, string>> GetDotnetReleaseChecksums(string? version)
+        private async Task<IDictionary<string, string>> GetDotnetReleaseChecksums(string? version)
         {
             string uri = $"{ReleaseDotnetBaseUrl}/checksums/{version}-sha.txt";
             if (s_releaseChecksumCache.TryGetValue(uri, out Dictionary<string, string>? checksumEntries))
@@ -425,7 +437,7 @@ namespace Dotnet.Docker
             s_releaseChecksumCache.Add(uri, checksumEntries);
 
             Trace.TraceInformation($"Downloading '{uri}'.");
-            using (HttpResponseMessage response = await s_httpClient.GetAsync(uri))
+            using (HttpResponseMessage response = await s_httpClient.GetAsync(ApplySasQueryStringIfNecessary(uri, _options.BinarySasQueryString)))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/eng/update-dependencies/ManifestHelper.cs
+++ b/eng/update-dependencies/ManifestHelper.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System.IO;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+/// <summary>
+/// Helper class for interacting with manifest files.
+/// </summary>
+public static class ManifestHelper
+{
+    private const string VariableGroupName = "variable";
+    private const string VariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.|]+)\\)";
+
+    /// <summary>
+    /// Gets the base URL based on the configured context.
+    /// </summary>
+    /// <param name="manifestVariables">JSON object of the variables from the manifest.</param>
+    /// <param name="options">Configured options from the app.</param>
+    public static string GetBaseUrl(JObject manifestVariables, Options options) =>
+        GetVariableValue(GetBaseUrlVariableName(options.DockerfileVersion, options.Branch), manifestVariables);
+
+    /// <summary>
+    /// Consstructs the name of the base URL variable.
+    /// </summary>
+    /// <param name="dockerfileVersion">Dockerfile version.</param>
+    /// <param name="branch">Name of the branch.</param>
+    public static string GetBaseUrlVariableName(string dockerfileVersion, string branch) =>
+        $"base-url|{dockerfileVersion}|{branch}";
+
+    /// <summary>
+    /// Gets the value of a manifest variable.
+    /// </summary>
+    /// <param name="variableName">Name of the variable.</param>
+    /// <param name="variables">JSON object of the variables from the manifest.</param>
+    public static string GetVariableValue(string variableName, JObject variables) =>
+        ResolveVariables((string)variables[variableName], variables);
+
+    /// <summary>
+    /// Loads the manifest from the given filename.
+    /// </summary>
+    /// <param name="filename">Name, not path, of the manifest file located at the root of the repo.</param>
+    public static JObject LoadManifest(string filename)
+    {
+        string path = Path.Combine(UpdateDependencies.RepoRoot, filename);
+        string contents = File.ReadAllText(path);
+        return JObject.Parse(contents);
+    }
+
+    /// <summary>
+    /// Gets the regex that identifies a manifest variable.
+    /// </summary>
+    /// <param name="variableName">Name of the variable.</param>
+    /// <param name="valuePattern">Regex pattern that identifies the value of the variable.</param>
+    /// <param name="options">Configured options from the app.</param>
+    public static Regex GetManifestVariableRegex(string variableName, string valuePattern, RegexOptions options = RegexOptions.None) =>
+        new($"\"{Regex.Escape(variableName)}\": \"{valuePattern}\"", options);
+
+    /// <summary>
+    /// Resolves the value of a variable, recursively resolving any variables referenced in the value.
+    /// </summary>
+    /// <param name="value">Variable value to be resolved.</param>
+    /// <param name="variables">JSON object of the variables from the manifest.</param>
+    private static string ResolveVariables(string value, JObject variables)
+    {
+        MatchCollection matches = Regex.Matches(value, VariablePattern);
+        foreach (Match match in matches)
+        {
+            string variableName = match.Groups[VariableGroupName].Value;
+            string variableValue = GetVariableValue(variableName, variables);
+            value = value.Replace(match.Value, variableValue);
+        }
+
+        return value;
+    }
+}
+#nullable disable

--- a/eng/update-dependencies/NuGetConfigUpdater.cs
+++ b/eng/update-dependencies/NuGetConfigUpdater.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.DotNet.VersionTools.Dependencies;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+/// <summary>
+/// Updates the NuGet.config test app artifact to add or remove an internal package feed.
+/// </summary>
+internal class NuGetConfigUpdater : IDependencyUpdater
+{
+    private const string PkgSrcSuffix = "_internal";
+    private readonly string _repoRoot;
+    private readonly Options _options;
+
+    public NuGetConfigUpdater(string repoRoot, Options options)
+    {
+        _repoRoot = repoRoot;
+        _options = options;
+    }
+
+    public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos) =>
+        dependencyInfos
+            .Where(info => info.SimpleName == "sdk")
+            .Select(info => new DependencyUpdateTask(
+                () => UpdateNuGetConfigFile(info.SimpleVersion),
+                new[] { info },
+                Enumerable.Empty<string>()));
+        
+
+    /// <summary>
+    /// Updates the NuGet.config file to include a URL to the internal package feed of the specified version.
+    /// </summary>
+    /// <param name="sdkVersion"></param>
+    private void UpdateNuGetConfigFile(string sdkVersion)
+    {
+        string configSuffix = (_options.Branch == "nightly" ? ".nightly" : string.Empty);
+        string configPath = Path.Combine(_repoRoot, $"tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config{configSuffix}");
+        string pkgSrcName = $"dotnet{_options.DockerfileVersion.Replace(".", "_")}{PkgSrcSuffix}";
+
+        XDocument doc = XDocument.Load(configPath);
+
+        XElement configuration = doc.Root!;
+        UpdatePackageSources(sdkVersion, pkgSrcName, configuration);
+        UpdatePackageSourceCredentials(pkgSrcName, configuration);
+
+        File.WriteAllText(configPath, ToStringWithDeclaration(doc) + Environment.NewLine);
+    }
+
+    private static string ToStringWithDeclaration(XDocument doc)
+    {
+        StringBuilder builder = new();
+        using (TextWriter writer = new Utf8StringWriter(builder))
+        {
+            // Using the Save method preserves the XML declaration header. ToString doesn't do that.
+            doc.Save(writer);
+        }
+        return builder.ToString();
+    }
+
+    private void UpdatePackageSourceCredentials(string pkgSrcName, XElement configuration)
+    {
+        XElement? pkgSourceCreds = configuration.Element("packageSourceCredentials");
+        if (_options.IsInternal)
+        {
+            pkgSourceCreds?.Remove();
+
+            pkgSourceCreds = GetOrCreateXObject(
+                pkgSourceCreds,
+                configuration,
+                () => new XElement("packageSourceCredentials"));
+
+            XElement pkgSrc = GetOrCreateXObject(
+                pkgSourceCreds.Element(pkgSrcName),
+                pkgSourceCreds,
+                () => new XElement(pkgSrcName));
+            UpdateAddElement(pkgSrc, "Username", "dotnet");
+            UpdateAddElement(pkgSrc, "ClearTextPassword", "%NuGetFeedPassword%");
+        }
+        else
+        {
+            pkgSourceCreds?.Remove();
+        }
+    }
+
+    private void UpdatePackageSources(string sdkVersion, string pkgSrcName, XElement configuration)
+    {      
+        XElement? pkgSources = configuration.Element("packageSources");
+        if (_options.IsInternal)
+        {
+            pkgSources = GetOrCreateXObject(
+                pkgSources,
+                configuration,
+                () => new XElement("packageSources"));
+
+            RemoveAllInternalPackageSources(pkgSources);
+
+            UpdateAddElement(
+                pkgSources,
+                pkgSrcName,
+                $"https://pkgs.dev.azure.com/dnceng/internal/_packaging/{sdkVersion}-shipping/nuget/v3/index.json");
+        }
+        else
+        {
+            if (pkgSources is not null)
+            {
+                RemoveAllInternalPackageSources(pkgSources);
+            }
+        }
+    }
+
+    private static void RemoveAllInternalPackageSources(XElement packageSources)
+    {
+        IEnumerable<XElement> elements = packageSources.Elements()
+            .Where(pkgSrc => pkgSrc.Attribute("key")?.Value.EndsWith(PkgSrcSuffix) == true)
+            .ToList();
+        foreach (XElement element in elements)
+        {
+            element.Remove();
+        }
+    }
+
+    private static void UpdateAddElement(XElement parentElement, string key, string value)
+    {
+        XElement addElement = GetOrCreateXObject(
+            parentElement.Elements("add").FirstOrDefault(element => HasKeyAttribute(element, key)),
+            parentElement,
+            () => CreateAddElement(key, value));
+
+        UpdateValueAttribute(addElement, value);
+    }
+
+    private static XElement CreateAddElement(string key, string value) =>
+        new("add",
+            new XAttribute("key", key),
+            new XAttribute("value", value));
+
+    private static void UpdateValueAttribute(XElement parentElement, string value)
+    {
+        XAttribute valueAttrib = GetOrCreateXObject(
+            parentElement.Attribute("value"),
+            parentElement,
+            () => new XAttribute("value", value));
+        valueAttrib.Value = value;
+    }
+
+    private static bool HasKeyAttribute(XElement element, string value) =>
+        element.Attribute("key")?.Value == value;
+
+    private static T GetOrCreateXObject<T>(T? node, XContainer parent, Func<T> createNode)
+        where T : XObject
+    {
+        if (node is null)
+        {
+            node = createNode();
+            parent.Add(node);
+        }
+
+        return node;
+    }
+
+    private class Utf8StringWriter : StringWriter
+    {
+        public Utf8StringWriter(StringBuilder stringBuilder)
+            : base(stringBuilder)
+        {
+        }
+
+        public override Encoding Encoding => Encoding.UTF8;
+    }
+}
+#nullable disable

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -10,6 +10,8 @@ namespace Dotnet.Docker
 {
     public class Options
     {
+        public string BinarySasQueryString { get; }
+        public string ChecksumSasQueryString { get; }
         public bool ComputeChecksums { get; }
         public string DockerfileVersion { get; }
         public string ChannelName { get; }
@@ -23,9 +25,10 @@ namespace Dotnet.Docker
         public string VersionSourceName { get; }
         public bool UseStableBranding { get; }
         public bool UpdateOnly => GitHubEmail == null || GitHubPassword == null || GitHubUser == null;
+        public bool IsInternal => !string.IsNullOrEmpty(BinarySasQueryString) || !string.IsNullOrEmpty(ChecksumSasQueryString);
 
         public Options(string dockerfileVersion, string[] productVersion, string channelName, string versionSourceName, string email, string password, string user,
-            bool computeShas, bool stableBranding, string branch)
+            bool computeShas, bool stableBranding, string binarySas, string checksumSas, string branch)
         {
             DockerfileVersion = dockerfileVersion;
             ProductVersions = productVersion
@@ -38,6 +41,8 @@ namespace Dotnet.Docker
             GitHubUser = user;
             ComputeChecksums = computeShas;
             UseStableBranding = stableBranding;
+            BinarySasQueryString = binarySas;
+            ChecksumSasQueryString = checksumSas;
             Branch = branch;
 
             // Special case for handling the shared dotnet product version variables.
@@ -63,7 +68,9 @@ namespace Dotnet.Docker
                 new Option<string>("--user", "GitHub user used to make PR (if not specified, a PR will not be created)"),
                 new Option<bool>("--compute-shas", "Compute the checksum if a published checksum cannot be found"),
                 new Option<bool>("--stable-branding", "Use stable branding version numbers to compute paths"),
-                new Option<string>("--branch", () => "nightly", "Git branch being targeted for update"),
+                new Option<string>("--branch", () => "nightly", "SAS query string used to access files in blob storage"),
+				new Option<string>("--binary-sas", "SAS query string used to access binary files in blob storage"),
+                new Option<string>("--checksum-sas", "SAS query string used to access checksum files in blob storage"),
             };
     }
 }

--- a/eng/update-dependencies/UpdateDependencies.cs
+++ b/eng/update-dependencies/UpdateDependencies.cs
@@ -8,6 +8,7 @@ using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using LibGit2Sharp;
 using Microsoft.DotNet.VersionTools;
@@ -20,10 +21,11 @@ namespace Dotnet.Docker
 {
     public static class UpdateDependencies
     {
+        public const string ManifestFilename = "manifest.json";
         public const string VersionsFilename = "manifest.versions.json";
 
         private static Options Options { get; set; }
-        private static string RepoRoot { get; } = Directory.GetCurrentDirectory();
+        public static string RepoRoot { get; } = Directory.GetCurrentDirectory();
 
         public static Task Main(string[] args)
         {
@@ -291,6 +293,9 @@ namespace Dotnet.Docker
         {
             // NOTE: The order in which the updaters are returned/invoked is important as there are cross dependencies
             // (e.g. sha updater requires the version numbers to be updated within the Dockerfiles)
+
+            yield return new NuGetConfigUpdater(RepoRoot, Options);
+            yield return new BaseUrlUpdater(RepoRoot, Options);
             foreach (string productName in Options.ProductVersions.Keys)
             {
                 yield return new VersionUpdater(VersionType.Build, productName, Options.DockerfileVersion, RepoRoot, Options);

--- a/eng/update-dependencies/VersionUpdater.cs
+++ b/eng/update-dependencies/VersionUpdater.cs
@@ -100,7 +100,9 @@ namespace Dotnet.Docker
         }
 
         private static Regex GetVersionVariableRegex(string versionVariableName) =>
-            new Regex($"\"{Regex.Escape(versionVariableName)}\": \"(?<{s_versionGroupName}>[\\d]+.[\\d]+.[\\d]+(-[\\w]+(.[\\d]+)*)?)\"");
+            ManifestHelper.GetManifestVariableRegex(
+                versionVariableName,
+                $"(?<{s_versionGroupName}>[\\d]+.[\\d]+.[\\d]+(-[\\w]+(.[\\d]+)*)?)");
 
         private static string GetVersionVariableName(VersionType versionType, string productName, string dockerfileVersion) =>
             $"{productName}|{dockerfileVersion}|{versionType.ToString().ToLowerInvariant()}-version";


### PR DESCRIPTION
This is further work to support https://github.com/dotnet/dotnet-docker/issues/2152. It updates the update-dependencies tool to handle several aspects of internal builds:
* Targets internal URLs with SAS token when executing the logic to get the checksum of the installer file.
* Update the appropriate base URL manifest variable from `public` to `internal`.
* Updates the test project's NuGet.config file to include a URL for the internal build's NuGet feed.

Related to the update-dependencies tool is the `get-drop-versions.sh` script. This script determines the product versions of the latest build that are used as input to the update-dependencies tool. I've also updated this script to be able to target internal builds.