### PR TITLE
Pipeline for building internal/release/nightly

### DIFF
--- a/eng/pipelines/dotnet-core-internal-nightly.yml
+++ b/eng/pipelines/dotnet-core-internal-nightly.yml
@@ -1,0 +1,50 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - internal/release/nightly
+  paths:
+    include:
+    - manifest.json
+    - manifest.versions.json
+    - src/*
+pr: none
+
+parameters:
+- name: isTest
+  displayName: Is Test Pipeline Run
+  type: boolean
+  default: false
+
+resources:
+  repositories:
+  - repository: InternalVersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: variables/core.yml
+- name: officialBranches
+  # comma-delimited list of branch names
+  value: internal/release/nightly
+- name: ingestKustoImageInfo
+  value: false
+- name: publishReadme
+  value: false
+- ${{ if parameters.isTest }}:
+  - name: publishRepoPrefix
+    value: test/private/internal/
+- ${{ else }}:
+  - name: publishRepoPrefix
+    value: private/internal/
+- name: publishImageInfo
+  value: false
+- name: noCache
+  value: true  
+
+stages:
+- template: stages/build-test-publish-repo.yml
+  parameters:
+    internalProjectName: ${{ variables.internalProjectName }}
+    publicProjectName: ${{ variables.publicProjectName }}


### PR DESCRIPTION
Adds the pipeline that will handle building the `internal/release/nightly` branch to publish internal build of .NET.

It's been hardcoded to prevent the publishing of readmes, Kusto data, and the image info file.

Related to https://github.com/dotnet/dotnet-docker/issues/2152