### PR TITLE
Shutdown build server in multi-stage Windows Dockerfiles

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.install-components
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.install-components
@@ -71,7 +71,7 @@ RUN powershell -Command " `
                 "dotnet-is-internal": ARGS["dotnet-is-internal"]
             ],
             "        ")}}{{
-if !(dotnetVersion = "3.1" || isServerCore): `
+if !(dotnetVersion = "3.1" || isServerCore) || ARGS["dotnet-is-internal"]: `
         `
         # Workaround for https://github.com/dotnet/sdk/issues/18410
         \dotnet\dotnet build-server shutdown;}}{{if !isSingleStage: `

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.install-components
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.install-components
@@ -71,7 +71,7 @@ RUN powershell -Command " `
                 "dotnet-is-internal": ARGS["dotnet-is-internal"]
             ],
             "        ")}}{{
-if !(dotnetVersion = "3.1" || isServerCore) || ARGS["dotnet-is-internal"]: `
+if dotnetVersion != "3.1" && !isSingleStage: `
         `
         # Workaround for https://github.com/dotnet/sdk/issues/18410
         \dotnet\dotnet build-server shutdown;}}{{if !isSingleStage: `


### PR DESCRIPTION
Building an SDK Dockerfile for Windows Server Core that is generated to target internal .NET builds fails because the MSBuild server is running while attempting to remove files to prepare the dotnet directory for copying:

```
Step 5/12 : RUN powershell -Command "         $ErrorActionPreference = 'Stop';         $ProgressPreference = 'SilentlyContinue';                 $sdk_version = '7.0.100-rc.1.22429.3';         Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.blob.core.windows.net/internal/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip$Env:SAS_QUERY_STRING;         $dotnet_sha512 = '8f46d0c6e7c0d04c42592546447fc4b7376ab32ec1227413a73c2835fe79e3fbee5df7a0481690e4bbcd93f0ca1f51b4c1116b034184a2a1ff389ca936777aa5';         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) {             Write-Host 'CHECKSUM VERIFICATION FAILED!';             exit 1;         };         mkdir dotnet;         tar -oxzf dotnet.zip -C dotnet;         Remove-Item -Force dotnet.zip;                 $powershell_version = '7.3.0-preview.7';         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg;         $powershell_sha512 = '8f00356af4d3a70da11af33ed19e025d2e7aa796d75be1b9a23b4ff590d818a1de8bf34da8ad2dd4cb75e90ee07e2ef55d5b68b48ec7ba45a2468aac81f32313';         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) {             Write-Host 'CHECKSUM VERIFICATION FAILED!';             exit 1;         };         & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64;         & \dotnet\dotnet nuget locals all --clear;         Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg;         Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;                 Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet             | Remove-Item -Force -Recurse;         Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared             | Remove-Item -Force -Recurse"
 ---> Running in 78742b092f3d


    Directory: C:\


Mode                LastWriteTime         Length Name                          
----                -------------         ------ ----                          
d-----        8/30/2022   6:19 PM                dotnet                        

Welcome to .NET 7.0!
---------------------
SDK Version: 7.0.100-rc.1.22429.3

----------------
Installed an ASP.NET Core HTTPS development certificate.
To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
Learn about HTTPS: https://aka.ms/dotnet-https
----------------
Write your first app: https://aka.ms/dotnet-hello-world
Find out what's new: https://aka.ms/dotnet-whats-new
Explore documentation: https://aka.ms/dotnet-docs
Report issues and find source on GitHub: https://github.com/dotnet/core
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
--------------------------------------------------------------------------------------
C:\dotnet\sdk\7.0.100-rc.1.22429.3\NuGet.targets(132,5): warning : Access to the path 'C:\Documents and Settings' is denied. [C:\Users\ContainerAdministrator\AppData\Local\Temp\kxwgdmqy.c0v\restore.csproj]
C:\dotnet\sdk\7.0.100-rc.1.22429.3\NuGet.targets(132,5): warning : Access to the path 'C:\WcSandboxState' is denied. [C:\Users\ContainerAdministrator\AppData\Local\Temp\kxwgdmqy.c0v\restore.csproj]
You can invoke the tool using the following command: pwsh
Tool 'powershell.windows.x64' (version '7.3.0-preview.7') was successfully installed.
Clearing NuGet HTTP cache: C:\Users\ContainerAdministrator\AppData\Local\NuGet\v3-cache
Clearing NuGet global packages folder: C:\Users\ContainerAdministrator\.nuget\packages\
Clearing NuGet Temp cache: C:\Users\ContainerAdministrator\AppData\Local\Temp\NuGetScratch
Clearing NuGet plugins cache: C:\Users\ContainerAdministrator\AppData\Local\NuGet\plugins-cache
Local resources cleared.
Remove-Item : Cannot remove item 
C:\dotnet\host\fxr\7.0.0-rc.1.22426.10\hostfxr.dll: Access to the path 
'hostfxr.dll' is denied.
At line:1 char:1979
+ ... hared' -Path dotnet             | Remove-Item -Force -Recurse;        ...
+                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (hostfxr.dll:FileInfo) [Remove 
   -Item], UnauthorizedAccessException
    + FullyQualifiedErrorId : RemoveFileSystemItemUnAuthorizedAccess,Microsoft 
   .PowerShell.Commands.RemoveItemCommand
The command 'cmd /S /C powershell -Command "         $ErrorActionPreference = 'Stop';         $ProgressPreference = 'SilentlyContinue';                 $sdk_version = '7.0.100-rc.1.22429.3';         Invoke-WebRequest -OutFile dotnet.zip https://dotnetbuilds.blob.core.windows.net/internal/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip$Env:SAS_QUERY_STRING;         $dotnet_sha512 = '8f46d0c6e7c0d04c42592546447fc4b7376ab32ec1227413a73c2835fe79e3fbee5df7a0481690e4bbcd93f0ca1f51b4c1116b034184a2a1ff389ca936777aa5';         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) {             Write-Host 'CHECKSUM VERIFICATION FAILED!';             exit 1;         };         mkdir dotnet;         tar -oxzf dotnet.zip -C dotnet;         Remove-Item -Force dotnet.zip;                 $powershell_version = '7.3.0-preview.7';         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg;         $powershell_sha512 = '8f00356af4d3a70da11af33ed19e025d2e7aa796d75be1b9a23b4ff590d818a1de8bf34da8ad2dd4cb75e90ee07e2ef55d5b68b48ec7ba45a2468aac81f32313';         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) {             Write-Host 'CHECKSUM VERIFICATION FAILED!';             exit 1;         };         & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64;         & \dotnet\dotnet nuget locals all --clear;         Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg;         Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force;                 Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet             | Remove-Item -Force -Recurse;         Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared             | Remove-Item -Force -Recurse"' returned a non-zero code: 1
```

This is already a [known issue](https://github.com/dotnet/sdk/issues/18410) that's accounted for in the Dockerfiles that are generated for public .NET builds. The differences is that for internal builds, the WSC Dockerfiles get generated as multi-stage instead of single-stage as they are for public builds. This means the Dockerfile then has logic to prepare the dotnet folder for copying which involves deleting some files. The hostfxr.dll file is locked by the MSBuild server in that case and causing the error.

The fix is just to ensure the the MSBuild server gets shutdown prior to deletion.