### PR TITLE
.NET Monitor CBL Mariner Distroless Images

### DIFF
--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -5,7 +5,9 @@
     set monitorMajor to split(PRODUCT_VERSION, ".")[0] ^
     set targetFrameworkMoniker to cat("net", dotnetMajorMinor) ^
     set targetFrameworkMonikerRegex to cat("net", dotnetMajor, "[.]0") ^
-    set installerBaseTag to cat(VARIABLES[cat("sdk|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
+    set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
+    set sdkDistro to when(isDistrolessMariner, cat("cbl-mariner", OS_VERSION_NUMBER), OS_VERSION) ^
+    set installerBaseTag to cat(VARIABLES[cat("sdk|", dotnetMajorMinor, "|product-version")], "-", sdkDistro, ARCH_TAG_SUFFIX) ^
     set monitorMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
     set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
@@ -44,6 +46,8 @@ RUN {{InsertTemplate("../Dockerfile.linux.download-file",
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -69,7 +73,5 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 {{InsertTemplate(cat("Dockerfile.entrypoint.monitorV", monitorMajor))}}

--- a/manifest.json
+++ b/manifest.json
@@ -5857,6 +5857,66 @@
           ]
         },
         {
+          "productVersion": "$(monitor|6.2|product-version)",
+          "sharedTags": {
+            "$(monitor|6.2|product-version)-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "6.2-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "6-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/6.2/cbl-mariner-distroless/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|6.2|product-version)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "6.2-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "6-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                }
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/6.2/cbl-mariner-distroless/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|6.2|product-version)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "6.2-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "6-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
           "productVersion": "$(monitor|7.0|product-version)",
           "sharedTags": {
             "$(monitor|7.0|product-version)-alpine": {},
@@ -5955,6 +6015,66 @@
                   "docType": "Undocumented"
                 },
                 "7-cbl-mariner-arm64v8": {
+                  "docType": "Undocumented"
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|7.0|product-version)",
+          "sharedTags": {
+            "$(monitor|7.0|product-version)-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "7.0-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "7-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/7.0/cbl-mariner-distroless/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|7.0|product-version)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "7.0-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "7-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                }
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/7.0/cbl-mariner-distroless/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|7.0|product-version)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "7.0-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "7-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 }
               },

--- a/src/monitor/6.1/alpine/amd64/Dockerfile
+++ b/src/monitor/6.1/alpine/amd64/Dockerfile
@@ -22,6 +22,8 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,7 +49,5 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/6.1/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.1/cbl-mariner/amd64/Dockerfile
@@ -22,6 +22,8 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,7 +49,5 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -22,6 +22,8 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,7 +49,5 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -22,6 +22,8 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,7 +49,5 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.301-cbl-mariner2.0-arm64v8 AS installer
+FROM $SDK_REPO:6.0.301-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.0
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0.6-cbl-mariner2.0-arm64v8
+FROM $ASPNET_REPO:6.0.6-cbl-mariner2.0-distroless-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0.6-cbl-mariner2.0-arm64v8
+FROM $ASPNET_REPO:6.0.6-cbl-mariner2.0-distroless-arm64v8
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -22,6 +22,8 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,7 +49,5 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -22,6 +22,8 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,8 +49,6 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor" ]
 CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.0/alpine/arm64v8/Dockerfile
+++ b/src/monitor/7.0/alpine/arm64v8/Dockerfile
@@ -22,6 +22,8 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,8 +49,6 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor" ]
 CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -2,22 +2,22 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.301-cbl-mariner2.0-arm64v8 AS installer
+FROM $SDK_REPO:7.0.100-preview.5-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=6.2.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.0-rtm.22306.2/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1e06afa71563de44aff836d06b3e9ef34b5e64418766f42ee588337117bf390c45d4df6f31b048db7db108d2cc44651947628fe22ab3f629fb78652a5fc9f5f5' \
+ENV DOTNET_MONITOR_VERSION=7.0.0-preview.6.22324.2
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='03cf9678f89258f4be50e5f36cc3c82db4ab23d914f5ac3a175a2d99b254fb80dfcbae89d2c572d85830c6de441a119282108d6dd5ce2abde0114a2fe03e0879' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
-    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
-    # To reduce image size, remove all non-net6.0 TFMs
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
+    # To reduce image size, remove all non-net7.0 TFMs
     # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
     # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
     # 1. Find any files in /app
     # 2. Match anything that is under a *folder* called 'dotnet-monitor'
-    # 3. Match anything from step 2 that isn't in a '/tools/net6.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
     # 4. Delete everything from step 3
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0.6-cbl-mariner2.0-arm64v8
+FROM $ASPNET_REPO:7.0.0-preview.5-cbl-mariner2.0-distroless-amd64
 
 WORKDIR /app
 COPY --from=installer /app .
@@ -50,4 +50,5 @@ ENV \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 
-ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -2,22 +2,22 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.301-cbl-mariner2.0-arm64v8 AS installer
+FROM $SDK_REPO:7.0.100-preview.5-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=6.2.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.0-rtm.22306.2/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1e06afa71563de44aff836d06b3e9ef34b5e64418766f42ee588337117bf390c45d4df6f31b048db7db108d2cc44651947628fe22ab3f629fb78652a5fc9f5f5' \
+ENV DOTNET_MONITOR_VERSION=7.0.0-preview.6.22324.2
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='03cf9678f89258f4be50e5f36cc3c82db4ab23d914f5ac3a175a2d99b254fb80dfcbae89d2c572d85830c6de441a119282108d6dd5ce2abde0114a2fe03e0879' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
-    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
-    # To reduce image size, remove all non-net6.0 TFMs
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
+    # To reduce image size, remove all non-net7.0 TFMs
     # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
     # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
     # 1. Find any files in /app
     # 2. Match anything that is under a *folder* called 'dotnet-monitor'
-    # 3. Match anything from step 2 that isn't in a '/tools/net6.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 3. Match anything from step 2 that isn't in a '/tools/net7.0' folder (/tools is the folder we use in a nuget file that is stable)
     # 4. Delete everything from step 3
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
@@ -28,7 +28,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
 
 
 # Monitor image
-FROM $ASPNET_REPO:6.0.6-cbl-mariner2.0-arm64v8
+FROM $ASPNET_REPO:7.0.0-preview.5-cbl-mariner2.0-distroless-arm64v8
 
 WORKDIR /app
 COPY --from=installer /app .
@@ -50,4 +50,5 @@ ENV \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 
-ENTRYPOINT [ "dotnet-monitor", "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
@@ -22,6 +22,8 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,8 +49,6 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor" ]
 CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
@@ -22,6 +22,8 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
     && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
 
 
@@ -47,8 +49,6 @@ ENV \
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
-
-RUN chmod 755 dotnet-monitor
 
 ENTRYPOINT [ "dotnet-monitor" ]
 CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -87,6 +87,14 @@ namespace Microsoft.DotNet.Docker.Tests
                     if (monitorImageData.Arch != sampleImageData.Arch)
                         continue;
 
+                    // Distroless .NET Monitor images must be tested with distroless samples because
+                    // the default user of the .NET Monitor image is a non-root user. If .NET Monitor
+                    // is running as non-root and the sample is running as root, .NET Monitor will fail
+                    // to communicate with the sample application or fail to start up due to lack of
+                    // permissions to create the diagnostic port.
+                    if (monitorImageData.IsDistroless != sampleImageData.IsDistroless)
+                        continue;
+
                     data.Add(new object[] { monitorImageData, sampleImageData });
                 }
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/OS.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/OS.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
         // Mariner
         public const string Mariner = "cbl-mariner";
+
+        public const string MarinerDistroless = $"{Mariner}-distroless";
         public const string Mariner10 = $"{Mariner}1.0";
         public const string Mariner10Distroless = $"{Mariner10}-distroless";
         public const string Mariner20 = $"{Mariner}2.0";

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -126,16 +126,20 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static readonly MonitorImageData[] s_linuxMonitorTestData =
         {
-            new MonitorImageData { Version = V6_1, RuntimeVersion = V6_0, OS = OS.Alpine316, OSTag = OS.Alpine, Arch = Arch.Amd64 },
-            new MonitorImageData { Version = V6_1, RuntimeVersion = V6_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Amd64 },
-            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Alpine316, OSTag = OS.Alpine, Arch = Arch.Amd64 },
-            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Alpine316, OSTag = OS.Alpine, Arch = Arch.Arm64 },
-            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Amd64 },
-            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Arm64 },
-            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Alpine316, OSTag = OS.Alpine, Arch = Arch.Amd64 },
-            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Alpine316, OSTag = OS.Alpine, Arch = Arch.Arm64 },
-            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Amd64 },
-            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20, OSTag = OS.Mariner, Arch = Arch.Arm64 },
+            new MonitorImageData { Version = V6_1, RuntimeVersion = V6_0, OS = OS.Alpine316,           OSTag = OS.Alpine,            Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V6_1, RuntimeVersion = V6_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Alpine316,           OSTag = OS.Alpine,            Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Alpine316,           OSTag = OS.Alpine,            Arch = Arch.Arm64 },
+            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Arm64 },
+            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V6_2, RuntimeVersion = V6_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Alpine316,           OSTag = OS.Alpine,            Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Alpine316,           OSTag = OS.Alpine,            Arch = Arch.Arm64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Arm64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Amd64 },
+            new MonitorImageData { Version = V7_0, RuntimeVersion = V7_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64 },
         };
 
         private static readonly MonitorImageData[] s_windowsMonitorTestData =

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -207,9 +207,13 @@
     "src/monitor/6.2/alpine/arm64v8": 119150710,
     "src/monitor/6.2/cbl-mariner/amd64": 220058031,
     "src/monitor/6.2/cbl-mariner/arm64v8": 217457652,
+    "src/monitor/6.2/cbl-mariner-distroless/amd64": 125187590,
+    "src/monitor/6.2/cbl-mariner-distroless/arm64v8": 131783453,
     "src/monitor/7.0/alpine/amd64": 109210745,
     "src/monitor/7.0/alpine/arm64v8": 119985095,
     "src/monitor/7.0/cbl-mariner/amd64": 220741666,
-    "src/monitor/7.0/cbl-mariner/arm64v8": 229878449
+    "src/monitor/7.0/cbl-mariner/arm64v8": 229878449,
+    "src/monitor/7.0/cbl-mariner-distroless/amd64": 126119268,
+    "src/monitor/7.0/cbl-mariner-distroless/arm64v8": 133547868
   }
 }


### PR DESCRIPTION
This is a reimplementation of #3868 with one small difference.

The difference is that the tests that use the sample images are effectively filtered out for distroless images. The distroless images run as a non-root user, so .NET Monitor would need a sample image with a corresponding non-root user. None of the sample images are distroless, thus these tests cannot be run with the distroless version of .NET Monitor.

cc @dotnet/dotnet-monitor 