### PR TITLE
Re-enable complex app sample test for Windows

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -90,12 +90,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [Fact]
         public void VerifyComplexAppSample()
         {
-            if (!DockerHelper.IsLinuxContainerModeEnabled)
-            {
-                OutputHelper.WriteLine("Disable this test for Windows due to https://github.com/dotnet/dotnet-docker/issues/3510. Reenable when fixed.");
-                return;
-            }
-
             string appTag = SampleImageData.GetImageName("complexapp-local-app");
             string testTag = SampleImageData.GetImageName("complexapp-local-test");
             string sampleFolder = Path.Combine(s_samplesPath, "complexapp");


### PR DESCRIPTION
Now that https://github.com/NuGet/Home/issues/11607 has been fixed, the test can be enabled again.

Fixes https://github.com/dotnet/dotnet-docker/issues/3510