### PR TITLE
Refactor runtime-deps Dockerfile template

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -3,13 +3,9 @@
     set isAlpine to find(OS_ARCH_HYPHENATED, "Alpine") >= 0 ^
     set isDebian to find(OS_ARCH_HYPHENATED, "Debian") >= 0 ^
     set isUbuntu to find(OS_ARCH_HYPHENATED, "Ubuntu") >= 0 ^
-    set isFullMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
-    set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
-    set isMariner to isFullMariner || isDistrolessMariner ^
+    set isMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
-    set distrolessStagingDir to "/staging" ^
-    set marinerRepo to "mcr.microsoft.com/cbl-mariner" ^
     set baseImageRepo to when(isAlpine,
         cat(ARCH_VERSIONED, "/alpine"),
         when(isDebian,
@@ -17,15 +13,15 @@
             when(isUbuntu,
                 cat(ARCH_VERSIONED, "/ubuntu"),
                 when(isMariner,
-                    cat(marinerRepo, "/base/core"),
+                    "mcr.microsoft.com/cbl-mariner/base/core",
                     "<NOT-IMPLEMENTED>")))) ^
     set baseImageTag to when(isAlpine || isMariner, OS_VERSION_NUMBER, OS_VERSION) ^
-    set isSingleStage to !isDistrolessMariner && !(isFullMariner && isInternal) ^
+    set isSingleStage to !(isMariner && isInternal) ^
     set urlSuffix to when(isInternal, "$SAS_QUERY_STRING", "") ^
     set rpmFilename to "dotnet-runtime-deps.rpm"
 }}{{
     if !isSingleStage:# Installer image
-}}FROM {{baseImageRepo}}:{{baseImageTag}}{{if !isSingleStage: AS installer}}{{ if isInternal && isFullMariner:
+}}FROM {{baseImageRepo}}:{{baseImageTag}}{{if !isSingleStage: AS installer}}{{ if isInternal && isMariner:
 
 ARG SAS_QUERY_STRING
 
@@ -35,41 +31,10 @@ RUN {{InsertTemplate("Dockerfile.download-runtime-deps-pkg",
         "filename": rpmFilename,
         "is-internal": isInternal
     ], "    ")}}}}
-{{ if isDistrolessMariner && find(OS_VERSION, "1.0") >= 0:
-RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
-    [
-        "pkgs": ["dnf"]
-    ])}}
+{{if isMariner && isInternal:FROM {{baseImageRepo}}:{{baseImageTag}}
 }}
-{{if isDistrolessMariner:# Install .NET's dependencies into a staging location
-^elif isMariner && isInternal:FROM {{baseImageRepo}}:{{baseImageTag}}
-
-}}RUN {{if isDistrolessMariner:mkdir {{distrolessStagingDir}} \
-    && }}{{InsertTemplate("../Dockerfile.linux.install-deps", ["distroless-staging-dir": distrolessStagingDir])}}
-{{ if isDistrolessMariner:
-# Create a non-root user and group
-RUN {{if find(OS_VERSION, "1.0") < 0:tdnf install -y shadow-utils \
-    && tdnf clean all \
-    && }}{{InsertTemplate("Dockerfile.linux.distroless-user", [], "    ")}} \
-    # Copy user/group info to staging
-    && cp /etc/passwd {{distrolessStagingDir}}/etc/passwd \
-    && cp /etc/group {{distrolessStagingDir}}/etc/group
-
-# Clean up staging
-RUN rm -rf {{distrolessStagingDir}}/etc/{{when(find(OS_VERSION, "1.0") >= 0, "dnf", "tdnf")}} \
-    && rm -rf {{distrolessStagingDir}}/run/* \
-    && rm -rf {{distrolessStagingDir}}/var/cache/{{when(find(OS_VERSION, "1.0") >= 0, "dnf", "tdnf")}} \
-    && rm -rf {{distrolessStagingDir}}/var/lib/rpm \
-    && rm -rf {{distrolessStagingDir}}/usr/share/doc \
-    && rm -rf {{distrolessStagingDir}}/usr/share/man \
-    && find {{distrolessStagingDir}}/var/log -type f -size +0 -delete
-
-
-# .NET runtime-deps image
-FROM {{marinerRepo}}/distroless/minimal:{{OS_VERSION_NUMBER}}
-
-COPY --from=installer {{distrolessStagingDir}}/ /
-^elif isFullMariner:
+RUN {{InsertTemplate("../Dockerfile.linux.install-deps")}}
+{{ if isMariner:
 {{if isInternal:{{InsertTemplate("../Dockerfile.linux.copy-files",
 [
     "files": [
@@ -87,7 +52,4 @@ COPY --from=installer {{distrolessStagingDir}}/ /
         "filename": rpmFilename
     ])}}
 }}
-{{InsertTemplate("../Dockerfile.common-dotnet-envs") ^
-if isDistrolessMariner:
-
-USER app}}
+{{InsertTemplate("../Dockerfile.common-dotnet-envs")}}

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
@@ -1,0 +1,42 @@
+{{
+    set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
+    set distrolessStagingDir to "/staging" ^
+    set marinerRepo to "mcr.microsoft.com/cbl-mariner"
+}}# Installer image
+FROM {{marinerRepo}}/base/core:{{OS_VERSION_NUMBER}} AS installer
+{{ if find(OS_VERSION, "1.0") >= 0:
+RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
+    [
+        "pkgs": ["dnf"]
+    ])}}
+}}
+# Install .NET's dependencies into a staging location
+RUN mkdir {{distrolessStagingDir}} \
+    && {{InsertTemplate("../Dockerfile.linux.install-deps", ["distroless-staging-dir": distrolessStagingDir])}}
+{{ if isDistrolessMariner:
+# Create a non-root user and group
+RUN {{if find(OS_VERSION, "1.0") < 0:tdnf install -y shadow-utils \
+    && tdnf clean all \
+    && }}{{InsertTemplate("Dockerfile.linux.distroless-user", [], "    ")}} \
+    # Copy user/group info to staging
+    && cp /etc/passwd {{distrolessStagingDir}}/etc/passwd \
+    && cp /etc/group {{distrolessStagingDir}}/etc/group
+
+# Clean up staging
+RUN rm -rf {{distrolessStagingDir}}/etc/{{when(find(OS_VERSION, "1.0") >= 0, "dnf", "tdnf")}} \
+    && rm -rf {{distrolessStagingDir}}/run/* \
+    && rm -rf {{distrolessStagingDir}}/var/cache/{{when(find(OS_VERSION, "1.0") >= 0, "dnf", "tdnf")}} \
+    && rm -rf {{distrolessStagingDir}}/var/lib/rpm \
+    && rm -rf {{distrolessStagingDir}}/usr/share/doc \
+    && rm -rf {{distrolessStagingDir}}/usr/share/man \
+    && find {{distrolessStagingDir}}/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM {{marinerRepo}}/distroless/minimal:{{OS_VERSION_NUMBER}}
+
+COPY --from=installer {{distrolessStagingDir}}/ /}}
+
+{{InsertTemplate("../Dockerfile.common-dotnet-envs")}}
+
+USER app

--- a/manifest.json
+++ b/manifest.json
@@ -758,7 +758,7 @@
           "platforms": [
             {
               "dockerfile": "src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner",
               "os": "linux",
               "osVersion": "cbl-mariner1.0-distroless",
               "tags": {
@@ -797,7 +797,7 @@
           "platforms": [
             {
               "dockerfile": "src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
@@ -824,7 +824,7 @@
             {
               "architecture": "arm64",
               "dockerfile": "src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
@@ -1104,7 +1104,7 @@
           "platforms": [
             {
               "dockerfile": "src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
@@ -1131,7 +1131,7 @@
             {
               "architecture": "arm64",
               "dockerfile": "src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {


### PR DESCRIPTION
The runtime-deps Dockerfile template is pretty complex and hard for a human to parse. This is mainly due to the fact that it has logic used to generate distroless Mariner Dockerfiles in addition to the usual distroful Dockerfiles. Because distroless Mariner Dockerfiles are so different from the others, it causes a lot of extra stuff in the template to wade through.

As part of the implementation for [Chiseled Ubuntu](https://github.com/dotnet/dotnet-docker/pull/3996), those runtime-deps Dockerfiles had the same issue, being markedly different than all the other runtime-deps Dockerfiles. Because of that, a separate runtime-deps template was defined specifically for Chiseled Ubuntu. This kept all that content specific to Chiseled Ubuntu isolated from everything else.

These changes follow that same pattern that was used for Chiseled Ubuntu and applies it to distroless Mariner. A separate Dockerfile template for distroless Mariner is added. All the content specific to distroless Mariner is pulled out of the default runtime-deps template and placed in this new template file. This cleans things up a lot, making it much easier to read all the runtime-deps templates.