### PR TITLE
update-deps: Maintain same container for each version

### DIFF
--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -9,6 +9,8 @@ parameters:
 steps:
 - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
   displayName: Build Update Dependencies Tool
+- script: docker run --name update-dependencies -d -t --entrypoint /bin/sh -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
+  displayName: Create Update Dependencies container
 - powershell: |
     if ("${{ parameters.useInternalBuild }}" -eq "true") {
       $pat="$(dn-bot-devdiv-dnceng-rw-code-pat)"
@@ -28,7 +30,10 @@ steps:
         $customArgs += " $credArgs"
       }
 
-      $command = "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock update-dependencies $customArgs"
+      $command = "docker exec update-dependencies update-dependencies $customArgs"
       Invoke-Expression $command
     }
   displayName: Run Update Dependencies
+- script: docker rm -f update-dependencies
+  displayName: Remove Update Dependencies container
+  condition: always()

--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -32,4 +32,6 @@ COPY --from=build-env /update-dependencies/out ./
 WORKDIR /repo
 COPY . ./
 
+RUN ln -s /update-dependencies/update-dependencies /usr/local/bin/update-dependencies
+
 ENTRYPOINT ["/update-dependencies/update-dependencies"]


### PR DESCRIPTION
The pipeline to run update-dependencies for internal .NET builds isn't working correctly when targeting multiple .NET versions. The PR that gets generated only has the changes of the last .NET version specified in the set. This is because the pipeline is creating a new container for each iteration of the tool. So repo changes from previous iterations of the tool are not carried over to the next iteration.

I've fixed this by ensuring that the loop which executes the tool targets a single container instance that is setup to run by the previous pipeline step.