### PR TITLE
Fix world-writable file path exclusion

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 .ReplaceLineEndings()
                 .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
                 // Writable files in the /tmp/.dotnet directory are allowed for global mutexes
-                .Where(line => !line.StartsWith("/tmp/.dotnet"));
+                .Where(line => !line.StartsWith($"{rootFsPath}tmp/.dotnet"));
 
             Assert.Empty(lines);
         }


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet-docker/pull/4088 didn't properly handle the testing scenario for distroless containers. In that scenario, the paths to be excluded start with a rootfs directory which was not being handled.

To fix this, I've updated to use the variable which indicates the root directory for either distroful or distroless scenarios.