### PR TITLE
Add pipeline to run builds for internal PRs

### DIFF
--- a/eng/pipelines/dotnet-core-internal-pr.yml
+++ b/eng/pipelines/dotnet-core-internal-pr.yml
@@ -1,0 +1,22 @@
+trigger: none
+# This pipeline is intended to be run for internal PRs only in AzDO.
+# Configuring the pipeline to run for PRs in AzDO is not supported from the YAML but instead
+# is configured through the build validation policy for the appropriate branch.
+# https://docs.microsoft.com/azure/devops/pipelines/troubleshooting/troubleshooting?view=azure-devops#pull-request-triggers-not-supported-with-azure-repos
+pr: none
+
+resources:
+  repositories:
+  - repository: InternalVersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+
+stages:
+- template: stages/build-test-publish-repo.yml
+  parameters:
+    internalProjectName: ${{ variables.internalProjectName }}
+    publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -12,10 +12,10 @@ stages:
     noCache: ${{ parameters.noCache }}
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
-    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+    ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), and(eq(variables['System.TeamProject'], parameters.internalProjectName), eq(variables['Build.Reason'], 'PullRequest'))) }}:
       buildMatrixType: platformVersionedOs
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies
-    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+    ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
     testMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
 


### PR DESCRIPTION
Due to the changes in https://github.com/dotnet/dotnet-docker/pull/3910, we now have the ability to create internal AzDO PRs that target internal builds of .NET. But we need to be able to run a build for that PR to validate the changes.

These changes add the pipeline that will be configured to run for any PR that targets the internal/release/nightly branch.

Related to https://github.com/dotnet/docker-tools/pull/1044 and https://github.com/dotnet/dotnet-docker/issues/2152.