### PR TITLE
Fix update-deps Dockerfile for NuGet.config path change

### DIFF
--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -8,7 +8,7 @@ ARG RID=alpine.3.14-x64
 
 # copy csproj and restore as distinct layers
 COPY eng/update-dependencies/*.csproj ./
-COPY eng/update-dependencies/NuGet.config ./
+COPY NuGet.config ./
 RUN dotnet restore -r $RID
 
 # copy everything else and build


### PR DESCRIPTION
Updates the path to the NuGet.config file in the Dockerfile for update-dependencies because of the path change in https://github.com/dotnet/dotnet-docker/pull/3936.