### PR TITLE
Fix .NET Monitor test image data to filter on image version

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageData.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.Docker.Tests
     public class MonitorImageData : ImageData
     {
         public Version RuntimeVersion { get; set; }
-        public string RuntimeVersionString => RuntimeVersion.ToString(2);
         public Version Version { get; set; }
         public string VersionString => Version.ToString(2);
         public string OSTag { get; set; }

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static IEnumerable<MonitorImageData> GetMonitorImageData()
         {
             return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxMonitorTestData : s_windowsMonitorTestData)
-                .FilterMonitorImagesByRuntimeVersion()
+                .FilterImagesByVersion()
                 .FilterImagesByArch()
                 .FilterImagesByOs()
                 .Cast<MonitorImageData>();
@@ -179,12 +179,12 @@ namespace Microsoft.DotNet.Docker.Tests
                     || Regex.IsMatch(imageData.VersionString, versionFilterPattern, RegexOptions.IgnoreCase));
         }
 
-        public static IEnumerable<ImageData> FilterMonitorImagesByRuntimeVersion(this IEnumerable<MonitorImageData> imageData)
+        public static IEnumerable<ImageData> FilterImagesByVersion(this IEnumerable<MonitorImageData> imageData)
         {
             string versionFilterPattern = GetFilterRegexPattern("IMAGE_VERSION");
             return imageData
                 .Where(imageData => versionFilterPattern == null
-                    || Regex.IsMatch(imageData.RuntimeVersionString, versionFilterPattern, RegexOptions.IgnoreCase));
+                    || Regex.IsMatch(imageData.VersionString, versionFilterPattern, RegexOptions.IgnoreCase));
         }
 
         public static IEnumerable<ImageData> FilterImagesByArch(this IEnumerable<ImageData> imageData)


### PR DESCRIPTION
The .NET Monitor tests were incorrectly filtering the images based on the runtime version (e.g. 6.0 and 7.0) whereas the IMAGE_VERSION environment variable is correctly set to the image version (e.g. 6.1, 6.2, and 7.0). This change fixes the filtering to correctly filter on the image version will allows the 6.1 and 6.2 image tests to execute.

fixes #3871 