### PR TITLE
Sample Dockerfile: explicitly restore test project

### DIFF
--- a/samples/complexapp/Dockerfile
+++ b/samples/complexapp/Dockerfile
@@ -24,6 +24,8 @@ COPY tests/*.csproj .
 RUN dotnet restore tests.csproj
 
 COPY tests/ .
+RUN dotnet build --no-restore
+
 ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 FROM build AS publish

--- a/samples/complexapp/Dockerfile
+++ b/samples/complexapp/Dockerfile
@@ -26,7 +26,7 @@ RUN dotnet restore tests.csproj
 COPY tests/ .
 RUN dotnet build --no-restore
 
-ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
+ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore", "--no-build"]
 
 FROM build AS publish
 RUN dotnet publish -c release --no-build -o /app

--- a/samples/complexapp/Dockerfile
+++ b/samples/complexapp/Dockerfile
@@ -19,8 +19,12 @@ RUN dotnet build -c release --no-restore
 # target entrypoint with: docker build --target test
 FROM build AS test
 WORKDIR /source/tests
+
+COPY tests/*.csproj .
+RUN dotnet restore tests.csproj
+
 COPY tests/ .
-ENTRYPOINT ["dotnet", "test", "--logger:trx"]
+ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 FROM build AS publish
 RUN dotnet publish -c release --no-build -o /app


### PR DESCRIPTION
The complexapp sample Dockerfile should explicitly restore the test project. Otherwise, the test project won't get restored until the container is actually executed, implicitly by the `dotnet test` ENTRYPOINT. That's wasteful because every execution of the container would cause it to get restored again. It only needs to get restored once and embedded within the image.