### PR TITLE
Generate readmes for MCR portal

### DIFF
--- a/.mcr/portal/README.aspnet.portal.md
+++ b/.mcr/portal/README.aspnet.portal.md
@@ -1,8 +1,9 @@
 ## About
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
 
 This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 

--- a/.mcr/portal/README.aspnet.portal.md
+++ b/.mcr/portal/README.aspnet.portal.md
@@ -36,7 +36,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-## Container sample: Run a web application
+### Container sample: Run a web application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 

--- a/.mcr/portal/README.aspnet.portal.md
+++ b/.mcr/portal/README.aspnet.portal.md
@@ -1,0 +1,76 @@
+## About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+
+This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
+
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `7.0` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:7.0`
+* `6.0` (Current, LTS)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
+
+## Related Repos
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+## Usage
+
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+## Container sample: Run a web application
+
+You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+
+Type the following command to run a sample web application:
+
+```console
+docker run -it --rm -p 8000:80 --name aspnetcore_sample mcr.microsoft.com/dotnet/samples:aspnetapp
+```
+
+After the application starts, navigate to `http://localhost:8000` in your web browser.
+
+See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
+
+## Support
+
+### Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/.mcr/portal/README.monitor.portal.md
+++ b/.mcr/portal/README.monitor.portal.md
@@ -1,0 +1,70 @@
+## About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+
+This image contains the .NET Monitor tool.
+
+Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
+
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `7` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
+* `6` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
+
+## Related Repos
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+## Usage
+
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+## Container sample: Run the tool
+
+You can run a container with a pre-built [.NET Docker Image](https://hub.docker.com/_/microsoft-dotnet-monitor/), based on the dotnet-monitor global tool.
+
+See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
+
+## Support
+
+### Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/.mcr/portal/README.monitor.portal.md
+++ b/.mcr/portal/README.monitor.portal.md
@@ -38,7 +38,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-## Container sample: Run the tool
+### Container sample: Run the tool
 
 You can run a container with a pre-built [.NET Docker Image](https://hub.docker.com/_/microsoft-dotnet-monitor/), based on the dotnet-monitor global tool.
 

--- a/.mcr/portal/README.monitor.portal.md
+++ b/.mcr/portal/README.monitor.portal.md
@@ -1,8 +1,9 @@
 ## About
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
 
 This image contains the .NET Monitor tool.
 

--- a/.mcr/portal/README.runtime-deps.portal.md
+++ b/.mcr/portal/README.runtime-deps.portal.md
@@ -1,8 +1,9 @@
 ## About
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
 
 This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
 

--- a/.mcr/portal/README.runtime-deps.portal.md
+++ b/.mcr/portal/README.runtime-deps.portal.md
@@ -1,0 +1,64 @@
+## About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+
+This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
+
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `7.0` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:7.0`
+* `6.0` (Current, LTS)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
+
+## Related Repos
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+## Usage
+
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+* [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/dotnet-docker-selfcontained.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian-x64-selfcontained) builds and runs an application as a self-contained application.
+
+## Support
+
+### Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/.mcr/portal/README.runtime.portal.md
+++ b/.mcr/portal/README.runtime.portal.md
@@ -1,8 +1,9 @@
 ## About
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
 
 This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
 

--- a/.mcr/portal/README.runtime.portal.md
+++ b/.mcr/portal/README.runtime.portal.md
@@ -36,7 +36,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-## Container sample: Run a simple application
+### Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 

--- a/.mcr/portal/README.runtime.portal.md
+++ b/.mcr/portal/README.runtime.portal.md
@@ -1,0 +1,72 @@
+## About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+
+This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
+
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `7.0` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:7.0`
+* `6.0` (Current, LTS)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
+
+## Related Repos
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+## Usage
+
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+## Container sample: Run a simple application
+
+You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+
+Type the following command to run a sample console application:
+
+```console
+docker run --rm mcr.microsoft.com/dotnet/samples
+```
+
+## Support
+
+### Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/.mcr/portal/README.samples.portal.md
+++ b/.mcr/portal/README.samples.portal.md
@@ -31,7 +31,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-## Container sample: Run a simple application
+### Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
@@ -41,7 +41,7 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/samples
 ```
 
-## Container sample: Run a web application
+### Container sample: Run a web application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 

--- a/.mcr/portal/README.samples.portal.md
+++ b/.mcr/portal/README.samples.portal.md
@@ -1,0 +1,82 @@
+## About
+
+These images contain sample .NET and ASP.NET Core applications.
+
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `dotnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile)
+  * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
+* `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
+  * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`
+
+## Related Repos
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
+* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
+
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+## Usage
+
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+## Container sample: Run a simple application
+
+You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+
+Type the following command to run a sample console application:
+
+```console
+docker run --rm mcr.microsoft.com/dotnet/samples
+```
+
+## Container sample: Run a web application
+
+You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+
+Type the following command to run a sample web application:
+
+```console
+docker run -it --rm -p 8000:80 --name aspnetcore_sample mcr.microsoft.com/dotnet/samples:aspnetapp
+```
+
+After the application starts, navigate to `http://localhost:8000` in your web browser.
+
+See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
+
+## Support
+
+### Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/.mcr/portal/README.sdk.portal.md
+++ b/.mcr/portal/README.sdk.portal.md
@@ -1,8 +1,9 @@
 ## About
 
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
 
 This image contains the .NET SDK which is comprised of three parts:
 

--- a/.mcr/portal/README.sdk.portal.md
+++ b/.mcr/portal/README.sdk.portal.md
@@ -42,12 +42,12 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-## Building .NET Apps with Docker
+### Building .NET Apps with Docker
 
 * [.NET Docker Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
 * [ASP.NET Core Docker Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Core Web App.
 
-## Develop .NET Apps in a Container
+### Develop .NET Apps in a Container
 
 The following samples show how to develop, build and test .NET applications with Docker without the need to install the .NET SDK.
 

--- a/.mcr/portal/README.sdk.portal.md
+++ b/.mcr/portal/README.sdk.portal.md
@@ -1,0 +1,81 @@
+## About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
+
+This image contains the .NET SDK which is comprised of three parts:
+
+1. .NET CLI
+1. .NET runtime
+1. ASP.NET Core
+
+Use this image for your development process (developing, building and testing applications).
+
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `7.0` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:7.0`
+* `6.0` (Current, LTS)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
+
+## Related Repos
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+## Usage
+
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+## Building .NET Apps with Docker
+
+* [.NET Docker Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
+* [ASP.NET Core Docker Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Core Web App.
+
+## Develop .NET Apps in a Container
+
+The following samples show how to develop, build and test .NET applications with Docker without the need to install the .NET SDK.
+
+* [Build .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/build-in-sdk-container.md)
+* [Test .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-tests-in-sdk-container.md)
+* [Run .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-in-sdk-container.md)
+
+## Support
+
+### Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -11,6 +11,7 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
 
 # About
+
 This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,3 +1,8 @@
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
 # Featured Tags
 
 * `7.0` (Preview)
@@ -6,11 +11,6 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
 
 # About
-
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,7 +1,3 @@
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 # Featured Tags
 
 * `7.0` (Preview)
@@ -9,13 +5,17 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * `6.0` (Current, LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
 
-# About This Image
+# About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
@@ -184,7 +184,6 @@ Tag | Dockerfile
 7.0.0-preview.4-windowsservercore-ltsc2019, 7.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.
-<!--End of generated tags-->
 
 For tags contained in the old dotnet/core-nightly/aspnet repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core-nightly/aspnet/tags/list.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 
 # About
+
 [.NET](https://docs.microsoft.com/dotnet/core/) is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
 
 .NET has several capabilities that make development easier, including automatic memory management, (runtime) generic types, reflection, asynchrony, concurrency, and native interop. Millions of developers take advantage of these capabilities to efficiently build high-quality applications.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
 # Featured Repos
 
 * [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
@@ -7,11 +12,6 @@
 * [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 
 # About
-
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 [.NET](https://docs.microsoft.com/dotnet/core/) is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
 
 .NET has several capabilities that make development easier, including automatic memory management, (runtime) generic types, reflection, asynchrony, concurrency, and native interop. Millions of developers take advantage of these capabilities to efficiently build high-quality applications.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 # Featured Repos
 
 * [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
@@ -10,7 +6,11 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 
-# About .NET
+# About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 [.NET](https://docs.microsoft.com/dotnet/core/) is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
 
@@ -29,7 +29,7 @@ You are invited to [contribute new features](https://github.com/dotnet/core/blob
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Images
+# Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -11,6 +11,7 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 # About
+
 This image contains the .NET Monitor tool.
 
 Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -1,7 +1,3 @@
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 # Featured Tags
 
 * `7` (Preview)
@@ -9,7 +5,11 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * `6` (Preview)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
-# About This Image
+# About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET Monitor tool.
 
@@ -17,7 +17,7 @@ Use this image as a sidecar container to collect diagnostic information from oth
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
@@ -64,7 +64,6 @@ Tags | Dockerfile | OS Version
 6.2.0-alpha.1-alpine-arm64v8, 6.2-alpine-arm64v8, 6.2.0-alpha.1-alpine, 6.2-alpine, 6.2.0-alpha.1, 6.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/arm64v8/Dockerfile) | Alpine 3.15
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
-<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -1,3 +1,8 @@
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
 # Featured Tags
 
 * `7` (Preview)
@@ -6,11 +11,6 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 # About
-
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 This image contains the .NET Monitor tool.
 
 Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -11,6 +11,7 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
 
 # About
+
 This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -1,3 +1,8 @@
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
 # Featured Tags
 
 * `7.0` (Preview)
@@ -6,11 +11,6 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
 
 # About
-
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -1,7 +1,3 @@
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 # Featured Tags
 
 * `7.0` (Preview)
@@ -9,13 +5,17 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * `6.0` (Current, LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
 
-# About This Image
+# About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
@@ -119,7 +119,6 @@ Tags | Dockerfile | OS Version
 7.0.0-preview.4-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.0-preview.4-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime-deps at https://mcr.microsoft.com/v2/dotnet/nightly/runtime-deps/tags/list.
-<!--End of generated tags-->
 
 For tags contained in the old dotnet/core-nightly/runtime-deps repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core-nightly/runtime-deps/tags/list.
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,7 +1,3 @@
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 # Featured Tags
 
 * `7.0` (Preview)
@@ -9,13 +5,17 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * `6.0` (Current, LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
 
-# About This Image
+# About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
@@ -180,7 +180,6 @@ Tag | Dockerfile
 7.0.0-preview.4-windowsservercore-ltsc2019, 7.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.
-<!--End of generated tags-->
 
 For tags contained in the old dotnet/core-nightly/runtime repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core-nightly/runtime/tags/list.
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,3 +1,8 @@
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
 # Featured Tags
 
 * `7.0` (Preview)
@@ -6,11 +11,6 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
 
 # About
-
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -11,6 +11,7 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
 
 # About
+
 This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/README.samples.md
+++ b/README.samples.md
@@ -5,13 +5,13 @@
 * `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`
 
-# About This Image
+# About
 
 These images contain sample .NET and ASP.NET Core applications.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
@@ -94,7 +94,6 @@ dotnetapp-nanoserver-1809, dotnetapp, latest | [Dockerfile](https://github.com/d
 aspnetapp-nanoserver-1809, aspnetapp | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/samples at https://mcr.microsoft.com/v2/dotnet/samples/tags/list.
-<!--End of generated tags-->
 
 For tags contained in the old dotnet/core/samples repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/samples/tags/list.
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,7 +1,3 @@
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 # Featured Tags
 
 * `7.0` (Preview)
@@ -9,7 +5,11 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * `6.0` (Current, LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
 
-# About This Image
+# About
+
+The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET SDK which is comprised of three parts:
 
@@ -21,7 +21,7 @@ Use this image for your development process (developing, building and testing ap
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
@@ -183,7 +183,6 @@ Tag | Dockerfile
 7.0.100-preview.4-windowsservercore-ltsc2019, 7.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.
-<!--End of generated tags-->
 
 For tags contained in the old dotnet/core-nightly/sdk repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core-nightly/sdk/tags/list.
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,3 +1,8 @@
+**IMPORTANT**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
 # Featured Tags
 
 * `7.0` (Preview)
@@ -6,11 +11,6 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
 
 # About
-
-The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
 This image contains the .NET SDK which is comprised of three parts:
 
 1. .NET CLI

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -11,6 +11,7 @@
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
 
 # About
+
 This image contains the .NET SDK which is comprised of three parts:
 
 1. .NET CLI

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1728424
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1773385
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/readme-templates/About.md
+++ b/eng/readme-templates/About.md
@@ -1,13 +1,10 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      is-mcr: Indicates whether the readme is being generated for the MCR portal
 }}{{ARGS["top-header"]}} About
-
-{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
-:The images from the dotnet/{{if IS_PRODUCT_FAMILY:nightly^else:{{PARENT_REPO}}}} repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
-}}{{InsertTemplate(join(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
+{{if ARGS["is-mcr"]:
+{{InsertTemplate("Announcement.md")}}}}{{
+InsertTemplate(join(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/eng/readme-templates/About.md
+++ b/eng/readme-templates/About.md
@@ -1,14 +1,13 @@
-[.NET](https://docs.microsoft.com/dotnet/core/) is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} About
 
-.NET has several capabilities that make development easier, including automatic memory management, (runtime) generic types, reflection, asynchrony, concurrency, and native interop. Millions of developers take advantage of these capabilities to efficiently build high-quality applications.
+{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
+:The images from the dotnet/{{if IS_PRODUCT_FAMILY:nightly^else:{{PARENT_REPO}}}} repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
 
-You can use C# or F# to write .NET apps. 
+See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
-- [C#](https://docs.microsoft.com/dotnet/csharp/) is simple, powerful, type-safe, and object-oriented while retaining the expressiveness and elegance of C-style languages. Anyone familiar with C and similar languages will find it straightforward to write in C#.
-- [F#](https://docs.microsoft.com/dotnet/fsharp/) is a cross-platform, open-source, functional programming language for .NET. It also includes object-oriented and imperative programming.
+}}{{InsertTemplate(join(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
 
-[.NET](https://github.com/dotnet/core) is open source (MIT and Apache 2 licenses) and was contributed to the [.NET Foundation](http://dotnetfoundation.org) by Microsoft in 2014. It can be freely adopted by individuals and companies, including for personal, academic or commercial purposes. Multiple companies use .NET as part of apps, tools, new platforms and hosting services.
-
-You are invited to [contribute new features](https://github.com/dotnet/core/blob/master/CONTRIBUTING.md), fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
-
-> https://docs.microsoft.com/dotnet/core/
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/eng/readme-templates/About.md
+++ b/eng/readme-templates/About.md
@@ -3,8 +3,7 @@
       top-header: The string to use as the top-level header.
       is-mcr: Indicates whether the readme is being generated for the MCR portal
 }}{{ARGS["top-header"]}} About
-{{if ARGS["is-mcr"]:
-{{InsertTemplate("Announcement.md")}}}}{{
-InsertTemplate(join(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
+{{if ARGS["is-mcr"]:{{InsertTemplate("Announcement.md", [ "leading-line-break": "true"])}}}}
+{{InsertTemplate(join(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/eng/readme-templates/About.product-family.md
+++ b/eng/readme-templates/About.product-family.md
@@ -1,0 +1,14 @@
+[.NET](https://docs.microsoft.com/dotnet/core/) is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
+
+.NET has several capabilities that make development easier, including automatic memory management, (runtime) generic types, reflection, asynchrony, concurrency, and native interop. Millions of developers take advantage of these capabilities to efficiently build high-quality applications.
+
+You can use C# or F# to write .NET apps. 
+
+- [C#](https://docs.microsoft.com/dotnet/csharp/) is simple, powerful, type-safe, and object-oriented while retaining the expressiveness and elegance of C-style languages. Anyone familiar with C and similar languages will find it straightforward to write in C#.
+- [F#](https://docs.microsoft.com/dotnet/fsharp/) is a cross-platform, open-source, functional programming language for .NET. It also includes object-oriented and imperative programming.
+
+[.NET](https://github.com/dotnet/core) is open source (MIT and Apache 2 licenses) and was contributed to the [.NET Foundation](http://dotnetfoundation.org) by Microsoft in 2014. It can be freely adopted by individuals and companies, including for personal, academic or commercial purposes. Multiple companies use .NET as part of apps, tools, new platforms and hosting services.
+
+You are invited to [contribute new features](https://github.com/dotnet/core/blob/master/CONTRIBUTING.md), fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+> https://docs.microsoft.com/dotnet/core/

--- a/eng/readme-templates/Announcement.md
+++ b/eng/readme-templates/Announcement.md
@@ -1,0 +1,7 @@
+{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
+:**IMPORTANT**
+**The images from the dotnet/{{if IS_PRODUCT_FAMILY:nightly^else:{{PARENT_REPO}}}} repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
+}}

--- a/eng/readme-templates/Announcement.md
+++ b/eng/readme-templates/Announcement.md
@@ -1,7 +1,12 @@
-{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
-:**IMPORTANT**
+{{
+    _ ARGS:
+      leading-line-break: Indicates whether to include a leading line break
+      trailing-line-break: Indicates whether to include a trailing line break
+}}{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
+:{{if ARGS["leading-line-break"]:
+}}**IMPORTANT**
 **The images from the dotnet/{{if IS_PRODUCT_FAMILY:nightly^else:{{PARENT_REPO}}}} repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
 **See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
-
-}}
+{{if ARGS["trailing-line-break"]:
+}}}}

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -1,0 +1,20 @@
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} Featured Tags
+
+{{if match(SHORT_REPO, "samples")
+:* `dotnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile)
+  * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
+* `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
+  * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`^
+elif match(SHORT_REPO, "monitor"):{{if VARIABLES["branch"] = "nightly":* `7` (Preview)
+  * `docker pull {{FULL_REPO}}:7`
+* `6` (Preview)
+  * `docker pull {{FULL_REPO}}:6`^
+else:* `6` (Current)
+  * `docker pull {{FULL_REPO}}:6`}}^
+else:{{if VARIABLES["branch"] = "nightly":* `7.0` (Preview)
+  * `docker pull {{FULL_REPO}}:7.0`
+}}* `6.0` (Current, LTS)
+  * `docker pull {{FULL_REPO}}:6.0`}}

--- a/eng/readme-templates/Get-GeneratedReadmes.ps1
+++ b/eng/readme-templates/Get-GeneratedReadmes.ps1
@@ -30,7 +30,6 @@ $onDockerfilesGenerated = {
         CopyReadme $ContainerName "README.sdk.md"
 
         CopyReadme $ContainerName ".mcr/portal/README.aspnet.portal.md"
-        CopyReadme $ContainerName ".mcr/portal/README.portal.md"
         CopyReadme $ContainerName ".mcr/portal/README.monitor.portal.md"
         CopyReadme $ContainerName ".mcr/portal/README.runtime-deps.portal.md"
         CopyReadme $ContainerName ".mcr/portal/README.runtime.portal.md"

--- a/eng/readme-templates/Get-GeneratedReadmes.ps1
+++ b/eng/readme-templates/Get-GeneratedReadmes.ps1
@@ -12,17 +12,30 @@ if ($Validate) {
 
 $repoRoot = (Get-Item "$PSScriptRoot").Parent.Parent.FullName
 
+function CopyReadme([string]$containerName, [string]$readmeRelativePath) {
+    $readmeDir = Split-Path $readmeRelativePath -Parent
+    Exec "docker cp ${containerName}:/repo/$readmeRelativePath $repoRoot/$readmeDir"
+}
+
 $onDockerfilesGenerated = {
     param($ContainerName)
 
     if (-Not $Validate) {
-        Exec "docker cp ${ContainerName}:/repo/README.aspnet.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.monitor.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.runtime-deps.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.runtime.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.samples.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.sdk.md $repoRoot"
+        CopyReadme $ContainerName "README.aspnet.md"
+        CopyReadme $ContainerName "README.md"
+        CopyReadme $ContainerName "README.monitor.md"
+        CopyReadme $ContainerName "README.runtime-deps.md"
+        CopyReadme $ContainerName "README.runtime.md"
+        CopyReadme $ContainerName "README.samples.md"
+        CopyReadme $ContainerName "README.sdk.md"
+
+        CopyReadme $ContainerName ".mcr/portal/README.aspnet.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.monitor.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.runtime-deps.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.runtime.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.samples.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.sdk.portal.md"
     }
 }
 

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -1,0 +1,11 @@
+{{
+  set headerArgs to [ "top-header": "##" ]
+}}{{InsertTemplate("About.md", headerArgs)}}
+
+{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+
+{{InsertTemplate("RelatedRepos.md", headerArgs)}}
+
+{{InsertTemplate("Use.md", headerArgs)}}
+
+{{InsertTemplate("Support.md", headerArgs)}}

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -1,5 +1,5 @@
 {{
-  set headerArgs to [ "top-header": "##" ]
+  set headerArgs to [ "top-header": "##", "is-mcr": "true" ]
 }}{{InsertTemplate("About.md", headerArgs)}}
 
 {{InsertTemplate("FeaturedTags.md", headerArgs)}}

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -1,8 +1,8 @@
 {{
   set headerArgs to [ "top-header": "#" ]
-}}{{if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
-}}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":
-# Featured Repos
+}}{{InsertTemplate("Announcement.md")}}{{
+if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+}}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":# Featured Repos
 
 * [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
 * [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -1,6 +1,6 @@
 {{
   set headerArgs to [ "top-header": "#" ]
-}}{{InsertTemplate("Announcement.md")}}{{
+}}{{InsertTemplate("Announcement.md", [ "trailing-line-break": "true"])}}{{
 if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
 }}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":# Featured Repos
 

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -1,27 +1,8 @@
-{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
-:The images from the dotnet/{{if IS_PRODUCT_FAMILY:nightly^else:{{PARENT_REPO}}}} repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
-
-See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
-
-}}{{if !IS_PRODUCT_FAMILY:# Featured Tags
-
-{{if match(SHORT_REPO, "samples")
-:* `dotnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile)
-  * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
-* `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
-  * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`
-^elif match(SHORT_REPO, "monitor"):{{if VARIABLES["branch"] = "nightly":* `7` (Preview)
-  * `docker pull {{FULL_REPO}}:7`
-* `6` (Preview)
-  * `docker pull {{FULL_REPO}}:6`
-^else:* `6` (Current)
-  * `docker pull {{FULL_REPO}}:6`
-}}^else:{{if VARIABLES["branch"] = "nightly":* `7.0` (Preview)
-  * `docker pull {{FULL_REPO}}:7.0`
-}}* `6.0` (Current, LTS)
-  * `docker pull {{FULL_REPO}}:6.0`
-}}}}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"
-:# Featured Repos
+{{
+  set headerArgs to [ "top-header": "#" ]
+}}{{if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+}}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":
+# Featured Repos
 
 * [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
 * [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
@@ -38,81 +19,15 @@ See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with officia
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 }}
-# About {{if IS_PRODUCT_FAMILY:.NET^else:This Image}}
+{{InsertTemplate("About.md", headerArgs)}}
 
-{{InsertTemplate(join(filter(["About", SHORT_REPO, "md"], len), "."))}}
+{{InsertTemplate("Use.md", headerArgs)}}
 
-Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
-
-# How to Use the Image{{if IS_PRODUCT_FAMILY:s}}
-
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
-
-{{InsertTemplate(join(filter(["Use", SHORT_REPO, "md"], len), "."))}}
-
-# Related Repos
-
-.NET:
-
-{{if (!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly")
-    :* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "sdk")
-    :* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "aspnet")
-    :* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime")
-    :* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime-deps")
-    :* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "monitor")
-    :* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-}}{{if ((!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly") && SHORT_REPO != "samples")
-    :* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "sdk") || (PARENT_REPO = "dotnet" && SHORT_REPO = "sdk") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "aspnet") || (PARENT_REPO = "dotnet" && SHORT_REPO = "aspnet") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime-deps") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime-deps") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "monitor") || (PARENT_REPO = "dotnet" && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
-}}
-.NET Framework:
-
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
-
-{{if !IS_PRODUCT_FAMILY:# Full Tag Listing
-<!--End of generated tags-->
-
+{{InsertTemplate("RelatedRepos.md", headerArgs)}}
+{{if !IS_PRODUCT_FAMILY:
+# Full Tag Listing
 {{if SHORT_REPO != "monitor":For tags contained in the old dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}} repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}}/tags/list.
 
 }}*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
-
-}}# Support
-
-## Lifecycle
-
-* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
-* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
-* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
-
-## Image Update Policy
-
-* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
-* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
-
-## Feedback
-
-* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
-* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# License
-
-* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
-* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
-* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
-* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
-* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)
+}}
+{{InsertTemplate("Support.md", headerArgs)}}

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -1,0 +1,36 @@
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} Related Repos
+
+.NET:
+
+{{if (!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly")
+    :* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "sdk")
+    :* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
+}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "aspnet")
+    :* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime")
+    :* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
+}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime-deps")
+    :* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
+}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "monitor")
+    :* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
+}}{{if ((!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly") && SHORT_REPO != "samples")
+    :* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "sdk") || (PARENT_REPO = "dotnet" && SHORT_REPO = "sdk") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+    :* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "aspnet") || (PARENT_REPO = "dotnet" && SHORT_REPO = "aspnet") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+    :* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+    :* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime-deps") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime-deps") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+    :* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "monitor") || (PARENT_REPO = "dotnet" && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+    :* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+}}
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples

--- a/eng/readme-templates/Support.md
+++ b/eng/readme-templates/Support.md
@@ -1,0 +1,28 @@
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} Support
+
+{{ARGS["top-header"]}}# Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+{{ARGS["top-header"]}}# Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+{{ARGS["top-header"]}}# Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+{{ARGS["top-header"]}} License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/eng/readme-templates/Use.aspnet.md
+++ b/eng/readme-templates/Use.aspnet.md
@@ -1,4 +1,7 @@
-## Container sample: Run a web application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a web application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -1,23 +1,8 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} Usage
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-Type the following command to run a sample console application:
-
-```console
-docker run --rm mcr.microsoft.com/dotnet/samples
-```
-
-## Container sample: Run a web application
-
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
-
-Type the following command to run a sample web application:
-
-```console
-docker run -it --rm -p 8000:80 --name aspnetcore_sample mcr.microsoft.com/dotnet/samples:aspnetapp
-```
-
-After the application starts, navigate to `http://localhost:8000` in your web browser.
-
-See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
+{{InsertTemplate(join(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -5,4 +5,5 @@
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-{{InsertTemplate(join(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
+{{InsertTemplate(join(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."),
+  [ "top-header": ARGS["top-header"]])}}

--- a/eng/readme-templates/Use.monitor.md
+++ b/eng/readme-templates/Use.monitor.md
@@ -1,4 +1,7 @@
-## Container sample: Run the tool
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run the tool
 
 You can run a container with a pre-built [.NET Docker Image](https://hub.docker.com/_/microsoft-dotnet-monitor/), based on the dotnet-monitor global tool.
 

--- a/eng/readme-templates/Use.product-family.md
+++ b/eng/readme-templates/Use.product-family.md
@@ -1,0 +1,23 @@
+## Container sample: Run a simple application
+
+You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+
+Type the following command to run a sample console application:
+
+```console
+docker run --rm mcr.microsoft.com/dotnet/samples
+```
+
+## Container sample: Run a web application
+
+You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+
+Type the following command to run a sample web application:
+
+```console
+docker run -it --rm -p 8000:80 --name aspnetcore_sample mcr.microsoft.com/dotnet/samples:aspnetapp
+```
+
+After the application starts, navigate to `http://localhost:8000` in your web browser.
+
+See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.

--- a/eng/readme-templates/Use.product-family.md
+++ b/eng/readme-templates/Use.product-family.md
@@ -1,4 +1,7 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
@@ -8,7 +11,7 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/samples
 ```
 
-## Container sample: Run a web application
+{{ARGS["top-header"]}}# Container sample: Run a web application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 

--- a/eng/readme-templates/Use.runtime.md
+++ b/eng/readme-templates/Use.runtime.md
@@ -1,4 +1,7 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 

--- a/eng/readme-templates/Use.samples.md
+++ b/eng/readme-templates/Use.samples.md
@@ -1,4 +1,7 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
@@ -8,7 +11,7 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/samples
 ```
 
-## Container sample: Run a web application
+{{ARGS["top-header"]}}# Container sample: Run a web application
 
 You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 

--- a/eng/readme-templates/Use.sdk.md
+++ b/eng/readme-templates/Use.sdk.md
@@ -1,9 +1,12 @@
-## Building .NET Apps with Docker
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Building .NET Apps with Docker
 
 * [.NET Docker Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
 * [ASP.NET Core Docker Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Core Web App.
 
-## Develop .NET Apps in a Container
+{{ARGS["top-header"]}}# Develop .NET Apps in a Container
 
 The following samples show how to develop, build and test .NET applications with Docker without the need to install the .NET SDK.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,8 @@
 {
-  "readme": "README.md",
-  "readmeTemplate": "eng/readme-templates/README.md",
+  "readme": {
+    "path": "README.md",
+    "templatePath": "eng/readme-templates/README.md"
+  },
   "registry": "mcr.microsoft.com",
   "variables": {
     "syndicatedRuntimeDepsRepo": "dotnet/core-nightly/runtime-deps",
@@ -15,8 +17,16 @@
     {
       "id": "runtime-deps",
       "name": "dotnet/nightly/runtime-deps",
-      "readme": "README.runtime-deps.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.runtime-deps.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.runtime-deps.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/runtime-deps-tags.yml",
       "images": [
         {
@@ -1335,8 +1345,16 @@
     {
       "id": "runtime",
       "name": "dotnet/nightly/runtime",
-      "readme": "README.runtime.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.runtime.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.runtime.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/runtime-tags.yml",
       "images": [
         {
@@ -3263,8 +3281,16 @@
     {
       "id": "aspnet",
       "name": "dotnet/nightly/aspnet",
-      "readme": "README.aspnet.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.aspnet.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.aspnet.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/aspnet-tags.yml",
       "images": [
         {
@@ -5242,8 +5268,16 @@
     {
       "id": "sdk",
       "name": "dotnet/nightly/sdk",
-      "readme": "README.sdk.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.sdk.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.sdk.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/sdk-tags.yml",
       "images": [
         {
@@ -6921,8 +6955,16 @@
     {
       "id": "monitor",
       "name": "dotnet/nightly/monitor",
-      "readme": "README.monitor.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.monitor.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.monitor.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/monitor-tags.yml",
       "images": [
         {

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -4,8 +4,16 @@
     {
       "id": "samples",
       "name": "dotnet/samples",
-      "readme": "README.samples.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.samples.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.samples.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/samples-tags.yml",
       "images": [
         {


### PR DESCRIPTION
* Updates the manifest to conform to the new schema defined by https://github.com/dotnet/docker-tools/pull/1001.
* Defines new readme files to be used for the MCR portal.
* Refactors the readme templates to enable more common content between the GH and MCR readmes.