### PR TITLE
Enable image caching support for internal pipelines

### DIFF
--- a/eng/pipelines/dotnet-core-internal-nightly.yml
+++ b/eng/pipelines/dotnet-core-internal-nightly.yml
@@ -21,10 +21,10 @@ resources:
   - repository: InternalVersionsRepo
     type: github
     endpoint: dotnet
-    name: dotnet/versions
+    name: dotnet/dotnet-docker-internal
 
 variables:
-- template: variables/core.yml
+- template: variables/internal-core.yml
 - name: officialBranches
   # comma-delimited list of branch names
   value: internal/release/nightly
@@ -38,10 +38,6 @@ variables:
 - ${{ else }}:
   - name: publishRepoPrefix
     value: internal/private/
-- name: publishImageInfo
-  value: false
-- name: noCache
-  value: true  
 
 stages:
 - template: stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-internal-pr.yml
+++ b/eng/pipelines/dotnet-core-internal-pr.yml
@@ -10,10 +10,10 @@ resources:
   - repository: InternalVersionsRepo
     type: github
     endpoint: dotnet
-    name: dotnet/versions
+    name: dotnet/dotnet-docker-internal
 
 variables:
-- template: variables/core.yml
+- template: variables/internal-core.yml
 
 stages:
 - template: stages/build-test-publish-repo.yml

--- a/eng/pipelines/variables/internal-core.yml
+++ b/eng/pipelines/variables/internal-core.yml
@@ -1,0 +1,15 @@
+# Common variables intended for pipelines that target internal .NET builds
+
+variables:
+- template: core.yml
+
+# Since the images published by the pipeline are only available internally, configure variables so that image info
+# is published to an internal repo.
+- name: gitHubVersionsRepoInfo.org
+  value: dotnet
+- name: gitHubVersionsRepoInfo.repo
+  value: dotnet-docker-internal
+- name: gitHubVersionsRepoInfo.branch
+  value: main
+- name: gitHubVersionsRepoInfo.path
+  value: image-infos


### PR DESCRIPTION
This updates the pipeline for publishing images of internal .NET builds so that it can support image caching. Image caching relies on an image info file being stored in a repo. Because these images are only available internally, this was originally disabled in order to prevent them from showing up in the default location: https://github.com/dotnet/versions/tree/main/build-info/docker.

Due to the changes in https://github.com/dotnet/docker-tools/pull/1055, it's now possible to target an internal repo as the location for storing image info files. So now the pipeline is updated to target the dotnet-docker-internal repo and caching has been enabled.

Related to https://github.com/dotnet/dotnet-docker/pull/4039 and https://github.com/dotnet/docker-tools/pull/1055