### PR TITLE
.NET Monitor: Remove symbol files and non-matching arch assemblies

### DIFF
--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -44,7 +44,13 @@ RUN {{InsertTemplate("../Dockerfile.linux.download-file",
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/{{targetFrameworkMonikerRegex}}' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the {{ARCH_SHORT}} architecture{{if ARCH_SHORT != "x64":
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \}}{{if ARCH_SHORT != "arm64":
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \}}
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -18,7 +18,8 @@
       Otherwise, use the account that is associated with the current branch. ^
     set urlBranch to when(find(monitorVersion, "-") >= 0 || buildVersion != monitorVersion, VARIABLES["branch"], "main") ^
     _ Use the $DOTNET_MONITOR_VERSION variable for the version folder if the build and product versions are the same. ^
-    set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$DOTNET_MONITOR_VERSION')
+    set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$DOTNET_MONITOR_VERSION') ^
+    set oppositeArchShort to when(ARCH_SHORT = "x64", "arm64", "x64")
 }}ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
 ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 
@@ -45,12 +46,10 @@ RUN {{InsertTemplate("../Dockerfile.linux.download-file",
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/{{targetFrameworkMonikerRegex}}' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
-    # To reduce image size further, remove linux assemblies that do not match the {{ARCH_SHORT}} architecture{{if ARCH_SHORT != "x64":
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \}}{{if ARCH_SHORT != "arm64":
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \}}
+    # To reduce image size further, remove linux assemblies that do not match the {{ARCH_SHORT}} architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-{{oppositeArchShort}}|linux-musl-{{oppositeArchShort}})' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -49,7 +49,7 @@ RUN {{InsertTemplate("../Dockerfile.linux.download-file",
     # To reduce image size further, remove linux assemblies that do not match the {{ARCH_SHORT}} architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-{{oppositeArchShort}}|linux-musl-{{oppositeArchShort}})' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -89,9 +89,9 @@
     "monitor|6.2|product-version": "6.2.2",
     "monitor|6.2|sha": "5d5df17e81ed66e644dc7323e89caee10f7eadbf62a28e0443e9fe12df1c5283fce2ebf6bc4dc2e5004c3c9e044101fc131ff293f382f15a32c91a6e159619d7",
 
-    "monitor|7.0|build-version": "7.0.0-rc.1.22464.1",
+    "monitor|7.0|build-version": "7.0.0-rc.1.22466.7",
     "monitor|7.0|product-version": "7.0.0-rc.1",
-    "monitor|7.0|sha": "7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b",
+    "monitor|7.0|sha": "7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902",
 
     "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha": "fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880",
 

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -19,7 +19,12 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -19,7 +19,12 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/6.2/ubuntu-chiseled/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/6.2/ubuntu-chiseled/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/6.2/ubuntu-chiseled/amd64/Dockerfile
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/6.2/ubuntu-chiseled/arm64v8/Dockerfile
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net6[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/6.2/ubuntu-chiseled/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/6.2/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/6.2/ubuntu-chiseled/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/alpine/arm64v8/Dockerfile
+++ b/src/monitor/7.0/alpine/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/alpine/arm64v8/Dockerfile
+++ b/src/monitor/7.0/alpine/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/alpine/arm64v8/Dockerfile
+++ b/src/monitor/7.0/alpine/arm64v8/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-alpine3.16-arm64v8 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.az
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the x64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-jammy-amd64 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -23,8 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb | xargs rm -rf \
-    && find /app -type f -name *.dbg | xargs rm -rf \
+    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
     # To reduce image size further, remove symbol files
-    && find /app -type f -name *.pdb -or -name *.dbg | xargs rm -rf \
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool

--- a/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -5,9 +5,9 @@ ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
 FROM $SDK_REPO:7.0.100-rc.2-jammy-arm64v8 AS installer
 
 # Install .NET Monitor
-ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22464.1
+ENV DOTNET_MONITOR_VERSION=7.0.0-rc.1.22466.7
 RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
-    && dotnetmonitor_sha512='7b41dcbff355dc482b93b9e862dcef62f043b5249b4a82168d9b6f63f649f2b102774f433a17522ef9435a0d1d365a8bd8155d1bdd07e3b3626801220a801f9b' \
+    && dotnetmonitor_sha512='7ff97fbf024b90679bff40158c4501749204639fae3be81ad3e7040c0d5a2176d109d2b3660aa502dd6ed98d17ed2a334aa01fd1c09df2bdbf20eb2cc20ef902' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net7.0 --no-cache \
     # To reduce image size, remove all non-net7.0 TFMs
@@ -19,7 +19,12 @@ RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotn
     # 4. Delete everything from step 3
     && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net7[.]0' | xargs rm -rf \
     # To reduce image size further, remove the non-linux assemblies
-    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shims)/(win|osx)' | xargs rm -rf \
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f -name *.pdb | xargs rm -rf \
+    && find /app -type f -name *.dbg | xargs rm -rf \
     # Remove all the empty directories left by the previous step
     && find /app -type d -empty -delete \
     # Allow other users to run the tool


### PR DESCRIPTION
The 7.0 package version in this change contains several new files that support new features that are in development. To mostly mitigate the size increase, I've amended the Dockerfiles to remove files that do not support the matching architecture for the Docker image as well as symbol files. This should be a net size reduction for the 6.x images and a minor net size increase for the 7.0 images.

cc @dotnet/dotnet-monitor 