### PR TITLE
Add default ENTRYPOINT for Chiseled Ubuntu

### DIFF
--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -82,7 +82,7 @@ FROM {{runtimeDepsBaseTag}}
         "installer-stage": "installer"
     ])}}}}{{ if isDistroless:
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
-COPY --from=installer ["/dotnet-symlink", "/usr/bin"]{{ if dotnetVersion != "3.1" && dotnetVersion != "6.0":
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]{{ if !isMariner || (dotnetVersion != "3.1" && dotnetVersion != "6.0"):
 
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]}}^

--- a/src/runtime/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime/6.0/jammy-chiseled/amd64/Dockerfile
@@ -24,3 +24,6 @@ ENV DOTNET_VERSION=6.0.8
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/src/runtime/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -24,3 +24,6 @@ ENV DOTNET_VERSION=6.0.8
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -80,7 +80,10 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             // For distroless, dotnet will be the default entrypoint so we don't need to specify "dotnet" in the command.
             // See https://github.com/dotnet/dotnet-docker/issues/3866
-            string executable = !IsDistroless || OS == Tests.OS.Mariner10Distroless || Version.Major <= 6 ? "dotnet " : string.Empty;
+            string executable = !IsDistroless ||
+                (OS.Contains(Tests.OS.Mariner) && (OS == Tests.OS.Mariner10Distroless || Version.Major <= 6)) ?
+                    "dotnet " :
+                    string.Empty;
             return executable + command;
         }
 


### PR DESCRIPTION
This sets the default ENTRYPOINT in the Chiseled Ubuntu Dockerfiles so that they run `dotnet`. Having a default allows there to be a good UX when just running the container as is. This follows the same pattern that was used in https://github.com/dotnet/dotnet-docker/pull/3886.