### PR TITLE
Update internal pool for builds from main branch

### DIFF
--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -16,3 +16,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
+    linuxAmd64Pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -5,6 +5,7 @@ parameters:
   noCache: false
   internalProjectName: null
   publicProjectName: null
+  linuxAmd64Pool: ""
 
 stages:
 - template: ../../common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -12,6 +13,7 @@ stages:
     noCache: ${{ parameters.noCache }}
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
+    linuxAmd64Pool: ${{ parameters.linuxAmd64Pool }}
     ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), and(eq(variables['System.TeamProject'], parameters.internalProjectName), eq(variables['Build.Reason'], 'PullRequest'))) }}:
       buildMatrixType: platformVersionedOs
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies


### PR DESCRIPTION
A new set of build pools have been created which are meant for release builds. This means that builds from the main branch should be using the `NetCore1ESPool-Svc-Internal` pool instead of `NetCore1ESPool-Internal`.

I've confirmed with the Eng Services team that this only applies to the main branch and not the nightly branch.