### PR TITLE
Use correct publishRepoPrefix for internal builds

### DIFF
--- a/eng/pipelines/dotnet-core-internal-nightly.yml
+++ b/eng/pipelines/dotnet-core-internal-nightly.yml
@@ -34,10 +34,10 @@ variables:
   value: false
 - ${{ if parameters.isTest }}:
   - name: publishRepoPrefix
-    value: test/private/internal/
+    value: test/internal/private/
 - ${{ else }}:
   - name: publishRepoPrefix
-    value: private/internal/
+    value: internal/private/
 - name: publishImageInfo
   value: false
 - name: noCache

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -31,7 +31,7 @@ stages:
     - template: ../../../pipelines/steps/set-public-source-branch-var.yml
     - powershell: |
         $imageBuilderBuildArgs = "$(imageBuilderBuildArgs)"
-        if ("$(publishRepoPrefix)".Contains("/internal/")) {
+        if ("$(publishRepoPrefix)".Contains("internal/")) {
           if ("$env:ENABLEINTERNAL3_1" -eq "true") {
             $sasQueryString = "$(dotnetclimsrc-read-sas-token)"
           }

--- a/eng/pipelines/steps/set-custom-test-variables.yml
+++ b/eng/pipelines/steps/set-custom-test-variables.yml
@@ -4,7 +4,7 @@ steps:
     $testRunnerOptions="-e SYSTEM_TEAMPROJECT='$env:SYSTEM_TEAMPROJECT'"
     $testInit=""
 
-    if ("$(publishRepoPrefix)".Contains("/internal/")) {
+    if ("$(publishRepoPrefix)".Contains("internal/")) {
       if ("$env:ENABLEINTERNAL3_1" -eq "true") {
         $sasQueryString = "$(dotnetclimsrc-read-sas-token)"
       }


### PR DESCRIPTION
The repo prefix for the internal repo is defined incorrectly in the `publishRepoPrefix` variable for the internal pipeline. See https://github.com/dotnet/docker-tools/pull/1048.

Updated with the correct repo name.