### PR TITLE
Include MinGit in .NET 7 SDK Windows containers

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.windows.download-file
+++ b/eng/dockerfile-templates/Dockerfile.windows.download-file
@@ -6,9 +6,12 @@
         url: URL to download
         sha: Expected checksum of the downloaded file
         sha-var-name: Name of variable that stores the checksum
+        hash-algorithm: Algorithm type to use to get the checksum. Defaults to sha512 ^
+
+    set hashAlgorithm to when(ARGS["hash-algorithm"], ARGS["hash-algorithm"], "sha512")
 }}Invoke-WebRequest -OutFile {{ARGS["out-file"]}} {{ARGS["url"]}}; `
 ${{ARGS["sha-var-name"]}} = '{{ARGS["sha"]}}'; `
-if ((Get-FileHash {{ARGS["out-file"]}} -Algorithm sha512).Hash -ne ${{ARGS["sha-var-name"]}}) { `
+if ((Get-FileHash {{ARGS["out-file"]}} -Algorithm {{hashAlgorithm}}).Hash -ne ${{ARGS["sha-var-name"]}}) { `
     Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
     exit 1; `
 }

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows
@@ -17,7 +17,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 {{InsertTemplate("Dockerfile.windows.install-components")}}
 
-{{InsertTemplate("Dockerfile.windows.set-powershell-path")}}
+{{InsertTemplate("Dockerfile.windows.set-path")}}
 
 {{InsertTemplate("Dockerfile.windows.first-run")}}^else:
 {{
@@ -43,11 +43,11 @@ FROM {{aspnetBaseTag}}
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-{{InsertTemplate("Dockerfile.windows.set-powershell-path")}}
+{{InsertTemplate("Dockerfile.windows.set-path")}}
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
-COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]{{ if dotnetVersion != "3.1" && dotnetVersion != "6.0":
+COPY --from=installer ["/Program Files/MinGit", "/Program Files/MinGit"]}}
 
 {{InsertTemplate("Dockerfile.windows.first-run")}}}}

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.install-components
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.install-components
@@ -32,6 +32,26 @@
     set getFormattedPath(path) to:{{
         return cat("'", path, "'")
     }}
+}}{{ if dotnetVersion != "3.1" && dotnetVersion != "6.0":# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        {{InsertTemplate("../Dockerfile.windows.download-file",
+            [
+                "out-file": "mingit.zip",
+                "url": VARIABLES[cat("mingit|", ARCH_SHORT, "|url")],
+                "sha": VARIABLES[cat("mingit|", ARCH_SHORT, "|sha")],
+                "sha-var-name": "mingit_sha256",
+                "hash-algorithm": "sha256"
+            ], "        ")}}; `
+        mkdir $Env:ProgramFiles\MinGit; `
+        {{InsertTemplate("../Dockerfile.windows.extract-zip",
+            [
+                "file": "mingit.zip",
+                "dest-dir": "$Env:ProgramFiles\MinGit"
+            ], "        ")}}"
+
 }}RUN powershell -Command " `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.set-path
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.set-path
@@ -1,0 +1,3 @@
+{{
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".")
+}}RUN setx /M PATH "%PATH%;C:\Program Files\powershell{{ if dotnetVersion != "3.1" && dotnetVersion != "6.0":;C:\Program Files\MinGit\cmd}}"

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.set-powershell-path
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.set-powershell-path
@@ -1,1 +1,0 @@
-RUN setx /M PATH "%PATH%;C:\Program Files\powershell"

--- a/eng/update-dependencies/JsonHelper.cs
+++ b/eng/update-dependencies/JsonHelper.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+public static class JsonHelper
+{
+    public static T GetRequiredToken<T>(this JToken token, string name)
+        where T : JToken =>
+        (T)(token[name] ?? throw new InvalidOperationException($"Missing '{name}' property"));
+}
+#nullable disable

--- a/eng/update-dependencies/MinGitHelper.cs
+++ b/eng/update-dependencies/MinGitHelper.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+public static class MinGitHelper
+{
+    public static async Task<JObject> GetLatestMinGitReleaseAsync()
+    {
+        HttpClient httpClient = new();
+        string url = "https://api.github.com/repos/git-for-windows/git/releases/latest";
+        httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Dotnet.Docker.UpdateDependencies", "1.0"));
+        string releaseString = await httpClient.GetStringAsync(url);
+        JObject release = (JObject)(JsonConvert.DeserializeObject(releaseString) ??
+            throw new InvalidOperationException($"Unable to deserialize response from '{url}' as JSON."));
+        return release;
+    }
+}
+#nullable disable

--- a/eng/update-dependencies/MinGitShaUpdater.cs
+++ b/eng/update-dependencies/MinGitShaUpdater.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.VersionTools.Dependencies;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+/// <summary>
+/// Updates the MinGit SHA checksum in the manifest.versions.json file.
+/// </summary>
+internal class MinGitShaUpdater : FileRegexUpdater
+{
+    private const string ShaGroupName = "Sha";
+    private readonly JObject _latestMinGitRelease;
+
+    public MinGitShaUpdater(string repoRoot, JObject latestMinGitRelease)
+    {
+        Path = System.IO.Path.Combine(repoRoot, UpdateDependencies.VersionsFilename);
+        VersionGroupName = ShaGroupName;
+        Regex = ManifestHelper.GetManifestVariableRegex("mingit|x64|sha", @$"(?<{ShaGroupName}>\S*)");
+        _latestMinGitRelease = latestMinGitRelease;
+    }
+
+    protected override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)
+    {
+        usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
+
+        JObject asset = MinGitUrlUpdater.GetMinGitAsset(_latestMinGitRelease);
+
+        // The SHA for the MinGit zip file is contained in the body description of the MinGit release as a table listing.
+
+        string name = asset.GetRequiredToken<JValue>("name").ToString();
+        string body = _latestMinGitRelease.GetRequiredToken<JValue>("body").ToString();
+
+        const string ShaGroupName = "sha";
+        Regex shaRegex = new(@$"{Regex.Escape(name)}\s\|\s(?<{ShaGroupName}>[0-9|a-f]+)");
+        string sha = shaRegex.Match(body).Groups[ShaGroupName].Value;
+        return sha;
+    }
+
+}
+#nullable disable

--- a/eng/update-dependencies/MinGitUrlUpdater.cs
+++ b/eng/update-dependencies/MinGitUrlUpdater.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.VersionTools.Dependencies;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+/// <summary>
+/// Updates the MinGit version in the manifest.versions.json file.
+/// </summary>
+internal class MinGitUrlUpdater : FileRegexUpdater
+{
+    private const string UrlGroupName = "Url";
+    private readonly JObject _latestMinGitRelease;
+
+    public MinGitUrlUpdater(string repoRoot, JObject latestMinGitRelease)
+    {
+        Path = System.IO.Path.Combine(repoRoot, UpdateDependencies.VersionsFilename);
+        VersionGroupName = UrlGroupName;
+        Regex = ManifestHelper.GetManifestVariableRegex("mingit|x64|url", @$"(?<{UrlGroupName}>\S*)");
+        _latestMinGitRelease = latestMinGitRelease;
+    }
+
+    protected override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)
+    {
+        usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
+
+        JObject mingitAsset = GetMinGitAsset(_latestMinGitRelease);
+        return mingitAsset.GetRequiredToken<JValue>("browser_download_url").ToString();
+    }
+
+    internal static JObject GetMinGitAsset(JObject release)
+    {
+        JArray assets = release.GetRequiredToken<JArray>("assets");
+
+        JObject mingitAsset = (JObject)(assets.FirstOrDefault(asset => IsMinGit64BitAsset((JObject)asset)) ??
+            throw new InvalidOperationException("Can't find 64-bit MinGit asset."));
+        return mingitAsset;
+    }
+
+    private static bool IsMinGit64BitAsset(JObject asset)
+    {
+        string name = asset.GetRequiredToken<JValue>("name").ToString();
+        return name.StartsWith("MinGit", StringComparison.OrdinalIgnoreCase) &&
+            name.Contains("64-bit", StringComparison.OrdinalIgnoreCase) &&
+            name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+    }
+}
+#nullable disable

--- a/eng/update-dependencies/UpdateDependencies.cs
+++ b/eng/update-dependencies/UpdateDependencies.cs
@@ -8,7 +8,6 @@ using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using LibGit2Sharp;
 using Microsoft.DotNet.VersionTools;
@@ -16,6 +15,7 @@ using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using Microsoft.DotNet.VersionTools.Dependencies;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
+using Newtonsoft.Json.Linq;
 
 namespace Dotnet.Docker
 {
@@ -67,7 +67,7 @@ namespace Dotnet.Docker
                 IEnumerable<IDependencyInfo> buildInfos = Options.ProductVersions
                     .Select(kvp => CreateDependencyBuildInfo(kvp.Key, kvp.Value))
                     .ToArray();
-                DependencyUpdateResults updateResults = UpdateFiles(buildInfos);
+                DependencyUpdateResults updateResults = await UpdateFilesAsync(buildInfos);
                 if (updateResults.ChangesDetected())
                 {
                     if (Options.UpdateOnly)
@@ -99,9 +99,9 @@ namespace Dotnet.Docker
             Environment.Exit(0);
         }
 
-        private static DependencyUpdateResults UpdateFiles(IEnumerable<IDependencyInfo> buildInfos)
+        private static async Task<DependencyUpdateResults> UpdateFilesAsync(IEnumerable<IDependencyInfo> buildInfos)
         {
-            IEnumerable<IDependencyUpdater> updaters = GetUpdaters();
+            IEnumerable<IDependencyUpdater> updaters = await GetUpdatersAsync();
 
             return DependencyUpdateUtils.Update(updaters, buildInfos);
         }
@@ -289,26 +289,36 @@ namespace Dotnet.Docker
             }
         }
 
-        private static IEnumerable<IDependencyUpdater> GetUpdaters()
+        private static async Task<IEnumerable<IDependencyUpdater>> GetUpdatersAsync()
         {
             // NOTE: The order in which the updaters are returned/invoked is important as there are cross dependencies
             // (e.g. sha updater requires the version numbers to be updated within the Dockerfiles)
 
-            yield return new NuGetConfigUpdater(RepoRoot, Options);
-            yield return new BaseUrlUpdater(RepoRoot, Options);
+            JObject release = await MinGitHelper.GetLatestMinGitReleaseAsync();
+
+            List<IDependencyUpdater> updaters = new()
+            {
+                new NuGetConfigUpdater(RepoRoot, Options),
+                new BaseUrlUpdater(RepoRoot, Options),
+                new MinGitUrlUpdater(RepoRoot, release),
+                new MinGitShaUpdater(RepoRoot, release)
+            };
+            
             foreach (string productName in Options.ProductVersions.Keys)
             {
-                yield return new VersionUpdater(VersionType.Build, productName, Options.DockerfileVersion, RepoRoot, Options);
-                yield return new VersionUpdater(VersionType.Product, productName, Options.DockerfileVersion, RepoRoot, Options);
+                updaters.Add(new VersionUpdater(VersionType.Build, productName, Options.DockerfileVersion, RepoRoot, Options));
+                updaters.Add(new VersionUpdater(VersionType.Product, productName, Options.DockerfileVersion, RepoRoot, Options));
 
                 foreach (IDependencyUpdater shaUpdater in DockerfileShaUpdater.CreateUpdaters(productName, Options.DockerfileVersion, RepoRoot, Options))
                 {
-                    yield return shaUpdater;
+                    updaters.Add(shaUpdater);
                 }
             }
 
-            yield return ScriptRunnerUpdater.GetDockerfileUpdater(RepoRoot);
-            yield return ScriptRunnerUpdater.GetReadMeUpdater(RepoRoot);
+            updaters.Add(ScriptRunnerUpdater.GetDockerfileUpdater(RepoRoot));
+            updaters.Add(ScriptRunnerUpdater.GetReadMeUpdater(RepoRoot));
+
+            return updaters;
         }
     }
 }

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -84,6 +84,9 @@
     "libssl|focal": "1.1",
     "libssl|jammy": "3",
 
+    "mingit|x64|url": "https://github.com/git-for-windows/git/releases/download/v2.37.1.windows.1/MinGit-2.37.1-64-bit.zip",
+    "mingit|x64|sha": "edacf2d5c39555c25a396e0b9d27182ab5587259dc2e824b4490996b373f9300",
+
     "monitor|6.1|build-version": "6.1.3",
     "monitor|6.1|product-version": "6.1.3",
     "monitor|6.1|sha": "eb330355e6ec489ae13cd51b18ad89e7bbe6614a6bd539c69b65f83a8b706b4bda39c6d60d7ed31704122c4a1c8d31b91b01ebc9733e5522544ad7a024486f3a",

--- a/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile
@@ -61,7 +61,6 @@ RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 
 # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-20H2/amd64/Dockerfile
@@ -61,7 +61,6 @@ RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 
 # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile
@@ -61,7 +61,6 @@ RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 
 # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile
@@ -68,7 +68,6 @@ RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 
 # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-20H2/amd64/Dockerfile
@@ -68,7 +68,6 @@ RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 
 # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -68,7 +68,6 @@ RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
 
 # Trigger first run experience by running arbitrary cmd

--- a/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile
@@ -5,6 +5,21 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
 
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        Invoke-WebRequest -OutFile mingit.zip https://github.com/git-for-windows/git/releases/download/v2.37.1.windows.1/MinGit-2.37.1-64-bit.zip; `
+        $mingit_sha256 = 'edacf2d5c39555c25a396e0b9d27182ab5587259dc2e824b4490996b373f9300'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir $Env:ProgramFiles\MinGit; `
+        tar -oxzf mingit.zip -C $Env:ProgramFiles\MinGit; `
+        Remove-Item -Force mingit.zip"
+
 RUN powershell -Command " `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -64,12 +79,12 @@ ENV `
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/Program Files/MinGit", "/Program Files/MinGit"]
 
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -5,6 +5,21 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 # Installer image
 FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
 
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        Invoke-WebRequest -OutFile mingit.zip https://github.com/git-for-windows/git/releases/download/v2.37.1.windows.1/MinGit-2.37.1-64-bit.zip; `
+        $mingit_sha256 = 'edacf2d5c39555c25a396e0b9d27182ab5587259dc2e824b4490996b373f9300'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir $Env:ProgramFiles\MinGit; `
+        tar -oxzf mingit.zip -C $Env:ProgramFiles\MinGit; `
+        Remove-Item -Force mingit.zip"
+
 RUN powershell -Command " `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -64,12 +79,12 @@ ENV `
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 USER ContainerUser
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
-
 COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/Program Files/MinGit", "/Program Files/MinGit"]
 
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/src/sdk/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/7.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -19,6 +19,21 @@ ENV `
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2019
 
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        Invoke-WebRequest -OutFile mingit.zip https://github.com/git-for-windows/git/releases/download/v2.37.1.windows.1/MinGit-2.37.1-64-bit.zip; `
+        $mingit_sha256 = 'edacf2d5c39555c25a396e0b9d27182ab5587259dc2e824b4490996b373f9300'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir $Env:ProgramFiles\MinGit; `
+        tar -oxzf mingit.zip -C $Env:ProgramFiles\MinGit; `
+        Remove-Item -Force mingit.zip"
+
 RUN powershell -Command " `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -46,7 +61,7 @@ RUN powershell -Command " `
         Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
         Remove-Item -Path $Env:ProgramFiles\powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;"
 
-RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/src/sdk/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/7.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -19,6 +19,21 @@ ENV `
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2022
 
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        Invoke-WebRequest -OutFile mingit.zip https://github.com/git-for-windows/git/releases/download/v2.37.1.windows.1/MinGit-2.37.1-64-bit.zip; `
+        $mingit_sha256 = 'edacf2d5c39555c25a396e0b9d27182ab5587259dc2e824b4490996b373f9300'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir $Env:ProgramFiles\MinGit; `
+        tar -oxzf mingit.zip -C $Env:ProgramFiles\MinGit; `
+        Remove-Item -Force mingit.zip"
+
 RUN powershell -Command " `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -46,7 +61,7 @@ RUN powershell -Command " `
         Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
         Remove-Item -Path $Env:ProgramFiles\powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;"
 
-RUN setx /M PATH "%PATH%;C:\Program Files\powershell"
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -225,6 +225,26 @@ namespace Microsoft.DotNet.Docker.Tests
             VerifyCommonDefaultUser(imageData);
         }
 
+        /// <summary>
+        /// Verifies that a git command can be executed without failure.
+        /// </summary>
+        [DotNetTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyGitInstallation(ProductImageData imageData)
+        {
+            if (!DockerHelper.IsLinuxContainerModeEnabled && imageData.Version.Major <= 6)
+            {
+                OutputHelper.WriteLine("Git is not installed on Windows containers older than .NET 7");
+                return;
+            }
+
+            DockerHelper.Run(
+                image: imageData.GetImage(DotNetImageType.SDK, DockerHelper),
+                name: imageData.GetIdentifier($"git"),
+                command: "git clone https://github.com/dotnet/dotnet-docker.git"
+            );
+        }
+
         private IEnumerable<SdkContentFileInfo> GetActualSdkContents(ProductImageData imageData)
         {
             string dotnetPath;


### PR DESCRIPTION
This provides consistency between Linux and Windows for the .NET SDK containers by including MinGit a slimmed down version of Git for Windows. This allows for git commands to be easily run from within these containers. [MinGit is intended for non-interactive scenarios](https://github.com/git-for-windows/git/wiki/MinGit) which is perfect for container environments. So it also has a smaller installation size than Git for Windows.

These changes are limited to .NET 7 since this is a breaking change.

A test is included for all SDK containers (Linux and Windows) where git is installed to verify that git is functional.

For maintaining the MinGit version, I've changed the update-dependencies tool to help manage this. It will check what the latest stable version of MinGit is and update the appropriate version information in the manifest.versions.json file. The Dockerfile template will then use those variables for generating the Dockerfiles that download MinGit.

Fixes #2338