### PR TITLE
Update-deps pipeline changes to support get-drop-versions.sh script

### DIFF
--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -18,7 +18,7 @@ stages:
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
-    - script: $(engPath)/get-drop-versions.sh $(channel)
+    - script: $(engPath)/get-drop-versions.sh $(channel) false "" ""
       displayName: Get Versions
     - powershell: $(engPath)/Set-DotnetVersions.ps1 $(dockerfileVersion) -RuntimeVersion $(runtimeVer) -AspnetVersion $(aspnetVer) -SdkVersion $(sdkVer) -ComputeShas -PrintArgsVariableOnly
       displayName: Get update-dependencies args


### PR DESCRIPTION
The update-dependencies pipeline is currently broken due to changes from https://github.com/dotnet/dotnet-docker/pull/3745. It's failing due to unbound variables for the get-drop-versions.sh script. These variables are not being passed in by the pipeline.

There are more extensive changes needed in order for this pipeline to support internal builds. For example, it would need to create a PR in AzDO instead of GitHub. So just to unblock things for now, I've defaulted the new parameters so that internal builds are not accounted for.