### PR TITLE
Fix target-branch for update-dependencies

### DIFF
--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -22,7 +22,11 @@ steps:
     $(engPath)/Set-DotnetVersions.ps1 @args
   displayName: Get update-dependencies args
 - powershell: |
-    $targetBranch = "internal/release/" + $(& $(engPath)/Get-Branch.ps1)
+    $branchPrefix = ""
+    if ("${{ parameters.useInternalBuild }}" -eq "true") {
+      $branchPrefix = "internal/release/"
+    }
+    $targetBranch = $branchPrefix + $(& $(engPath)/Get-Branch.ps1)
     echo "##vso[task.setvariable variable=targetBranch]$targetBranch"
   displayName: Set Target Branch Var
 - template: update-dependencies.yml


### PR DESCRIPTION
The update-dependencies pipeline is currently broken after being updated to target .NET 7 RC1. This is due to the changes https://github.com/dotnet/dotnet-docker/pull/3910 and the fact that it's now attempting to create a PR.

When attempting to create the PR, it's failing because the parameters were configured to use a target branch of `internal/release/nightly`. That's the wrong target branch to be using for a non-internal build.

This is fixed by changing the build step which sets the target branch to only use the `internal/release/` prefix when targeting internal builds.