### PR TITLE
.NET Monitor 6.2.2 update

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -91,9 +91,9 @@
     "monitor|6.1|product-version": "6.1.3",
     "monitor|6.1|sha": "eb330355e6ec489ae13cd51b18ad89e7bbe6614a6bd539c69b65f83a8b706b4bda39c6d60d7ed31704122c4a1c8d31b91b01ebc9733e5522544ad7a024486f3a",
 
-    "monitor|6.2|build-version": "6.2.2-servicing.22377.3",
+    "monitor|6.2|build-version": "6.2.2-servicing.22378.3",
     "monitor|6.2|product-version": "6.2.2",
-    "monitor|6.2|sha": "1fc75d2cac97a8185b9aebd2a0e434022fa9bf4307f7f409f7cbc9b41bc6feecfd49c58d95204f121572873c1e4da0abada90cfa29131a1add5cddf24514cf1d",
+    "monitor|6.2|sha": "c70b8d63a254a23ea34b493205e17bead559f768753d8020414db719149152de3d3ec8740a42276d24147b37428a222a1f2d9e6a6ddc1f10b43d1cb0baaa126b",
 
     "monitor|7.0|build-version": "7.0.0-preview.7.22377.7",
     "monitor|7.0|product-version": "7.0.0-preview.7",

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -6,8 +6,8 @@ FROM $SDK_REPO:6.0.302-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22377.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1fc75d2cac97a8185b9aebd2a0e434022fa9bf4307f7f409f7cbc9b41bc6feecfd49c58d95204f121572873c1e4da0abada90cfa29131a1add5cddf24514cf1d' \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22378.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='c70b8d63a254a23ea34b493205e17bead559f768753d8020414db719149152de3d3ec8740a42276d24147b37428a222a1f2d9e6a6ddc1f10b43d1cb0baaa126b' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove all non-net6.0 TFMs

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -6,8 +6,8 @@ FROM $SDK_REPO:6.0.302-alpine3.16-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22377.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1fc75d2cac97a8185b9aebd2a0e434022fa9bf4307f7f409f7cbc9b41bc6feecfd49c58d95204f121572873c1e4da0abada90cfa29131a1add5cddf24514cf1d' \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22378.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='c70b8d63a254a23ea34b493205e17bead559f768753d8020414db719149152de3d3ec8740a42276d24147b37428a222a1f2d9e6a6ddc1f10b43d1cb0baaa126b' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove all non-net6.0 TFMs

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -6,8 +6,8 @@ FROM $SDK_REPO:6.0.302-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22377.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1fc75d2cac97a8185b9aebd2a0e434022fa9bf4307f7f409f7cbc9b41bc6feecfd49c58d95204f121572873c1e4da0abada90cfa29131a1add5cddf24514cf1d' \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22378.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='c70b8d63a254a23ea34b493205e17bead559f768753d8020414db719149152de3d3ec8740a42276d24147b37428a222a1f2d9e6a6ddc1f10b43d1cb0baaa126b' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove all non-net6.0 TFMs

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -6,8 +6,8 @@ FROM $SDK_REPO:6.0.302-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22377.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1fc75d2cac97a8185b9aebd2a0e434022fa9bf4307f7f409f7cbc9b41bc6feecfd49c58d95204f121572873c1e4da0abada90cfa29131a1add5cddf24514cf1d' \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22378.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='c70b8d63a254a23ea34b493205e17bead559f768753d8020414db719149152de3d3ec8740a42276d24147b37428a222a1f2d9e6a6ddc1f10b43d1cb0baaa126b' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove all non-net6.0 TFMs

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -6,8 +6,8 @@ FROM $SDK_REPO:6.0.302-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22377.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1fc75d2cac97a8185b9aebd2a0e434022fa9bf4307f7f409f7cbc9b41bc6feecfd49c58d95204f121572873c1e4da0abada90cfa29131a1add5cddf24514cf1d' \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22378.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='c70b8d63a254a23ea34b493205e17bead559f768753d8020414db719149152de3d3ec8740a42276d24147b37428a222a1f2d9e6a6ddc1f10b43d1cb0baaa126b' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove all non-net6.0 TFMs

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -6,8 +6,8 @@ FROM $SDK_REPO:6.0.302-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22377.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='1fc75d2cac97a8185b9aebd2a0e434022fa9bf4307f7f409f7cbc9b41bc6feecfd49c58d95204f121572873c1e4da0abada90cfa29131a1add5cddf24514cf1d' \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.2.2-servicing.22378.3/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='c70b8d63a254a23ea34b493205e17bead559f768753d8020414db719149152de3d3ec8740a42276d24147b37428a222a1f2d9e6a6ddc1f10b43d1cb0baaa126b' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
     # To reduce image size, remove all non-net6.0 TFMs


### PR DESCRIPTION
Manually updating to latest candidate build due to broken update dependencies pipeline.