### PR TITLE
Allow writable files for global mutexes

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -77,7 +77,13 @@ namespace Microsoft.DotNet.Docker.Tests
                 optionalRunArgs: "--entrypoint /bin/sh"
             );
 
-            Assert.Empty(output);
+            IEnumerable<string> lines = output
+                .ReplaceLineEndings()
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+                // Writable files in the /tmp/.dotnet directory are allowed for global mutexes
+                .Where(line => !line.StartsWith("/tmp/.dotnet"));
+
+            Assert.Empty(lines);
         }
 
         protected void VerifyCommonDefaultUser(ProductImageData imageData)

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -42,11 +42,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyInsecureFiles(ProductImageData imageData)
         {
-            if (imageData.Version.Major == 7)
-            {
-                return;
-            }
-            
             base.VerifyCommonInsecureFiles(imageData);
         }
 


### PR DESCRIPTION
I've confirmed that globally writable files are expected for .NET global mutexes. This means that such files can show up in the /tmp/.dotnet directory. I've updated the unit test to allow for such files in this path only.