### PR TITLE
Misc fixes to support internal .NET builds

### DIFF
--- a/eng/get-drop-versions.sh
+++ b/eng/get-drop-versions.sh
@@ -32,7 +32,10 @@ commitSha=${commitSha%?} # Remove last character (newline)
 # Example URL: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100-rtm.21522.1/dotnet-sdk-6.0.100-win-x64.zip
 #   The sed command below extracts the 6.0.100-rtm.21522.1 from the URL
 # We don't want the version contained in the SDK's .version file because that may be a stable branding version
-sdkVer=$(echo $sdkUrl | sed 's|.*/Sdk/\(.*\)/.*|\1|g')
+# The sed command doesn't support non-greedy matching so we have to be careful with the trailing slash after
+# the version because there may be more than one slash if a SAS token is present. To handle this, we just look
+# for the beginning of the filename with starts with "dotnet".
+sdkVer=$(echo $sdkUrl | sed 's|.*/Sdk/\(.*\)/dotnet.*|\1|g')
 
 rm sdkversion
 

--- a/eng/update-dependencies/NuGetConfigUpdater.cs
+++ b/eng/update-dependencies/NuGetConfigUpdater.cs
@@ -89,10 +89,8 @@ internal class NuGetConfigUpdater : IDependencyUpdater
         {
             pkgSourceCreds?.Remove();
 
-            pkgSourceCreds = GetOrCreateXObject(
-                pkgSourceCreds,
-                configuration,
-                () => new XElement("packageSourceCredentials"));
+            pkgSourceCreds = new XElement("packageSourceCredentials");
+            configuration.Add(pkgSourceCreds);
 
             XElement pkgSrc = GetOrCreateXObject(
                 pkgSourceCreds.Element(pkgSrcName),
@@ -119,10 +117,12 @@ internal class NuGetConfigUpdater : IDependencyUpdater
 
             RemoveAllInternalPackageSources(pkgSources);
 
+            string project = _options.DockerfileVersion != "3.1" ? "/internal" : string.Empty;
+
             UpdateAddElement(
                 pkgSources,
                 pkgSrcName,
-                $"https://pkgs.dev.azure.com/dnceng/internal/_packaging/{sdkVersion}-shipping/nuget/v3/index.json");
+                $"https://pkgs.dev.azure.com/dnceng{project}/_packaging/{sdkVersion}-shipping/nuget/v3/index.json");
         }
         else
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             const string NuGetFeedPasswordVar = "NuGetFeedPassword";
 
-            if (Config.IsInternal(_imageData.VersionString))
+            if (!string.IsNullOrEmpty(Config.NuGetFeedPassword))
             {
                 buildArgs.Add(NuGetFeedPasswordVar);
                 Environment.SetEnvironmentVariable(NuGetFeedPasswordVar, Config.NuGetFeedPassword);
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
             finally
             {
-                if (Config.IsInternal(_imageData.VersionString))
+                if (!string.IsNullOrEmpty(Config.NuGetFeedPassword))
                 {
                     Environment.SetEnvironmentVariable(NuGetFeedPasswordVar, null);
                 }


### PR DESCRIPTION
These changes contain several infrastructure and test fixes related to supporting [internal .NET builds](https://github.com/dotnet/dotnet-docker/issues/2152):

* The `get-drop-versions.sh` script needs to compensate for the SDK URL containing slashes in the SAS query string when parsing to find the SDK version.
* The logic to update the nuget.config file in the update-dependencies tool requires some fixes:
  * Don't remove the `packageSourceCredentials` element on successive runs.
  * Use a slightly different NuGet feed URL for .NET Core 3.1 compared to later .NET versions.
* Test execution needs to always provide the NuGet feed password if it's provided when building a test Dockerfile. Before it was only providing it if the version being tested was internal. But other non-internal versions will also be tested with the same nuget.config file. So if the password isn't provided, those other versions will get auth errors because nuget will enumerate all the feeds to resolve packages.