### PR TITLE
Re-enable aspnet test for distroless Mariner

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -24,13 +24,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
-            if (imageData.IsDistroless)
-            {
-                OutputHelper.WriteLine(
-                    "Skipping test for distroless due to https://github.com/dotnet/dotnet-docker/issues/3448. Re-enable when fixed.");
-                return;
-            }
-
             if (imageData.IsArm && imageData.OS == OS.Jammy)
             {
                 OutputHelper.WriteLine(


### PR DESCRIPTION
The ASP.NET Core scenario test can be re-enabled now that the underlying issue has been fixed by https://github.com/dotnet/dotnet-docker/pull/3835.

Fixes #3448