### PR TITLE
Roll back NuGet signature validation for 6.0 Linux Dockerfiles

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -61,11 +61,11 @@ The following samples show how to develop, build and test .NET applications with
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-6.0.400-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.400-bullseye-slim, 6.0-bullseye-slim, 6.0.400, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
-6.0.400-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.400-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
-6.0.400-alpine3.15-amd64, 6.0-alpine3.15-amd64, 6.0.400-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/amd64/Dockerfile) | Alpine 3.15
-6.0.400-jammy-amd64, 6.0-jammy-amd64, 6.0.400-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
-6.0.400-focal-amd64, 6.0-focal-amd64, 6.0.400-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+6.0.400-1-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.400-1-bullseye-slim, 6.0-bullseye-slim, 6.0.400-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
+6.0.400-1-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.400-1-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+6.0.400-1-alpine3.15-amd64, 6.0-alpine3.15-amd64, 6.0.400-1-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/amd64/Dockerfile) | Alpine 3.15
+6.0.400-1-jammy-amd64, 6.0-jammy-amd64, 6.0.400-1-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
+6.0.400-1-focal-amd64, 6.0-focal-amd64, 6.0.400-1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.422-bullseye, 3.1-bullseye | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bullseye/amd64/Dockerfile) | Debian 11
 3.1.422-buster, 3.1-buster, 3.1.422, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/buster/amd64/Dockerfile) | Debian 10
 3.1.422-alpine3.16, 3.1-alpine3.16, 3.1-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/alpine3.16/amd64/Dockerfile) | Alpine 3.16
@@ -83,11 +83,11 @@ Tags | Dockerfile | OS Version
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-6.0.400-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.400-bullseye-slim, 6.0-bullseye-slim, 6.0.400, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-6.0.400-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.400-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
-6.0.400-alpine3.15-arm64v8, 6.0-alpine3.15-arm64v8, 6.0.400-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile) | Alpine 3.15
-6.0.400-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.400-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
-6.0.400-focal-arm64v8, 6.0-focal-arm64v8, 6.0.400-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
+6.0.400-1-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.400-1-bullseye-slim, 6.0-bullseye-slim, 6.0.400-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
+6.0.400-1-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.400-1-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
+6.0.400-1-alpine3.15-arm64v8, 6.0-alpine3.15-arm64v8, 6.0.400-1-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile) | Alpine 3.15
+6.0.400-1-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.400-1-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
+6.0.400-1-focal-arm64v8, 6.0-focal-arm64v8, 6.0.400-1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.422-bullseye-arm64v8, 3.1-bullseye-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bullseye/arm64v8/Dockerfile) | Debian 11
 3.1.422-buster-arm64v8, 3.1-buster-arm64v8, 3.1.422, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/buster/arm64v8/Dockerfile) | Debian 10
 3.1.422-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
@@ -103,11 +103,11 @@ Tags | Dockerfile | OS Version
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-6.0.400-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.400-bullseye-slim, 6.0-bullseye-slim, 6.0.400, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-6.0.400-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.400-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
-6.0.400-alpine3.15-arm32v7, 6.0-alpine3.15-arm32v7, 6.0.400-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile) | Alpine 3.15
-6.0.400-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.400-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
-6.0.400-focal-arm32v7, 6.0-focal-arm32v7, 6.0.400-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
+6.0.400-1-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.400-1-bullseye-slim, 6.0-bullseye-slim, 6.0.400-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
+6.0.400-1-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.400-1-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
+6.0.400-1-alpine3.15-arm32v7, 6.0-alpine3.15-arm32v7, 6.0.400-1-alpine3.15, 6.0-alpine3.15 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile) | Alpine 3.15
+6.0.400-1-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.400-1-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
+6.0.400-1-focal-arm32v7, 6.0-focal-arm32v7, 6.0.400-1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 3.1.422-bullseye-arm32v7, 3.1-bullseye-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bullseye/arm32v7/Dockerfile) | Debian 11
 3.1.422-buster-arm32v7, 3.1-buster-arm32v7, 3.1.422, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/buster/arm32v7/Dockerfile) | Debian 10
 3.1.422-focal-arm32v7, 3.1-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/focal/arm32v7/Dockerfile) | Ubuntu 20.04
@@ -123,7 +123,7 @@ Tags | Dockerfile | OS Version
 ## Nano Server 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.400-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6.0.400, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile)
+6.0.400-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6.0.400-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile)
 3.1.422-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, 3.1.422, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile)
 
 ##### .NET 7 Preview Tags
@@ -144,7 +144,7 @@ Tag | Dockerfile
 ## Nano Server, version 1809 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.400-nanoserver-1809, 6.0-nanoserver-1809, 6.0.400, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile)
+6.0.400-nanoserver-1809, 6.0-nanoserver-1809, 6.0.400-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile)
 3.1.422-nanoserver-1809, 3.1-nanoserver-1809, 3.1.422, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile)
 
 ##### .NET 7 Preview Tags

--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -7,7 +7,7 @@
     set targetFrameworkMonikerRegex to cat("net", dotnetMajor, "[.]0") ^
     set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
     set sdkDistro to when(isDistrolessMariner, cat("cbl-mariner", OS_VERSION_NUMBER), OS_VERSION) ^
-    set installerBaseTag to cat(VARIABLES[cat("sdk|", dotnetMajorMinor, "|product-version")], "-", sdkDistro, ARCH_TAG_SUFFIX) ^
+    set installerBaseTag to cat(VARIABLES[cat("sdk|", dotnetMajorMinor, "|product-version")], when(dotnetMajor = "6", "-1", ""), "-", sdkDistro, ARCH_TAG_SUFFIX) ^
     set monitorMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
     set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^

--- a/eng/dockerfile-templates/sdk/Dockerfile.envs
+++ b/eng/dockerfile-templates/sdk/Dockerfile.envs
@@ -13,9 +13,7 @@
     # Do not generate certificate
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false {{lineContinuation}}{{if dotnetVersion != "3.1":
     # Do not show first run text
-    DOTNET_NOLOGO=true {{lineContinuation}}}}{{if !isWindows && dotnetVersion = "6.0":
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true {{lineContinuation}}}}{{if dotnetVersion != "3.1":
+    DOTNET_NOLOGO=true {{lineContinuation}}}}{{if dotnetVersion != "3.1":
     # SDK version
     DOTNET_SDK_VERSION={{VARIABLES[cat("sdk|", dotnetVersion, "|build-version")]}} {{lineContinuation}}}}{{if isAlpine:
     # Disable the invariant mode (set in base image)

--- a/manifest.json
+++ b/manifest.json
@@ -4769,7 +4769,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)": {},
+            "$(sdk|6.0|product-version)-1": {},
             "6.0": {}
           },
           "platforms": [
@@ -4782,7 +4782,7 @@
               "os": "linux",
               "osVersion": "bullseye-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-bullseye-slim-amd64": {},
+                "$(sdk|6.0|product-version)-1-bullseye-slim-amd64": {},
                 "6.0-bullseye-slim-amd64": {}
               }
             },
@@ -4796,7 +4796,7 @@
               "os": "linux",
               "osVersion": "bullseye-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-bullseye-slim-arm32v7": {},
+                "$(sdk|6.0|product-version)-1-bullseye-slim-arm32v7": {},
                 "6.0-bullseye-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -4811,7 +4811,7 @@
               "os": "linux",
               "osVersion": "bullseye-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-bullseye-slim-arm64v8": {},
+                "$(sdk|6.0|product-version)-1-bullseye-slim-arm64v8": {},
                 "6.0-bullseye-slim-arm64v8": {}
               },
               "variant": "v8"
@@ -4848,7 +4848,7 @@
           "id": "bullseye-slim",
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-bullseye-slim": {},
+            "$(sdk|6.0|product-version)-1-bullseye-slim": {},
             "6.0-bullseye-slim": {}
           },
           "platforms": [
@@ -4891,7 +4891,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-alpine3.15": {},
+            "$(sdk|6.0|product-version)-1-alpine3.15": {},
             "6.0-alpine3.15": {}
           },
           "platforms": [
@@ -4904,7 +4904,7 @@
               "os": "linux",
               "osVersion": "alpine3.15",
               "tags": {
-                "$(sdk|6.0|product-version)-alpine3.15-amd64": {},
+                "$(sdk|6.0|product-version)-1-alpine3.15-amd64": {},
                 "6.0-alpine3.15-amd64": {}
               }
             },
@@ -4918,7 +4918,7 @@
               "os": "linux",
               "osVersion": "alpine3.15",
               "tags": {
-                "$(sdk|6.0|product-version)-alpine3.15-arm32v7": {},
+                "$(sdk|6.0|product-version)-1-alpine3.15-arm32v7": {},
                 "6.0-alpine3.15-arm32v7": {}
               },
               "variant": "v7"
@@ -4933,7 +4933,7 @@
               "os": "linux",
               "osVersion": "alpine3.15",
               "tags": {
-                "$(sdk|6.0|product-version)-alpine3.15-arm64v8": {},
+                "$(sdk|6.0|product-version)-1-alpine3.15-arm64v8": {},
                 "6.0-alpine3.15-arm64v8": {}
               },
               "variant": "v8"
@@ -4943,7 +4943,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-alpine3.16": {},
+            "$(sdk|6.0|product-version)-1-alpine3.16": {},
             "6.0-alpine3.16": {},
             "6.0-alpine": {}
           },
@@ -4957,7 +4957,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|6.0|product-version)-alpine3.16-amd64": {},
+                "$(sdk|6.0|product-version)-1-alpine3.16-amd64": {},
                 "6.0-alpine3.16-amd64": {},
                 "6.0-alpine-amd64": {}
               }
@@ -4972,7 +4972,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|6.0|product-version)-alpine3.16-arm32v7": {},
+                "$(sdk|6.0|product-version)-1-alpine3.16-arm32v7": {},
                 "6.0-alpine3.16-arm32v7": {},
                 "6.0-alpine-arm32v7": {}
               },
@@ -4988,7 +4988,7 @@
               "os": "linux",
               "osVersion": "alpine3.16",
               "tags": {
-                "$(sdk|6.0|product-version)-alpine3.16-arm64v8": {},
+                "$(sdk|6.0|product-version)-1-alpine3.16-arm64v8": {},
                 "6.0-alpine3.16-arm64v8": {},
                 "6.0-alpine-arm64v8": {}
               },
@@ -4999,7 +4999,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-focal": {},
+            "$(sdk|6.0|product-version)-1-focal": {},
             "6.0-focal": {}
           },
           "platforms": [
@@ -5012,7 +5012,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(sdk|6.0|product-version)-focal-amd64": {},
+                "$(sdk|6.0|product-version)-1-focal-amd64": {},
                 "6.0-focal-amd64": {}
               }
             },
@@ -5026,7 +5026,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(sdk|6.0|product-version)-focal-arm32v7": {},
+                "$(sdk|6.0|product-version)-1-focal-arm32v7": {},
                 "6.0-focal-arm32v7": {}
               },
               "variant": "v7"
@@ -5041,7 +5041,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(sdk|6.0|product-version)-focal-arm64v8": {},
+                "$(sdk|6.0|product-version)-1-focal-arm64v8": {},
                 "6.0-focal-arm64v8": {}
               },
               "variant": "v8"
@@ -5051,7 +5051,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-jammy": {},
+            "$(sdk|6.0|product-version)-1-jammy": {},
             "6.0-jammy": {}
           },
           "platforms": [
@@ -5064,7 +5064,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|6.0|product-version)-jammy-amd64": {},
+                "$(sdk|6.0|product-version)-1-jammy-amd64": {},
                 "6.0-jammy-amd64": {}
               }
             },
@@ -5078,7 +5078,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|6.0|product-version)-jammy-arm32v7": {},
+                "$(sdk|6.0|product-version)-1-jammy-arm32v7": {},
                 "6.0-jammy-arm32v7": {}
               },
               "variant": "v7"
@@ -5093,7 +5093,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|6.0|product-version)-jammy-arm64v8": {},
+                "$(sdk|6.0|product-version)-1-jammy-arm64v8": {},
                 "6.0-jammy-arm64v8": {}
               },
               "variant": "v8"
@@ -5103,7 +5103,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-cbl-mariner1.0": {
+            "$(sdk|6.0|product-version)-1-cbl-mariner1.0": {
               "docType": "Undocumented"
             },
             "6.0-cbl-mariner1.0": {
@@ -5120,7 +5120,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "$(sdk|6.0|product-version)-cbl-mariner1.0-amd64": {
+                "$(sdk|6.0|product-version)-1-cbl-mariner1.0-amd64": {
                   "docType": "Undocumented"
                 },
                 "6.0-cbl-mariner1.0-amd64": {
@@ -5133,7 +5133,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-cbl-mariner2.0": {
+            "$(sdk|6.0|product-version)-1-cbl-mariner2.0": {
               "docType": "Undocumented"
             },
             "6.0-cbl-mariner2.0": {
@@ -5153,7 +5153,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "$(sdk|6.0|product-version)-cbl-mariner2.0-amd64": {
+                "$(sdk|6.0|product-version)-1-cbl-mariner2.0-amd64": {
                   "docType": "Undocumented"
                 },
                 "6.0-cbl-mariner2.0-amd64": {
@@ -5174,7 +5174,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "$(sdk|6.0|product-version)-cbl-mariner2.0-arm64v8": {
+                "$(sdk|6.0|product-version)-1-cbl-mariner2.0-arm64v8": {
                   "docType": "Undocumented"
                 },
                 "6.0-cbl-mariner2.0-arm64v8": {

--- a/src/monitor/6.1/alpine/amd64/Dockerfile
+++ b/src/monitor/6.1/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-alpine3.16-amd64 AS installer
+FROM $SDK_REPO:6.0.400-1-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.1.4

--- a/src/monitor/6.1/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.1/cbl-mariner/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-cbl-mariner2.0-amd64 AS installer
+FROM $SDK_REPO:6.0.400-1-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.1.4

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-alpine3.16-amd64 AS installer
+FROM $SDK_REPO:6.0.400-1-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-alpine3.16-arm64v8 AS installer
+FROM $SDK_REPO:6.0.400-1-alpine3.16-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-cbl-mariner2.0-amd64 AS installer
+FROM $SDK_REPO:6.0.400-1-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-cbl-mariner2.0-arm64v8 AS installer
+FROM $SDK_REPO:6.0.400-1-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-cbl-mariner2.0-amd64 AS installer
+FROM $SDK_REPO:6.0.400-1-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
 # Installer image
-FROM $SDK_REPO:6.0.400-cbl-mariner2.0-arm64v8 AS installer
+FROM $SDK_REPO:6.0.400-1-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.2.2

--- a/src/sdk/6.0/alpine3.15/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/amd64/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm32v7/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.15/arm64v8/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.16/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.16/amd64/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Disable the invariant mode (set in base image)

--- a/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
+++ b/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner1.0/amd64/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/focal/amd64/Dockerfile
+++ b/src/sdk/6.0/focal/amd64/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/focal/arm32v7/Dockerfile
+++ b/src/sdk/6.0/focal/arm32v7/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/focal/arm64v8/Dockerfile
+++ b/src/sdk/6.0/focal/arm64v8/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/jammy/amd64/Dockerfile
+++ b/src/sdk/6.0/jammy/amd64/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/6.0/jammy/arm32v7/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/src/sdk/6.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/6.0/jammy/arm64v8/Dockerfile
@@ -8,8 +8,6 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # Do not show first run text
     DOTNET_NOLOGO=true \
-    # Enable validation for signed NuGet packages
-    DOTNET_NUGET_SIGNATURE_VERIFICATION=true \
     # SDK version
     DOTNET_SDK_VERSION=6.0.400 \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -89,11 +89,6 @@ namespace Microsoft.DotNet.Docker.Tests
                 variables.Add(RuntimeImageTests.GetRuntimeVersionVariableInfo(imageData, DockerHelper));
             }
 
-            if (imageData.Version.Major == 6 && DockerHelper.IsLinuxContainerModeEnabled)
-            {
-                variables.Add(new EnvironmentVariableInfo("DOTNET_NUGET_SIGNATURE_VERIFICATION", "true"));
-            }
-
             if (imageData.Version.Major >= 6)
             {
                 variables.Add(new EnvironmentVariableInfo("DOTNET_NOLOGO", "true"));


### PR DESCRIPTION
Due to [unexpected issues with NuGet signature validation](https://github.com/NuGet/Home/issues/12017), we're going to roll back the [change to enable this by default in the .NET 6 `sdk` images](https://github.com/dotnet/dotnet-docker/pull/3974). This will allow the `sdk` images to have the same behavior as a default installation of the .NET SDK wrt to NuGet signature validation.