### PR TITLE
Remove tag change for Alpine 3.16 localization hotfix

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -62,14 +62,14 @@ The following samples show how to develop, build and test .NET applications with
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 6.0.301-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.301-bullseye-slim, 6.0-bullseye-slim, 6.0.301, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
-6.0.301-1-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.301-1-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+6.0.301-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.301-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
 6.0.301-alpine3.15-amd64, 6.0-alpine3.15-amd64, 6.0.301-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/amd64/Dockerfile) | Alpine 3.15
 6.0.301-alpine3.14-amd64, 6.0-alpine3.14-amd64, 6.0.301-alpine3.14, 6.0-alpine3.14 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.14/amd64/Dockerfile) | Alpine 3.14
 6.0.301-jammy-amd64, 6.0-jammy-amd64, 6.0.301-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
 6.0.301-focal-amd64, 6.0-focal-amd64, 6.0.301-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.420-bullseye, 3.1-bullseye | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bullseye/amd64/Dockerfile) | Debian 11
 3.1.420-buster, 3.1-buster, 3.1.420, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/buster/amd64/Dockerfile) | Debian 10
-3.1.420-1-alpine3.16, 3.1-alpine3.16, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+3.1.420-alpine3.16, 3.1-alpine3.16, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.16/amd64/Dockerfile) | Alpine 3.16
 3.1.420-alpine3.15, 3.1-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.15/amd64/Dockerfile) | Alpine 3.15
 3.1.420-alpine3.14, 3.1-alpine3.14 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.14/amd64/Dockerfile) | Alpine 3.14
 3.1.420-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
@@ -79,14 +79,14 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.0.100-preview.5-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.100-preview.5-bullseye-slim, 7.0-bullseye-slim, 7.0.100-preview.5, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/amd64/Dockerfile) | Debian 11
-7.0.100-preview.5-1-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.100-preview.5-1-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+7.0.100-preview.5-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.100-preview.5-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
 7.0.100-preview.5-jammy-amd64, 7.0-jammy-amd64, 7.0.100-preview.5-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 6.0.301-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.301-bullseye-slim, 6.0-bullseye-slim, 6.0.301, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-6.0.301-1-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.301-1-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
+6.0.301-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.301-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
 6.0.301-alpine3.15-arm64v8, 6.0-alpine3.15-arm64v8, 6.0.301-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile) | Alpine 3.15
 6.0.301-alpine3.14-arm64v8, 6.0-alpine3.14-arm64v8, 6.0.301-alpine3.14, 6.0-alpine3.14 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.14/arm64v8/Dockerfile) | Alpine 3.14
 6.0.301-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.301-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
@@ -100,14 +100,14 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.0.100-preview.5-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.100-preview.5-bullseye-slim, 7.0-bullseye-slim, 7.0.100-preview.5, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-7.0.100-preview.5-1-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.100-preview.5-1-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
+7.0.100-preview.5-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.100-preview.5-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
 7.0.100-preview.5-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.100-preview.5-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
 
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 6.0.301-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.301-bullseye-slim, 6.0-bullseye-slim, 6.0.301, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-6.0.301-1-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.301-1-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
+6.0.301-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.301-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
 6.0.301-alpine3.15-arm32v7, 6.0-alpine3.15-arm32v7, 6.0.301-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile) | Alpine 3.15
 6.0.301-alpine3.14-arm32v7, 6.0-alpine3.14-arm32v7, 6.0.301-alpine3.14, 6.0-alpine3.14 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.14/arm32v7/Dockerfile) | Alpine 3.14
 6.0.301-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.301-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
@@ -121,7 +121,7 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.0.100-preview.5-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.100-preview.5-bullseye-slim, 7.0-bullseye-slim, 7.0.100-preview.5, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-7.0.100-preview.5-1-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.100-preview.5-1-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
+7.0.100-preview.5-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.100-preview.5-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
 7.0.100-preview.5-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.100-preview.5-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 
 ## Nano Server 2022 amd64 Tags

--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -5,7 +5,7 @@
     set monitorMajor to split(PRODUCT_VERSION, ".")[0] ^
     set targetFrameworkMoniker to cat("net", dotnetMajorMinor) ^
     set targetFrameworkMonikerRegex to cat("net", dotnetMajor, "[.]0") ^
-    set installerBaseTag to cat(VARIABLES[cat("sdk|", dotnetMajorMinor, "|product-version")], "-", when(OS_VERSION = "alpine3.16", "1-", ""), OS_VERSION, ARCH_TAG_SUFFIX) ^
+    set installerBaseTag to cat(VARIABLES[cat("sdk|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
     set monitorMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
     set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^

--- a/manifest.json
+++ b/manifest.json
@@ -4601,7 +4601,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|3.1|product-version)-1-alpine3.16": {},
+                "$(sdk|3.1|product-version)-alpine3.16": {},
                 "3.1-alpine3.16": {},
                 "3.1-alpine": {
                   "syndication": {
@@ -5076,7 +5076,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-alpine3.16": {},
+            "$(sdk|6.0|product-version)-alpine3.16": {},
             "6.0-alpine3.16": {},
             "6.0-alpine": {}
           },
@@ -5090,7 +5090,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.16-amd64": {},
+                "$(sdk|6.0|product-version)-alpine3.16-amd64": {},
                 "6.0-alpine3.16-amd64": {},
                 "6.0-alpine-amd64": {}
               }
@@ -5105,7 +5105,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.16-arm32v7": {},
+                "$(sdk|6.0|product-version)-alpine3.16-arm32v7": {},
                 "6.0-alpine3.16-arm32v7": {},
                 "6.0-alpine-arm32v7": {}
               },
@@ -5121,7 +5121,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.16-arm64v8": {},
+                "$(sdk|6.0|product-version)-alpine3.16-arm64v8": {},
                 "6.0-alpine3.16-arm64v8": {},
                 "6.0-alpine-arm64v8": {}
               },
@@ -5483,7 +5483,7 @@
         {
           "productVersion": "$(sdk|7.0|product-version)",
           "sharedTags": {
-            "$(sdk|7.0|product-version)-1-alpine3.16": {},
+            "$(sdk|7.0|product-version)-alpine3.16": {},
             "7.0-alpine3.16": {},
             "7.0-alpine": {}
           },
@@ -5497,7 +5497,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|7.0|product-version)-1-alpine3.16-amd64": {},
+                "$(sdk|7.0|product-version)-alpine3.16-amd64": {},
                 "7.0-alpine3.16-amd64": {},
                 "7.0-alpine-amd64": {}
               }
@@ -5512,7 +5512,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|7.0|product-version)-1-alpine3.16-arm32v7": {},
+                "$(sdk|7.0|product-version)-alpine3.16-arm32v7": {},
                 "7.0-alpine3.16-arm32v7": {},
                 "7.0-alpine-arm32v7": {}
               },
@@ -5528,7 +5528,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|7.0|product-version)-1-alpine3.16-arm64v8": {},
+                "$(sdk|7.0|product-version)-alpine3.16-arm64v8": {},
                 "7.0-alpine3.16-arm64v8": {},
                 "7.0-alpine-arm64v8": {}
               },

--- a/src/monitor/6.1/alpine/amd64/Dockerfile
+++ b/src/monitor/6.1/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.301-1-alpine3.16-amd64 AS installer
+FROM $SDK_REPO:6.0.301-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.1.2

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.301-1-alpine3.16-amd64 AS installer
+FROM $SDK_REPO:6.0.301-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.0

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.301-1-alpine3.16-arm64v8 AS installer
+FROM $SDK_REPO:6.0.301-alpine3.16-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.0

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:7.0.100-preview.5-1-alpine3.16-amd64 AS installer
+FROM $SDK_REPO:7.0.100-preview.5-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-preview.6.22315.2

--- a/src/monitor/7.0/alpine/arm64v8/Dockerfile
+++ b/src/monitor/7.0/alpine/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:7.0.100-preview.5-1-alpine3.16-arm64v8 AS installer
+FROM $SDK_REPO:7.0.100-preview.5-alpine3.16-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=7.0.0-preview.6.22315.2


### PR DESCRIPTION
Updates the nightly branch to have the [hotfix tag change](https://github.com/dotnet/dotnet-docker/pull/3847) reverted since we don't want to have this tag suffix applied for the next release.