### PR TITLE
Include home directory for non-root user

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
@@ -4,6 +4,7 @@
         staging-dir: Path to the distroless staging directory
         create-dir (optional): Indicates whether the etc directory should be created in staging
         exclusive (optional): Indicates whether the app user is the only user and all other users are removed ^
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isMariner to find(OS_VERSION, "cbl-mariner") >= 0
 }}groupadd \
     --system \
@@ -12,10 +13,12 @@
 && adduser \
     --uid {{if isMariner && find(OS_VERSION, "1.0") >= 0:1000^else:101}} \
     --gid {{if isMariner && find(OS_VERSION, "1.0") >= 0:1000^else:101}} \
-    --shell /bin/false \
-    --no-create-home \
+    --shell /bin/false \{{if dotnetVersion = "6.0" && isMariner:
+    --no-create-home \}}
     --system \
     app \{{
+if dotnetVersion != "6.0" || !isMariner:
+&& mkdir -p "{{ARGS["staging-dir"]}}/home/app" \}}{{
 if ARGS["exclusive"]:{{if ARGS["create-dir"]:
 && mkdir -p "{{ARGS["staging-dir"]}}/etc" \}}
 && tail -1 < /etc/passwd > "{{ARGS["staging-dir"]}}/etc/passwd" \

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -18,9 +18,9 @@ RUN groupadd \
         --uid 101 \
         --gid 101 \
         --shell /bin/false \
-        --no-create-home \
         --system \
         app \
+    && mkdir -p "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && tail -1 < /etc/passwd > "/rootfs/etc/passwd" \
     && tail -1 < /etc/group > "/rootfs/etc/group"

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -18,9 +18,9 @@ RUN groupadd \
         --uid 101 \
         --gid 101 \
         --shell /bin/false \
-        --no-create-home \
         --system \
         app \
+    && mkdir -p "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && tail -1 < /etc/passwd > "/rootfs/etc/passwd" \
     && tail -1 < /etc/group > "/rootfs/etc/group"

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -26,9 +26,9 @@ RUN tdnf install -y shadow-utils \
         --uid 101 \
         --gid 101 \
         --shell /bin/false \
-        --no-create-home \
         --system \
         app \
+    && mkdir -p "/staging/home/app" \
     && tail -1 < /etc/passwd > "/staging/etc/passwd" \
     && tail -1 < /etc/group > "/staging/etc/group"
 

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -26,9 +26,9 @@ RUN tdnf install -y shadow-utils \
         --uid 101 \
         --gid 101 \
         --shell /bin/false \
-        --no-create-home \
         --system \
         app \
+    && mkdir -p "/staging/home/app" \
     && tail -1 < /etc/passwd > "/staging/etc/passwd" \
     && tail -1 < /etc/group > "/staging/etc/group"
 


### PR DESCRIPTION
Ensures that a home directory exists for the non-root user that is created in distroless/chiseled images. This allows tools that are expecting this directory to exist to work without issue.
Fixes #4083 