### PR TITLE
Remove unused .NET Monitor 6.0 version variables

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -95,10 +95,6 @@
     "libssl|focal": "1.1",
     "libssl|jammy": "3",
 
-    "monitor|6.0|build-version": "6.0.2-servicing.22077.7",
-    "monitor|6.0|product-version": "6.0.2",
-    "monitor|6.0|sha": "3203e455fe4fa9e7b251ba957ddf286a3a3fcf1c88663315547d5f4f7df9ee1c1f164dfcc42edeebaf786bf1b893753c5a5339377b259798208d5f07c48f9a10",
-
     "monitor|6.1|build-version": "6.1.1",
     "monitor|6.1|product-version": "6.1.1",
     "monitor|6.1|sha": "94dae789f43304656198751d183389502b8076913ac0924d3269f74463b4d2b90c7514658dad910a39ccc6e1d1f9e5cd7f7bd036a807588c08c389b5aba6b5ce",


### PR DESCRIPTION
The 6.0 Dockerfiles were removed in #3742, however the version and hash value variables were left behind.

cc @dotnet/dotnet-monitor 