### PR TITLE
Define single user for distroless Mariner in .NET 7

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -13,10 +13,13 @@ FROM {{ARCH_VERSIONED}}/ubuntu:{{osVersionBase}} as builder
 RUN apt-get update && \
     apt-get install -y ca-certificates
 
-RUN {{InsertTemplate("Dockerfile.linux.distroless-user", [], "    ")}} \
-    && mkdir -p "/rootfs/etc" \
-    && tail -1 < /etc/passwd > "/rootfs/etc/passwd" \
-    && tail -1 < /etc/group > "/rootfs/etc/group"
+RUN {{InsertTemplate("Dockerfile.linux.distroless-user",
+    [
+        "staging-dir": "/rootfs",
+        "exclusive": "true",
+        "create-dir": "true"
+    ],
+    "    ")}}
 
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
 RUN chisel cut --release "ubuntu-{{osVersionNumber}}" --root /rootfs \

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
@@ -1,7 +1,8 @@
 {{
     set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
     set distrolessStagingDir to "/staging" ^
-    set marinerRepo to "mcr.microsoft.com/cbl-mariner"
+    set marinerRepo to "mcr.microsoft.com/cbl-mariner" ^
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".")
 }}# Installer image
 FROM {{marinerRepo}}/base/core:{{OS_VERSION_NUMBER}} AS installer
 {{ if find(OS_VERSION, "1.0") >= 0:
@@ -17,10 +18,12 @@ RUN mkdir {{distrolessStagingDir}} \
 # Create a non-root user and group
 RUN {{if find(OS_VERSION, "1.0") < 0:tdnf install -y shadow-utils \
     && tdnf clean all \
-    && }}{{InsertTemplate("Dockerfile.linux.distroless-user", [], "    ")}} \
-    # Copy user/group info to staging
-    && cp /etc/passwd {{distrolessStagingDir}}/etc/passwd \
-    && cp /etc/group {{distrolessStagingDir}}/etc/group
+    && }}{{InsertTemplate("Dockerfile.linux.distroless-user",
+        [
+            "staging-dir": distrolessStagingDir
+            "exclusive": dotnetVersion != "6.0"
+        ],
+        "    ")}}
 
 # Clean up staging
 RUN rm -rf {{distrolessStagingDir}}/etc/{{when(find(OS_VERSION, "1.0") >= 0, "dnf", "tdnf")}} \

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
@@ -1,6 +1,9 @@
 {{
-    _ Configures the app user and group for distroless containers ^
-
+    _ Configures the app user and group for distroless containers
+    _ ARGS:
+        staging-dir: Path to the distroless staging directory
+        create-dir (optional): Indicates whether the etc directory should be created in staging
+        exclusive (optional): Indicates whether the app user is the only user and all other users are removed ^
     set isMariner to find(OS_VERSION, "cbl-mariner") >= 0
 }}groupadd \
     --system \
@@ -12,4 +15,12 @@
     --shell /bin/false \
     --no-create-home \
     --system \
-    app
+    app \{{
+if ARGS["exclusive"]:{{if ARGS["create-dir"]:
+&& mkdir -p "{{ARGS["staging-dir"]}}/etc" \}}
+&& tail -1 < /etc/passwd > "{{ARGS["staging-dir"]}}/etc/passwd" \
+&& tail -1 < /etc/group > "{{ARGS["staging-dir"]}}/etc/group"^
+else:
+# Copy user/group info to staging
+&& cp /etc/passwd {{ARGS["staging-dir"]}}/etc/passwd \
+&& cp /etc/group {{ARGS["staging-dir"]}}/etc/group}}

--- a/manifest.json
+++ b/manifest.json
@@ -1103,7 +1103,7 @@
           },
           "platforms": [
             {
-              "dockerfile": "src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64",
+              "dockerfile": "src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
@@ -1130,7 +1130,7 @@
             },
             {
               "architecture": "arm64",
-              "dockerfile": "src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8",
+              "dockerfile": "src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,0 +1,58 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        krb5 \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        zlib \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN tdnf install -y shadow-utils \
+    && tdnf clean all \
+    && groupadd \
+        --system \
+        --gid=101 \
+        app \
+    && adduser \
+        --uid 101 \
+        --gid 101 \
+        --shell /bin/false \
+        --no-create-home \
+        --system \
+        app \
+    && tail -1 < /etc/passwd > "/staging/etc/passwd" \
+    && tail -1 < /etc/group > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+COPY --from=installer /staging/ /
+
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+USER app

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,0 +1,58 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        krb5 \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        zlib \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN tdnf install -y shadow-utils \
+    && tdnf clean all \
+    && groupadd \
+        --system \
+        --gid=101 \
+        app \
+    && adduser \
+        --uid 101 \
+        --gid 101 \
+        --shell /bin/false \
+        --no-create-home \
+        --system \
+        app \
+    && tail -1 < /etc/passwd > "/staging/etc/passwd" \
+    && tail -1 < /etc/group > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+COPY --from=installer /staging/ /
+
+ENV \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_URLS=http://+:8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+USER app

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -31,7 +31,9 @@
     "src/runtime-deps/6.0/jammy-chiseled/amd64": 12935991,
     "src/runtime-deps/6.0/jammy-chiseled/arm64v8": 10176580,
     "src/runtime-deps/7.0/cbl-mariner2.0/amd64": 107608523,
-    "src/runtime-deps/7.0/cbl-mariner2.0/arm64v8": 101990930
+    "src/runtime-deps/7.0/cbl-mariner2.0/arm64v8": 101990930,
+    "src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64": 25570883,
+    "src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8": 22586819
   },
   "dotnet/nightly/runtime": {
     "src/runtime/3.1/bullseye-slim/amd64": 198162495,


### PR DESCRIPTION
The intention of the distroless containers for Mariner is to have a hardened environment specific for running a .NET application. To achieve this, a non-root user named `app` is defined and configured to be used by default. However, this only adds a user. It doesn't remove the existing users that are already defined. This means you can still run the container as root:

```console
> docker run --rm --user root mcr.microsoft.com/dotnet/runtime:7.0-cbl-mariner2.0-distroless

Host:
  Version:      7.0.0-preview.7.22375.6
  Architecture: x64
  Commit:       eecb028078
...
```

Here is the full set of users in the container as indicated by the contents of the `/etc/passwd` file:

```
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/dev/null:/bin/false
daemon:x:6:6:Daemon User:/dev/null:/bin/false
messagebus:x:18:18:D-Bus Message Daemon User:/var/run/dbus:/bin/false
systemd-bus-proxy:x:72:72:systemd Bus Proxy:/:/bin/false
systemd-journal-gateway:x:73:73:systemd Journal Gateway:/:/bin/false
systemd-journal-remote:x:74:74:systemd Journal Remote:/:/bin/false
systemd-journal-upload:x:75:75:systemd Journal Upload:/:/bin/false
systemd-network:x:76:76:systemd Network Management:/:/bin/false
systemd-resolve:x:77:77:systemd Resolver:/:/bin/false
systemd-timesync:x:78:78:systemd Time Synchronization:/:/bin/false
nobody:x:65534:65533:Unprivileged User:/dev/null:/bin/false
app:x:101:101::/home/app:/bin/false
```

To truly lock down the container, we should remove all users except for `app`. This pattern is already done in the [Chiseled Ubuntu Dockerfile](https://github.com/dotnet/dotnet-docker/blob/3579cf232bb0bd476d2a274bce796085d34907d3/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile#L25-L26):

```console
> docker run --rm --user root mcr.microsoft.com/dotnet/nightly/runtime:7.0-jammy-chiseled
docker: Error response from daemon: unable to find user root: no matching entries in passwd file.
```

Since this is a breaking change, it will only be applied to the .NET 7 Dockerfiles. Since the runtime-deps Dockerfiles were previously shared between .NET 6 and .NET 7, they will now diverge and have separate Dockerfiles.