### PR TITLE
Reference MAR URLs in readmes for MAR portal

### DIFF
--- a/.mar/portal/README.aspnet.portal.md
+++ b/.mar/portal/README.aspnet.portal.md
@@ -13,7 +13,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
 * [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
 * [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
 * [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
@@ -23,7 +22,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET Framework:
 
-* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework): .NET Framework, ASP.NET and WCF
 * [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage

--- a/.mar/portal/README.aspnet.portal.md
+++ b/.mar/portal/README.aspnet.portal.md
@@ -13,18 +13,18 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
-* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
+* [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
+* [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
+* [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
+* [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about): .NET Monitor Tool
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
+* [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 
 .NET Framework:
 
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage
 
@@ -32,7 +32,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 ### Container sample: Run a web application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image](https://mcr.microsoft.com/product/dotnet/samples/about), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 
 Type the following command to run a sample web application:
 

--- a/.mar/portal/README.monitor.portal.md
+++ b/.mar/portal/README.monitor.portal.md
@@ -1,44 +1,42 @@
 ## About
 
-This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
+This image contains the .NET Monitor tool.
+
+Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
 ## Featured Tags
 
-* `6.0` (Current, LTS)
-  * `docker pull mcr.microsoft.com/dotnet/runtime:6.0`
+* `6` (Current)
+  * `docker pull mcr.microsoft.com/dotnet/monitor:6`
 
 ## Related Repos
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
-* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
+* [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
+* [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
+* [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
+* [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
+* [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
 
 .NET Framework:
 
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-### Container sample: Run a simple application
+### Container sample: Run the tool
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+You can run a container with a pre-built [.NET Docker Image](https://mcr.microsoft.com/product/dotnet/monitor/about), based on the dotnet-monitor global tool.
 
-Type the following command to run a sample console application:
-
-```console
-docker run --rm mcr.microsoft.com/dotnet/samples
-```
+See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
 
 ## Support
 

--- a/.mar/portal/README.monitor.portal.md
+++ b/.mar/portal/README.monitor.portal.md
@@ -15,7 +15,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
 * [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
 * [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
 * [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
@@ -25,7 +24,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET Framework:
 
-* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework): .NET Framework, ASP.NET and WCF
 * [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage

--- a/.mar/portal/README.runtime-deps.portal.md
+++ b/.mar/portal/README.runtime-deps.portal.md
@@ -13,18 +13,18 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
-* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
-* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
+* [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
+* [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
+* [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
+* [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about): .NET Monitor Tool
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
+* [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
 
 .NET Framework:
 
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage
 

--- a/.mar/portal/README.runtime-deps.portal.md
+++ b/.mar/portal/README.runtime-deps.portal.md
@@ -13,7 +13,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
 * [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
 * [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
 * [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
@@ -23,7 +22,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET Framework:
 
-* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework): .NET Framework, ASP.NET and WCF
 * [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage

--- a/.mar/portal/README.runtime.portal.md
+++ b/.mar/portal/README.runtime.portal.md
@@ -13,7 +13,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
 * [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
 * [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
 * [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
@@ -23,7 +22,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET Framework:
 
-* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework): .NET Framework, ASP.NET and WCF
 * [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage

--- a/.mar/portal/README.runtime.portal.md
+++ b/.mar/portal/README.runtime.portal.md
@@ -1,42 +1,44 @@
 ## About
 
-This image contains the .NET Monitor tool.
-
-Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
+This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
 ## Featured Tags
 
-* `6` (Current)
-  * `docker pull mcr.microsoft.com/dotnet/monitor:6`
+* `6.0` (Current, LTS)
+  * `docker pull mcr.microsoft.com/dotnet/runtime:6.0`
 
 ## Related Repos
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
-* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
+* [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
+* [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
+* [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
+* [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about): .NET Monitor Tool
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
+* [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 
 .NET Framework:
 
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-### Container sample: Run the tool
+### Container sample: Run a simple application
 
-You can run a container with a pre-built [.NET Docker Image](https://hub.docker.com/_/microsoft-dotnet-monitor/), based on the dotnet-monitor global tool.
+You can quickly run a container with a pre-built [.NET Docker image](https://mcr.microsoft.com/product/dotnet/samples/about), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
-See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
+Type the following command to run a sample console application:
+
+```console
+docker run --rm mcr.microsoft.com/dotnet/samples
+```
 
 ## Support
 

--- a/.mar/portal/README.samples.portal.md
+++ b/.mar/portal/README.samples.portal.md
@@ -15,7 +15,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
 * [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
 * [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
 * [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
@@ -24,7 +23,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET Framework:
 
-* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework): .NET Framework, ASP.NET and WCF
 * [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage

--- a/.mar/portal/README.samples.portal.md
+++ b/.mar/portal/README.samples.portal.md
@@ -15,17 +15,17 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
-* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
+* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
+* [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
+* [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
+* [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
+* [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
+* [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about): .NET Monitor Tool
 
 .NET Framework:
 
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage
 
@@ -33,7 +33,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 ### Container sample: Run a simple application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image](https://mcr.microsoft.com/product/dotnet/samples/about), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
 Type the following command to run a sample console application:
 
@@ -43,7 +43,7 @@ docker run --rm mcr.microsoft.com/dotnet/samples
 
 ### Container sample: Run a web application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image](https://mcr.microsoft.com/product/dotnet/samples/about), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 
 Type the following command to run a sample web application:
 

--- a/.mar/portal/README.sdk.portal.md
+++ b/.mar/portal/README.sdk.portal.md
@@ -19,7 +19,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
 * [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
 * [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
 * [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
@@ -29,7 +28,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET Framework:
 
-* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework): .NET Framework, ASP.NET and WCF
 * [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage

--- a/.mar/portal/README.sdk.portal.md
+++ b/.mar/portal/README.sdk.portal.md
@@ -19,18 +19,18 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet](https://mcr.microsoft.com/catalog/search=dotnet): .NET
+* [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
+* [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
+* [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
+* [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about): .NET Monitor Tool
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
+* [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 
 .NET Framework:
 
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework](https://mcr.microsoft.com/catalog/search=dotnet/framework): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples/about): .NET Framework, ASP.NET and WCF Samples
 
 ## Usage
 

--- a/eng/readme-templates/About.md
+++ b/eng/readme-templates/About.md
@@ -1,9 +1,13 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
-      is-mcr: Indicates whether the readme is being generated for the MCR portal
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}} About
-{{if ARGS["is-mcr"]:{{InsertTemplate("Announcement.md", [ "leading-line-break": "true"])}}}}
+{{if ARGS["readme-host"] = "mar":{{InsertTemplate("Announcement.md",
+  [
+    "leading-line-break": "true",
+    "readme-host": ARGS["readme-host"]
+  ])}}}}
 {{InsertTemplate(join(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/eng/readme-templates/Announcement.md
+++ b/eng/readme-templates/Announcement.md
@@ -2,11 +2,14 @@
     _ ARGS:
       leading-line-break: Indicates whether to include a leading line break
       trailing-line-break: Indicates whether to include a trailing line break
+      readme-host: Moniker of the site that will host the readme ^
+    set nonNightlyRepo to join(split(REPO, "/nightly"), "")
 }}{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
 :{{if ARGS["leading-line-break"]:
 }}**IMPORTANT**
+
 **The images from the dotnet/{{if IS_PRODUCT_FAMILY:nightly^else:{{PARENT_REPO}}}} repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
-**See [dotnet](https://hub.docker.com/_/microsoft-dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+**See [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": nonNightlyRepo ])}}) for images with official releases of [.NET](https://github.com/dotnet/core).**
 {{if ARGS["trailing-line-break"]:
 }}}}

--- a/eng/readme-templates/Get-GeneratedReadmes.ps1
+++ b/eng/readme-templates/Get-GeneratedReadmes.ps1
@@ -29,12 +29,12 @@ $onDockerfilesGenerated = {
         CopyReadme $ContainerName "README.samples.md"
         CopyReadme $ContainerName "README.sdk.md"
 
-        CopyReadme $ContainerName ".mcr/portal/README.aspnet.portal.md"
-        CopyReadme $ContainerName ".mcr/portal/README.monitor.portal.md"
-        CopyReadme $ContainerName ".mcr/portal/README.runtime-deps.portal.md"
-        CopyReadme $ContainerName ".mcr/portal/README.runtime.portal.md"
-        CopyReadme $ContainerName ".mcr/portal/README.samples.portal.md"
-        CopyReadme $ContainerName ".mcr/portal/README.sdk.portal.md"
+        CopyReadme $ContainerName ".mar/portal/README.aspnet.portal.md"
+        CopyReadme $ContainerName ".mar/portal/README.monitor.portal.md"
+        CopyReadme $ContainerName ".mar/portal/README.runtime-deps.portal.md"
+        CopyReadme $ContainerName ".mar/portal/README.runtime.portal.md"
+        CopyReadme $ContainerName ".mar/portal/README.samples.portal.md"
+        CopyReadme $ContainerName ".mar/portal/README.sdk.portal.md"
     }
 }
 

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -1,11 +1,11 @@
 {{
-  set headerArgs to [ "top-header": "##", "is-mcr": "true" ]
-}}{{InsertTemplate("About.md", headerArgs)}}
+  set commonArgs to [ "top-header": "##", "readme-host": "mar" ]
+}}{{InsertTemplate("About.md", commonArgs)}}
 
-{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 
-{{InsertTemplate("RelatedRepos.md", headerArgs)}}
+{{InsertTemplate("RelatedRepos.md", commonArgs)}}
 
-{{InsertTemplate("Use.md", headerArgs)}}
+{{InsertTemplate("Use.md", commonArgs)}}
 
-{{InsertTemplate("Support.md", headerArgs)}}
+{{InsertTemplate("Support.md", commonArgs)}}

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -1,29 +1,32 @@
 {{
-  set headerArgs to [ "top-header": "#" ]
-}}{{InsertTemplate("Announcement.md", [ "trailing-line-break": "true"])}}{{
-if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+  set commonArgs to [
+    "top-header": "#"
+    "readme-host": "dockerhub"
+  ]
+}}{{InsertTemplate("Announcement.md", union(commonArgs, [ "trailing-line-break": "true" ]))}}{{
+if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 }}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":# Featured Repos
 
-* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
-* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/sdk]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/sdk" ])}}): .NET SDK
+* [dotnet/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/aspnet" ])}}): ASP.NET Core Runtime
+* [dotnet/runtime]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/runtime" ])}}): .NET Runtime
+* [dotnet/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/runtime-deps" ])}}): .NET Runtime Dependencies
+* [dotnet/monitor]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/monitor" ])}}): .NET Monitor Tool
+* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/samples" ])}}): .NET Samples
 ^elif IS_PRODUCT_FAMILY && VARIABLES["branch"] = "nightly"
 :# Featured Repos
 
-* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+* [dotnet/nightly/sdk]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/nightly/sdk" ])}}): .NET SDK (Preview)
+* [dotnet/nightly/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/nightly/aspnet" ])}}): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/nightly/runtime" ])}}): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/nightly/runtime-deps" ])}}): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/nightly/monitor" ])}}): .NET Monitor Tool (Preview)
 }}
-{{InsertTemplate("About.md", headerArgs)}}
+{{InsertTemplate("About.md", commonArgs)}}
 
-{{InsertTemplate("Use.md", headerArgs)}}
+{{InsertTemplate("Use.md", commonArgs)}}
 
-{{InsertTemplate("RelatedRepos.md", headerArgs)}}
+{{InsertTemplate("RelatedRepos.md", commonArgs)}}
 {{if !IS_PRODUCT_FAMILY:
 # Full Tag Listing
 <!--End of generated tags-->
@@ -31,4 +34,4 @@ if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
 
 }}*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 }}
-{{InsertTemplate("Support.md", headerArgs)}}
+{{InsertTemplate("Support.md", commonArgs)}}

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -6,7 +6,7 @@
 
 .NET:
 
-{{if (!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly")
+{{if (!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly") && ARGS["readme-host"] = "dockerhub"
     :* [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet", "is-product-family": "true" ])}}): .NET
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "sdk")
     :* [dotnet/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/sdk" ])}}): .NET SDK

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -1,36 +1,37 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}} Related Repos
 
 .NET:
 
 {{if (!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly")
-    :* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+    :* [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet", "is-product-family": "true" ])}}): .NET
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "sdk")
-    :* [dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/): .NET SDK
+    :* [dotnet/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/sdk" ])}}): .NET SDK
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "aspnet")
-    :* [dotnet/aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet/): ASP.NET Core Runtime
+    :* [dotnet/aspnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/aspnet" ])}}): ASP.NET Core Runtime
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime")
-    :* [dotnet/runtime](https://hub.docker.com/_/microsoft-dotnet-runtime/): .NET Runtime
+    :* [dotnet/runtime]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/runtime" ])}}): .NET Runtime
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime-deps")
-    :* [dotnet/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-runtime-deps/): .NET Runtime Dependencies
+    :* [dotnet/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/runtime-deps" ])}}): .NET Runtime Dependencies
 }}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "monitor")
-    :* [dotnet/monitor](https://hub.docker.com/_/microsoft-dotnet-monitor/): .NET Monitor Tool
+    :* [dotnet/monitor]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/monitor" ])}}): .NET Monitor Tool
 }}{{if ((!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly") && SHORT_REPO != "samples")
-    :* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+    :* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/samples" ])}}): .NET Samples
 }}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "sdk") || (PARENT_REPO = "dotnet" && SHORT_REPO = "sdk") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+    :* [dotnet/nightly/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/sdk" ])}}): .NET SDK (Preview)
 }}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "aspnet") || (PARENT_REPO = "dotnet" && SHORT_REPO = "aspnet") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+    :* [dotnet/nightly/aspnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/aspnet" ])}}): ASP.NET Core Runtime (Preview)
 }}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+    :* [dotnet/nightly/runtime]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime" ])}}): .NET Runtime (Preview)
 }}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime-deps") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime-deps") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+    :* [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime-deps" ])}}): .NET Runtime Dependencies (Preview)
 }}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "monitor") || (PARENT_REPO = "dotnet" && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
-    :* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+    :* [dotnet/nightly/monitor]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/monitor" ])}}): .NET Monitor Tool (Preview)
 }}
 .NET Framework:
 
-* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework", "is-product-family": "true" ])}}): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}): .NET Framework, ASP.NET and WCF Samples

--- a/eng/readme-templates/Url.md
+++ b/eng/readme-templates/Url.md
@@ -7,7 +7,7 @@
 }}{{
 when(ARGS["readme-host"] = "mar",
     when(ARGS["is-product-family"],
-        cat("https://mcr.microsoft.com/catalog/search=", ARGS["repo"]),
+        cat("https://mcr.microsoft.com/catalog?search=", ARGS["repo"]),
         cat("https://mcr.microsoft.com/product/", ARGS["repo"], "/about")),
     when(ARGS["readme-host"] = "dockerhub",
         cat("https://hub.docker.com/_/microsoft-", join(split(ARGS["repo"], "/"), "-"), "/"),

--- a/eng/readme-templates/Url.md
+++ b/eng/readme-templates/Url.md
@@ -1,0 +1,14 @@
+{{
+    _ Generates a URL formatted for the site that will host the readme
+    ARGS:
+      readme-host: Moniker of the site that will host the readme
+      repo: Repo path of the URL to be generated
+      is-product-family: Indicates whether the URL refers to a product family page
+}}{{
+when(ARGS["readme-host"] = "mar",
+    when(ARGS["is-product-family"],
+        cat("https://mcr.microsoft.com/catalog/search=", ARGS["repo"]),
+        cat("https://mcr.microsoft.com/product/", ARGS["repo"], "/about")),
+    when(ARGS["readme-host"] = "dockerhub",
+        cat("https://hub.docker.com/_/microsoft-", join(split(ARGS["repo"], "/"), "-"), "/"),
+        cat("UNKNOWN HOST: ", ARGS["readme-host"])))}}

--- a/eng/readme-templates/Use.aspnet.md
+++ b/eng/readme-templates/Use.aspnet.md
@@ -1,9 +1,10 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a web application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/samples"])}}), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 
 Type the following command to run a sample web application:
 

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -1,9 +1,10 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}} Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
 {{InsertTemplate(join(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."),
-  [ "top-header": ARGS["top-header"]])}}
+  [ "top-header": ARGS["top-header"], "readme-host": ARGS["readme-host"]])}}

--- a/eng/readme-templates/Use.monitor.md
+++ b/eng/readme-templates/Use.monitor.md
@@ -1,8 +1,9 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run the tool
 
-You can run a container with a pre-built [.NET Docker Image](https://hub.docker.com/_/microsoft-dotnet-monitor/), based on the dotnet-monitor global tool.
+You can run a container with a pre-built [.NET Docker Image]({{InsertTemplate("Url.md", [ "repo": "dotnet/monitor" "readme-host": ARGS["readme-host"] ])}}), based on the dotnet-monitor global tool.
 
 See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.

--- a/eng/readme-templates/Use.product-family.md
+++ b/eng/readme-templates/Use.product-family.md
@@ -1,9 +1,10 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image]({{InsertTemplate("Url.md", [ "repo": "dotnet/samples" "readme-host": ARGS["readme-host"] ])}}), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
 Type the following command to run a sample console application:
 
@@ -13,7 +14,7 @@ docker run --rm mcr.microsoft.com/dotnet/samples
 
 {{ARGS["top-header"]}}# Container sample: Run a web application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image]({{InsertTemplate("Url.md", [ "repo": "dotnet/samples" "readme-host": ARGS["readme-host"] ])}}), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 
 Type the following command to run a sample web application:
 

--- a/eng/readme-templates/Use.runtime-deps.md
+++ b/eng/readme-templates/Use.runtime-deps.md
@@ -1,1 +1,5 @@
-* [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/dotnet-docker-selfcontained.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian-x64-selfcontained) builds and runs an application as a self-contained application.
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
+}}* [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/dotnet-docker-selfcontained.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian-x64-selfcontained) builds and runs an application as a self-contained application.

--- a/eng/readme-templates/Use.runtime.md
+++ b/eng/readme-templates/Use.runtime.md
@@ -1,9 +1,10 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image]({{InsertTemplate("Url.md", [ "repo": "dotnet/samples" "readme-host": ARGS["readme-host"] ])}}), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
 Type the following command to run a sample console application:
 

--- a/eng/readme-templates/Use.samples.md
+++ b/eng/readme-templates/Use.samples.md
@@ -1,9 +1,10 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image]({{InsertTemplate("Url.md", [ "repo": "dotnet/samples" "readme-host": ARGS["readme-host"] ])}}), based on the [.NET console sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md).
 
 Type the following command to run a sample console application:
 
@@ -13,7 +14,7 @@ docker run --rm mcr.microsoft.com/dotnet/samples
 
 {{ARGS["top-header"]}}# Container sample: Run a web application
 
-You can quickly run a container with a pre-built [.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-samples/), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Docker image]({{InsertTemplate("Url.md", [ "repo": "dotnet/samples" "readme-host": ARGS["readme-host"] ])}}), based on the [ASP.NET Core sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/README.md).
 
 Type the following command to run a sample web application:
 

--- a/eng/readme-templates/Use.sdk.md
+++ b/eng/readme-templates/Use.sdk.md
@@ -1,6 +1,7 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Building .NET Apps with Docker
 
 * [.NET Docker Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
           "templatePath": "eng/readme-templates/README.md"
         },
         {
-          "path": ".mcr/portal/README.runtime-deps.portal.md",
+          "path": ".mar/portal/README.runtime-deps.portal.md",
           "templatePath": "eng/readme-templates/README.mcr.md"
         }
       ],
@@ -1351,7 +1351,7 @@
           "templatePath": "eng/readme-templates/README.md"
         },
         {
-          "path": ".mcr/portal/README.runtime.portal.md",
+          "path": ".mar/portal/README.runtime.portal.md",
           "templatePath": "eng/readme-templates/README.mcr.md"
         }
       ],
@@ -3287,7 +3287,7 @@
           "templatePath": "eng/readme-templates/README.md"
         },
         {
-          "path": ".mcr/portal/README.aspnet.portal.md",
+          "path": ".mar/portal/README.aspnet.portal.md",
           "templatePath": "eng/readme-templates/README.mcr.md"
         }
       ],
@@ -5274,7 +5274,7 @@
           "templatePath": "eng/readme-templates/README.md"
         },
         {
-          "path": ".mcr/portal/README.sdk.portal.md",
+          "path": ".mar/portal/README.sdk.portal.md",
           "templatePath": "eng/readme-templates/README.mcr.md"
         }
       ],
@@ -6961,7 +6961,7 @@
           "templatePath": "eng/readme-templates/README.md"
         },
         {
-          "path": ".mcr/portal/README.monitor.portal.md",
+          "path": ".mar/portal/README.monitor.portal.md",
           "templatePath": "eng/readme-templates/README.mcr.md"
         }
       ],

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -10,7 +10,7 @@
           "templatePath": "eng/readme-templates/README.md"
         },
         {
-          "path": ".mcr/portal/README.samples.portal.md",
+          "path": ".mar/portal/README.samples.portal.md",
           "templatePath": "eng/readme-templates/README.mcr.md"
         }
       ],


### PR DESCRIPTION
The two sets of readmes that we have between DH and MAR should have links which are relative to those sites. In other words, readmes hosted in DH should contain links to DH pages while readmes hosted in MAR should contain links to MAR pages.

I've updated the readme templates to use a sub-template which will generate the appropriate URL depending on the context of the readme host site.

Since MAR doesn't have product family pages currently, I resorted to using a search query to approximate that.