### PR TITLE
3.1 targeting pack support in update-dependencies tool

### DIFF
--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -73,7 +73,9 @@ namespace Dotnet.Docker
                     new string[]
                     {
                         $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-targeting-pack-$VERSION_FILE-$ARCH.$ARCHIVE_EXT",
-                        $"$DOTNET_BASE_URL/Runtime/$DF_VERSION.0/dotnet-targeting-pack-$DF_VERSION.0-$ARCH.$ARCHIVE_EXT"
+                        $"$DOTNET_BASE_URL/Runtime/$DF_VERSION.0/dotnet-targeting-pack-$DF_VERSION.0-$ARCH.$ARCHIVE_EXT",
+                        // Fallback for legacy targeting pack versions (not needed for > 3.1)
+                        $"https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DF_VERSION.0/dotnet-targeting-pack-$DF_VERSION.0-$ARCH.$ARCHIVE_EXT"
                     }
                 },
                 { "runtime-apphost-pack", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-apphost-pack-$VERSION_FILE-$ARCH.$ARCHIVE_EXT" } },
@@ -86,7 +88,9 @@ namespace Dotnet.Docker
                     new string[]
                     {
                         $"$DOTNET_BASE_URL/aspnetcore/Runtime/$VERSION_DIR/aspnetcore-targeting-pack-$VERSION_FILE{GetAspnetTargetingPackArchFormat()}.$ARCHIVE_EXT",
-                        $"$DOTNET_BASE_URL/aspnetcore/Runtime/$DF_VERSION.0/aspnetcore-targeting-pack-$DF_VERSION.0{GetAspnetTargetingPackArchFormat()}.$ARCHIVE_EXT"
+                        $"$DOTNET_BASE_URL/aspnetcore/Runtime/$DF_VERSION.0/aspnetcore-targeting-pack-$DF_VERSION.0{GetAspnetTargetingPackArchFormat()}.$ARCHIVE_EXT",
+                        // Fallback for legacy targeting pack versions (not needed for > 3.1)
+                        $"https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$DF_VERSION.0/aspnetcore-targeting-pack-$DF_VERSION.0{GetAspnetTargetingPackArchFormat()}.$ARCHIVE_EXT"
                     }
                 },
 


### PR DESCRIPTION
When attempting to run the update-dependencies tool targeting an internal build of .NET Core 3.1, it ends up failing to resolve the checksums for the targeting packs. This produces errors which cause the execution to fail.

This happens because it's attempting to access these targeting pack files are stable versioned and don't exist at the dotnetclimsrc.blob.core.windows.net location. Because of the URL variable replacement, it ends up using the dotnetclimsrc.blob.core.windows.net hostname.

To fix this, I've added an additional fallback which is hardcoded to the dotnetcli.blob.core.windows.net hostname.