### PR TITLE
Update Alpine samples for localization scenario

### DIFF
--- a/samples/aspnetapp/Dockerfile.alpine-arm32
+++ b/samples/aspnetapp/Dockerfile.alpine-arm32
@@ -22,4 +22,6 @@ ENTRYPOINT ["./aspnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs

--- a/samples/aspnetapp/Dockerfile.alpine-arm64
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64
@@ -22,4 +22,6 @@ ENTRYPOINT ["./aspnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -22,4 +22,6 @@ ENTRYPOINT ["./aspnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs

--- a/samples/aspnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-x64-slim
@@ -22,4 +22,6 @@ ENTRYPOINT ["./aspnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs

--- a/samples/dotnetapp/Dockerfile.alpine-arm32
+++ b/samples/dotnetapp/Dockerfile.alpine-arm32
@@ -22,4 +22,6 @@ ENTRYPOINT ["./dotnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs

--- a/samples/dotnetapp/Dockerfile.alpine-arm64
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64
@@ -22,4 +22,6 @@ ENTRYPOINT ["./dotnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs

--- a/samples/dotnetapp/Dockerfile.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.alpine-x64
@@ -22,4 +22,6 @@ ENTRYPOINT ["./dotnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs

--- a/samples/dotnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-x64-slim
@@ -22,4 +22,6 @@ ENTRYPOINT ["./dotnetapp"]
 #     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     LC_ALL=en_US.UTF-8 \
 #     LANG=en_US.UTF-8
-# RUN apk add --no-cache icu-libs
+# RUN apk add --no-cache \
+#     icu-data-full \
+#     icu-libs


### PR DESCRIPTION
In Alpine 3.16, the ICU data was split across two packages: icu-libs and icu-data-full. See https://github.com/dotnet/dotnet-docker/issues/3844 for more info. Since our Alpine sample Dockerfiles are based on Alpine 3.16, the content needs to be updated to reflect this requirement for localization scenarios.

Related:
https://github.com/dotnet/dotnet-docker/issues/3844#issuecomment-1268233473
https://github.com/dotnet/dotnet-docker/issues/4126