### PR TITLE
Prevent tdnf cache from being populated

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-rpms
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-rpms
@@ -7,5 +7,5 @@
     set fileList to join(ARGS["files"], " ") ^
     set isMariner to find(OS_VERSION, "cbl-mariner") >= 0 ^
     set useTdnf to isMariner && find(OS_VERSION, "1.0") < 0
-}}{{if useTdnf:tdnf install -y^else:rpm --install}} {{fileList}} \
+}}{{if useTdnf:tdnf install -y --disablerepo=*^else:rpm --install}} {{fileList}} \
 && rm {{fileList}}

--- a/src/aspnet/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -8,5 +8,5 @@ ENV ASPNET_VERSION=6.0.6
 RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
     && aspnetcore_sha512='17944895ae7b4ff5e713da183947d88cf581173f824e534832874553d3067a3cfc17616cd9276dda119efd3c93c4936078b23c0559c53239e90c9a8d0907a482' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
-    && tdnf install -y aspnetcore.rpm \
+    && tdnf install -y --disablerepo=* aspnetcore.rpm \
     && rm aspnetcore.rpm

--- a/src/aspnet/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/aspnet/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -8,5 +8,5 @@ ENV ASPNET_VERSION=6.0.6
 RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-aarch64.rpm \
     && aspnetcore_sha512='f5cd46d8f0ed09750893b8c828c9df872363c5d709f16d8be437304bdbd09f6127a43d57cbb01a66f0ac75771e7e29c4254302ef74dfc1b5267bc3296ceab8cb' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
-    && tdnf install -y aspnetcore.rpm \
+    && tdnf install -y --disablerepo=* aspnetcore.rpm \
     && rm aspnetcore.rpm

--- a/src/aspnet/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -8,5 +8,5 @@ ENV ASPNET_VERSION=7.0.0-preview.5.22303.8
 RUN curl -fSL --output aspnetcore.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
     && aspnetcore_sha512='7b8be4201dc7038d39b21854e6378e1470aa67a1497336661b850b1a7739800a06e8f2a4e94d59762151285d871fe56d357be8b92b6b919c2038ed37d6c768d7' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
-    && tdnf install -y aspnetcore.rpm \
+    && tdnf install -y --disablerepo=* aspnetcore.rpm \
     && rm aspnetcore.rpm

--- a/src/aspnet/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -8,5 +8,5 @@ ENV ASPNET_VERSION=7.0.0-preview.5.22303.8
 RUN curl -fSL --output aspnetcore.rpm https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-aarch64.rpm \
     && aspnetcore_sha512='5d76eb32c33f233a3aca22ba853b9c254ece59e6f6c726475a6f4dca1d61f10e1eb304f7d7ec067cf58a6909bb5e63e573a44cb85531f094141486472ee0070d' \
     && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
-    && tdnf install -y aspnetcore.rpm \
+    && tdnf install -y --disablerepo=* aspnetcore.rpm \
     && rm aspnetcore.rpm

--- a/src/runtime-deps/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN dotnet_version=6.0.6 \
     && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.2-x64.rpm \
     && dotnet_sha512='bf220e321cfd16b062d60fffd9766ee1898a5a9d6aa0e1ab4b026b48c83969d8d883d09601c133c70bc7e46e4da37f8bd0dc6949ab31ff2c1986b48e3791fc4c' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
-    && tdnf install -y dotnet-runtime-deps.rpm \
+    && tdnf install -y --disablerepo=* dotnet-runtime-deps.rpm \
     && rm dotnet-runtime-deps.rpm
 
 ENV \

--- a/src/runtime-deps/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -18,7 +18,7 @@ RUN dotnet_version=6.0.6 \
     && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.2-aarch64.rpm \
     && dotnet_sha512='02de1bab70f66e26d3fdf2b97b9b751a62bb42b632a645e0326a7e8b42d45c843dcf9c05ad2887dd0f594cf1e4838a727a69ceeed14f7e18461bd5ac39ec9c5d' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
-    && tdnf install -y dotnet-runtime-deps.rpm \
+    && tdnf install -y --disablerepo=* dotnet-runtime-deps.rpm \
     && rm dotnet-runtime-deps.rpm
 
 ENV \

--- a/src/runtime-deps/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN dotnet_version=7.0.0-preview.5.22301.12 \
     && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.2-x64.rpm \
     && dotnet_sha512='8e524a3285c45742ed1dbd60b9db93223860e87877e9d8c5514deef8fba38f86492d55db12f4d3d1b945c419b6f682254d766b7d18538f7df12c5d39d4ac42ec' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
-    && tdnf install -y dotnet-runtime-deps.rpm \
+    && tdnf install -y --disablerepo=* dotnet-runtime-deps.rpm \
     && rm dotnet-runtime-deps.rpm
 
 ENV \

--- a/src/runtime-deps/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -18,7 +18,7 @@ RUN dotnet_version=7.0.0-preview.5.22301.12 \
     && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetbuilds.azureedge.net/public/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.2-aarch64.rpm \
     && dotnet_sha512='d188dee7463bf53512523ba093355d73a74de5a75a7c00212ab79f66a73eba6c87f34534f8655398355de461f9c563466859c30c37a425f586a8049bb36102ed' \
     && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
-    && tdnf install -y dotnet-runtime-deps.rpm \
+    && tdnf install -y --disablerepo=* dotnet-runtime-deps.rpm \
     && rm dotnet-runtime-deps.rpm
 
 ENV \

--- a/src/runtime/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Ru
     && dotnet_sha512='3b0005328297ccf66a5209043f1a2e9684772bd61230aa2a4d15948bc30c5a29b2b8ab9222091cf31c9d360db2f0d387c25d66defb78d12a806dcda251780649' \
     && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
+    && tdnf install -y --disablerepo=* dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
     && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm

--- a/src/runtime/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Ru
     && dotnet_sha512='96556c12057b8ca927aa3c2976cbcc505e31c5c46f0b7abc01d71d471d6080d20aef0e6479515142f45e93ddc099b1de414b4c044da57af7aebacb4ec81d6b16' \
     && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
+    && tdnf install -y --disablerepo=* dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
     && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm

--- a/src/runtime/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -fSL --output dotnet-host.rpm https://dotnetbuilds.azureedge.net/public
     && dotnet_sha512='3e4e16471f8cc3ddbf20c7a75c5418c4d72afcb3ece4cf96e9b7c6fe61c993f4b5a85950904963a77c36439a35fe631ebbd98843900490e01b4e3b91aa085d06' \
     && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
+    && tdnf install -y --disablerepo=* dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
     && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm

--- a/src/runtime/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -fSL --output dotnet-host.rpm https://dotnetbuilds.azureedge.net/public
     && dotnet_sha512='68471b1888f7e2f030c37c0cb961b92bd6717dab47fa5163a2b25c730230313043fbe5eaaa5d74352fab821289c53a150fd677c614347c8eeb45228727c13f58' \
     && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
+    && tdnf install -y --disablerepo=* dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
     && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm

--- a/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fSL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DO
     && dotnet_sha512='fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880' \
     && echo "$dotnet_sha512  netstandard-targeting-pack.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
+    && tdnf install -y --disablerepo=* dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
     && rm dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -fSL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DO
     && dotnet_sha512='2888f361728e83428fa9a0d54bc27269ed870459962eb49624e6267f3dca882ef7804d9da5f99a6ed17ecf8e596e6b45b7587975cec078c100c6a224e38a0c43' \
     && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
+    && tdnf install -y --disablerepo=* dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
     && rm dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -fSL --output dotnet.rpm https://dotnetbuilds.azureedge.net/public/Sdk/
     && dotnet_sha512='fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880' \
     && echo "$dotnet_sha512  netstandard-targeting-pack.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
+    && tdnf install -y --disablerepo=* dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
     && rm dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/src/sdk/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -fSL --output dotnet.rpm https://dotnetbuilds.azureedge.net/public/Sdk/
     && dotnet_sha512='7fd221c46bf5c390dfc28ab72fa0c6d046acb7491ea106203dc203cf5c190ed204140730a7f7b940192f91db155e634f8d1525e9b4bae7c83678bd3d9f3c87af' \
     && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
     \
-    && tdnf install -y dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
+    && tdnf install -y --disablerepo=* dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
     && rm dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help


### PR DESCRIPTION
This fixes #3864 by preventing the tdnf repo caches from ever being populated with the use of the `disablerepo` option. This is only done in cases where we're installing from a local RPM file that doesn't have any dependencies that aren't already installed.

Fixes #3864