### PR TITLE
update-dependencies: support multiple internal versions

### DIFF
--- a/eng/update-dependencies/NuGetConfigUpdater.cs
+++ b/eng/update-dependencies/NuGetConfigUpdater.cs
@@ -87,17 +87,17 @@ internal class NuGetConfigUpdater : IDependencyUpdater
         XElement? pkgSourceCreds = configuration.Element("packageSourceCredentials");
         if (_options.IsInternal)
         {
-            pkgSourceCreds?.Remove();
+            pkgSourceCreds = GetOrCreateXObject(
+                pkgSourceCreds,
+                configuration,
+                () => new XElement("packageSourceCredentials"));
 
-            pkgSourceCreds = new XElement("packageSourceCredentials");
-            configuration.Add(pkgSourceCreds);
-
-            XElement pkgSrc = GetOrCreateXObject(
+            XElement pkgSrcCredsEntry = GetOrCreateXObject(
                 pkgSourceCreds.Element(pkgSrcName),
                 pkgSourceCreds,
                 () => new XElement(pkgSrcName));
-            UpdateAddElement(pkgSrc, "Username", "dotnet");
-            UpdateAddElement(pkgSrc, "ClearTextPassword", "%NuGetFeedPassword%");
+            UpdateAddElement(pkgSrcCredsEntry, "Username", "dotnet");
+            UpdateAddElement(pkgSrcCredsEntry, "ClearTextPassword", "%NuGetFeedPassword%");
         }
         else
         {
@@ -114,8 +114,6 @@ internal class NuGetConfigUpdater : IDependencyUpdater
                 pkgSources,
                 configuration,
                 () => new XElement("packageSources"));
-
-            RemoveAllInternalPackageSources(pkgSources);
 
             string project = _options.DockerfileVersion != "3.1" ? "/internal" : string.Empty;
 


### PR DESCRIPTION
The update-dependencies tool doesn't correctly handle updates to the test NuGet.config file when multiple internal versions are being targeted in a branch. It ends up deleting the internal configuration from a previous run.

For example, let's say you've run update-dependencies for an internal build of .NET 6. It will have updated the test [NuGet.config](https://github.com/dotnet/dotnet-docker/blob/main/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config.nightly) file to include package source and credentials named `dotnet6_0_internal`. After committing those changes you then run update-dependencies again, this time targeting an internal build of .NET 7. Doing that will remove the `dotnet6_0_internal` entries and replace them with `dotnet7_0_internal`. This will cause testing to fail for .NET 6 because it won't have access to the internal .NET 6 NuGet feed.

The fix is to simply change the update logic to be additive and not remove existing entries.