### PR TITLE
Test support for internal .NET builds

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -77,6 +77,13 @@ namespace Microsoft.DotNet.Docker.Tests
                     .Concat(RuntimeImageTests.GetExpectedRpmPackagesInstalled(imageData)));
         }
 
+        [DotNetTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyNoSasToken(ProductImageData imageData)
+        {
+            base.VerifyCommonNoSasToken(imageData);
+        }
+
         public static EnvironmentVariableInfo GetAspnetVersionVariableInfo(ProductImageData imageData, DockerHelper dockerHelper)
         {
             if (imageData.Version.Major >= 5)

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -82,7 +82,10 @@ namespace Microsoft.DotNet.Docker.Tests
             if (imageData.Version.Major >= 5)
             {
                 string version = imageData.GetProductVersion(DotNetImageType.Aspnet, dockerHelper);
-                return new EnvironmentVariableInfo("ASPNET_VERSION", version);
+                return new EnvironmentVariableInfo("ASPNET_VERSION", version)
+                {
+                    IsProductVersion = true
+                };
             }
 
             return null;

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -90,12 +90,5 @@ namespace Microsoft.DotNet.Docker.Tests
 
             Assert.Contains("Exit code: 127", ex.Message);
         }
-
-        [DotNetTheory]
-        [MemberData(nameof(GetImageData))]
-        public void VerifyNoSasToken(ProductImageData imageData)
-        {
-            base.VerifyCommonNoSasToken(imageData);
-        }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -90,5 +90,12 @@ namespace Microsoft.DotNet.Docker.Tests
 
             Assert.Contains("Exit code: 127", ex.Message);
         }
+
+        [DotNetTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyNoSasToken(ProductImageData imageData)
+        {
+            base.VerifyCommonNoSasToken(imageData);
+        }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 variables.AddRange(customVariables);
             }
 
-            if (imageData.OS.StartsWith(OS.AlpinePrefix) ||
+            if (imageData.OS.StartsWith(OS.Alpine) ||
                 (imageData.IsDistroless && imageData.OS != OS.Mariner10Distroless))
             {
                 variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true"));

--- a/tests/Microsoft.DotNet.Docker.Tests/Config.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/Config.cs
@@ -30,6 +30,16 @@ namespace Microsoft.DotNet.Docker.Tests
             Environment.GetEnvironmentVariable("IMAGE_OS") ?? string.Empty;
         public static string SourceBranch { get; } =
             Environment.GetEnvironmentVariable("SOURCE_BRANCH") ?? string.Empty;
+        public static string SasQueryString { get; } =
+            Environment.GetEnvironmentVariable("SAS_QUERY_STRING") ?? string.Empty;
+        public static string NuGetFeedPassword { get; } =
+            Environment.GetEnvironmentVariable("NUGET_FEED_PASSWORD") ?? string.Empty;
+
+        public static bool IsInternal(string dotnetVersion)
+        {
+            string versionBaseUrl = GetBaseUrl(dotnetVersion);
+            return versionBaseUrl.Contains("msrc") || versionBaseUrl.Contains("internal");
+        }
 
         private static bool GetIsNightlyRepo()
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -208,6 +208,9 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public void Pull(string image) => ExecuteWithLogging($"pull {image}", autoRetry: true);
 
+        public string GetHistory(string image) =>
+            ExecuteWithLogging($"history --no-trunc --format \"{{{{ .CreatedBy }}}}\" {image}");
+
         private static bool ResourceExists(string type, string filterArg)
         {
             string output = Execute($"{type} ls -a -q {filterArg}", true);

--- a/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
@@ -87,13 +87,21 @@ namespace Microsoft.DotNet.Docker.Tests
                 else
                 {
                     // If we're validating a product version environment variable for an internal build
-                    // we need to trim off the "servicing" part of the version value.
+                    // we need to trim off the "servicing" or "rtm" part of the version value.
                     if (variable.IsProductVersion && !string.IsNullOrEmpty(Config.SasQueryString))
                     {
-                        int index = actualValue.IndexOf("-servicing.");
-                        if (index != -1)
+                        int servicingIndex = actualValue.IndexOf("-servicing.");
+                        if (servicingIndex != -1)
                         {
-                            actualValue = actualValue.Substring(0, index);
+                            actualValue = actualValue.Substring(0, servicingIndex);
+                        }
+                        else
+                        {
+                            int rtmIndex = actualValue.IndexOf("-rtm.");
+                            if (rtmIndex != -1)
+                            {
+                                actualValue = actualValue.Substring(0, rtmIndex);
+                            }
                         }
                     }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public bool AllowAnyValue { get; private set; }
         public string ExpectedValue { get; private set; }
         public string Name { get; private set; }
+        public bool IsProductVersion { get; set; }
 
         public EnvironmentVariableInfo(string name, string expectedValue)
         {
@@ -85,6 +86,17 @@ namespace Microsoft.DotNet.Docker.Tests
                 }
                 else
                 {
+                    // If we're validating a product version environment variable for an internal build
+                    // we need to trim off the "servicing" part of the version value.
+                    if (variable.IsProductVersion && !string.IsNullOrEmpty(Config.SasQueryString))
+                    {
+                        int index = actualValue.IndexOf("-servicing.");
+                        if (index != -1)
+                        {
+                            actualValue = actualValue.Substring(0, index);
+                        }
+                    }
+
                     Assert.Equal(variable.ExpectedValue, actualValue);
                 }
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -42,38 +42,25 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public string Rid
         {
-            get {
+            get
+            {
                 string rid;
 
-                if (Arch == Arch.Arm)
+                if (OS.StartsWith(Tests.OS.NanoServer) || OS.StartsWith(Tests.OS.ServerCore))
                 {
-                    if (OS.StartsWith(Tests.OS.AlpinePrefix))
-                    {
-                        rid = "linux-musl-arm";
-                    }
-                    else
-                    {
-                        rid = "linux-arm";
-                    }
-                }
-                else if (Arch == Arch.Arm64)
-                {
-                    if (OS.StartsWith(Tests.OS.AlpinePrefix))
-                    {
-                        rid = "linux-musl-arm64";
-                    }
-                    else
-                    {
-                        rid = "linux-arm64";
-                    }
-                }
-                else if (OS.StartsWith(Tests.OS.AlpinePrefix))
-                {
-                    rid = "linux-musl-x64";
+                    rid = "win-x64";
                 }
                 else
                 {
-                    rid = "linux-x64";
+                    string arch = Arch switch
+                    {
+                        Arch.Arm => "arm",
+                        Arch.Arm64 => "arm64",
+                        Arch.Amd64 => "x64",
+                        _ => throw new NotImplementedException()
+                    };
+                    string modifier = OS.StartsWith(Tests.OS.Alpine) ? "musl-" : "";
+                    rid = $"linux-{modifier}{arch}";
                 }
 
                 return rid;

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -151,11 +151,30 @@ namespace Microsoft.DotNet.Docker.Tests
                 buildArgs.AddRange(customBuildArgs);
             }
 
-            _dockerHelper.Build(
-                tag: tag,
-                target: stageTarget,
-                contextDir: contextDir,
-                buildArgs: buildArgs.ToArray());
+            const string NuGetFeedPasswordVar = "NuGetFeedPassword";
+
+            if (Config.IsInternal(_imageData.VersionString))
+            {
+                buildArgs.Add(NuGetFeedPasswordVar);
+                Environment.SetEnvironmentVariable(NuGetFeedPasswordVar, Config.NuGetFeedPassword);
+            }
+
+            try
+            {
+                _dockerHelper.Build(
+                    tag: tag,
+                    target: stageTarget,
+                    contextDir: contextDir,
+                    buildArgs: buildArgs.ToArray());
+            }
+            finally
+            {
+                if (Config.IsInternal(_imageData.VersionString))
+                {
+                    Environment.SetEnvironmentVariable(NuGetFeedPasswordVar, null);
+                }
+            }
+            
 
             return tag;
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     string buildTag = BuildTestAppImage("build", appDir, customBuildArgs);
                     tags.Add(buildTag);
                     string dotnetRunArgs = _isWeb ? " --urls http://0.0.0.0:80" : string.Empty;
-                    await RunTestAppImage(buildTag, command: $"dotnet run{dotnetRunArgs}", customBuildArgs);
+                    await RunTestAppImage(buildTag, command: $"dotnet run{dotnetRunArgs}");
                 }
 
                 // Use `sdk` image to publish FX dependent app and run with `runtime` or `aspnet` image

--- a/tests/Microsoft.DotNet.Docker.Tests/OS.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/OS.cs
@@ -8,23 +8,21 @@ namespace Microsoft.DotNet.Docker.Tests
     {
         // Alpine
         public const string Alpine = "alpine";
-        public const string Alpine314 = "alpine3.14";
-        public const string Alpine315 = "alpine3.15";
+        public const string Alpine314 = $"{Alpine}3.14";
+        public const string Alpine315 = $"{Alpine}3.15";
 
         // Debian
         public const string Bullseye = "bullseye";
-        public const string BullseyeSlim = "bullseye-slim";
+        public const string BullseyeSlim = $"{Bullseye}{SlimSuffix}";
         public const string Buster = "buster";
-        public const string BusterSlim = "buster-slim";
-        public const string Stretch = "stretch";
-        public const string StretchSlim = "stretch-slim";
+        public const string BusterSlim = $"{Buster}{SlimSuffix}";
 
         // Mariner
         public const string Mariner = "cbl-mariner";
-        public const string Mariner10 = "cbl-mariner1.0";
-        public const string Mariner10Distroless = "cbl-mariner1.0-distroless";
-        public const string Mariner20 = "cbl-mariner2.0";
-        public const string Mariner20Distroless = "cbl-mariner2.0-distroless";
+        public const string Mariner10 = $"{Mariner}1.0";
+        public const string Mariner10Distroless = $"{Mariner10}-distroless";
+        public const string Mariner20 = $"{Mariner}2.0";
+        public const string Mariner20Distroless = $"{Mariner20}-distroless";
 
         // Ubuntu
         public const string Bionic = "bionic";
@@ -32,14 +30,15 @@ namespace Microsoft.DotNet.Docker.Tests
         public const string Jammy = "jammy";
 
         // Windows
-        public const string NanoServer1809 = "nanoserver-1809";
-        public const string NanoServer20H2 = "nanoserver-20H2";
-        public const string NanoServerLtsc2022 = "nanoserver-ltsc2022";
-        public const string ServerCoreLtsc2019 = "windowsservercore-ltsc2019";
-        public const string ServerCoreLtsc2022 = "windowsservercore-ltsc2022";
+        public const string NanoServer = "nanoserver";
+        public const string NanoServer1809 = $"{NanoServer}-1809";
+        public const string NanoServer20H2 = $"{NanoServer}-20H2";
+        public const string NanoServerLtsc2022 = $"{NanoServer}-ltsc2022";
+        public const string ServerCore = "windowsservercore";
+        public const string ServerCoreLtsc2019 = $"{ServerCore}-ltsc2019";
+        public const string ServerCoreLtsc2022 = $"{ServerCore}-ltsc2022";
 
         // Helpers
-        public const string AlpinePrefix = "alpine";
         public const string SlimSuffix = "-slim";
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,6 +22,17 @@ namespace Microsoft.DotNet.Docker.Tests
         protected DockerHelper DockerHelper { get; }
         protected ITestOutputHelper OutputHelper { get; }
         protected abstract DotNetImageType ImageType { get; }
+
+        /// <summary>
+        /// Verifies that a SAS token isn't accidentally leaked through the Docker history of the image.
+        /// </summary>
+        protected void VerifyCommonNoSasToken(ProductImageData imageData)
+        {
+            string imageTag = imageData.GetImage(ImageType, DockerHelper);
+            string historyContents = DockerHelper.GetHistory(imageTag);
+            Match match = Regex.Match(historyContents, @"=\?(sig|\S+&sig)=\S+");
+            Assert.False(match.Success, $"A SAS token was detected in the Docker history of '{imageTag}'.");
+        }
 
         protected void VerifyCommonInsecureFiles(ProductImageData imageData)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Docker.Tests
             Assert.NotEqual("0", userId);
         }
 
-        [DotNetTheory]
+        [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyPackageInstallation(ProductImageData imageData)
         {
@@ -56,6 +56,13 @@ namespace Microsoft.DotNet.Docker.Tests
             VerifyExpectedInstalledRpmPackages(
                 imageData,
                 GetExpectedRpmPackagesInstalled(imageData));
+        }
+
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyNoSasToken(ProductImageData imageData)
+        {
+            base.VerifyCommonNoSasToken(imageData);
         }
 
         internal static string[] GetExpectedRpmPackagesInstalled(ProductImageData imageData) =>

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -67,7 +67,10 @@ namespace Microsoft.DotNet.Docker.Tests
         public static EnvironmentVariableInfo GetRuntimeVersionVariableInfo(ProductImageData imageData, DockerHelper dockerHelper)
         {
             string version = imageData.GetProductVersion(DotNetImageType.Runtime, dockerHelper);
-            return new EnvironmentVariableInfo("DOTNET_VERSION", version);
+            return new EnvironmentVariableInfo("DOTNET_VERSION", version)
+            {
+                IsProductVersion = true
+            };
         }
 
         internal static string[] GetExpectedRpmPackagesInstalled(ProductImageData imageData) =>

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -64,6 +64,13 @@ namespace Microsoft.DotNet.Docker.Tests
                     .Concat(RuntimeDepsImageTests.GetExpectedRpmPackagesInstalled(imageData)));
         }
 
+        [DotNetTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyNoSasToken(ProductImageData imageData)
+        {
+            base.VerifyCommonNoSasToken(imageData);
+        }
+
         public static EnvironmentVariableInfo GetRuntimeVersionVariableInfo(ProductImageData imageData, DockerHelper dockerHelper)
         {
             string version = imageData.GetProductVersion(DotNetImageType.Runtime, dockerHelper);

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 variables.Add(new EnvironmentVariableInfo("DOTNET_NOLOGO", "true"));
             }
 
-            if (imageData.SdkOS.StartsWith(OS.AlpinePrefix))
+            if (imageData.SdkOS.StartsWith(OS.Alpine))
             {
                 variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "false"));
 
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (!(imageData.Version.Major >= 5 ||
                 (imageData.Version.Major >= 3 &&
-                    (imageData.SdkOS.StartsWith(OS.AlpinePrefix) || !DockerHelper.IsLinuxContainerModeEnabled))))
+                    (imageData.SdkOS.StartsWith(OS.Alpine) || !DockerHelper.IsLinuxContainerModeEnabled))))
             {
                 return;
             }
@@ -297,7 +297,7 @@ namespace Microsoft.DotNet.Docker.Tests
             string sdkFileVersionLabel = isInternal ? imageData.GetProductVersion(ImageType, DockerHelper) : sdkBuildVersion;
 
             string osType = DockerHelper.IsLinuxContainerModeEnabled ? "linux" : "win";
-            if (imageData.SdkOS.StartsWith(OS.AlpinePrefix))
+            if (imageData.SdkOS.StartsWith(OS.Alpine))
             {
                 osType += "-musl";
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
@@ -48,6 +47,13 @@ namespace Microsoft.DotNet.Docker.Tests
 
         [DotNetTheory]
         [MemberData(nameof(GetImageData))]
+        public void VerifyNoSasToken(ProductImageData imageData)
+        {
+            base.VerifyCommonNoSasToken(imageData);
+        }
+
+        [DotNetTheory]
+        [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ProductImageData imageData)
         {
             List<EnvironmentVariableInfo> variables = new()
@@ -67,7 +73,10 @@ namespace Microsoft.DotNet.Docker.Tests
             if (imageData.Version.Major >= 5)
             {
                 string version = imageData.GetProductVersion(ImageType, DockerHelper);
-                variables.Add(new EnvironmentVariableInfo("DOTNET_SDK_VERSION", version));
+                variables.Add(new EnvironmentVariableInfo("DOTNET_SDK_VERSION", version)
+                {
+                    IsProductVersion = true
+                });
             }
 
             if (imageData.Version.Major >= 5)
@@ -283,8 +292,9 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private string GetSdkUrl(ProductImageData imageData)
         {
+            bool isInternal = Config.IsInternal(imageData.VersionString);
             string sdkBuildVersion = Config.GetBuildVersion(ImageType, imageData.VersionString);
-            string sdkFileVersionLabel = sdkBuildVersion;
+            string sdkFileVersionLabel = isInternal ? imageData.GetProductVersion(ImageType, DockerHelper) : sdkBuildVersion;
 
             string osType = DockerHelper.IsLinuxContainerModeEnabled ? "linux" : "win";
             if (imageData.SdkOS.StartsWith(OS.AlpinePrefix))
@@ -301,14 +311,14 @@ namespace Microsoft.DotNet.Docker.Tests
             };
 
             string fileType = DockerHelper.IsLinuxContainerModeEnabled ? "tar.gz" : "zip";
-
-            string baseUrl = "https://dotnetcli.azureedge.net/dotnet";
-            if (imageData.Version.Major >= 7)
+            string baseUrl = Config.GetBaseUrl(imageData.VersionString);
+            string url = $"{baseUrl}/Sdk/{sdkBuildVersion}/dotnet-sdk-{sdkFileVersionLabel}-{osType}-{architecture}.{fileType}";
+            if (isInternal)
             {
-                baseUrl = Config.GetBaseUrl(imageData.VersionString);
+                url += Config.SasQueryString;
             }
 
-            return $"{baseUrl}/Sdk/{sdkBuildVersion}/dotnet-sdk-{sdkFileVersionLabel}-{osType}-{architecture}.{fileType}";
+            return url;
         }
 
         private void PowerShellScenario_Execute(ProductImageData imageData, string optionalArgs)

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
@@ -4,6 +4,8 @@ ARG runtime_deps_image
 
 FROM $sdk_image as build
 
+ARG NuGetFeedPassword
+
 EXPOSE 80
 
 WORKDIR app

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
@@ -4,6 +4,7 @@ ARG runtime_deps_image
 
 FROM $sdk_image as build
 
+ARG rid
 ARG NuGetFeedPassword
 
 EXPOSE 80
@@ -11,7 +12,7 @@ EXPOSE 80
 WORKDIR app
 COPY NuGet.config .
 COPY *.csproj .
-RUN dotnet restore
+RUN dotnet restore -r $rid
 
 COPY . .
 RUN dotnet build --no-restore

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
@@ -11,7 +11,7 @@ EXPOSE 80
 WORKDIR app
 COPY NuGet.config .
 COPY *.csproj .
-RUN dotnet restore -r $rid
+RUN dotnet restore -r %rid%
 
 COPY . .
 RUN dotnet build --no-restore

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
@@ -3,6 +3,8 @@ ARG runtime_image
 
 FROM $sdk_image as build
 
+ARG NuGetFeedPassword
+
 EXPOSE 80
 
 WORKDIR app

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
@@ -3,6 +3,7 @@ ARG runtime_image
 
 FROM $sdk_image as build
 
+ARG rid
 ARG NuGetFeedPassword
 
 EXPOSE 80
@@ -10,7 +11,7 @@ EXPOSE 80
 WORKDIR app
 COPY NuGet.config .
 COPY *.csproj .
-RUN dotnet restore
+RUN dotnet restore -r $rid
 
 COPY . .
 RUN dotnet build --no-restore


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/issues/2152

This updates the test project to allow internal .NET builds to be targeted. It needs the SAS query string in order to be able to download the SDK for file comparison validation. It also needs the NuGet feed password to be able to authenticate for NuGet restore operations in the containers being tested.

A new test is added to verify that our built images do not accidentally contain any SAS tokens.