### PR TITLE
Set version source name in Set-DotnetVersions.ps1 script

### DIFF
--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -12,18 +12,22 @@ param(
     $ProductVersion,
 
     # Build version of the SDK
+    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetInstaller')]
     [string]
     $SdkVersion,
 
     # Build version of ASP.NET Core
+    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetInstaller')]
     [string]
     $AspnetVersion,
 
     # Build version of the .NET runtime
+    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetInstaller')]
     [string]
     $RuntimeVersion,
 
     # Build verison of the .NET Monitor tool
+    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetMonitor')]
     [string]
     $MonitorVersion,
 
@@ -53,22 +57,18 @@ $updateDepsArgs = @($ProductVersion)
 $versionSourceName = "";
 if ($SdkVersion) {
     $updateDepsArgs += @("--product-version", "sdk=$SdkVersion")
-    $versionSourceName = "dotnet/installer"
 }
 
 if ($AspnetVersion) {
     $updateDepsArgs += @("--product-version", "aspnet=$AspnetVersion", "--product-version", "aspnet-runtime-targeting-pack=$AspnetVersion")
-    $versionSourceName = "dotnet/installer"
 }
 
 if ($RuntimeVersion) {
     $updateDepsArgs += @("--product-version", "runtime=$RuntimeVersion", "--product-version", "runtime-apphost-pack=$RuntimeVersion", "--product-version", "runtime-targeting-pack=$RuntimeVersion", "--product-version", "runtime-host=$RuntimeVersion", "--product-version", "runtime-hostfxr=$RuntimeVersion", "--product-version", "runtime-deps-cm.1=$RuntimeVersion", "--product-version", "netstandard-targeting-pack-2.1.0")
-    $versionSourceName = "dotnet/installer"
 }
 
 if ($MonitorVersion) {
     $updateDepsArgs += @("--product-version", "monitor=$MonitorVersion")
-    $versionSourceName = "dotnet/dotnet-monitor"
 }
 
 if ($ComputeShas) {
@@ -85,6 +85,12 @@ if ($ChecksumSasQueryString) {
 
 if ($UseStableBranding) {
     $updateDepsArgs += "--stable-branding"
+}
+
+$versionSourceName = switch ($PSCmdlet.ParameterSetName) {
+    "DotnetInstaller" { "dotnet/installer" }
+    "DotnetMonitor" { "dotnet/dotnet-monitor" }
+    default { Write-Error -Message "Unknown version source" -ErrorAction Stop }
 }
 
 if ($versionSourceName) {

--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -54,7 +54,6 @@ param(
 
 $updateDepsArgs = @($ProductVersion)
 
-$versionSourceName = "";
 if ($SdkVersion) {
     $updateDepsArgs += @("--product-version", "sdk=$SdkVersion")
 }

--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -50,20 +50,25 @@ param(
 
 $updateDepsArgs = @($ProductVersion)
 
+$versionSourceName = "";
 if ($SdkVersion) {
     $updateDepsArgs += @("--product-version", "sdk=$SdkVersion")
+    $versionSourceName = "dotnet/installer"
 }
 
 if ($AspnetVersion) {
     $updateDepsArgs += @("--product-version", "aspnet=$AspnetVersion", "--product-version", "aspnet-runtime-targeting-pack=$AspnetVersion")
+    $versionSourceName = "dotnet/installer"
 }
 
 if ($RuntimeVersion) {
     $updateDepsArgs += @("--product-version", "runtime=$RuntimeVersion", "--product-version", "runtime-apphost-pack=$RuntimeVersion", "--product-version", "runtime-targeting-pack=$RuntimeVersion", "--product-version", "runtime-host=$RuntimeVersion", "--product-version", "runtime-hostfxr=$RuntimeVersion", "--product-version", "runtime-deps-cm.1=$RuntimeVersion", "--product-version", "netstandard-targeting-pack-2.1.0")
+    $versionSourceName = "dotnet/installer"
 }
 
 if ($MonitorVersion) {
     $updateDepsArgs += @("--product-version", "monitor=$MonitorVersion")
+    $versionSourceName = "dotnet/dotnet-monitor"
 }
 
 if ($ComputeShas) {
@@ -80,6 +85,10 @@ if ($ChecksumSasQueryString) {
 
 if ($UseStableBranding) {
     $updateDepsArgs += "--stable-branding"
+}
+
+if ($versionSourceName) {
+    $updateDepsArgs += "--version-source-name=$versionSourceName"
 }
 
 $branch = & $PSScriptRoot/Get-Branch.ps1


### PR DESCRIPTION
The update-dependencies tool requires that the `--version-source-name` parameter is passed for .NET Monitor due to .NET Monitor having its own url version variables in versions.manifest.json. Without it, it causes a NRE when attempting to look up the variable key constructed from the .NET Monitor version.