### PR TITLE
Enable PowerShell tests for Alpine 3.16

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -136,12 +136,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {
-            if (imageData.OS == OS.Alpine316)
-            {
-                OutputHelper.WriteLine("Test disabled until https://github.com/dotnet/dotnet-docker/issues/3793 is fixed");
-                return;
-            }
-
             // Disable this test for Arm-based Alpine until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
             if (imageData.OS.Contains("alpine") && imageData.IsArm)
             {
@@ -340,12 +334,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private void PowerShellScenario_Execute(ProductImageData imageData, string optionalArgs)
         {
-            if (imageData.OS == OS.Alpine316)
-            {
-                OutputHelper.WriteLine("Test disabled until https://github.com/dotnet/dotnet-docker/issues/3793 is fixed");
-                return;
-            }
-
             // Disable this test for Arm-based Alpine until PowerShell has support (https://github.com/PowerShell/PowerShell/issues/14667, https://github.com/PowerShell/PowerShell/issues/12937)
             if (imageData.OS.Contains("alpine") && imageData.IsArm)
             {


### PR DESCRIPTION
These tests can be enabled now that https://github.com/dotnet/dotnet-docker/issues/3793 is fixed.

This is only relevant to the nightly branch. This change was already made as part of the merge from nightly to main in June servicing. But it never made its way back to nightly from the main-to-nightly merge.