### PR TITLE
Update Dockerfiles to not use stable branding for internal previews

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
@@ -23,7 +23,10 @@
         when(ARGS["is-internal"],
             VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")],
             "$ASPNET_VERSION")) ^
-    set aspnetVersionFile to when(ARGS["is-internal"],
+    set isInternalStableBranding to ARGS["is-internal"] &&
+        (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set aspnetVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         aspnetVersionDir) ^
     set fileArch to when(useRpm && ARCH_SHORT = "arm64", "aarch64", ARCH_SHORT) ^

--- a/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.windows.install-aspnet
@@ -12,7 +12,10 @@
     set dotnetDir to when(useProgramFilesDir, "$Env:ProgramFiles\dotnet", "dotnet") ^
     set aspnetCoreZipFile to "aspnetcore.zip" ^
     set aspnetVersion to when(ARGS["use-local-version-var"], "$aspnetcore_version", "$Env:ASPNET_VERSION") ^
-    set aspnetVersionFile to when(ARGS["is-internal"],
+    set isInternalStableBranding to ARGS["is-internal"] &&
+        (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set aspnetVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         aspnetVersion) ^
     set url to cat(

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.download-runtime-deps-pkg
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.download-runtime-deps-pkg
@@ -7,7 +7,10 @@
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set marinerVersionRegexMatch to match(OS_VERSION, "^cbl-mariner(\d+)\.\d+$") ^
     set marinerMajorVersion to marinerVersionRegexMatch[1] ^
-    set runtimeVersionFile to when(ARGS["is-internal"],
+    set isInternalStableBranding to ARGS["is-internal"] &&
+        (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set runtimeVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         "$dotnet_version") ^
     set rpmFileArch to when(ARCH_SHORT = "arm64", "aarch64", ARCH_SHORT)

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
@@ -18,7 +18,10 @@
         when(ARGS["is-internal"],
             VARIABLES[cat("runtime|", dotnetVersion, "|build-version")],
             "$DOTNET_VERSION")) ^
-    set runtimeVersionFile to when(ARGS["is-internal"],
+    set isInternalStableBranding to ARGS["is-internal"] &&
+        (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set runtimeVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         runtimeVersionDir) ^
     set runtimeBaseUrl to cat(

--- a/eng/dockerfile-templates/runtime/Dockerfile.windows.install-runtime
+++ b/eng/dockerfile-templates/runtime/Dockerfile.windows.install-runtime
@@ -14,7 +14,10 @@
         when(ARGS["is-internal"],
             VARIABLES[cat("runtime|", dotnetVersion, "|build-version")],
             "$Env:DOTNET_VERSION")) ^
-    set runtimeVersionFile to when(ARGS["is-internal"],
+    set isInternalStableBranding to ARGS["is-internal"] &&
+        (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set runtimeVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         runtimeVersionDir) ^
     set url to cat(

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
@@ -22,17 +22,20 @@
         when(ARGS["is-internal"],
             VARIABLES[cat("sdk|", dotnetVersion, "|build-version")]
             "$DOTNET_SDK_VERSION")) ^
-    set sdkVersionFile to when(ARGS["is-internal"],
+    set isInternalStableBranding to ARGS["is-internal"] &&
+        (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set sdkVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("sdk|", dotnetVersion, "|product-version")],
         sdkVersionDir) ^
     set runtimeVersionDir to when(ARGS["use-local-version-var"], "$dotnet_version", "$DOTNET_VERSION") ^
-    set runtimeVersionFile to when(ARGS["is-internal"],
+    set runtimeVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         runtimeVersionDir) ^
-    set runtimeTargetingPackVersionFile to when(ARGS["is-internal"],
+    set runtimeTargetingPackVersionFile to when(isInternalStableBranding,
         split(VARIABLES[cat("runtime|", dotnetVersion, "|targeting-pack-version")], "-")[0],
         VARIABLES[cat("runtime|", dotnetVersion, "|targeting-pack-version")]) ^
-    set aspnetTargetingPackVersionFile to when(ARGS["is-internal"],
+    set aspnetTargetingPackVersionFile to when(isInternalStableBranding,
         split(VARIABLES[cat("aspnet|", dotnetVersion, "|targeting-pack-version")], "-")[0],
         VARIABLES[cat("aspnet|", dotnetVersion, "|targeting-pack-version")]) ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.install-sdk
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.install-sdk
@@ -16,7 +16,10 @@
         when(ARGS["is-internal"],
             VARIABLES[cat("sdk|", dotnetVersion, "|build-version")],
             "$Env:DOTNET_SDK_VERSION")) ^
-    set sdkVersionFile to when(ARGS["is-internal"],
+    set isInternalStableBranding to ARGS["is-internal"] &&
+        (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set sdkVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("sdk|", dotnetVersion, "|product-version")],
         sdkVersionDir) ^
     set url to cat(


### PR DESCRIPTION
Generating Dockerfiles for internal preview builds of .NET 7 is generating incorrect URLs for the binary files to be downloaded from blob storage. It's using a stable branding pattern for the filename when it should be use the full build version. For example, it's using `dotnet-runtime-deps-7.0.0-rc.1-cm.2-aarch64.rpm` when it should be using `dotnet-runtime-deps-7.0.0-rc.1.22426.10-cm.2-aarch64.rpm`.

I've updated the Dockerfile templates to account for this by checking the label in the build version. Unfortunately, this needs to be repeated in all the templates.