### PR TITLE
Set custom test variables in build job

### DIFF
--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -43,44 +43,12 @@ stages:
         }
         echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
       displayName: Set Custom Build Variables
-    - powershell: |
-        # Forward team project name for consumption by test script
-        $testRunnerOptions="-e SYSTEM_TEAMPROJECT='$env:SYSTEM_TEAMPROJECT'"
-
-        echo "##vso[task.setvariable variable=testRunner.options]$testRunnerOptions"
-      displayName: Set Custom Test Variables
+    - template: ../../../pipelines/steps/set-custom-test-variables.yml
     - template: ../../../pipelines/steps/set-base-image-override-options.yml
       parameters:
         variableName: imageBuilderBuildArgs
     customTestInitSteps:
-    - powershell: |
-        # Forward team project name for consumption by test script
-        $testRunnerOptions="-e SYSTEM_TEAMPROJECT='$env:SYSTEM_TEAMPROJECT'"
-        $testInit=""
-
-        if ("$(publishRepoPrefix)".Contains("/internal/")) {
-          if ("$env:ENABLEINTERNAL3_1" -eq "true") {
-            $sasQueryString = "$(dotnetclimsrc-read-sas-token)"
-          }
-          else {
-            $sasQueryString = "$(dotnetbuilds-internal-container-read-token)"
-          }
-
-          if ($Env:AGENT_OS -eq 'Linux') {
-            $testRunnerOptions="$testRunnerOptions -e SAS_QUERY_STRING='$sasQueryString' -e NUGET_FEED_PASSWORD='$(dn-bot-dnceng-artifact-feeds-rw)'"
-          }
-
-          if ($Env:AGENT_OS -eq 'Windows_NT') {
-              # Be sure to use a verbatim string when referencing the environment variables. We don't want the
-              # variables to be resolved in this script. We're generating the script here to be executed by the
-              # test step.
-              $testInit='$Env:SAS_QUERY_STRING=' + "'$sasQueryString'" + '; $Env:NUGET_FEED_PASSWORD=''$(dn-bot-dnceng-artifact-feeds-rw)'''
-          }
-        }
-        
-        echo "##vso[task.setvariable variable=testRunner.options]$testRunnerOptions"
-        echo "##vso[task.setvariable variable=test.init]$testInit"
-      displayName: Set Custom Test Variables
+    - template: ../../../pipelines/steps/set-custom-test-variables.yml
     customPublishInitSteps:
     - template: ../../../pipelines/steps/set-public-source-branch-var.yml
     - template: ../../../pipelines/steps/set-publish-mcrdocs-args-var.yml

--- a/eng/pipelines/steps/set-custom-test-variables.yml
+++ b/eng/pipelines/steps/set-custom-test-variables.yml
@@ -1,0 +1,29 @@
+steps:
+- powershell: |
+    # Forward team project name for consumption by test script
+    $testRunnerOptions="-e SYSTEM_TEAMPROJECT='$env:SYSTEM_TEAMPROJECT'"
+    $testInit=""
+
+    if ("$(publishRepoPrefix)".Contains("/internal/")) {
+      if ("$env:ENABLEINTERNAL3_1" -eq "true") {
+        $sasQueryString = "$(dotnetclimsrc-read-sas-token)"
+      }
+      else {
+        $sasQueryString = "$(dotnetbuilds-internal-container-read-token)"
+      }
+
+      if ($Env:AGENT_OS -eq 'Linux') {
+        $testRunnerOptions="$testRunnerOptions -e SAS_QUERY_STRING='$sasQueryString' -e NUGET_FEED_PASSWORD='$(dn-bot-dnceng-artifact-feeds-rw)'"
+      }
+
+      if ($Env:AGENT_OS -eq 'Windows_NT') {
+          # Be sure to use a verbatim string when referencing the environment variables. We don't want the
+          # variables to be resolved in this script. We're generating the script here to be executed by the
+          # test step.
+          $testInit='$Env:SAS_QUERY_STRING=' + "'$sasQueryString'" + '; $Env:NUGET_FEED_PASSWORD=''$(dn-bot-dnceng-artifact-feeds-rw)'''
+      }
+    }
+    
+    echo "##vso[task.setvariable variable=testRunner.options]$testRunnerOptions"
+    echo "##vso[task.setvariable variable=test.init]$testInit"
+  displayName: Set Custom Test Variables


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/pull/4016

Internal PR builds fail when attempting to run tests. The call to invoke the tests is not configured with the secrets to access blob storage and NuGet feed. This is because the tests are run in the build stage. The pipeline was configured in a way that these secrets are only set in the test stage.

I've updated this to factor things out for setting custom test variables such that it is shared by both the build and test stage.