### PR TITLE
Fix update-deps when targeting a single SDK version

### DIFF
--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -19,7 +19,9 @@ steps:
     $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
 
     # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions
-    $customArgsArray = '${{ parameters.customArgsArray }}' | ConvertFrom-Json
+    # Ensure that the value is treated as an array by wrapping it in an array literal. This deals with the quirk of
+    # how PowerShell treats a single item as a string instead of an array.
+    $customArgsArray = @('${{ parameters.customArgsArray }}' | ConvertFrom-Json)
     foreach ($customArgs in $customArgsArray) {
       # If this is the last iteration, include the credentials to cause a PR to be generated
       if ($customArgs -eq $customArgsArray[-1]) {


### PR DESCRIPTION
This fixes an issue introduced from https://github.com/dotnet/dotnet-docker/pull/4057 where a single SDK version is provided. In that case, a PR will not be generated for the changes. The intent is that a PR will only be generated after the latest iteration of the set of SDK versions being targeted. But when providing only a single SDK version as input, the PowerShell logic ends up not executing as intended. 

When converting the customArgsArray parameter to JSON, PowerShell has a weird quirk where a JSON array with only a single element will be deserialized as just a string and not an array. This messes up the `for` loop where it checks if the value is the last item in the array. It's not recognized as being the last item, and so the credentials are never provided to update-dependencies and, thus, a PR never gets generated.

The fix is to simply wrap the result in an array. This works fine even in the case where the JSON has more than one item in the array. You don't get an array of arrays in that case, again because of the weirdness of PowerShell and single-item arrays.