### PR TITLE
Preserve root user in distroless-style containers

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
@@ -21,8 +21,9 @@ if dotnetVersion != "6.0" || !isMariner:
 && mkdir -p "{{ARGS["staging-dir"]}}/home/app" \}}{{
 if ARGS["exclusive"]:{{if ARGS["create-dir"]:
 && mkdir -p "{{ARGS["staging-dir"]}}/etc" \}}
-&& tail -1 < /etc/passwd > "{{ARGS["staging-dir"]}}/etc/passwd" \
-&& tail -1 < /etc/group > "{{ARGS["staging-dir"]}}/etc/group"^
+&& rootOrAppRegex='@^\(root\|app\):' \
+&& cat /etc/passwd | grep $rootOrAppRegex > "{{ARGS["staging-dir"]}}/etc/passwd" \
+&& cat /etc/group | grep $rootOrAppRegex > "{{ARGS["staging-dir"]}}/etc/group"^
 else:
 # Copy user/group info to staging
 && cp /etc/passwd {{ARGS["staging-dir"]}}/etc/passwd \

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -22,8 +22,9 @@ RUN groupadd \
         app \
     && mkdir -p "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
-    && tail -1 < /etc/passwd > "/rootfs/etc/passwd" \
-    && tail -1 < /etc/group > "/rootfs/etc/group"
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
 RUN chisel cut --release "ubuntu-22.04" --root /rootfs \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -22,8 +22,9 @@ RUN groupadd \
         app \
     && mkdir -p "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
-    && tail -1 < /etc/passwd > "/rootfs/etc/passwd" \
-    && tail -1 < /etc/group > "/rootfs/etc/group"
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
 RUN chisel cut --release "ubuntu-22.04" --root /rootfs \

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -45,8 +45,9 @@ RUN groupadd \
         --system \
         app \
     && mkdir -p "/staging/home/app" \
-    && tail -1 < /etc/passwd > "/staging/etc/passwd" \
-    && tail -1 < /etc/group > "/staging/etc/group"
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
 
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \

--- a/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -45,8 +45,9 @@ RUN groupadd \
         --system \
         app \
     && mkdir -p "/staging/home/app" \
-    && tail -1 < /etc/passwd > "/staging/etc/passwd" \
-    && tail -1 < /etc/group > "/staging/etc/group"
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
 
 # Clean up staging
 RUN rm -rf /staging/etc/tdnf \


### PR DESCRIPTION
The intent with the distroless-style containers is to have a non-root user by default. As part of that implementation, the users that were actually registered in the container have been scoped down to just that non-root user `app`.

However, all of the files in the system are actually owned by the root user (technically owned by UID 0 since there is no user named root). So it's a bit odd that there are files in the container that are owned by a user that is not registered.

Not having a root user exist doesn't actually buy us any sort of protection. The container can still be run with root-level permissions by running the container with `--user 0` instead of `--user root`.

So to make things more correct and consistent, the root user will be preserved.