### PR TITLE
Fix distroless-related testing

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -77,11 +77,17 @@ namespace Microsoft.DotNet.Docker.Tests
                 optionalRunArgs: "--entrypoint /bin/sh"
             );
 
+            string rootFsPathWithTrailingSlash = rootFsPath;
+            if (!rootFsPathWithTrailingSlash.EndsWith("/"))
+            {
+                rootFsPathWithTrailingSlash += "/";
+            }
+
             IEnumerable<string> lines = output
                 .ReplaceLineEndings()
                 .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
                 // Writable files in the /tmp/.dotnet directory are allowed for global mutexes
-                .Where(line => !line.StartsWith($"{rootFsPath}tmp/.dotnet"));
+                .Where(line => !line.StartsWith($"{rootFsPathWithTrailingSlash}tmp/.dotnet"));
 
             Assert.Empty(lines);
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static IEnumerable<object[]> GetImageData()
         {
             return TestData.GetImageData()
+                .Where(imageData => !imageData.IsDistroless)
                 // Filter the image data down to the distinct SDK OSes
                 .Distinct(new SdkImageDataEqualityComparer())
                 .Select(imageData => new object[] { imageData });


### PR DESCRIPTION
These changes fix an issue with the change made in https://github.com/dotnet/dotnet-docker/pull/4097 because it wasn't setting the path correctly. It was missing a trailing slash after `/rootfs`.

This issue wasn't caught by the PR build and only showed up in the internal build. The reason for this is a bit complicated. The test which produces the world-writable files is for the SDK and that's the test that was failing. In the PR build, this test was run but only ended up targeting the distroful version of the image, not the distroless. This is because both the distroful and distroless versions were being tested in the same job. So when the SDK test class ran, it filters out the image data down to distinct SDK OS. Since both distroful and distroless share the same SDK OS, the distroless image data was getting thrown out. This doesn't happen in the internal build where distroful and distroless are tested in separate jobs. So the SDK test was executing against a distroless image and exposing this error in the path logic.

However, it doesn't make sense for the SDK tests to be executing on a distroless image since they're specific to SDK images and there are no distroless SDK images. For that reason, I've updated the image data filtering to ignore any distroless image data entries.