### PR TITLE
Updates to image size baselines

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -25,14 +25,14 @@
     "src/runtime-deps/6.0/cbl-mariner1.0/amd64": 229251169,
     "src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64": 63825551,
     "src/runtime-deps/6.0/cbl-mariner2.0/amd64": 117182974,
-    "src/runtime-deps/6.0/cbl-mariner2.0/arm64v8": 101425521,
+    "src/runtime-deps/6.0/cbl-mariner2.0/arm64v8": 113639067,
     "src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64": 25570883,
     "src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8": 22586819,
     "src/runtime-deps/6.0/jammy/amd64": 118850628,
     "src/runtime-deps/6.0/jammy/arm32v7": 92396848,
     "src/runtime-deps/6.0/jammy/arm64v8": 109539947,
     "src/runtime-deps/7.0/cbl-mariner2.0/amd64": 117182974,
-    "src/runtime-deps/7.0/cbl-mariner2.0/arm64v8": 101425521
+    "src/runtime-deps/7.0/cbl-mariner2.0/arm64v8": 113631221
   },
   "dotnet/nightly/runtime": {
     "src/runtime/3.1/bullseye-slim/amd64": 198162495,
@@ -159,7 +159,7 @@
     "src/sdk/3.1/buster/arm64v8": 712029090,
     "src/sdk/3.1/alpine3.14/amd64": 427100352,
     "src/sdk/3.1/alpine3.15/amd64": 427467315,
-    "src/sdk/3.1/alpine3.16/amd64": 402447215,
+    "src/sdk/3.1/alpine3.16/amd64": 433281171,
     "src/sdk/3.1/bionic/amd64": 645025486,
     "src/sdk/3.1/bionic/arm32v7": 601961403,
     "src/sdk/3.1/bionic/arm64v8": 662952556,
@@ -177,7 +177,7 @@
     "src/sdk/6.0/alpine3.15/arm32v7": 525278326,
     "src/sdk/6.0/alpine3.15/arm64v8": 568133665,
     "src/sdk/6.0/alpine3.16/amd64": 569899299,
-    "src/sdk/6.0/alpine3.16/arm32v7": 515340714,
+    "src/sdk/6.0/alpine3.16/arm32v7": 543104181,
     "src/sdk/6.0/alpine3.16/arm64v8": 559437185,
     "src/sdk/6.0/focal/amd64": 723650881,
     "src/sdk/6.0/focal/arm32v7": 665193304,
@@ -191,9 +191,9 @@
     "src/sdk/7.0/bullseye-slim/amd64": 776238295,
     "src/sdk/7.0/bullseye-slim/arm32v7": 719341335,
     "src/sdk/7.0/bullseye-slim/arm64v8": 798856900,
-    "src/sdk/7.0/alpine3.16/amd64": 578027922,
-    "src/sdk/7.0/alpine3.16/arm32v7": 519957283,
-    "src/sdk/7.0/alpine3.16/arm64v8": 567275756,
+    "src/sdk/7.0/alpine3.16/amd64": 612051392,
+    "src/sdk/7.0/alpine3.16/arm32v7": 553764212,
+    "src/sdk/7.0/alpine3.16/arm64v8": 601175553,
     "src/sdk/7.0/jammy/amd64": 730544508,
     "src/sdk/7.0/jammy/arm32v7": 722423439,
     "src/sdk/7.0/jammy/arm64v8": 746949416,
@@ -210,6 +210,6 @@
     "src/monitor/7.0/alpine/amd64": 109210745,
     "src/monitor/7.0/alpine/arm64v8": 119985095,
     "src/monitor/7.0/cbl-mariner/amd64": 220741666,
-    "src/monitor/7.0/cbl-mariner/arm64v8": 218645560
+    "src/monitor/7.0/cbl-mariner/arm64v8": 229878449
   }
 }

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -6,11 +6,11 @@
     "src/runtime/6.0/nanoserver-1809/amd64": 339178589,
     "src/runtime/6.0/nanoserver-20H2/amd64": 331505218,
     "src/runtime/6.0/nanoserver-ltsc2022/amd64": 369353141,
-    "src/runtime/6.0/windowsservercore-ltsc2019/amd64": 5345663713,
+    "src/runtime/6.0/windowsservercore-ltsc2019/amd64": 5658815336,
     "src/runtime/6.0/windowsservercore-ltsc2022/amd64": 4891855163,
     "src/runtime/7.0/nanoserver-1809/amd64": 328470826,
     "src/runtime/7.0/nanoserver-ltsc2022/amd64": 367604122,
-    "src/runtime/7.0/windowsservercore-ltsc2019/amd64": 5343516928,
+    "src/runtime/7.0/windowsservercore-ltsc2019/amd64": 5656851022,
     "src/runtime/7.0/windowsservercore-ltsc2022/amd64": 4999608453
   },
   "dotnet/nightly/aspnet": {
@@ -20,11 +20,11 @@
     "src/aspnet/6.0/nanoserver-1809/amd64": 362186301,
     "src/aspnet/6.0/nanoserver-20H2/amd64": 352141366,
     "src/aspnet/6.0/nanoserver-ltsc2022/amd64": 391627241,
-    "src/aspnet/6.0/windowsservercore-ltsc2019/amd64": 5374360211,
+    "src/aspnet/6.0/windowsservercore-ltsc2019/amd64": 5687534230,
     "src/aspnet/6.0/windowsservercore-ltsc2022/amd64": 4926375762,
     "src/aspnet/7.0/nanoserver-1809/amd64": 349969843,
     "src/aspnet/7.0/nanoserver-ltsc2022/amd64": 389103139,
-    "src/aspnet/7.0/windowsservercore-ltsc2019/amd64": 5372788184,
+    "src/aspnet/7.0/windowsservercore-ltsc2019/amd64": 5686161226,
     "src/aspnet/7.0/windowsservercore-ltsc2022/amd64": 5034052450
   },
   "dotnet/nightly/sdk": {
@@ -38,7 +38,7 @@
     "src/sdk/6.0/windowsservercore-ltsc2022/amd64": 5556352529,
     "src/sdk/7.0/nanoserver-1809/amd64": 975012837,
     "src/sdk/7.0/nanoserver-ltsc2022/amd64": 1058152303,
-    "src/sdk/7.0/windowsservercore-ltsc2019/amd64": 6008394397,
+    "src/sdk/7.0/windowsservercore-ltsc2019/amd64": 6333303763,
     "src/sdk/7.0/windowsservercore-ltsc2022/amd64": 5629364231
   }
 }


### PR DESCRIPTION
Reasons for size differences:

* Alpine 3.16 SDK: Addition of the icu-data-full package (https://github.com/dotnet/dotnet-docker/pull/3847)
* CBL-Mariner 2.0 Arm64: A combination of https://github.com/dotnet/dotnet-docker/pull/3825, which added installation of local RPM files, and https://github.com/dotnet/dotnet-docker/issues/3864.
* Windows Server Core: Size increase in the servicing layer of the base Windows image.