### PR TITLE
Set correct ownership of non-root user's home dir

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -44,7 +44,7 @@ FROM scratch
 COPY --from=builder /rootfs /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=installer --chown={{uid}}:{{gid}} /rootfs/home/{{username}} /home/{{username}}
+COPY --from=builder --chown={{uid}}:{{gid}} /rootfs/home/{{username}} /home/{{username}}
 
 {{InsertTemplate("../Dockerfile.common-dotnet-envs")}}
 

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -1,6 +1,9 @@
 {{
     set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
-    set osVersionNumber to split(OS_ARCH_HYPHENATED, "-")[1]
+    set osVersionNumber to split(OS_ARCH_HYPHENATED, "-")[1] ^
+    set username to "app" ^
+    set uid to 101 ^
+    set gid to uid
 }}FROM {{ARCH_VERSIONED}}/golang:1.18 as chisel
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
@@ -17,7 +20,11 @@ RUN {{InsertTemplate("Dockerfile.linux.distroless-user",
     [
         "staging-dir": "/rootfs",
         "exclusive": "true",
-        "create-dir": "true"
+        "create-dir": "true",
+        "name": username,
+        "uid": uid,
+        "gid": gid,
+        "create-home": "true"
     ],
     "    ")}}
 
@@ -35,6 +42,9 @@ RUN chisel cut --release "ubuntu-{{osVersionNumber}}" --root /rootfs \
 FROM scratch
 
 COPY --from=builder /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown={{uid}}:{{gid}} /rootfs/home/{{username}} /home/{{username}}
 
 {{InsertTemplate("../Dockerfile.common-dotnet-envs")}}
 

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
@@ -1,8 +1,11 @@
 {{
-    set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
     set distrolessStagingDir to "/staging" ^
     set marinerRepo to "mcr.microsoft.com/cbl-mariner" ^
-    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".")
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set username to "app" ^
+    set uid to when(find(OS_VERSION, "1.0") >= 0, 1000, 101) ^
+    set gid to uid ^
+    set createUserHome to dotnetVersion != "6.0"
 }}# Installer image
 FROM {{marinerRepo}}/base/core:{{OS_VERSION_NUMBER}} AS installer
 {{ if find(OS_VERSION, "1.0") >= 0:
@@ -14,14 +17,18 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 # Install .NET's dependencies into a staging location
 RUN mkdir {{distrolessStagingDir}} \
     && {{InsertTemplate("../Dockerfile.linux.install-deps", ["distroless-staging-dir": distrolessStagingDir])}}
-{{ if isDistrolessMariner:
+
 # Create a non-root user and group
 RUN {{if find(OS_VERSION, "1.0") < 0:tdnf install -y shadow-utils \
     && tdnf clean all \
     && }}{{InsertTemplate("Dockerfile.linux.distroless-user",
         [
-            "staging-dir": distrolessStagingDir
-            "exclusive": dotnetVersion != "6.0"
+            "staging-dir": distrolessStagingDir,
+            "exclusive": dotnetVersion != "6.0",
+            "name": username,
+            "uid": uid,
+            "gid": gid,
+            "create-home": createUserHome
         ],
         "    ")}}
 
@@ -38,7 +45,10 @@ RUN rm -rf {{distrolessStagingDir}}/etc/{{when(find(OS_VERSION, "1.0") >= 0, "dn
 # .NET runtime-deps image
 FROM {{marinerRepo}}/distroless/minimal:{{OS_VERSION_NUMBER}}
 
-COPY --from=installer {{distrolessStagingDir}}/ /}}
+COPY --from=installer {{distrolessStagingDir}}/ /{{if createUserHome:
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown={{uid}}:{{gid}} {{distrolessStagingDir}}/home/{{username}} /home/{{username}}}}
 
 {{InsertTemplate("../Dockerfile.common-dotnet-envs")}}
 

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
@@ -3,22 +3,26 @@
     _ ARGS:
         staging-dir: Path to the distroless staging directory
         create-dir (optional): Indicates whether the etc directory should be created in staging
-        exclusive (optional): Indicates whether the app user is the only user and all other users are removed ^
+        exclusive (optional): Indicates whether the app user is the only user and all other users are removed
+        name: Name of the user/group to create
+        uid: ID of the user to be created
+        gid: ID of the group to be created
+        create-home (optional): Indicates whether a home directory should be created for the user ^
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isMariner to find(OS_VERSION, "cbl-mariner") >= 0
 }}groupadd \
     --system \
-    --gid={{if isMariner && find(OS_VERSION, "1.0") >= 0:1000^else:101}} \
-    app \
+    --gid={{ARGS["gid"]}} \
+    {{ARGS["name"]}} \
 && adduser \
-    --uid {{if isMariner && find(OS_VERSION, "1.0") >= 0:1000^else:101}} \
-    --gid {{if isMariner && find(OS_VERSION, "1.0") >= 0:1000^else:101}} \
-    --shell /bin/false \{{if dotnetVersion = "6.0" && isMariner:
+    --uid {{ARGS["uid"]}} \
+    --gid {{ARGS["gid"]}} \
+    --shell /bin/false \{{if !ARGS["create-home"]:
     --no-create-home \}}
     --system \
-    app \{{
-if dotnetVersion != "6.0" || !isMariner:
-&& mkdir -p "{{ARGS["staging-dir"]}}/home/app" \}}{{
+    {{ARGS["name"]}} \{{
+if ARGS["create-home"]:
+&& install -d -m 0755 -o {{ARGS["uid"]}} -g {{ARGS["gid"]}} "{{ARGS["staging-dir"]}}/home/{{ARGS["name"]}}" \}}{{
 if ARGS["exclusive"]:{{if ARGS["create-dir"]:
 && mkdir -p "{{ARGS["staging-dir"]}}/etc" \}}
 && tail -1 < /etc/passwd > "{{ARGS["staging-dir"]}}/etc/passwd" \

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -41,7 +41,7 @@ FROM scratch
 COPY --from=builder /rootfs /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=installer --chown=101:101 /rootfs/home/app /home/app
+COPY --from=builder --chown=101:101 /rootfs/home/app /home/app
 
 ENV \
     # Configure web servers to bind to port 8080 when present

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -20,7 +20,7 @@ RUN groupadd \
         --shell /bin/false \
         --system \
         app \
-    && mkdir -p "/rootfs/home/app" \
+    && install -d -m 0755 -o 101 -g 101 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && tail -1 < /etc/passwd > "/rootfs/etc/passwd" \
     && tail -1 < /etc/group > "/rootfs/etc/group"
@@ -39,6 +39,9 @@ RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
 FROM scratch
 
 COPY --from=builder /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=101:101 /rootfs/home/app /home/app
 
 ENV \
     # Configure web servers to bind to port 8080 when present

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -41,7 +41,7 @@ FROM scratch
 COPY --from=builder /rootfs /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=installer --chown=101:101 /rootfs/home/app /home/app
+COPY --from=builder --chown=101:101 /rootfs/home/app /home/app
 
 ENV \
     # Configure web servers to bind to port 8080 when present

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -20,7 +20,7 @@ RUN groupadd \
         --shell /bin/false \
         --system \
         app \
-    && mkdir -p "/rootfs/home/app" \
+    && install -d -m 0755 -o 101 -g 101 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && tail -1 < /etc/passwd > "/rootfs/etc/passwd" \
     && tail -1 < /etc/group > "/rootfs/etc/group"
@@ -39,6 +39,9 @@ RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
 FROM scratch
 
 COPY --from=builder /rootfs /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=101:101 /rootfs/home/app /home/app
 
 ENV \
     # Configure web servers to bind to port 8080 when present

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -28,7 +28,7 @@ RUN tdnf install -y shadow-utils \
         --shell /bin/false \
         --system \
         app \
-    && mkdir -p "/staging/home/app" \
+    && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
     && tail -1 < /etc/passwd > "/staging/etc/passwd" \
     && tail -1 < /etc/group > "/staging/etc/group"
 
@@ -46,6 +46,9 @@ RUN rm -rf /staging/etc/tdnf \
 FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 
 COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
 ENV \
     # Configure web servers to bind to port 8080 when present

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -28,7 +28,7 @@ RUN tdnf install -y shadow-utils \
         --shell /bin/false \
         --system \
         app \
-    && mkdir -p "/staging/home/app" \
+    && install -d -m 0755 -o 101 -g 101 "/staging/home/app" \
     && tail -1 < /etc/passwd > "/staging/etc/passwd" \
     && tail -1 < /etc/group > "/staging/etc/group"
 
@@ -46,6 +46,9 @@ RUN rm -rf /staging/etc/tdnf \
 FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 
 COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=101:101 /staging/home/app /home/app
 
 ENV \
     # Configure web servers to bind to port 8080 when present

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -87,7 +87,11 @@ namespace Microsoft.DotNet.Docker.Tests
                 .ReplaceLineEndings()
                 .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
                 // Writable files in the /tmp/.dotnet directory are allowed for global mutexes
-                .Where(line => !line.StartsWith($"{rootFsPathWithTrailingSlash}tmp/.dotnet"));
+                .Where(line => !line.StartsWith($"{rootFsPathWithTrailingSlash}tmp/.dotnet"))
+                // Exclude the non-root user's home directory. It will show up as a directory without a user or group
+                // because we're not examining the distroless container directly, but rather copying its contents into
+                // a container with a shell but doesn't have the non-root user defined.
+                .Where(line => !imageData.IsDistroless || line != $"{rootFsPathWithTrailingSlash}home/app");
 
             Assert.Empty(lines);
         }


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet-docker/pull/4092 didn't correctly set the ownership of the home directory. So if an app running in the context of the non-root user `app` attempted to write to its `/home/app` directory, it would get an access denied error.

This happens because the directory is created while running as the root user and nothing is done further to set ownership.

This has now been updated to both create the directory and set ownership using the `install` command. That in itself isn't enough, however. Due to https://github.com/moby/moby/issues/38710, a workaround is necessary to ensure that the `/home/app` directory that gets copied into the final stage has the ownership that was initially set. This is done by including another `COPY` instruction that explicitly targets that directory and sets ownership with the `--chown` option.

I've also updated the unit test to verify the user can write to its home directory. I've generalized this to apply to all relevant environments.