### PR TITLE
Delete RPM DB in distroless CBL-Mariner

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -69,6 +69,7 @@ RUN {{if find(OS_VERSION, "1.0") < 0:tdnf install -y shadow-utils \
 RUN rm -rf {{distrolessStagingDir}}/etc/{{when(find(OS_VERSION, "1.0") >= 0, "dnf", "tdnf")}} \
     && rm -rf {{distrolessStagingDir}}/run/* \
     && rm -rf {{distrolessStagingDir}}/var/cache/{{when(find(OS_VERSION, "1.0") >= 0, "dnf", "tdnf")}} \
+    && rm -rf {{distrolessStagingDir}}/var/lib/rpm \
     && rm -rf {{distrolessStagingDir}}/usr/share/doc \
     && rm -rf {{distrolessStagingDir}}/usr/share/man \
     && find {{distrolessStagingDir}}/var/log -type f -size +0 -delete

--- a/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -40,6 +40,7 @@ RUN groupadd \
 RUN rm -rf /staging/etc/dnf \
     && rm -rf /staging/run/* \
     && rm -rf /staging/var/cache/dnf \
+    && rm -rf /staging/var/lib/rpm \
     && rm -rf /staging/usr/share/doc \
     && rm -rf /staging/usr/share/man \
     && find /staging/var/log -type f -size +0 -delete

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -37,6 +37,7 @@ RUN tdnf install -y shadow-utils \
 RUN rm -rf /staging/etc/tdnf \
     && rm -rf /staging/run/* \
     && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
     && rm -rf /staging/usr/share/doc \
     && rm -rf /staging/usr/share/man \
     && find /staging/var/log -type f -size +0 -delete

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -37,6 +37,7 @@ RUN tdnf install -y shadow-utils \
 RUN rm -rf /staging/etc/tdnf \
     && rm -rf /staging/run/* \
     && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
     && rm -rf /staging/usr/share/doc \
     && rm -rf /staging/usr/share/man \
     && find /staging/var/log -type f -size +0 -delete


### PR DESCRIPTION
The RPM DB is mistakenly being included in the distroless CBL-Mariner images. It's not needed because there is no package manager in distroless. This leads to about 500 KB of unnecessary image bloat.

Fixes #3941