### PR TITLE
Enable .NET Monitor distroless image scenario testing

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -242,14 +242,24 @@ namespace Microsoft.DotNet.Docker.Tests
                 $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg} {optionalRunArgs} {image} {command}");
         }
 
+        /// <summary>
+        /// Creates a file system volume that is backed by memory instead of disk.
+        /// </summary>
         public string CreateTmpfsVolume(string name, bool ownedByDistrolessUser = false)
         {
+            // Create volume using the local driver (the default driver),
+            // which accepts options similar to the 'mount' command.
+            //
+            // Additional options are specified to:
+            // - make this volume an in-memory file system with a unique device name (type=tmpfs, device={guid}}).
+            // - to set the owner of the root of the file system (o=uid=101).
             string optionalArgs = string.Empty;
             if (ownedByDistrolessUser)
             {
                 optionalArgs += " --opt o=uid=101";
             }
-            return ExecuteWithLogging($"volume create --driver local --opt type=tmpfs --opt device=tmpfs{optionalArgs} {name}");
+            string device = Guid.NewGuid().ToString("D");
+            return ExecuteWithLogging($"volume create --opt type=tmpfs --opt device={device}{optionalArgs} {name}");
         }
 
         public string DeleteVolume(string name)

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -242,9 +242,14 @@ namespace Microsoft.DotNet.Docker.Tests
                 $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg} {optionalRunArgs} {image} {command}");
         }
 
-        public string CreateVolume(string name)
+        public string CreateTmpfsVolume(string name, bool ownedByDistrolessUser = false)
         {
-            return ExecuteWithLogging($"volume create {name}");
+            string optionalArgs = string.Empty;
+            if (ownedByDistrolessUser)
+            {
+                optionalArgs += " --opt o=uid=101";
+            }
+            return ExecuteWithLogging($"volume create --driver local --opt type=tmpfs --opt device=tmpfs{optionalArgs} {name}");
         }
 
         public string DeleteVolume(string name)

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Docker.Tests
         /// Gets each dotnet-monitor image paired with each sample aspnetcore image of the same architecture.
         /// Allows for testing volume mounts and diagnostic port usage among different distros.
         /// </summary>
-        public static IEnumerable<object[]> GetScenarioData()
+        private static IEnumerable<object[]> GetScenarioData(bool isConnectMode)
         {
             IList<object[]> data = new List<object[]>();
             foreach (MonitorImageData monitorImageData in TestData.GetMonitorImageData())
@@ -87,18 +87,38 @@ namespace Microsoft.DotNet.Docker.Tests
                     if (monitorImageData.Arch != sampleImageData.Arch)
                         continue;
 
-                    // Distroless .NET Monitor images must be tested with distroless samples because
-                    // the default user of the .NET Monitor image is a non-root user. If .NET Monitor
-                    // is running as non-root and the sample is running as root, .NET Monitor will fail
-                    // to communicate with the sample application or fail to start up due to lack of
-                    // permissions to create the diagnostic port.
-                    if (monitorImageData.IsDistroless != sampleImageData.IsDistroless)
-                        continue;
+                    if (isConnectMode)
+                    {
+                        // The dotnet-monitor process is only able to connect to the other container process' diagnostic port
+                        // if it is running as the same user or is running as root. If the target application container is
+                        // running as root, then the dotnet-monitor must be running as root, which is not the case for distroless.
+                        if (monitorImageData.IsDistroless && !sampleImageData.IsDistroless)
+                            continue;
+                    }
+                    else
+                    {
+                        // In listen mode, if the dotnet-monitor container is non-distroless, then it has a communication
+                        // pipe that is established as root. This requires that the target application container to be running
+                        // as root in order for it to connect to the pipe. If dotnet-monitor is distroless, then either
+                        // distroless (as long as it is the same user) or non-distroless will be able to communicate with it.
+                        if (!monitorImageData.IsDistroless && sampleImageData.IsDistroless)
+                            continue;
+                    }
 
                     data.Add(new object[] { monitorImageData, sampleImageData });
                 }
             }
             return data;
+        }
+
+        public static IEnumerable<object[]> GetConnectModeScenarioData()
+        {
+            return GetScenarioData(isConnectMode: true);
+        }
+
+        public static IEnumerable<object[]> GetListenModeScenarioData()
+        {
+            return GetScenarioData(isConnectMode: false);
         }
 
         /// <summary>
@@ -276,7 +296,7 @@ namespace Microsoft.DotNet.Docker.Tests
         /// in another container via mounting the /tmp directory.
         /// </summary>
         [LinuxImageTheory]
-        [MemberData(nameof(GetScenarioData))]
+        [MemberData(nameof(GetConnectModeScenarioData))]
         public Task VerifyConnectMode(MonitorImageData imageData, SampleImageData sampleData)
         {
             return VerifyScenarioAsync(
@@ -311,7 +331,7 @@ namespace Microsoft.DotNet.Docker.Tests
         /// in other containers by having them connect to the diagnostic port listener.
         /// </summary>
         [LinuxImageTheory]
-        [MemberData(nameof(GetScenarioData))]
+        [MemberData(nameof(GetListenModeScenarioData))]
         public Task VerifyListenMode(MonitorImageData imageData, SampleImageData sampleData)
         {
             return VerifyScenarioAsync(
@@ -441,10 +461,12 @@ namespace Microsoft.DotNet.Docker.Tests
 
             try
             {
+                bool allowDistrolessUserToUseVolume = monitorImageData.IsDistroless || sampleImageData.IsDistroless;
+
                 // Create a volume for the two containers to share the /tmp directory.
                 if (shareTmpVolume)
                 {
-                    tmpVolumeName = DockerHelper.CreateVolume(UniqueName("tmpvol"));
+                    tmpVolumeName = DockerHelper.CreateTmpfsVolume(UniqueName("tmpvol"), allowDistrolessUserToUseVolume);
 
                     monitorArgsBuilder.VolumeMount(tmpVolumeName, Directory_Tmp);
 
@@ -456,7 +478,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 // process can connect to the dotnet-monitor process.
                 if (listenDiagPortVolume)
                 {
-                    diagPortVolumeName = DockerHelper.CreateVolume(UniqueName("diagportvol"));
+                    diagPortVolumeName = DockerHelper.CreateTmpfsVolume(UniqueName("diagportvol"), allowDistrolessUserToUseVolume);
 
                     monitorArgsBuilder.VolumeMount(diagPortVolumeName, Directory_Diag);
                     monitorArgsBuilder.MonitorListen(File_DiagPort);


### PR DESCRIPTION
Currently, the distroless .NET Monitor image does not participate in the scenario tests because the filtering criteria requires that the .NET Monitor image and the sample image are the same type in terms of distroless vs non-distroless. This is not strictly necessary because non-distroless .NET Monitor can connect to either image type and distroless .NET Monitor can listen for either image type. These changes broaden the test combinations as described to allow distroless images to be mixed with non-distroless images in the scenario tests.