### PR TITLE
Fix skipping of update-deps PR generation

### DIFF
--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -48,7 +48,10 @@ namespace Dotnet.Docker
             BinarySasQueryString = binarySas;
             ChecksumSasQueryString = checksumSas;
             SourceBranch = sourceBranch;
-            TargetBranch = targetBranch;
+
+            // Default TargetBranch to SourceBranch if it's not explicitly provided
+            TargetBranch = string.IsNullOrEmpty(targetBranch) ? sourceBranch : targetBranch;
+
             AzdoOrganization = org;
             AzdoProject = project;
             AzdoRepo = repo;
@@ -77,7 +80,7 @@ namespace Dotnet.Docker
                 new Option<bool>("--compute-shas", "Compute the checksum if a published checksum cannot be found"),
                 new Option<bool>("--stable-branding", "Use stable branding version numbers to compute paths"),
                 new Option<string>("--source-branch", () => "nightly", "Branch where the Dockerfiles are hosted"),
-                new Option<string>("--target-branch", "Target branch of the generated PR"),
+                new Option<string>("--target-branch", "Target branch of the generated PR (defaults to value of source-branch)"),
                 new Option<string>("--binary-sas", "SAS query string used to access binary files in blob storage"),
                 new Option<string>("--checksum-sas", "SAS query string used to access checksum files in blob storage"),
                 new Option<string>("--org", "Name of the AzDO organization"),


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-docker/pull/3910 are causing the normal (non-internal builds) scenarios from generating a PR when updates are made to files. It contains this message in the output: `Changes made but no GitHub credentials specified, skipping PR creation`.

This happens because a change was made to only generate a PR if the `target-branch` option is set. That option is only being set for the pipeline that handles internal builds.

To fix this, I've updated it to default the value of `target-branch` to be the value of `source-branch` if `target-branch` wasn't explicitly set. That's the value that's desired in these scenarios that target public builds.