### PR TITLE
Only update MinGet version for sdk changes

### DIFF
--- a/eng/update-dependencies/MinGitShaUpdater.cs
+++ b/eng/update-dependencies/MinGitShaUpdater.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.DotNet.VersionTools.Dependencies;
 using Newtonsoft.Json.Linq;
 
 #nullable enable
@@ -13,29 +10,24 @@ namespace Dotnet.Docker;
 /// <summary>
 /// Updates the MinGit SHA checksum in the manifest.versions.json file.
 /// </summary>
-internal class MinGitShaUpdater : FileRegexUpdater
+internal class MinGitShaUpdater : MinGitUpdater
 {
-    private const string ShaGroupName = "Sha";
-    private readonly JObject _latestMinGitRelease;
-
     public MinGitShaUpdater(string repoRoot, JObject latestMinGitRelease)
+        : base(
+            repoRoot,
+            latestMinGitRelease,
+            "mingit|x64|sha")
     {
-        Path = System.IO.Path.Combine(repoRoot, UpdateDependencies.VersionsFilename);
-        VersionGroupName = ShaGroupName;
-        Regex = ManifestHelper.GetManifestVariableRegex("mingit|x64|sha", @$"(?<{ShaGroupName}>\S*)");
-        _latestMinGitRelease = latestMinGitRelease;
     }
 
-    protected override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)
+    protected override string GetValue()
     {
-        usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
-
-        JObject asset = MinGitUrlUpdater.GetMinGitAsset(_latestMinGitRelease);
+        JObject asset = MinGitUrlUpdater.GetMinGitAsset(LatestMinGitRelease);
 
         // The SHA for the MinGit zip file is contained in the body description of the MinGit release as a table listing.
 
         string name = asset.GetRequiredToken<JValue>("name").ToString();
-        string body = _latestMinGitRelease.GetRequiredToken<JValue>("body").ToString();
+        string body = LatestMinGitRelease.GetRequiredToken<JValue>("body").ToString();
 
         const string ShaGroupName = "sha";
         Regex shaRegex = new(@$"{Regex.Escape(name)}\s\|\s(?<{ShaGroupName}>[0-9|a-f]+)");

--- a/eng/update-dependencies/MinGitUpdater.cs
+++ b/eng/update-dependencies/MinGitUpdater.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.VersionTools.Dependencies;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+namespace Dotnet.Docker;
+
+internal abstract class MinGitUpdater : FileRegexUpdater
+{
+    private readonly Lazy<JObject> _manifestVariables;
+    private readonly string _variableName;
+
+    public MinGitUpdater(string repoRoot, JObject latestMinGitRelease, string variableName)
+    {
+        _variableName = variableName;
+        Path = System.IO.Path.Combine(repoRoot, UpdateDependencies.VersionsFilename);
+        VersionGroupName = "val";
+        Regex = ManifestHelper.GetManifestVariableRegex(variableName, @$"(?<{VersionGroupName}>\S*)");
+        LatestMinGitRelease = latestMinGitRelease;
+
+        _manifestVariables = new Lazy<JObject>(
+            () =>
+            {
+                const string VariablesProperty = "variables";
+                JToken? variables = ManifestHelper.LoadManifest(UpdateDependencies.VersionsFilename)[VariablesProperty];
+                if (variables is null)
+                {
+                    throw new InvalidOperationException($"'{VariablesProperty}' property missing in '{UpdateDependencies.VersionsFilename}'");
+                }
+                return (JObject)variables;
+            });
+    }
+
+    protected JObject LatestMinGitRelease { get; }
+
+    protected sealed override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)
+    {
+        IDependencyInfo? sdkDependencyInfo = dependencyInfos.FirstOrDefault(info => info.SimpleName == "sdk");
+
+        // Only update MinGit variables when we're updating the SDK Dockerfiles
+        if (sdkDependencyInfo is null)
+        {
+            usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
+            return ManifestHelper.GetVariableValue(_variableName, _manifestVariables.Value);
+        }
+
+        usedDependencyInfos = new[] { sdkDependencyInfo };
+        return GetValue();
+    }
+
+    protected abstract string GetValue();
+
+}
+#nullable disable

--- a/eng/update-dependencies/MinGitUrlUpdater.cs
+++ b/eng/update-dependencies/MinGitUrlUpdater.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.DotNet.VersionTools.Dependencies;
 using Newtonsoft.Json.Linq;
 
 #nullable enable
@@ -13,24 +11,19 @@ namespace Dotnet.Docker;
 /// <summary>
 /// Updates the MinGit version in the manifest.versions.json file.
 /// </summary>
-internal class MinGitUrlUpdater : FileRegexUpdater
+internal class MinGitUrlUpdater : MinGitUpdater
 {
-    private const string UrlGroupName = "Url";
-    private readonly JObject _latestMinGitRelease;
-
     public MinGitUrlUpdater(string repoRoot, JObject latestMinGitRelease)
+        : base(
+            repoRoot,
+            latestMinGitRelease,
+            "mingit|x64|url")
     {
-        Path = System.IO.Path.Combine(repoRoot, UpdateDependencies.VersionsFilename);
-        VersionGroupName = UrlGroupName;
-        Regex = ManifestHelper.GetManifestVariableRegex("mingit|x64|url", @$"(?<{UrlGroupName}>\S*)");
-        _latestMinGitRelease = latestMinGitRelease;
     }
 
-    protected override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)
+    protected override string GetValue()
     {
-        usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
-
-        JObject mingitAsset = GetMinGitAsset(_latestMinGitRelease);
+        JObject mingitAsset = GetMinGitAsset(LatestMinGitRelease);
         return mingitAsset.GetRequiredToken<JValue>("browser_download_url").ToString();
     }
 


### PR DESCRIPTION
The update-dependencies pipeline is getting an error when attempting to update a .NET Monitor version that has no changes.

The error is the following:

```
Failed to update dependencies:
System.Exception: 'git status' does not match DependencyInfo information. Git has modified files: True. DependencyInfo is updated: False.
   at Microsoft.DotNet.VersionTools.Automation.DependencyUpdateResults.ChangesDetected() in /_/src/Microsoft.DotNet.VersionTools/lib/src/Automation/DependencyUpdateResults.cs:line 46
   at Dotnet.Docker.UpdateDependencies.ExecuteAsync(Options options) in /update-dependencies/UpdateDependencies.cs:line 82
```

This means there are git changes that have been detected but not expected based on the logic of what update-dependencies did.

This is happening because of the changes in https://github.com/dotnet/dotnet-docker/pull/3929. A new version of MinGit is now available, which is causing manifest.versions.json file to be updated as a result of running update-dependencies. But the updaters for the MinGit variables are not specifying any updated "dependency infos". And the .NET Monitor version hasn't changed. As a result, no git changes are expected. However, changes were made because no values were provided by the MinGit updaters. This is what causes the error.

The MinGit updaters should be returning the correct dependency info that is relevant to the update. Since MinGit is specific to the `sdk` Dockerfiles, that's the dependency info that it should be referencing. I've refactored the classes to encapsulate the logic for determining this. In the new base class, `MinGitUpdater`, it will check whether it's being invoked in the context of an `sdk` update. If so, it returns that as a used dependency info.

What this means is that update-dependencies will only update the MinGit variables if `sdk` is specified as a product to be updated.