### PR TITLE
Remove redundant version-source-name arg for update-deps

### DIFF
--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -31,7 +31,6 @@ stages:
         --email $(dotnetDockerBot.email)
         --password $(BotAccount-dotnet-docker-bot-PAT)
         --stable-branding $(dotnetStableBranding)
-        --version-source-name dotnet/installer
       displayName: Run Update Dependencies
 - stage: Monitor
   condition: eq(variables['update-monitor-enabled'], 'true')


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-docker/pull/3829 now cause the running of that script to include the `--version-source-name` in the output when using the `PrintArgsVariableOnly` option. This causes the update-dependencies tool to be executed with duplicate `--version-source-name` args which it doesn't like; it gives this error: `Option '--version-source-name' expects a single argument but 2 were provided.`

The fix is to simply remove the redundant arg option.