### PR TITLE
Override Ubuntu image source location

### DIFF
--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -20,6 +20,12 @@ stages:
     testMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
 
     # Template paths must be relative to the YAML job that executes them
+
+    customCopyBaseImagesInitSteps:
+    - template: ../../../pipelines/steps/set-base-image-override-options.yml
+      parameters:
+        variableName: customCopyBaseImagesArgs
+
     customBuildInitSteps:
     - template: ../../../pipelines/steps/set-imagebuilder-build-args-var.yml
     - template: ../../../pipelines/steps/set-public-source-branch-var.yml
@@ -43,6 +49,9 @@ stages:
 
         echo "##vso[task.setvariable variable=testRunner.options]$testRunnerOptions"
       displayName: Set Custom Test Variables
+    - template: ../../../pipelines/steps/set-base-image-override-options.yml
+      parameters:
+        variableName: imageBuilderBuildArgs
     customTestInitSteps:
     - powershell: |
         # Forward team project name for consumption by test script

--- a/eng/pipelines/steps/set-base-image-override-options.yml
+++ b/eng/pipelines/steps/set-base-image-override-options.yml
@@ -1,0 +1,22 @@
+parameters:
+  # Name of the pipeline variable to append the options to
+  variableName: null
+
+steps:
+# Configures Image Builder options to override the base image tags for Ubuntu as defined in the Dockerfiles
+# and instead use the corresponding image from the Ubuntu ACR.
+- powershell: |
+    # Because the Ubuntu ACR doesn't have arch-specific tags, we configure the regex and substitution
+    # to strip off the arch for the repo name. (e.g. "amd64/ubuntu:jammy" becomes "ubuntu.azurecr.io/ubuntu:jammy")".
+    # These tags are multi-arch tags so they'll work across all the architectures we provide.
+    $baseOverrideRegex = ".*\/(ubuntu:.+)"
+
+    # Be sure to use the string literal syntax here (single quote) to avoid $1 being interpreted as a variable
+    $baseOverrideSubstitution = 'ubuntu.azurecr.io/$1'
+
+    # Assume the variable already exists and append to it. This allows us to dynamically append additional
+    # options to a general purpose variable.
+    $options = "$(${{ parameters.variableName }})"
+    $options += " --base-override-regex '$baseOverrideRegex' --base-override-sub '$baseOverrideSubstitution'"
+    echo "##vso[task.setvariable variable=${{ parameters.variableName }}]$options"
+  displayName: Set Base Image Override Options

--- a/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
+++ b/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
@@ -2,7 +2,10 @@ steps:
 - powershell: |
     $imageBuilderBuildArgs = $env:IMAGEBUILDERBUILDARGS
     # Disable platform checks for CBL-Mariner on ARM64 due to https://github.com/dotnet/dotnet-docker/issues/3520
-    if ("$(osVersions)".Contains("cbl-mariner") -and "$(architecture)" -eq "arm64") {
+    # Similar issue with Ubuntu images in ACR missing the arch variant metadata
+    $isUbuntu = "$(osVersions)".Contains("bionic") -or "$(osVersions)".Contains("focal") -or "$(osVersions)".Contains("jammy")
+    if (("$(osVersions)".Contains("cbl-mariner") -and "$(architecture)" -eq "arm64") -or
+        ($isUbuntu -and "$(architecture)".Contains("arm"))) {
       $imageBuilderBuildArgs += " --skip-platform-check"
     }
 


### PR DESCRIPTION
Uses the base tag override options introduced by https://github.com/dotnet/docker-tools/pull/1031 to override the Ubuntu image tags so that they are retrieved from an ACR instead of Docker Hub.