### PR TITLE
Enable distroless Mariner images to be scanned correctly

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-pkgs
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-pkgs
@@ -24,8 +24,8 @@ else:apt-get update \
     for index, pkg in ARGS["pkgs"]:
         {{pkg}}{{if appendPkgSuffix(pkg, index):{{if pkg != "": }}\}}}}{{
 if isTdnf:
-    && tdnf clean all^
+    && tdnf clean all{{ARGS["pkg-mgr-opts"]}}^
 elif isDnf:
-    && dnf clean all^
+    && dnf clean all{{ARGS["pkg-mgr-opts"]}}^
 elif !isApk:
     && rm -rf /var/lib/apt/lists/*}}

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
@@ -1,24 +1,40 @@
 {{
-    set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
     set distrolessStagingDir to "/staging" ^
     set marinerRepo to "mcr.microsoft.com/cbl-mariner" ^
-    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".")
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set baseImage to cat(marinerRepo, "/distroless/minimal:", OS_VERSION_NUMBER) ^
+    set finalStageBase to when(find(OS_VERSION, "1.0") < 0, "base", baseImage)
+}}{{ if find(OS_VERSION, "1.0") < 0:# Base distroless image
+FROM {{baseImage}} AS base
+
+
 }}# Installer image
 FROM {{marinerRepo}}/base/core:{{OS_VERSION_NUMBER}} AS installer
 {{ if find(OS_VERSION, "1.0") >= 0:
 RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
     [
         "pkgs": ["dnf"]
-    ])}}
-}}
+    ])}}^else:
+RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
+    [
+        "pkgs": ["gawk", "shadow-utils"]
+    ])}}}}
+
 # Install .NET's dependencies into a staging location
 RUN mkdir {{distrolessStagingDir}} \
     && {{InsertTemplate("../Dockerfile.linux.install-deps", ["distroless-staging-dir": distrolessStagingDir])}}
-{{ if isDistrolessMariner:
+{{if find(OS_VERSION, "1.0") < 0:
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+}}
 # Create a non-root user and group
-RUN {{if find(OS_VERSION, "1.0") < 0:tdnf install -y shadow-utils \
-    && tdnf clean all \
-    && }}{{InsertTemplate("Dockerfile.linux.distroless-user",
+RUN {{InsertTemplate("Dockerfile.linux.distroless-user",
         [
             "staging-dir": distrolessStagingDir
             "exclusive": dotnetVersion != "6.0"
@@ -36,9 +52,9 @@ RUN rm -rf {{distrolessStagingDir}}/etc/{{when(find(OS_VERSION, "1.0") >= 0, "dn
 
 
 # .NET runtime-deps image
-FROM {{marinerRepo}}/distroless/minimal:{{OS_VERSION_NUMBER}}
+FROM {{finalStageBase}}
 
-COPY --from=installer {{distrolessStagingDir}}/ /}}
+COPY --from=installer {{distrolessStagingDir}}/ /
 
 {{InsertTemplate("../Dockerfile.common-dotnet-envs")}}
 

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
@@ -27,7 +27,7 @@ RUN mkdir {{distrolessStagingDir}} \
 # Generate RPM manifest file by appending to the original manifest file from base distroless image
 COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
 RUN tmpManifestPath="/tmp/rpmmanifest" \
-    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
     && mkdir -p /staging/var/lib/rpmmanifest \
     # Remove duplicates that match on the first field (package name)
     && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2

--- a/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner1.0-distroless/amd64/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /staging \
         libstdc++ \
         openssl-libs \
         zlib \
-    && dnf clean all
+    && dnf clean all --releasever=1.0 --installroot /staging
 
 # Create a non-root user and group
 RUN groupadd \

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir /staging \
 # Generate RPM manifest file by appending to the original manifest file from base distroless image
 COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
 RUN tmpManifestPath="/tmp/rpmmanifest" \
-    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
     && mkdir -p /staging/var/lib/rpmmanifest \
     # Remove duplicates that match on the first field (package name)
     && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,5 +1,14 @@
+# Base distroless image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS base
+
+
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
 
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
@@ -13,12 +22,19 @@ RUN mkdir /staging \
         libstdc++ \
         openssl-libs \
         zlib \
-    && tdnf clean all
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
 
 # Create a non-root user and group
-RUN tdnf install -y shadow-utils \
-    && tdnf clean all \
-    && groupadd \
+RUN groupadd \
         --system \
         --gid=101 \
         app \
@@ -44,7 +60,7 @@ RUN rm -rf /staging/etc/tdnf \
 
 
 # .NET runtime-deps image
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM base
 
 COPY --from=installer /staging/ /
 

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir /staging \
 # Generate RPM manifest file by appending to the original manifest file from base distroless image
 COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
 RUN tmpManifestPath="/tmp/rpmmanifest" \
-    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
     && mkdir -p /staging/var/lib/rpmmanifest \
     # Remove duplicates that match on the first field (package name)
     && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2

--- a/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,5 +1,14 @@
+# Base distroless image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS base
+
+
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
 
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
@@ -13,12 +22,19 @@ RUN mkdir /staging \
         libstdc++ \
         openssl-libs \
         zlib \
-    && tdnf clean all
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
 
 # Create a non-root user and group
-RUN tdnf install -y shadow-utils \
-    && tdnf clean all \
-    && groupadd \
+RUN groupadd \
         --system \
         --gid=101 \
         app \
@@ -44,7 +60,7 @@ RUN rm -rf /staging/etc/tdnf \
 
 
 # .NET runtime-deps image
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM base
 
 COPY --from=installer /staging/ /
 

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir /staging \
 # Generate RPM manifest file by appending to the original manifest file from base distroless image
 COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
 RUN tmpManifestPath="/tmp/rpmmanifest" \
-    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
     && mkdir -p /staging/var/lib/rpmmanifest \
     # Remove duplicates that match on the first field (package name)
     && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,5 +1,14 @@
+# Base distroless image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS base
+
+
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
 
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
@@ -13,12 +22,19 @@ RUN mkdir /staging \
         libstdc++ \
         openssl-libs \
         zlib \
-    && tdnf clean all
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
 
 # Create a non-root user and group
-RUN tdnf install -y shadow-utils \
-    && tdnf clean all \
-    && groupadd \
+RUN groupadd \
         --system \
         --gid=101 \
         app \
@@ -43,7 +59,7 @@ RUN rm -rf /staging/etc/tdnf \
 
 
 # .NET runtime-deps image
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM base
 
 COPY --from=installer /staging/ /
 

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir /staging \
 # Generate RPM manifest file by appending to the original manifest file from base distroless image
 COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
 RUN tmpManifestPath="/tmp/rpmmanifest" \
-    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
     && mkdir -p /staging/var/lib/rpmmanifest \
     # Remove duplicates that match on the first field (package name)
     && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,5 +1,14 @@
+# Base distroless image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 AS base
+
+
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
 
 # Install .NET's dependencies into a staging location
 RUN mkdir /staging \
@@ -13,12 +22,19 @@ RUN mkdir /staging \
         libstdc++ \
         openssl-libs \
         zlib \
-    && tdnf clean all
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=base /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
 
 # Create a non-root user and group
-RUN tdnf install -y shadow-utils \
-    && tdnf clean all \
-    && groupadd \
+RUN groupadd \
         --system \
         --gid=101 \
         app \
@@ -43,7 +59,7 @@ RUN rm -rf /staging/etc/tdnf \
 
 
 # .NET runtime-deps image
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM base
 
 COPY --from=installer /staging/ /
 

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -232,14 +232,16 @@ namespace Microsoft.DotNet.Docker.Tests
             string optionalRunArgs = null,
             bool detach = false,
             string runAsUser = null,
-            bool skipAutoCleanup = false)
+            bool skipAutoCleanup = false,
+            bool useMountedDockerSocket = false)
         {
             string cleanupArg = skipAutoCleanup ? string.Empty : " --rm";
             string detachArg = detach ? " -d -t" : string.Empty;
             string userArg = runAsUser != null ? $" -u {runAsUser}" : string.Empty;
             string workdirArg = workdir == null ? string.Empty : $" -w {workdir}";
+            string mountedDockerSocketArg = useMountedDockerSocket ? " -v /var/run/docker.sock:/var/run/docker.sock" : string.Empty;
             return ExecuteWithLogging(
-                $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg} {optionalRunArgs} {image} {command}");
+                $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg}{mountedDockerSocketArg} {optionalRunArgs} {image} {command}");
         }
 
         /// <summary>

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -94,7 +94,6 @@ namespace Microsoft.DotNet.Docker.Tests
                 "e2fsprogs-libs",
                 "filesystem",
                 "glibc",
-                "gpg-pubkey",
                 "krb5",
                 "libgcc",
                 "libstdc++",

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,6 +54,69 @@ namespace Microsoft.DotNet.Docker.Tests
         public void VerifyDefaultUser(ProductImageData imageData)
         {
             VerifyCommonDefaultUser(imageData);
+        }
+
+        /// <summary>
+        /// Verifies that the packages installed in distroless images are scannable by security tools.
+        /// </summary>
+        [LinuxImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyDistrolessPackages(ProductImageData imageData)
+        {
+            if (!imageData.IsDistroless)
+            {
+                OutputHelper.WriteLine("This test is only relevant to distroless images.");
+                return;
+            }
+
+            if (imageData.OS == OS.Mariner10Distroless)
+            {
+                OutputHelper.WriteLine("Scanning support not implemented for Mariner 1.0.");
+                return;
+            }
+
+            if (imageData.OS == OS.JammyChiseled)
+            {
+                OutputHelper.WriteLine("Scanning support not implemented for Chiseled Ubuntu images.");
+                return;
+            }
+
+            const string SyftImage = "anchore/syft";
+            DockerHelper.Pull(SyftImage);
+
+            string imageName = imageData.GetImage(ImageType, DockerHelper);
+            string output = DockerHelper.Run(
+                SyftImage, "distroless-packages", $"packages docker:{imageName} -o json", useMountedDockerSocket: true);
+
+            string[] expectedPackages = new[]
+            {
+                "distroless-packages-minimal",
+                "e2fsprogs-libs",
+                "filesystem",
+                "glibc",
+                "gpg-pubkey",
+                "krb5",
+                "libgcc",
+                "libstdc++",
+                "mariner-release",
+                "openssl",
+                "openssl-libs",
+                "prebuilt-ca-certificates",
+                "prebuilt-ca-certificates-base",
+                "zlib"
+            };
+
+            JsonNode node = JsonNode.Parse(output);
+            if (node is null)
+            {
+                throw new JsonException($"Unable to parse the output as JSON:{Environment.NewLine}{output}");
+            }
+
+            string[] actualPackages = ((JsonArray)node["artifacts"])
+                .Select(artifact => artifact["name"]?.ToString())
+                .ToArray();
+
+            Assert.Equal(expectedPackages, actualPackages);
         }
 
         internal static string[] GetExpectedRpmPackagesInstalled(ProductImageData imageData) =>


### PR DESCRIPTION
The distroless Mariner images that we produce aren't configured properly to allow scanning tools to correctly identify the RPM packages that exist in them, specifically the RPM packages that are being directly installed by the .NET Dockerfiles. The scanning tools are only recognizing the RPM packages that exist in the base distroless Mariner image that the .NET image is based on.

This is because these scanning tools are looking for an [RPM manifest file](https://github.com/microsoft/CBL-Mariner/blob/2.0/toolkit/docs/how_it_works/5_misc.md#rpm-manifest-file) that's specific to Mariner. This file exists in the base distroless Mariner image but is not updated to reflect the RPM packages that are installed by the .NET Dockerfile.

There is a broader [work item](https://dev.azure.com/microsoft/OS/_queries/query/53e3fbc5-e40d-4e8a-824a-e924ef86b4f3/) (internal only link) already logged to provide a better overall experience in managing the scenario of installing additional packages in distroless Mariner images that should better address this. But we need a short-term solution now to address this issue.

These changes propose that we add commands to the Dockerfile to directly update the contents of the RPM manifest file using the [format as documented by Mariner](https://github.com/microsoft/CBL-Mariner/blob/2.0/toolkit/docs/how_it_works/5_misc.md#rpm-manifest-file). Care needs to be taken here to include the original contents of that file from the base distroless image and handling any duplicates between the original contents and the new output.

The effect of this is that scanning tools, such as [syft](https://github.com/anchore/syft), are able to correctly identify the packages that have been installed by .NET.

Before:

```console
> syft packages docker:mcr.microsoft.com/dotnet/runtime-deps:6.0-cbl-mariner2.0-distroless-amd64
NAME                           VERSION              TYPE
distroless-packages-minimal    0.1-2.cm2    rpm
filesystem                     1.1-10.cm2   rpm
mariner-release                2.0-21.cm2   rpm
prebuilt-ca-certificates-base  2.0.0-7.cm2  rpm
```

After:

```console
> syft packages docker:mcr.microsoft.com/dotnet/runtime-deps:6.0-cbl-mariner2.0-distroless-amd64
NAME                           VERSION              TYPE
distroless-packages-minimal    0.1-2.cm2            rpm
e2fsprogs-libs                 1.46.5-3.cm2         rpm
filesystem                     1.1-10.cm2           rpm
glibc                          2.35-2.cm2           rpm
gpg-pubkey                     be1229cf-5631588c    rpm
krb5                           1.19.3-1.cm2         rpm
libgcc                         11.2.0-2.cm2         rpm
libstdc++                      11.2.0-2.cm2         rpm
mariner-release                2.0-21.cm2           rpm
openssl                        1.1.1k-20.cm2        rpm
openssl-libs                   1.1.1k-20.cm2        rpm
prebuilt-ca-certificates       2549185:2.0.0-7.cm2  rpm
prebuilt-ca-certificates-base  2.0.0-7.cm2          rpm
zlib                           1.2.12-2.cm2         rpm
```

cc @mandeepsplaha