### PR TITLE
Support internal NuGet feed in test stage of Dockerfiles for unit tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
@@ -21,9 +21,17 @@ RUN dotnet build --no-restore
 
 
 FROM build AS test
+
+ARG rid
+ARG NuGetFeedPassword
+
 WORKDIR /source/tests
+
+COPY tests/*.csproj .
+RUN dotnet restore -r $rid
+
 COPY tests/ .
-ENTRYPOINT ["dotnet", "test", "--logger:trx"]
+ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 
 FROM build as publish_fx_dependent

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
@@ -20,9 +20,17 @@ RUN dotnet build --no-restore
 
 
 FROM build AS test
+
+ARG rid
+ARG NuGetFeedPassword
+
 WORKDIR /source/tests
+
+COPY tests/*.csproj .
+RUN dotnet restore -r %rid%
+
 COPY tests/ .
-ENTRYPOINT ["dotnet", "test", "--logger:trx"]
+ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 
 FROM build as publish_fx_dependent


### PR DESCRIPTION
Updates the Dockerfiles used for unit testing so that they can support restoring NuGet packages from internal feeds. This occurs in the test stage of the Dockerfile which was added by https://github.com/dotnet/dotnet-docker/pull/3847. This was discovered after attempting to run a build/test pass on an internal 6.0 build. It ended up failing when attempting to run a container that ran the dynamically-generated unit test project: see https://github.com/dotnet/dotnet-docker/blob/1297d21bbf695bcb87580bea2ccefdced894eeeb/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs#L68

This is because `dotnet test` will attempt to restore packages by default for the test project. But the Dockerfile stage hadn't been configured to use the `NuGetFeedPassword` environment variable needed by the NuGet.config file.

I've fixed it now to declare the usage of `NuGetFeedPassword` environment variable as well as the `rid` variable. It now explicitly runs `dotnet restore` on the test project to ensure packages are restored before an attempt is made to run the container.