### PR TITLE
Remove platform check workaround for Ubuntu Arm64

### DIFF
--- a/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
+++ b/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
@@ -2,10 +2,7 @@ steps:
 - powershell: |
     $imageBuilderBuildArgs = $env:IMAGEBUILDERBUILDARGS
     # Disable platform checks for CBL-Mariner on ARM64 due to https://github.com/dotnet/dotnet-docker/issues/3520
-    # Similar issue with Ubuntu images in ACR missing the arch variant metadata
-    $isUbuntu = "$(osVersions)".Contains("bionic") -or "$(osVersions)".Contains("focal") -or "$(osVersions)".Contains("jammy")
-    if (("$(osVersions)".Contains("cbl-mariner") -and "$(architecture)" -eq "arm64") -or
-        ($isUbuntu -and "$(architecture)".Contains("arm"))) {
+    if ("$(osVersions)".Contains("cbl-mariner") -and "$(architecture)" -eq "arm64") {
       $imageBuilderBuildArgs += " --skip-platform-check"
     }
 


### PR DESCRIPTION
This removes the platform check workaround that was added for Ubuntu's Arm64 images as part of https://github.com/dotnet/dotnet-docker/pull/3971. Those images had `docker inspect` metadata that didn't have the architecture variant set. Since ImageBuilder has a validation check to ensure the image meets our architecture expectations, the workaround was needed at that time. The images now have that metadata correctly populated which removes the need for this workaround.