### PR TITLE
Fix SDK tests from failing in distroless scenarios

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -47,7 +47,7 @@ if ($Mode -eq "BuildAndTest" -or $Mode -eq "Build") {
     # Build the sample images
     & ./eng/common/build.ps1 `
         -Version $Version `
-        -OS $OS `
+        -OSVersions @($OS) `
         -Architecture $Architecture `
         -Paths $Paths `
         -OptionalImageBuilderArgs $OptionalImageBuilderArgs `
@@ -64,7 +64,7 @@ if ($Mode -eq "BuildAndTest" -or $Mode -eq "Test") {
 
     & ./tests/run-tests.ps1 `
         -Version $Version `
-        -OS $OS `
+        -OSVersions @($OS) `
         -Architecture $Architecture `
         -TestCategories $localTestCategories
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             return imageType switch
             {
-                DotNetImageType.SDK => dockerHelper.Run(imageName, containerName, FormatDotnetCommand("--version")),
+                DotNetImageType.SDK => dockerHelper.Run(imageName, containerName, "dotnet --version"),
                 DotNetImageType.Runtime => GetRuntimeVersion(imageName, containerName, "Microsoft.NETCore.App", dockerHelper),
                 DotNetImageType.Aspnet => GetRuntimeVersion(imageName, containerName, "Microsoft.AspNetCore.App", dockerHelper),
                 _ => throw new NotSupportedException($"Unsupported image type '{imageType}'"),


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet-docker/pull/3886 caused one of the SDK tests to fail in the internal build:

```
  Failed Microsoft.DotNet.Docker.Tests.SdkImageTests.VerifyEnvironmentVariables(imageData: RuntimeVersion='7.0', HasCustomSdk='True', SdkOS='cbl-mariner2.0', RuntimeVersionString='7.0', Version='7.0', VersionString='7.0', Arch='Amd64', IsArm='False', OS='cbl-mariner2.0-distroless', IsDistroless='True', DefaultPort='8080', Rid='linux-x64', OsVersion='2.0') [1 s]
  Error Message:
   System.InvalidOperationException : Failed to execute docker run --name 7.0-GetProductVersion-SDK-133020281693392190 --rm  dotnetdocker.azurecr.io/build-staging/1872208/dotnet/nightly/sdk:7.0-cbl-mariner2.0-amd64 --version
Exit code: 127
Standard Error: docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "--version": executable file not found in $PATH: unknown.
  Stack Trace:
     at Microsoft.DotNet.Docker.Tests.DockerHelper.Execute(String args, Boolean ignoreErrors, Boolean autoRetry, ITestOutputHelper outputHelper) in /repo/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs:line 122
   at Microsoft.DotNet.Docker.Tests.DockerHelper.ExecuteWithLogging(String args, Boolean ignoreErrors, Boolean autoRetry) in /repo/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs:line 137
   at Microsoft.DotNet.Docker.Tests.DockerHelper.Run(String image, String name, String command, String workdir, String optionalRunArgs, Boolean detach, String runAsUser, Boolean skipAutoCleanup) in /repo/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs:line 239
   at Microsoft.DotNet.Docker.Tests.ProductImageData.GetProductVersion(DotNetImageType imageType, DockerHelper dockerHelper) in /repo/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs:line 62
   at Microsoft.DotNet.Docker.Tests.SdkImageTests.VerifyEnvironmentVariables(ProductImageData imageData) in /repo/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs:line 79
  Standard Output Messages:
 Executing: docker run --name 7.0-GetProductVersion-SDK-133020281693392190 --rm  dotnetdocker.azurecr.io/build-staging/1872208/dotnet/nightly/sdk:7.0-cbl-mariner2.0-amd64 --version
 docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "--version": executable file not found in $PATH: unknown.
```

This happens because the test code is incorrectly formatting the `dotnet --version` command to exclude `dotnet` because it mistakenly thinks it's for a distroless container that will have `dotne` set as the ENTRYPOINT. But it's not a distroless container since it's for the sdk.

The reason this wasn't caught in the PR build is interesting. In the PR build, the `OSVersions` parameter for the tests was set to `cbl-mariner2.0` and `cbl-mariner2.0-distroless`. So the tests handled both those versions. It correctly gathered ImageData instances for both those versions. However, the ImageData gets filtered down for the SDK to avoid duplication: https://github.com/dotnet/dotnet-docker/blob/c49a28769b9209c3cbd472fb29cfaf09e4931c6f/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs#L37

So it ended up taking only the first ImageData, the non-distroless one. So when it got to the point of computing the `dotnet --version` command, it saw that the ImageData was not distroless and didn't exclude `dotnet` from the command.

Compare that to the internal build which generates a test job that has `OSVersions` set only to `cbl-mariner2.0-distroless`. In that case, we're only selecting ImageData for that version which would obviously be configured to have `IsDistroless` set to `true. That same SDK ImageData filtering rule would apply but since there's not any non-distroless ImageData, it's only getting the distroless one. So when it gets to the point of computing the `dotnet --version` command here, it sees that the ImageData is distroless now and because of that it excludes `dotnet`, leading to the failure.

I've simply fixed this by not applying any formatting in the SDK case because that won't ever be distroless.

I also fixed the build-and-test script to pass the correct parameters to the run-test script.