### PR TITLE
Fix update-dependencies tool for optional sdk

### DIFF
--- a/eng/update-dependencies/NuGetConfigUpdater.cs
+++ b/eng/update-dependencies/NuGetConfigUpdater.cs
@@ -35,25 +35,25 @@ internal class NuGetConfigUpdater : IDependencyUpdater
     public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos)
     {
         string existingContent = File.ReadAllText(_configPath);
-        IDependencyInfo sdkInfo = dependencyInfos
-            .First(info => info.SimpleName == "sdk");
-
-        string newContent = GetUpdatedNuGetConfigContent(sdkInfo.SimpleVersion);
-
-        if (newContent != existingContent)
+        IDependencyInfo? sdkInfo = dependencyInfos
+            .FirstOrDefault(info => info.SimpleName == "sdk");
+        if (sdkInfo is not null)
         {
-            return new[]
+            string newContent = GetUpdatedNuGetConfigContent(sdkInfo.SimpleVersion);
+
+            if (newContent != existingContent)
             {
-                new DependencyUpdateTask(
-                    () => File.WriteAllText(_configPath, newContent),
-                    new[] { sdkInfo },
-                    Enumerable.Empty<string>())
-            };
+                return new[]
+                {
+                    new DependencyUpdateTask(
+                        () => File.WriteAllText(_configPath, newContent),
+                        new[] { sdkInfo },
+                        Enumerable.Empty<string>())
+                };
+            }
         }
-        else
-        {
-            return Enumerable.Empty<DependencyUpdateTask>();
-        }
+
+        return Enumerable.Empty<DependencyUpdateTask>();
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/dotnet/dotnet-docker/pull/3773. If a `product-version` option is not provided for `sdk`, it will result in a `Sequence contains no matching element` error in `NuGetConfigUpdater` because it's expecting that an `sdk` product version will always exist. This was identified by the build for updating .NET Monitor which does not include an `sdk` product version option.