### PR TITLE
Change Mariner to use MCR instead of ACR

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux
@@ -12,7 +12,7 @@
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set installerImageTag to when(isDistrolessMariner,
         cat(
-            "cblmariner.azurecr.io/base/core:",
+            "mcr.microsoft.com/cbl-mariner/base/core:",
             OS_VERSION_NUMBER),
         when(isAlpine || isFullMariner,
             runtimeBaseTag,

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -9,7 +9,7 @@
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
     set distrolessStagingDir to "/staging" ^
-    set marinerRegistry to "cblmariner.azurecr.io" ^
+    set marinerRepo to "mcr.microsoft.com/cbl-mariner" ^
     set baseImageRepo to when(isAlpine,
         cat(ARCH_VERSIONED, "/alpine"),
         when(isDebian,
@@ -17,7 +17,7 @@
             when(isUbuntu,
                 cat(ARCH_VERSIONED, "/ubuntu"),
                 when(isMariner,
-                    cat(marinerRegistry, "/base/core"),
+                    cat(marinerRepo, "/base/core"),
                     "<NOT-IMPLEMENTED>")))) ^
     set baseImageTag to when(isAlpine || isMariner, OS_VERSION_NUMBER, OS_VERSION) ^
     set isSingleStage to !isDistrolessMariner && !(isFullMariner && isInternal && ARCH_SHORT != "arm64") ^
@@ -68,7 +68,7 @@ RUN rm -rf {{distrolessStagingDir}}/etc/dnf \
 
 
 # .NET runtime-deps image
-FROM {{marinerRegistry}}/distroless/minimal:{{OS_VERSION_NUMBER}}
+FROM {{marinerRepo}}/distroless/minimal:{{OS_VERSION_NUMBER}}
 
 COPY --from=installer {{distrolessStagingDir}}/ /
 ^elif isFullMariner && ARCH_SHORT != "arm64":

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -11,7 +11,7 @@
         "$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", OS_VERSION, archTagSuffix) ^
     set installerImageTag to when(isDistrolessMariner,
         cat(
-            "cblmariner.azurecr.io/base/core:",
+            "mcr.microsoft.com/cbl-mariner/base/core:",
             OS_VERSION_NUMBER),
         when(isAlpine || isFullMariner,
             runtimeDepsBaseTag,

--- a/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:1.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/aspnet/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/aspnet/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/aspnet/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/aspnet/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime-deps/3.1/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/3.1/cbl-mariner1.0/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0
 
 RUN tdnf install -y \
         ca-certificates \

--- a/src/runtime-deps/5.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/5.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0
 
 RUN tdnf install -y \
         ca-certificates \

--- a/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -1,5 +1,5 @@
 # Installer image
-FROM cblmariner.azurecr.io/base/core:1.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0 AS installer
 
 RUN tdnf install -y \
         dnf \
@@ -44,7 +44,7 @@ RUN rm -rf /staging/etc/dnf \
 
 
 # .NET runtime-deps image
-FROM cblmariner.azurecr.io/distroless/minimal:1.0
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:1.0
 
 COPY --from=installer /staging/ /
 

--- a/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,5 +1,5 @@
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
@@ -41,7 +41,7 @@ RUN rm -rf /staging/etc/dnf \
 
 
 # .NET runtime-deps image
-FROM cblmariner.azurecr.io/distroless/minimal:2.0
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 
 COPY --from=installer /staging/ /
 

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
@@ -41,7 +41,7 @@ RUN rm -rf /staging/etc/dnf \
 
 
 # .NET runtime-deps image
-FROM cblmariner.azurecr.io/distroless/minimal:2.0
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 
 COPY --from=installer /staging/ /
 

--- a/src/runtime-deps/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime-deps/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime-deps/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime-deps/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM cblmariner.azurecr.io/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:1.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \

--- a/src/runtime/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM cblmariner.azurecr.io/base/core:2.0 AS installer
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates-microsoft \


### PR DESCRIPTION
CBL-Mariner image tags are available on MCR now. I've updated all usage of `cblmariner.azurecr.io` to `mcr.microsoft.com/cbl-mariner`.