### PR TITLE
Remove tag change for CBL-Mariner 1.0 distroless hotfix

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux
@@ -8,7 +8,7 @@
     set isSingleStage to (dotnetVersion = "3.1" || isAlpine || isFullMariner) && !isInternal ^
     set archTagSuffix to when(dotnetVersion != "3.1" || ARCH_VERSIONED != "amd64", ARCH_TAG_SUFFIX, "") ^
     set runtimeBaseTag to
-        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", when(OS_VERSION = "cbl-mariner1.0-distroless", "1-", ""), OS_VERSION, archTagSuffix) ^
+        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", OS_VERSION, archTagSuffix) ^
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set installerImageTag to when(isDistrolessMariner,
         cat(

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -8,7 +8,7 @@
     set isSingleStage to (dotnetVersion = "3.1" || isAlpine || isFullMariner) && !isInternal ^
     set archTagSuffix to when(dotnetVersion != "3.1" || ARCH_VERSIONED != "amd64", ARCH_TAG_SUFFIX, "") ^
     set runtimeDepsBaseTag to cat(
-        "$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", when(OS_VERSION = "cbl-mariner1.0-distroless", "1-", "")OS_VERSION, archTagSuffix) ^
+        "$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", OS_VERSION, archTagSuffix) ^
     set installerImageTag to when(isDistrolessMariner,
         cat(
             "mcr.microsoft.com/cbl-mariner/base/core:",

--- a/manifest.json
+++ b/manifest.json
@@ -774,7 +774,7 @@
         {
           "productVersion": "$(dotnet|6.0|product-version)",
           "sharedTags": {
-            "$(dotnet|6.0|product-version)-1-cbl-mariner1.0-distroless": {
+            "$(dotnet|6.0|product-version)-cbl-mariner1.0-distroless": {
               "docType": "Undocumented"
             },
             "6.0-cbl-mariner1.0-distroless": {
@@ -788,7 +788,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0-distroless",
               "tags": {
-                "$(dotnet|6.0|product-version)-1-cbl-mariner1.0-distroless-amd64": {
+                "$(dotnet|6.0|product-version)-cbl-mariner1.0-distroless-amd64": {
                   "docType": "Undocumented"
                 },
                 "6.0-cbl-mariner1.0-distroless-amd64": {
@@ -2166,7 +2166,7 @@
         {
           "productVersion": "$(dotnet|6.0|product-version)",
           "sharedTags": {
-            "$(dotnet|6.0|product-version)-1-cbl-mariner1.0-distroless": {
+            "$(dotnet|6.0|product-version)-cbl-mariner1.0-distroless": {
               "docType": "Undocumented"
             },
             "6.0-cbl-mariner1.0-distroless": {
@@ -2183,7 +2183,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0-distroless",
               "tags": {
-                "$(dotnet|6.0|product-version)-1-cbl-mariner1.0-distroless-amd64": {
+                "$(dotnet|6.0|product-version)-cbl-mariner1.0-distroless-amd64": {
                   "docType": "Undocumented"
                 },
                 "6.0-cbl-mariner1.0-distroless-amd64": {
@@ -3746,7 +3746,7 @@
         {
           "productVersion": "$(dotnet|6.0|product-version)",
           "sharedTags": {
-            "$(dotnet|6.0|product-version)-1-cbl-mariner1.0-distroless": {
+            "$(dotnet|6.0|product-version)-cbl-mariner1.0-distroless": {
               "docType": "Undocumented"
             },
             "6.0-cbl-mariner1.0-distroless": {
@@ -3763,7 +3763,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0-distroless",
               "tags": {
-                "$(dotnet|6.0|product-version)-1-cbl-mariner1.0-distroless-amd64": {
+                "$(dotnet|6.0|product-version)-cbl-mariner1.0-distroless-amd64": {
                   "docType": "Undocumented"
                 },
                 "6.0-cbl-mariner1.0-distroless-amd64": {

--- a/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN aspnetcore_version=6.0.6 \
 
 
 # ASP.NET Core image
-FROM $REPO:6.0.6-1-cbl-mariner1.0-distroless-amd64
+FROM $REPO:6.0.6-cbl-mariner1.0-distroless-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=6.0.6

--- a/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:6.0.6-1-cbl-mariner1.0-distroless-amd64
+FROM $REPO:6.0.6-cbl-mariner1.0-distroless-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=6.0.6


### PR DESCRIPTION
Updates the nightly branch to have the [hotfix tag change](https://github.com/dotnet/dotnet-docker/pull/3850) reverted since we don't want to have this tag suffix applied for the next release.