### PR TITLE
Support multiple SDK versions in update-dependencies

### DIFF
--- a/eng/Get-DropVersions.ps1
+++ b/eng/Get-DropVersions.ps1
@@ -7,9 +7,14 @@ Returns the various component versions of the latest .NET build.
 [cmdletbinding()]
 param(
     # The release channel to use for determining the latest .NET build.
-    [Parameter(Mandatory)]
+    [Parameter(ParameterSetName = "Channel")]
     [string]
     $Channel,
+
+    [Parameter(ParameterSetName = "Explicit")]
+    # SDK versions to target
+    [string[]]
+    $SdkVersions,
 
     # Whether to target an internal .NET build
     [switch]
@@ -24,26 +29,46 @@ param(
     $AzdoVersionsRepoInfoAccessToken
 )
 
-function GetSdkInfo() {
-    if ($UseInternalBuild) {
-        $Channel = "internal/$Channel"
-        $queryString = "$BlobStorageSasQueryString"
-    }
-    else {
-        $queryString = ""
-    }
-
-    # Download the SDK
+function GetLatestSdkVersionFromChannel([string]$queryString) {
     $sdkFile = "dotnet-sdk-win-x64.zip"
     $akaMsUrl = "https://aka.ms/dotnet/$Channel/$sdkFile$queryString"
-    Write-Host "Downloading SDK from $akaMsUrl"
-    $sdkOutPath = "$tempDir/$sdkFile"
-    $response = Invoke-WebRequest -Uri $akaMsUrl -OutFile $sdkOutPath -PassThru
+    Write-Host "Querying $akaMsUrl"
+    $response = Invoke-WebRequest -Uri $akaMsUrl -Method Head
     $sdkUrl = $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
     Write-Host "Resolved SDK URL: $sdkUrl"
 
+    # Resolve the SDK build version from the SDK URL
+    # Example URL: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100-rtm.21522.1/dotnet-sdk-6.0.100-win-x64.zip
+    #   The command below extracts the 6.0.100-rtm.21522.1 from the URL
+    $sdkUrlPath = "/Sdk/"
+    $versionUrlPath = $sdkUrl.Substring($sdkUrl.IndexOf($sdkUrlPath) + $sdkUrlPath.Length)
+    $sdkVersion = $versionUrlPath.Substring(0, $versionUrlPath.IndexOf("/"))
+    return $sdkVersion
+}
+
+function GetCommitSha([string]$sdkVersion, [string]$queryString, [switch]$useStableBranding) {
+    if ($useStableBranding) {
+        $sdkStableVersion = ($sdkVersion -split "-")[0]
+    }
+    else {
+        $sdkStableVersion = $sdkVersion
+    }
+
+    if ($UseInternalBuild) {
+        $blobContainer = "internal"
+    }
+    else {
+        $blobContainer = "public"
+    }
+    
+    # Download the SDK
+    $sdkUrl = "https://dotnetbuilds.blob.core.windows.net/$blobContainer/Sdk/$sdkVersion/dotnet-sdk-$sdkStableVersion-win-x64.zip$queryString"
+    Write-Host "Downloading SDK from $sdkUrl"
+    $sdkOutPath = "$tempDir/sdk.zip"
+    Invoke-WebRequest -Uri $sdkUrl -OutFile $sdkOutPath
+    
     # Extract .version file from SDK zip
-    $zipFile = [IO.Compression.ZipFile]::OpenRead("$tempDir/$sdkFile")
+    $zipFile = [IO.Compression.ZipFile]::OpenRead($sdkOutPath)
     try {
         $zipFile.Entries | Where-Object { $_.FullName -like "sdk/*/.version" } | ForEach-Object {
             [IO.Compression.ZipFileExtensions]::ExtractToFile($_, "$tempDir/$($_.Name)")
@@ -56,17 +81,7 @@ function GetSdkInfo() {
     # Get the commit SHA from the .version file
     $commitSha = $(Get-Content "$tempDir/.version")[0].Trim()
 
-    # Resolve the SDK build version from the SDK URL
-    # Example URL: https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.100-rtm.21522.1/dotnet-sdk-6.0.100-win-x64.zip
-    #   The command below extracts the 6.0.100-rtm.21522.1 from the URL
-    $sdkUrlPath = "/Sdk/"
-    $versionUrlPath = $sdkUrl.Substring($sdkUrl.IndexOf($sdkUrlPath) + $sdkUrlPath.Length)
-    $sdkVersion = $versionUrlPath.Substring(0, $versionUrlPath.IndexOf("/"))
-
-    return @{
-        SdkVersion = $sdkVersion;
-        CommitSha = $commitSha;
-    }
+    return $commitSha
 }
 
 function GetVersionDetails([string]$commitSha) {
@@ -100,30 +115,67 @@ $ProgressPreference = 'SilentlyContinue'
 Set-StrictMode -Version 2.0
 
 $tempDir = "$([System.IO.Path]::GetTempPath())/dotnet-docker-get-dropversions"
-New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
 
-try {
-    $sdkInfo = GetSdkInfo
-    $versionDetails = GetVersionDetails $sdkInfo.CommitSha
-
-    $runtimeVersion = GetDependencyVersion "VS.Redist.Common.NetCore.SharedFramework.x64" $versionDetails
-
-    $aspnetVersion = GetDependencyVersion "VS.Redist.Common.AspNetCore.SharedFramework.x64" $versionDetails
-
-    if (-not $runtimeVersion) {
-        Write-Error "Unable to resolve the runtime version"
-        exit 1
+if ($UseInternalBuild) {
+    if ($Channel)
+    {
+        $Channel = "internal/$Channel"
     }
+    
+    $queryString = "$BlobStorageSasQueryString"
+}
+else {
+    $queryString = ""
+}
 
-    if (-not $aspnetVersion) {
-        Write-Error "Unable to resolve the ASP.NET Core runtime version"
-        exit 1
+if ($Channel) {
+    $SdkVersions += GetLatestSdkVersionFromChannel $queryString
+}
+
+Write-Host "Resolved SDK versions: $SdkVersions"
+$versionInfos = @()
+foreach ($sdkVersion in $SdkVersions) {
+    New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+
+    try {
+        $useStableBranding = & $PSScriptRoot/Get-IsStableBranding.ps1 -Version $sdkVersion
+        $commitSha = GetCommitSha $sdkVersion $queryString -useStableBranding:$useStableBranding
+        $versionDetails = GetVersionDetails $commitSha
+
+        $runtimeVersion = GetDependencyVersion "VS.Redist.Common.NetCore.SharedFramework.x64" $versionDetails
+
+        $aspnetVersion = GetDependencyVersion "VS.Redist.Common.AspNetCore.SharedFramework.x64" $versionDetails
+
+        if (-not $runtimeVersion) {
+            Write-Error "Unable to resolve the runtime version"
+            exit 1
+        }
+
+        if (-not $aspnetVersion) {
+            Write-Error "Unable to resolve the ASP.NET Core runtime version"
+            exit 1
+        }
+
+        $sdkVersionParts = $sdkVersion -split "\."
+        $dockerfileVersion = "$($sdkVersionParts[0]).$($sdkVersionParts[1])"
+
+        Write-Host "Dockerfile version: $dockerfileVersion"
+        Write-Host "SDK version: $sdkVersion"
+        Write-Host "Runtime version: $runtimeVersion"
+        Write-Host "ASP.NET Core version: $aspnetVersion"
+        Write-Host
+
+        $versionInfos += @{
+            DockerfileVersion = $dockerfileVersion
+            SdkVersion = $sdkVersion
+            RuntimeVersion = $runtimeVersion
+            AspnetVersion = $aspnetVersion
+            StableBranding = $useStableBranding
+        }
     }
+    finally {
+        Remove-Item $tempDir -Force -Recurse -ErrorAction Ignore
+    }
+}
 
-    Write-Output "##vso[task.setvariable variable=sdkVer]$($sdkInfo.SdkVersion)"
-    Write-Output "##vso[task.setvariable variable=runtimeVer]$runtimeVersion"
-    Write-Output "##vso[task.setvariable variable=aspnetVer]$aspnetVersion"
-}
-finally {
-    Remove-Item $tempDir -Force -Recurse -ErrorAction Ignore
-}
+Write-Output "##vso[task.setvariable variable=versionInfos]$($versionInfos | ConvertTo-Json -Compress -AsArray)"

--- a/eng/Get-IsStableBranding.ps1
+++ b/eng/Get-IsStableBranding.ps1
@@ -1,0 +1,21 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+Returns a value indicating whether the specified version is associated with stable branding.
+#>
+[cmdletbinding()]
+param(
+    # Build version of the product
+    [string]
+    $Version
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+if ($Version.Contains("-servicing") -or $Version.Contains("-rtm")) {
+    return $true
+}
+
+return $false

--- a/eng/Get-MonitorDropVersions.ps1
+++ b/eng/Get-MonitorDropVersions.ps1
@@ -15,4 +15,7 @@ param(
 $url = "https://aka.ms/dotnet/diagnostics/monitor$Channel/dotnet-monitor.nupkg.buildversion"
 $monitorVersion = $(Invoke-RestMethod $url).Trim()
 
+$stableBranding = & $PSScriptRoot/Get-IsStableBranding.ps1 -Version $monitorVersion
+
 Write-Output "##vso[task.setvariable variable=monitorVer]$monitorVersion"
+Write-Output "##vso[task.setvariable variable=stableBranding]$stableBranding"

--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -40,8 +40,8 @@ param(
     $UseStableBranding,
 
     # When set, only prints out an Azure DevOps variable with the value of the args to pass to update-dependencies.
-    [Switch]
-    $PrintArgsVariableOnly,
+    [string]
+    $AzdoVariableName,
 
     # SAS query string used to access files in the binary blob container
     [string]
@@ -99,8 +99,8 @@ if ($versionSourceName) {
 $branch = & $PSScriptRoot/Get-Branch.ps1
 $updateDepsArgs += "--source-branch=$branch"
 
-if ($PrintArgsVariableOnly) {
-    Write-Host "##vso[task.setvariable variable=updateDepsArgs]$updateDepsArgs"
+if ($AzdoVariableName) {
+    Write-Host "##vso[task.setvariable variable=$AzdoVariableName]$updateDepsArgs"
 }
 else {
     & dotnet run --project $PSScriptRoot/update-dependencies/update-dependencies.csproj @updateDepsArgs

--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -1,21 +1,33 @@
 parameters:
-  customArgs: ""
+  # The customArgsArray parameter is used to specify the configuration for multiple Dockerfile versions.
+  # This allows for a single PR to be generated for different internal .NET build versions.
+  # This is required in order to publish a single set of internal images when the PR is merged.
+  customArgsArray: ""
+
   stableBranding: false
   useInternalBuild: false
 
 steps:
 - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
   displayName: Build Update Dependencies Tool
-- script: >
-    if [ "${{ parameters.useInternalBuild }}" == "true" ]; then
-      pat="$(dn-bot-devdiv-dnceng-rw-code-pat)"
-    else
-      pat="$(BotAccount-dotnet-docker-bot-PAT)"
-    fi &&
-    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies \
-      ${{parameters.customArgs}} \
-      --user $(dotnetDockerBot.userName) \
-      --email $(dotnetDockerBot.email) \
-      --password $pat \
-      --stable-branding ${{parameters.stableBranding}}
+- powershell: |
+    if ("${{ parameters.useInternalBuild }}" -eq "true") {
+      $pat="$(dn-bot-devdiv-dnceng-rw-code-pat)"
+    } else {
+      $pat="$(BotAccount-dotnet-docker-bot-PAT)"
+    }
+
+    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
+
+    # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions
+    $customArgsArray = '${{ parameters.customArgsArray }}' | ConvertFrom-Json
+    foreach ($customArgs in $customArgsArray) {
+      # If this is the last iteration, include the credentials to cause a PR to be generated
+      if ($customArgs -eq $customArgsArray[-1]) {
+        $customArgs += " $credArgs"
+      }
+
+      $command = "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies $customArgs"
+      Invoke-Expression $command
+    }
   displayName: Run Update Dependencies

--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -4,7 +4,6 @@ parameters:
   # This is required in order to publish a single set of internal images when the PR is merged.
   customArgsArray: ""
 
-  stableBranding: false
   useInternalBuild: false
 
 steps:

--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -74,5 +74,4 @@ steps:
 - template: update-dependencies.yml
   parameters:
     customArgsArray: "$(customArgsArray)"
-    stableBranding: $(dotnetStableBranding)
     useInternalBuild: ${{ parameters.useInternalBuild }}

--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -1,10 +1,20 @@
 parameters:
   useInternalBuild: false
 
+  # Comma-delimited list of SDK versions to target (overrides the use of channel var to determine latest version)
+  sdkVersions: ""
+
 steps:
-- pwsh: |
-    $args = @{
-      Channel = "$(channel)"
+- powershell: |
+    if ("${{ parameters.sdkVersions }}" -ne "") {
+      $args = @{
+        SdkVersions = "${{ parameters.sdkVersions }}" -split ","
+      }
+    }
+    else {
+      $args = @{
+        Channel = "$(channel)"
+      }
     }
 
     if ("${{ parameters.useInternalBuild }}" -eq "true") {
@@ -16,21 +26,29 @@ steps:
     $(engPath)/Get-DropVersions.ps1 @args
   displayName: Get Versions
 - powershell: |
-    $args = @{
-      ProductVersion = "$(dockerfileVersion)"
-      RuntimeVersion = "$(runtimeVer)"
-      AspnetVersion = "$(aspnetVer)"
-      SdkVersion = "$(sdkVer)"
-      ComputeShas = $true
-      PrintArgsVariableOnly = $true
-    }
+    $versionInfos = '$(versionInfos)' | ConvertFrom-Json
 
-    if ("${{ parameters.useInternalBuild }}" -eq "true") {
-      $args["BinarySasQueryString"] = '"$(dotnetbuilds-internal-container-read-token)"'
-      $args["ChecksumSasQueryString"] = '"$(dotnetbuilds-internal-checksums-container-read-token)"'
-    }
+    $index=0
+    foreach ($versionInfo in $versionInfos) {
+      $args = @{
+        ProductVersion = $versionInfo.DockerfileVersion
+        RuntimeVersion = $versionInfo.RuntimeVersion
+        AspnetVersion = $versionInfo.AspnetVersion
+        SdkVersion = $versionInfo.SdkVersion
+        ComputeShas = $true
+        AzdoVariableName = "updateDepsArgs-$index"
+        UseStableBranding = $versionInfo.StableBranding
+      }
 
-    $(engPath)/Set-DotnetVersions.ps1 @args
+      if ("${{ parameters.useInternalBuild }}" -eq "true") {
+        $args["BinarySasQueryString"] = '"$(dotnetbuilds-internal-container-read-token)"'
+        $args["ChecksumSasQueryString"] = '"$(dotnetbuilds-internal-checksums-container-read-token)"'
+      }
+
+      Write-Host "Executing Set-DotnetVersions.ps1 for $($versionInfo.DockerfileVersion)"
+      $(engPath)/Set-DotnetVersions.ps1 @args
+      $index++
+    }
   displayName: Get update-dependencies args
 - powershell: |
     $branchPrefix = ""
@@ -38,11 +56,23 @@ steps:
       $branchPrefix = "internal/release/"
     }
     $targetBranch = $branchPrefix + $(& $(engPath)/Get-Branch.ps1)
-    echo "##vso[task.setvariable variable=targetBranch]$targetBranch"
-  displayName: Set Target Branch Var
+
+    $customArgsArray = @()
+    $index=0
+
+    # Grab the variables that were set by the multiple calls to Set-DotnetVersions.ps1 and
+    # add them to an array. This allows us to pass args for multiple Dockerfile versions.
+    while ([Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index") -ne $null) {
+      $updateDepsArgs = [Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index")
+      $updateDepsArgs = "$updateDepsArgs --org dnceng --project $(System.TeamProject) --repo $(Build.Repository.Name) --target-branch $targetBranch"
+      $customArgsArray += $updateDepsArgs
+      $index++
+    }
+    
+    echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
+  displayName: Set Custom Args
 - template: update-dependencies.yml
   parameters:
-    # The updateDepsArgs variable gets set by the Set-DotnetVersions.ps1 script
-    customArgs: "$(updateDepsArgs) --org dnceng --project $(System.TeamProject) --repo $(Build.Repository.Name) --target-branch $(targetBranch)"
+    customArgsArray: "$(customArgsArray)"
     stableBranding: $(dotnetStableBranding)
     useInternalBuild: ${{ parameters.useInternalBuild }}

--- a/eng/pipelines/update-dependencies-internal.yml
+++ b/eng/pipelines/update-dependencies-internal.yml
@@ -7,7 +7,7 @@ variables:
 - group: DotNet-AllOrgs-Darc-Pats
 stages:
 - stage: DotNet
-  condition: eq(variables['update-dotnet-enabled'], 'true')
+  condition: and(not(canceled()), eq(variables['update-dotnet-enabled'], 'true'))
   jobs:
   - job: UpdateDependencies
     displayName: Update Dependencies (dotnet/installer)
@@ -25,3 +25,4 @@ stages:
     - template: steps/update-dotnet-dependencies.yml
       parameters:
         useInternalBuild: true
+        sdkVersions: $(sdkVersions)

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -11,7 +11,7 @@ variables:
 - template: ../common/templates/variables/dotnet/common.yml
 stages:
 - stage: DotNet
-  condition: eq(variables['update-dotnet-enabled'], 'true')
+  condition: and(not(canceled()), eq(variables['update-dotnet-enabled'], 'true'))
   jobs:
   - job: UpdateDependencies
     displayName: Update Dependencies (dotnet/installer)
@@ -20,7 +20,7 @@ stages:
     steps:
     - template: steps/update-dotnet-dependencies.yml
 - stage: Monitor
-  condition: eq(variables['update-monitor-enabled'], 'true')
+  condition: and(not(canceled()), eq(variables['update-monitor-enabled'], 'true'))
   dependsOn: [] # Allows it to run in parallel
   jobs:
   - job: UpdateDependencies
@@ -32,15 +32,18 @@ stages:
         Update6:
           MajorMinorVersion: 6.$(monitor6MinorVersion)
           ChannelQuality: $(monitor6Quality)
-          StableBranding: $(monitor6StableBranding)
         Update7:
           MajorMinorVersion: 7.$(monitor7MinorVersion)
           ChannelQuality: $(monitor7Quality)
-          StableBranding: $(monitor7StableBranding)
     steps:
     - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -Channel $(MajorMinorVersion)/$(ChannelQuality)
       displayName: Get Versions
+    - powershell: |
+        $customArgs = "$(MajorMinorVersion) --product-version monitor=$(monitorVer) --channel-name $(MajorMinorVersion)/$(ChannelQuality) --version-source-name dotnet/dotnet-monitor/$(MajorMinorVersion) --stable-branding=$(stableBranding)"
+        
+        $customArgsArray = @($customArgs)
+        echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
+      displayName: Set Custom Args
     - template: steps/update-dependencies.yml
       parameters:
-        customArgs: "$(MajorMinorVersion) --product-version monitor=$(monitorVer) --channel-name $(MajorMinorVersion)/$(ChannelQuality) --version-source-name dotnet/dotnet-monitor/$(MajorMinorVersion)"
-        stableBranding: $(StableBranding)
+        customArgsArray: $(customArgsArray)


### PR DESCRIPTION
This updates the infrastructure related to update-dependencies so that it can support the targeting of multiple SDK versions. This is necessary for https://github.com/dotnet/dotnet-docker/issues/2152. By having the update-dependencies pipeline generate a PR that targets multiple internal builds of .NET. This approach is mentioned in https://github.com/dotnet/dotnet-docker/issues/2152#issuecomment-1150402553. This allows the `internal/release/nightly` branch to remain up-to-date with the latest updates from `nightly` but also have the latest internal .NET builds applied to it for each PR.

When targeting internal builds, we'll have an `sdkVersions` pipeline variable that will be used to explicitly define which builds should be targeted. But for the public builds, those will continue to be dynamically retrieved by the use of an aka.ms URL with a channel specified. This means the `Get-DropVersions.ps1` script needs to handle either scenario. It's been updated to either use a Channel or an array of SDK versions. Because multiple versions can now be targeted, its output has been changed to in JSON format that represents an array of version sets (each one representing a Dockerfile version). This JSON representation is then consumed by the pipeline and fed into the Set-DotNetVersion.ps1 script for each of those Dockerfile versions. Lastly, the update-dependencies container is then invoked multiple times for each of the Dockerfile versions, each having its own specific set of version information specified. This is applied iteratively in the repo, allowing the repo to contain the full set of changes for all Dockerfile versions. Once they're all applied, the PR gets generated.