### PR TITLE
Update dependencies fixes

### DIFF
--- a/eng/update-dependencies/BaseUrlUpdater.cs
+++ b/eng/update-dependencies/BaseUrlUpdater.cs
@@ -23,7 +23,7 @@ internal class BaseUrlUpdater : FileRegexUpdater
         Path = System.IO.Path.Combine(repoRoot, UpdateDependencies.VersionsFilename);
         VersionGroupName = BaseUrlGroupName;
         Regex = ManifestHelper.GetManifestVariableRegex(
-            ManifestHelper.GetBaseUrlVariableName(options.DockerfileVersion, options.Branch),
+            ManifestHelper.GetBaseUrlVariableName(options.DockerfileVersion, options.Branch, options.VersionSourceName),
             $"(?<{BaseUrlGroupName}>.+)");
         _options = options;
 
@@ -34,7 +34,7 @@ internal class BaseUrlUpdater : FileRegexUpdater
     {
         usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
 
-        string baseUrlVersionVarName = ManifestHelper.GetBaseUrlVariableName(_options.DockerfileVersion, _options.Branch);
+        string baseUrlVersionVarName = ManifestHelper.GetBaseUrlVariableName(_options.DockerfileVersion, _options.Branch, _options.VersionSourceName);
         string unresolvedBaseUrl = _manifestVariables[baseUrlVersionVarName].ToString();
 
         if (_options.IsInternal)

--- a/eng/update-dependencies/ManifestHelper.cs
+++ b/eng/update-dependencies/ManifestHelper.cs
@@ -23,15 +23,18 @@ public static class ManifestHelper
     /// <param name="manifestVariables">JSON object of the variables from the manifest.</param>
     /// <param name="options">Configured options from the app.</param>
     public static string GetBaseUrl(JObject manifestVariables, Options options) =>
-        GetVariableValue(GetBaseUrlVariableName(options.DockerfileVersion, options.Branch), manifestVariables);
+        GetVariableValue(GetBaseUrlVariableName(options.DockerfileVersion, options.Branch, options.VersionSourceName), manifestVariables);
 
     /// <summary>
     /// Consstructs the name of the base URL variable.
     /// </summary>
     /// <param name="dockerfileVersion">Dockerfile version.</param>
     /// <param name="branch">Name of the branch.</param>
-    public static string GetBaseUrlVariableName(string dockerfileVersion, string branch) =>
-        $"base-url|{dockerfileVersion}|{branch}";
+    public static string GetBaseUrlVariableName(string dockerfileVersion, string branch, string versionSourceName)
+    {
+        string version = versionSourceName.Contains("dotnet-monitor") ? $"{dockerfileVersion}-monitor" : dockerfileVersion;
+        return $"base-url|{version}|{branch}";
+    }
 
     /// <summary>
     /// Gets the value of a manifest variable.

--- a/eng/update-dependencies/NuGetConfigUpdater.cs
+++ b/eng/update-dependencies/NuGetConfigUpdater.cs
@@ -21,39 +21,54 @@ internal class NuGetConfigUpdater : IDependencyUpdater
     private const string PkgSrcSuffix = "_internal";
     private readonly string _repoRoot;
     private readonly Options _options;
+    private readonly string _configPath;
 
     public NuGetConfigUpdater(string repoRoot, Options options)
     {
         _repoRoot = repoRoot;
         _options = options;
+
+        string configSuffix = (_options.Branch == "nightly" ? ".nightly" : string.Empty);
+        _configPath = Path.Combine(_repoRoot, $"tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config{configSuffix}");
     }
 
-    public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos) =>
-        dependencyInfos
-            .Where(info => info.SimpleName == "sdk")
-            .Select(info => new DependencyUpdateTask(
-                () => UpdateNuGetConfigFile(info.SimpleVersion),
-                new[] { info },
-                Enumerable.Empty<string>()));
-        
+    public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos)
+    {
+        string existingContent = File.ReadAllText(_configPath);
+        IDependencyInfo sdkInfo = dependencyInfos
+            .First(info => info.SimpleName == "sdk");
+
+        string newContent = GetUpdatedNuGetConfigContent(sdkInfo.SimpleVersion);
+
+        if (newContent != existingContent)
+        {
+            return new[]
+            {
+                new DependencyUpdateTask(
+                    () => File.WriteAllText(_configPath, newContent),
+                    new[] { sdkInfo },
+                    Enumerable.Empty<string>())
+            };
+        }
+        else
+        {
+            return Enumerable.Empty<DependencyUpdateTask>();
+        }
+    }
 
     /// <summary>
     /// Updates the NuGet.config file to include a URL to the internal package feed of the specified version.
     /// </summary>
-    /// <param name="sdkVersion"></param>
-    private void UpdateNuGetConfigFile(string sdkVersion)
+    private string GetUpdatedNuGetConfigContent(string sdkVersion)
     {
-        string configSuffix = (_options.Branch == "nightly" ? ".nightly" : string.Empty);
-        string configPath = Path.Combine(_repoRoot, $"tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config{configSuffix}");
         string pkgSrcName = $"dotnet{_options.DockerfileVersion.Replace(".", "_")}{PkgSrcSuffix}";
 
-        XDocument doc = XDocument.Load(configPath);
+        XDocument doc = XDocument.Load(_configPath);
 
         XElement configuration = doc.Root!;
         UpdatePackageSources(sdkVersion, pkgSrcName, configuration);
         UpdatePackageSourceCredentials(pkgSrcName, configuration);
-
-        File.WriteAllText(configPath, ToStringWithDeclaration(doc) + Environment.NewLine);
+        return ToStringWithDeclaration(doc) + Environment.NewLine;
     }
 
     private static string ToStringWithDeclaration(XDocument doc)


### PR DESCRIPTION
There are two issues with the update-dependencies tool caused by the changes in https://github.com/dotnet/dotnet-docker/pull/3745:

* An NRE occurs when attempting to update the version for .NET Monitor. This happens because `BaseUrlUpdater` is not constructing the URL variable correctly. This is described in https://github.com/dotnet/dotnet-docker/issues/3769. I've fixed this by updating the logic to construct a variable name specific to .NET Monitor when appropriate.
* The will throw this error for the base .NET Dockerfiles: `System.Exception: 'git status' does not match DependencyInfo information. Git has modified files: False. DependencyInfo is updated: True.` This happens because of `NuGetConfigUpdater` causing it to seem like the file is updated without actually updating the file. The behavior of the `Microsoft.DotNet.VersionTools` infra requires that the `GetUpdateTasks` method only return tasks for things that are actually going to be updated. In thise case, `NuGetConfigUpdater` is doing it all the time regardless of whether the file is updated. I've fixed this to not return anything if the file will have no changes.

Fixes https://github.com/dotnet/dotnet-docker/issues/3769
