### PR TITLE
Dockerfile template fixes for internal .NET builds

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -21,16 +21,19 @@
                     "<NOT-IMPLEMENTED>")))) ^
     set baseImageTag to when(isAlpine || isMariner, OS_VERSION_NUMBER, OS_VERSION) ^
     set isSingleStage to !isDistrolessMariner && !(isFullMariner && isInternal && ARCH_SHORT != "arm64") ^
-    set urlSuffix to when(isInternal, "SAS_QUERY_STRING", "") ^
+    set urlSuffix to when(isInternal, "$SAS_QUERY_STRING", "") ^
     set rpmFilename to "dotnet-runtime-deps.rpm"
 }}{{
     if !isSingleStage:# Installer image
 }}FROM {{baseImageRepo}}:{{baseImageTag}}{{if !isSingleStage: AS installer}}{{ if isInternal && isFullMariner && ARCH_SHORT != "arm64":
 
+ARG SAS_QUERY_STRING
+
 RUN {{InsertTemplate("Dockerfile.download-runtime-deps-pkg",
     [
         "url-suffix": urlSuffix,
-        "filename": rpmFilename
+        "filename": rpmFilename,
+        "is-internal": isInternal
     ], "    ")}}}}
 {{ if isDistrolessMariner && find(OS_VERSION, "1.0") >= 0:
 RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
@@ -39,6 +42,8 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
     ])}}
 }}
 {{if isDistrolessMariner:# Install .NET's dependencies into a staging location
+^elif isMariner && isInternal:FROM {{baseImageRepo}}:{{baseImageTag}}
+
 }}RUN {{if isDistrolessMariner:mkdir {{distrolessStagingDir}} \
     && }}{{InsertTemplate("../Dockerfile.linux.install-deps", ["distroless-staging-dir": distrolessStagingDir])}}
 {{ if isDistrolessMariner:

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.download-runtime-deps-pkg
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.download-runtime-deps-pkg
@@ -1,14 +1,18 @@
 {{
     _ ARGS:
         url-suffix (optional): Suffix string to append the end of the URL.
-        filename: Name of the file to download ^
+        filename: Name of the file to download
+        is-internal (optional): Whether the Dockerfile is targeting an internal build of the product. ^
     
-    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".")
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set runtimeVersionFile to when(ARGS["is-internal"],
+        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
+        "$dotnet_version")
 }}dotnet_version={{VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]}} \
 && {{InsertTemplate("../Dockerfile.linux.download-file",
     [
         "out-file": ARGS["filename"],
-        "url": cat(VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])], "/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.1-", ARCH_SHORT, ".rpm", ARGS["url-suffix"]),
+        "url": cat(VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])], "/Runtime/$dotnet_version/dotnet-runtime-deps-", runtimeVersionFile, "-cm.1-", ARCH_SHORT, ".rpm", ARGS["url-suffix"]),
         "sha": VARIABLES[cat("runtime-deps-cm.1|", dotnetVersion, "|linux-rpm|", ARCH_SHORT, "|sha")],
         "sha-var-name": "dotnet_sha512"
     ])}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
@@ -16,7 +16,7 @@
     set runtimeVersionDir to when(ARGS["use-local-version-var"],
         "$dotnet_version",
         when(ARGS["is-internal"],
-            VARIABLES[cat("runtime|", dotnetVersion"|build-version")],
+            VARIABLES[cat("runtime|", dotnetVersion, "|build-version")],
             "$DOTNET_VERSION")) ^
     set runtimeVersionFile to when(ARGS["is-internal"],
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -39,7 +39,7 @@ ARG SAS_QUERY_STRING
 {{InsertTemplate("Dockerfile.linux.install-sdk",
     [
         "install-method": when(isFullMariner, "download", "download-and-install"),
-        "based-on-buildpack-deps": "true",
+        "based-on-buildpack-deps": isBasedOnBuildpackDeps,
         "use-local-version-var": (dotnetVersion = "3.1"),
         "is-internal": isInternal,
         "url-suffix": "$SAS_QUERY_STRING"
@@ -70,7 +70,10 @@ if isFullMariner:{{InsertTemplate("Dockerfile.linux.install-sdk",
         "url-suffix": "$SAS_QUERY_STRING",
         "installer-stage": "installer"
     ])}}^
-else:COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+else:COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]{{
+if isBasedOnBuildpackDeps:
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet}}
 
 {{InsertTemplate("Dockerfile.linux.first-run")}}}}^
 else:{{InsertTemplate("Dockerfile.linux.install-sdk",

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
@@ -25,8 +25,14 @@
     set sdkVersionFile to when(ARGS["is-internal"],
         VARIABLES[cat("sdk|", dotnetVersion, "|product-version")],
         sdkVersionDir) ^
-    set runtimeVersionVar to when(ARGS["use-local-version-var"], "$dotnet_version", "$DOTNET_VERSION") ^
+    set runtimeVersionDir to when(ARGS["use-local-version-var"], "$dotnet_version", "$DOTNET_VERSION") ^
+    set runtimeVersionFile to when(ARGS["is-internal"],
+        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
+        runtimeVersionDir) ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
+    set legacyBaseUrl to VARIABLES[cat("base-url|public|maintenance-legacy|", VARIABLES["branch"])] ^
+    set targetingPackBaseUrl to when(dotnetVersion = "3.1" || dotnetVersion = "5.0", legacyBaseUrl, baseUrl) ^
+    set targetingPackUrlSuffix to when(dotnetVersion = "3.1" || dotnetVersion = "5.0", "", ARGS["url-suffix"]) ^
     set commonShaVarName to "dotnet_sha512" ^
     set rpms to [
         [
@@ -38,31 +44,31 @@
         ],
         [
             "filename": "apphost.rpm",
-            "url": cat(baseUrl, "/Runtime/", runtimeVersionVar, "/dotnet-apphost-pack-", runtimeVersionVar, "-",
+            "url": cat(baseUrl, "/Runtime/", runtimeVersionDir, "/dotnet-apphost-pack-", runtimeVersionFile, "-",
                 ARCH_SHORT, ".rpm", ARGS["url-suffix"]),
             "sha": VARIABLES[join(["runtime-apphost-pack", dotnetVersion, "linux-rpm", ARCH_SHORT, "sha"], "|")],
             "sha-var-name": commonShaVarName
         ],
         [
             "filename": "targeting-pack.rpm",
-            "url": cat(baseUrl, "/Runtime/", VARIABLES[cat("runtime|", dotnetVersion, "|targeting-pack-version")],
+            "url": cat(targetingPackBaseUrl, "/Runtime/", VARIABLES[cat("runtime|", dotnetVersion, "|targeting-pack-version")],
                 "/dotnet-targeting-pack-", VARIABLES[cat("runtime|", dotnetVersion, "|targeting-pack-version")],
-                "-", ARCH_SHORT, ".rpm", ARGS["url-suffix"]),
+                "-", ARCH_SHORT, ".rpm", targetingPackUrlSuffix),
             "sha": VARIABLES[join(["runtime-targeting-pack", dotnetVersion, "linux-rpm", ARCH_SHORT, "sha"], "|")],
             "sha-var-name": commonShaVarName
         ],
         [
             "filename": "aspnetcore-targeting-pack.rpm",
-            "url": cat(baseUrl, "/aspnetcore/Runtime/", VARIABLES[cat("aspnet|", dotnetVersion, "|targeting-pack-version")],
+            "url": cat(targetingPackBaseUrl, "/aspnetcore/Runtime/", VARIABLES[cat("aspnet|", dotnetVersion, "|targeting-pack-version")],
                 "/aspnetcore-targeting-pack-", VARIABLES[cat("aspnet|", dotnetVersion, "|targeting-pack-version")],
-                when(dotnetVersion = "3.1" || dotnetVersion = "5.0", "", cat("-", ARCH_SHORT)), ".rpm", ARGS["url-suffix"]),
+                when(dotnetVersion = "3.1" || dotnetVersion = "5.0", "", cat("-", ARCH_SHORT)), ".rpm", targetingPackUrlSuffix),
             "sha": VARIABLES[join(["aspnet-runtime-targeting-pack", dotnetVersion, "linux-rpm", ARCH_SHORT, "sha"], "|")],
             "sha-var-name": commonShaVarName
         ],
         [
             "filename": "netstandard-targeting-pack.rpm",
             "url": cat("https://dotnetcli.azureedge.net/dotnet/Runtime/", VARIABLES["runtime|3.1|targeting-pack-version"],
-                "/netstandard-targeting-pack-2.1.0-", ARCH_SHORT, ".rpm", ARGS["url-suffix"]),
+                "/netstandard-targeting-pack-2.1.0-", ARCH_SHORT, ".rpm"),
             "sha": VARIABLES[join(["netstandard-targeting-pack-2.1.0", "linux-rpm", ARCH_SHORT, "sha"], "|")],
             "sha-var-name": commonShaVarName
         ]
@@ -117,6 +123,6 @@ if isFullMariner:    dotnet_version={{VARIABLES[cat("runtime|", dotnetVersion, "
         "skip-install": !installEnabled,
         "install-dir": installDir,
         "create-install-dir": !isFullMariner
-    ], "    ")}}{{if !ARGS["is-internal"] || isFullMariner:{{if ARGS["based-on-buildpack-deps"]: \
+    ], "    ")}}{{if !ARGS["is-internal"] || (isFullMariner && installEnabled):{{if ARGS["based-on-buildpack-deps"]: \
     && ln -s {{installDir}}/dotnet /usr/bin/dotnet}} \
     {{InsertTemplate("Dockerfile.linux.first-run", ["append-cmd": "true"], "    ")}}}}


### PR DESCRIPTION
As part of the work to [support internal builds](https://github.com/dotnet/dotnet-docker/issues/2152), I discovered that the Dockerfiles were being incorrectly generated for this scenario.

There are various issues fixed by these changes.

You can see the effect of these changes by looking at this branch comparison: https://github.com/mthalman/dotnet-docker/compare/3.1-internal-before...mthalman:3.1-internal-after?expand=1