### PR TITLE
Windows templates: only switch user to set path for Nano Server

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.windows.set-path
+++ b/eng/dockerfile-templates/Dockerfile.windows.set-path
@@ -1,0 +1,10 @@
+{{
+    _ Appends a path to the PATH environment variable.
+    ARGS:
+        path: Path to append to the PATH environment variable ^
+
+    set isNanoServer to find(OS_VERSION, "nanoserver") >= 0
+}}{{ if isNanoServer:# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+}}RUN setx /M PATH "%PATH%;{{ARGS["path"]}}"{{ if isNanoServer:
+USER ContainerUser}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.windows
+++ b/eng/dockerfile-templates/runtime/Dockerfile.windows
@@ -20,7 +20,7 @@
 # Install .NET Runtime
 {{InsertTemplate("Dockerfile.windows.install-runtime")}}
 
-{{InsertTemplate("Dockerfile.windows.set-path")}}^
+{{InsertTemplate("../Dockerfile.windows.set-path", [ "path": "C:\Program Files\dotnet"])}}^
 else:{{
 
     _ MULTI STAGE
@@ -45,9 +45,6 @@ FROM mcr.microsoft.com/windows/{{finalStageBaseRepo}}:{{OS_VERSION_NUMBER}}-amd6
 {{InsertTemplate("../Dockerfile.common-dotnet-envs")}}{{if dotnetVersion != "3.1": `
     {{InsertTemplate("Dockerfile.envs", [], "    ")}}}}
 
-# In order to set system PATH, ContainerAdministrator must be used
-USER ContainerAdministrator
-{{InsertTemplate("Dockerfile.windows.set-path")}}
-USER ContainerUser
+{{InsertTemplate("../Dockerfile.windows.set-path", [ "path": "C:\Program Files\dotnet"])}}
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.windows.set-path
+++ b/eng/dockerfile-templates/runtime/Dockerfile.windows.set-path
@@ -1,1 +1,0 @@
-RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows
@@ -17,7 +17,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 {{InsertTemplate("Dockerfile.windows.install-components")}}
 
-{{InsertTemplate("Dockerfile.windows.set-powershell-path")}}
+{{InsertTemplate("../Dockerfile.windows.set-path", [ "path": "C:\Program Files\powershell"])}}
 
 {{InsertTemplate("Dockerfile.windows.first-run")}}^else:
 {{
@@ -41,10 +41,7 @@ FROM {{aspnetBaseTag}}
 
 {{InsertTemplate("Dockerfile.envs")}}
 
-# In order to set system PATH, ContainerAdministrator must be used
-USER ContainerAdministrator
-{{InsertTemplate("Dockerfile.windows.set-powershell-path")}}
-USER ContainerUser
+{{InsertTemplate("../Dockerfile.windows.set-path", [ "path": "C:\Program Files\powershell"])}}
 
 COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
 

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.set-powershell-path
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.set-powershell-path
@@ -1,1 +1,0 @@
-RUN setx /M PATH "%PATH%;C:\Program Files\powershell"


### PR DESCRIPTION
The Windows Server Core Dockerfiles that are generated when targeting an internal .NET build are setting the user to ContainerAdministrator in order to set the `PATH` environment variable and then setting the user back to `ContainerUser`. This behavior is incorrect for the following reasons:
* It doesn't need to explicitly set the user to `ContainerAdministrator` in Windows Server Core because that's what it's running as by default.
* It's incorrect to switch the user to `ContainerUser` after setting the variable because we want to maintain the user as the default.

This was caught by new testing that was added in https://github.com/dotnet/dotnet-docker/pull/3863 verifying the correct user is set for Windows containers.

This only occurs for Dockerfiles generated for internal builds. In that scenario, we use a multi-stage Dockerfile for Server Core; for public builds, we don't. This is in order to keep the SAS token out of the final image. The template logic for setting the `PATH` variable is assuming that a multi-stage Dockerfile should require switching the user because for public builds, that means its Nano Server. But that's not true in this scenario.

To fix this, I've refactored the templates to use a common template for setting the Windows `PATH` variable. It will include the user-switching instructions only if it's targeting Nano Server. This allows the Server Core scenarios to remain as the default user.

