### PR TITLE
Fix Set-DotnetVersions script to allow positional parameter

### DIFF
--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -7,7 +7,7 @@ Updates dependencies for the specified .NET version.
 [cmdletbinding()]
 param(
     # The major/minor version of the product (e.g. 6.0).
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, Position = 0)]
     [string]
     $ProductVersion,
 


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-docker/pull/3829 prevent the use of `ProductVersion` as a positional parameter:

```powershell
./Set-DotnetVersions 7.0

A positional parameter cannot be found that accepts argument '7.0'.
```

The fix is to explicitly set its position.