### PR TITLE
Enable signed NuGet package validation

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile.envs
+++ b/eng/dockerfile-templates/sdk/Dockerfile.envs
@@ -13,7 +13,9 @@
     # Do not generate certificate
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false {{lineContinuation}}{{if dotnetVersion != "3.1":
     # Do not show first run text
-    DOTNET_NOLOGO=true {{lineContinuation}}}}{{if dotnetVersion != "3.1":
+    DOTNET_NOLOGO=true {{lineContinuation}}}}{{if !isWindows && dotnetVersion = "6.0":
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true {{lineContinuation}}}}{{if dotnetVersion != "3.1":
     # SDK version
     DOTNET_SDK_VERSION={{VARIABLES[cat("sdk|", dotnetVersion, "|build-version")]}} {{lineContinuation}}}}{{if isAlpine:
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/amd64/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.16/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.16/amd64/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/focal/amd64/Dockerfile
+++ b/src/sdk/6.0/focal/amd64/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/6.0/focal/arm32v7/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/6.0/focal/arm64v8/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/jammy/amd64/Dockerfile
+++ b/src/sdk/6.0/jammy/amd64/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/6.0/jammy/arm32v7/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/6.0/jammy/arm64v8/Dockerfile
@@ -8,6 +8,8 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
+    # Enable validation for signed NuGet packages
+    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.302 \
     # Enable correct mode for dotnet watch (only mode supported in a container)


### PR DESCRIPTION
Fixes #3932 by setting the `DOTNET_NUGET_SIGNATURE_VERIFICATION` environment variable in Linux-based 6.0 Dockerfiles. This enables signature validation for NuGet packages once these Dockerfiles are updated to 6.0.400.