### PR TITLE
Update readmes for how tags are listed and featured

### DIFF
--- a/.mar/portal/README.aspnet.portal.md
+++ b/.mar/portal/README.aspnet.portal.md
@@ -12,9 +12,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
 
 ## Related Repos

--- a/.mar/portal/README.monitor.portal.md
+++ b/.mar/portal/README.monitor.portal.md
@@ -16,7 +16,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 * `7` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
-* `6` (Standard Support)
+* `6` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 ## Related Repos

--- a/.mar/portal/README.monitor.portal.md
+++ b/.mar/portal/README.monitor.portal.md
@@ -14,9 +14,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7` (Preview)
+* `7` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
-* `6` (Preview)
+* `6` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 ## Related Repos

--- a/.mar/portal/README.runtime-deps.portal.md
+++ b/.mar/portal/README.runtime-deps.portal.md
@@ -12,9 +12,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
 
 ## Related Repos

--- a/.mar/portal/README.runtime.portal.md
+++ b/.mar/portal/README.runtime.portal.md
@@ -12,9 +12,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
 
 ## Related Repos

--- a/.mar/portal/README.sdk.portal.md
+++ b/.mar/portal/README.sdk.portal.md
@@ -18,9 +18,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
 
 ## Related Repos

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
 
 # About
@@ -56,6 +56,10 @@ See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotn
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
+7.0.0-rc.2-jammy-chiseled-amd64, 7.0-jammy-chiseled-amd64, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.9-bullseye-slim, 6.0-bullseye-slim, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
 6.0.9-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
 6.0.9-jammy-amd64, 6.0-jammy-amd64, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
@@ -67,17 +71,13 @@ Tags | Dockerfile | OS Version
 3.1.29-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/bullseye-slim/amd64/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
-7.0.0-rc.2-jammy-chiseled-amd64, 7.0-jammy-chiseled-amd64, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
+7.0.0-rc.2-jammy-chiseled-arm64v8, 7.0-jammy-chiseled-arm64v8, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.9-bullseye-slim, 6.0-bullseye-slim, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
 6.0.9-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
 6.0.9-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
@@ -89,17 +89,12 @@ Tags | Dockerfile | OS Version
 3.1.29-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
-7.0.0-rc.2-jammy-chiseled-arm64v8, 7.0-jammy-chiseled-arm64v8, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.9-bullseye-slim, 6.0-bullseye-slim, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
 6.0.9-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
 6.0.9-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
@@ -109,54 +104,31 @@ Tags | Dockerfile | OS Version
 3.1.29-focal-arm32v7, 3.1-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
-
 ## Nano Server 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+7.0.0-rc.2-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/nanoserver-ltsc2022/amd64/Dockerfile)
 6.0.9-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/nanoserver-ltsc2022/amd64/Dockerfile)
 3.1.29-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, 3.1.29, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/nanoserver-ltsc2022/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
-7.0.0-rc.2-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/nanoserver-ltsc2022/amd64/Dockerfile)
 
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.9-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
 7.0.0-rc.2-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/windowsservercore-ltsc2022/amd64/Dockerfile)
+6.0.9-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
 
 ## Nano Server, version 1809 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+7.0.0-rc.2-nanoserver-1809, 7.0-nanoserver-1809, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/nanoserver-1809/amd64/Dockerfile)
 6.0.9-nanoserver-1809, 6.0-nanoserver-1809, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile)
 3.1.29-nanoserver-1809, 3.1-nanoserver-1809, 3.1.29, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
-7.0.0-rc.2-nanoserver-1809, 7.0-nanoserver-1809, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/nanoserver-1809/amd64/Dockerfile)
 
 ## Windows Server Core 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.9-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
 7.0.0-rc.2-windowsservercore-ltsc2019, 7.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/7.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+6.0.9-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspnet/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/aspnet at https://mcr.microsoft.com/v2/dotnet/nightly/aspnet/tags/list.
 <!--End of generated tags-->

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -8,7 +8,7 @@
 
 * `7` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
-* `6` (Standard Support)
+* `6` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 # About

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7` (Preview)
+* `7` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
-* `6` (Preview)
+* `6` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 # About
@@ -50,28 +50,20 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-rc.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-rc.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.16
+7.0.0-rc.1-ubuntu-chiseled-amd64, 7.0-ubuntu-chiseled-amd64, 7-ubuntu-chiseled-amd64, 7.0.0-rc.1-ubuntu-chiseled, 7.0-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.3.0-alpine-amd64, 6.3-alpine-amd64, 6-alpine-amd64, 6.3.0-alpine, 6.3-alpine, 6-alpine, 6.3.0, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/amd64/Dockerfile) | Alpine 3.16
 6.3.0-ubuntu-chiseled-amd64, 6.3-ubuntu-chiseled-amd64, 6-ubuntu-chiseled-amd64, 6.3.0-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.2.2-alpine-amd64, 6.2-alpine-amd64, 6.2.2-alpine, 6.2-alpine, 6.2.2, 6.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/amd64/Dockerfile) | Alpine 3.16
 
-##### .NET Monitor Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.0-rc.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-rc.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.16
-7.0.0-rc.1-ubuntu-chiseled-amd64, 7.0-ubuntu-chiseled-amd64, 7-ubuntu-chiseled-amd64, 7.0.0-rc.1-ubuntu-chiseled, 7.0-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm64 Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-6.3.0-alpine-arm64v8, 6.3-alpine-arm64v8, 6.3.0-alpine, 6.3-alpine, 6-alpine, 6.3.0, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/arm64v8/Dockerfile) | Alpine 3.16
-6.3.0-ubuntu-chiseled-arm64v8, 6.3-ubuntu-chiseled-arm64v8, 6-ubuntu-chiseled-arm64v8, 6.3.0-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-6.2.2-alpine-arm64v8, 6.2-alpine-arm64v8, 6.2.2-alpine, 6.2-alpine, 6.2.2, 6.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/arm64v8/Dockerfile) | Alpine 3.16
-
-##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.0.0-rc.1-alpine-arm64v8, 7.0-alpine-arm64v8, 7-alpine-arm64v8, 7.0.0-rc.1-alpine, 7.0-alpine, 7-alpine, 7.0.0-rc.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/arm64v8/Dockerfile) | Alpine 3.16
 7.0.0-rc.1-ubuntu-chiseled-arm64v8, 7.0-ubuntu-chiseled-arm64v8, 7-ubuntu-chiseled-arm64v8, 7.0.0-rc.1-ubuntu-chiseled, 7.0-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+6.3.0-alpine-arm64v8, 6.3-alpine-arm64v8, 6.3.0-alpine, 6.3-alpine, 6-alpine, 6.3.0, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/arm64v8/Dockerfile) | Alpine 3.16
+6.3.0-ubuntu-chiseled-arm64v8, 6.3-ubuntu-chiseled-arm64v8, 6-ubuntu-chiseled-arm64v8, 6.3.0-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+6.2.2-alpine-arm64v8, 6.2-alpine-arm64v8, 6.2.2-alpine, 6.2-alpine, 6.2.2, 6.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/arm64v8/Dockerfile) | Alpine 3.16
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
 
 # About
@@ -44,6 +44,10 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.0-rc.2, 7.0.0-rc.2-bullseye-slim, 7.0, 7.0-bullseye-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/amd64/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
+7.0.0-rc.2-jammy-chiseled-amd64, 7.0-jammy-chiseled-amd64, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.9, 6.0.9-bullseye-slim, 6.0, 6.0-bullseye-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/amd64/Dockerfile) | Debian 11
 6.0.9-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.16/amd64/Dockerfile) | Alpine 3.16
 6.0.9-jammy-amd64, 6.0-jammy-amd64, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
@@ -55,17 +59,13 @@ Tags | Dockerfile | OS Version
 3.1.29-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.0-rc.2, 7.0.0-rc.2-bullseye-slim, 7.0, 7.0-bullseye-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/amd64/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.16/amd64/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
-7.0.0-rc.2-jammy-chiseled-amd64, 7.0-jammy-chiseled-amd64, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.0-rc.2, 7.0.0-rc.2-bullseye-slim, 7.0, 7.0-bullseye-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/arm64v8/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
+7.0.0-rc.2-jammy-chiseled-arm64v8, 7.0-jammy-chiseled-arm64v8, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.9, 6.0.9-bullseye-slim, 6.0, 6.0-bullseye-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/arm64v8/Dockerfile) | Debian 11
 6.0.9-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
 6.0.9-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
@@ -77,17 +77,12 @@ Tags | Dockerfile | OS Version
 3.1.29-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.0-rc.2, 7.0.0-rc.2-bullseye-slim, 7.0, 7.0-bullseye-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
-7.0.0-rc.2-jammy-chiseled-arm64v8, 7.0-jammy-chiseled-arm64v8, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.0-rc.2, 7.0.0-rc.2-bullseye-slim, 7.0, 7.0-bullseye-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/arm32v7/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.9, 6.0.9-bullseye-slim, 6.0, 6.0-bullseye-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/arm32v7/Dockerfile) | Debian 11
 6.0.9-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
 6.0.9-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
@@ -96,13 +91,6 @@ Tags | Dockerfile | OS Version
 3.1.29-buster-slim-arm32v7, 3.1-buster-slim-arm32v7, 3.1.29, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile) | Debian 10
 3.1.29-focal-arm32v7, 3.1-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
-
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.0-rc.2, 7.0.0-rc.2-bullseye-slim, 7.0, 7.0-bullseye-slim, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/3.1/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime-deps/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime-deps at https://mcr.microsoft.com/v2/dotnet/nightly/runtime-deps/tags/list.
 <!--End of generated tags-->

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
 
 # About
@@ -52,6 +52,10 @@ docker run --rm mcr.microsoft.com/dotnet/samples
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/bullseye-slim/amd64/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
+7.0.0-rc.2-jammy-chiseled-amd64, 7.0-jammy-chiseled-amd64, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.9-bullseye-slim, 6.0-bullseye-slim, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
 6.0.9-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
 6.0.9-jammy-amd64, 6.0-jammy-amd64, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
@@ -63,17 +67,13 @@ Tags | Dockerfile | OS Version
 3.1.29-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/bullseye-slim/amd64/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
-7.0.0-rc.2-jammy-chiseled-amd64, 7.0-jammy-chiseled-amd64, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
+7.0.0-rc.2-jammy-chiseled-arm64v8, 7.0-jammy-chiseled-arm64v8, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.9-bullseye-slim, 6.0-bullseye-slim, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
 6.0.9-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
 6.0.9-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
@@ -85,17 +85,12 @@ Tags | Dockerfile | OS Version
 3.1.29-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
-7.0.0-rc.2-jammy-chiseled-arm64v8, 7.0-jammy-chiseled-arm64v8, 7.0.0-rc.2-jammy-chiseled, 7.0-jammy-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.0-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
+7.0.0-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
+7.0.0-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 6.0.9-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.9-bullseye-slim, 6.0-bullseye-slim, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
 6.0.9-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.9-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
 6.0.9-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.9-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
@@ -105,54 +100,31 @@ Tags | Dockerfile | OS Version
 3.1.29-focal-arm32v7, 3.1-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 3.1.29-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.0-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.0-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-7.0.0-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.0-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
-7.0.0-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.0-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
-
 ## Nano Server 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+7.0.0-rc.2-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile)
 6.0.9-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/nanoserver-ltsc2022/amd64/Dockerfile)
 3.1.29-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, 3.1.29, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/nanoserver-ltsc2022/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
-7.0.0-rc.2-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/nanoserver-ltsc2022/amd64/Dockerfile)
 
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.9-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
 7.0.0-rc.2-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/windowsservercore-ltsc2022/amd64/Dockerfile)
+6.0.9-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
 
 ## Nano Server, version 1809 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+7.0.0-rc.2-nanoserver-1809, 7.0-nanoserver-1809, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile)
 6.0.9-nanoserver-1809, 6.0-nanoserver-1809, 6.0.9, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/nanoserver-1809/amd64/Dockerfile)
 3.1.29-nanoserver-1809, 3.1-nanoserver-1809, 3.1.29, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
-7.0.0-rc.2-nanoserver-1809, 7.0-nanoserver-1809, 7.0.0-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/nanoserver-1809/amd64/Dockerfile)
 
 ## Windows Server Core 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.9-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
 7.0.0-rc.2-windowsservercore-ltsc2019, 7.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/7.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+6.0.9-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/runtime/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/runtime at https://mcr.microsoft.com/v2/dotnet/nightly/runtime/tags/list.
 <!--End of generated tags-->

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (Preview)
+* `7.0` (RC)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:7.0`
-* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
 
 # About
@@ -61,6 +61,9 @@ The following samples show how to develop, build and test .NET applications with
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.100-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.100-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/amd64/Dockerfile) | Debian 11
+7.0.100-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.100-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
+7.0.100-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.100-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
 6.0.401-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.401-bullseye-slim, 6.0-bullseye-slim, 6.0.401, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
 6.0.401-alpine3.16-amd64, 6.0-alpine3.16-amd64, 6.0-alpine-amd64, 6.0.401-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
 6.0.401-jammy-amd64, 6.0-jammy-amd64, 6.0.401-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
@@ -71,16 +74,12 @@ Tags | Dockerfile | OS Version
 3.1.423-focal, 3.1-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/focal/amd64/Dockerfile) | Ubuntu 20.04
 3.1.423-bionic, 3.1-bionic | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bionic/amd64/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.100-rc.2-bullseye-slim-amd64, 7.0-bullseye-slim-amd64, 7.0.100-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/amd64/Dockerfile) | Debian 11
-7.0.100-rc.2-alpine3.16-amd64, 7.0-alpine3.16-amd64, 7.0-alpine-amd64, 7.0.100-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/amd64/Dockerfile) | Alpine 3.16
-7.0.100-rc.2-jammy-amd64, 7.0-jammy-amd64, 7.0.100-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.100-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.100-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
+7.0.100-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.100-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
+7.0.100-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.100-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
 6.0.401-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.401-bullseye-slim, 6.0-bullseye-slim, 6.0.401, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
 6.0.401-alpine3.16-arm64v8, 6.0-alpine3.16-arm64v8, 6.0-alpine-arm64v8, 6.0.401-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
 6.0.401-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.401-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
@@ -90,16 +89,12 @@ Tags | Dockerfile | OS Version
 3.1.423-focal-arm64v8, 3.1-focal-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 3.1.423-bionic-arm64v8, 3.1-bionic-arm64v8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bionic/arm64v8/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.100-rc.2-bullseye-slim-arm64v8, 7.0-bullseye-slim-arm64v8, 7.0.100-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-7.0.100-rc.2-alpine3.16-arm64v8, 7.0-alpine3.16-arm64v8, 7.0-alpine-arm64v8, 7.0.100-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm64v8/Dockerfile) | Alpine 3.16
-7.0.100-rc.2-jammy-arm64v8, 7.0-jammy-arm64v8, 7.0.100-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
-
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
+7.0.100-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.100-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
+7.0.100-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.100-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
+7.0.100-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.100-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 6.0.401-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.401-bullseye-slim, 6.0-bullseye-slim, 6.0.401, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
 6.0.401-alpine3.16-arm32v7, 6.0-alpine3.16-arm32v7, 6.0-alpine-arm32v7, 6.0.401-alpine3.16, 6.0-alpine3.16, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
 6.0.401-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.401-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
@@ -109,54 +104,31 @@ Tags | Dockerfile | OS Version
 3.1.423-focal-arm32v7, 3.1-focal-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 3.1.423-bionic-arm32v7, 3.1-bionic-arm32v7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/bionic/arm32v7/Dockerfile) | Ubuntu 18.04
 
-##### .NET 7 Preview Tags
-Tags | Dockerfile | OS Version
------------| -------------| -------------
-7.0.100-rc.2-bullseye-slim-arm32v7, 7.0-bullseye-slim-arm32v7, 7.0.100-rc.2-bullseye-slim, 7.0-bullseye-slim, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-7.0.100-rc.2-alpine3.16-arm32v7, 7.0-alpine3.16-arm32v7, 7.0-alpine-arm32v7, 7.0.100-rc.2-alpine3.16, 7.0-alpine3.16, 7.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/alpine3.16/arm32v7/Dockerfile) | Alpine 3.16
-7.0.100-rc.2-jammy-arm32v7, 7.0-jammy-arm32v7, 7.0.100-rc.2-jammy, 7.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
-
 ## Nano Server 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+7.0.100-rc.2-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile)
 6.0.401-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6.0.401, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile)
 3.1.423-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, 3.1.423, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/nanoserver-ltsc2022/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
-7.0.100-rc.2-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/nanoserver-ltsc2022/amd64/Dockerfile)
 
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.401-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
 7.0.100-rc.2-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/windowsservercore-ltsc2022/amd64/Dockerfile)
+6.0.401-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
 
 ## Nano Server, version 1809 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+7.0.100-rc.2-nanoserver-1809, 7.0-nanoserver-1809, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile)
 6.0.401-nanoserver-1809, 6.0-nanoserver-1809, 6.0.401, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile)
 3.1.423-nanoserver-1809, 3.1-nanoserver-1809, 3.1.423, 3.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
-7.0.100-rc.2-nanoserver-1809, 7.0-nanoserver-1809, 7.0.100-rc.2, 7.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/nanoserver-1809/amd64/Dockerfile)
 
 ## Windows Server Core 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-6.0.401-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
-
-##### .NET 7 Preview Tags
-Tag | Dockerfile
----------| ---------------
 7.0.100-rc.2-windowsservercore-ltsc2019, 7.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/7.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+6.0.401-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/nightly/sdk at https://mcr.microsoft.com/v2/dotnet/nightly/sdk/tags/list.
 <!--End of generated tags-->

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -1,12 +1,8 @@
 $(McrTagsYmlRepo:aspnet)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-chiseled-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-amd64)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-amd64)
 $(McrTagsYmlTagGroup:6.0-jammy-amd64)
@@ -18,13 +14,9 @@ $(McrTagsYmlTagGroup:3.1-alpine3.16)
 $(McrTagsYmlTagGroup:3.1-focal)
 $(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-chiseled-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm64v8)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm64v8)
 $(McrTagsYmlTagGroup:6.0-jammy-arm64v8)
@@ -36,11 +28,8 @@ $(McrTagsYmlTagGroup:3.1-alpine3.16-arm64v8)
 $(McrTagsYmlTagGroup:3.1-focal-arm64v8)
 $(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm32v7)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm32v7)
 $(McrTagsYmlTagGroup:6.0-jammy-arm32v7)
@@ -50,16 +39,12 @@ $(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
 $(McrTagsYmlTagGroup:3.1-focal-arm32v7)
 $(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:7.0-nanoserver-ltsc2022)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-windowsservercore-ltsc2022)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-nanoserver-ltsc2022)
 $(McrTagsYmlTagGroup:6.0-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.1-nanoserver-ltsc2022)
 $(McrTagsYmlTagGroup:7.0-nanoserver-1809)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-windowsservercore-ltsc2019)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-nanoserver-1809)
 $(McrTagsYmlTagGroup:6.0-windowsservercore-ltsc2019)
 $(McrTagsYmlTagGroup:3.1-nanoserver-1809)

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -1,12 +1,8 @@
 $(McrTagsYmlRepo:monitor)
 $(McrTagsYmlTagGroup:7.0-alpine-amd64)
-    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine-arm64v8)
-    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:7.0-ubuntu-chiseled-amd64)
-    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:7.0-ubuntu-chiseled-arm64v8)
-    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:6.3-alpine-amd64)
 $(McrTagsYmlTagGroup:6.3-alpine-arm64v8)
 $(McrTagsYmlTagGroup:6.3-ubuntu-chiseled-amd64)

--- a/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-deps-tags.yml
@@ -1,12 +1,8 @@
 $(McrTagsYmlRepo:runtime-deps)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-chiseled-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-amd64)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-amd64)
 $(McrTagsYmlTagGroup:6.0-jammy-amd64)
@@ -18,13 +14,9 @@ $(McrTagsYmlTagGroup:3.1-alpine3.16)
 $(McrTagsYmlTagGroup:3.1-focal)
 $(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-chiseled-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm64v8)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm64v8)
 $(McrTagsYmlTagGroup:6.0-jammy-arm64v8)
@@ -36,11 +28,8 @@ $(McrTagsYmlTagGroup:3.1-alpine3.16-arm64v8)
 $(McrTagsYmlTagGroup:3.1-focal-arm64v8)
 $(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm32v7)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm32v7)
 $(McrTagsYmlTagGroup:6.0-jammy-arm32v7)

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -1,12 +1,8 @@
 $(McrTagsYmlRepo:runtime)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-chiseled-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-amd64)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-amd64)
 $(McrTagsYmlTagGroup:6.0-jammy-amd64)
@@ -18,13 +14,9 @@ $(McrTagsYmlTagGroup:3.1-alpine3.16)
 $(McrTagsYmlTagGroup:3.1-focal)
 $(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-chiseled-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm64v8)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm64v8)
 $(McrTagsYmlTagGroup:6.0-jammy-arm64v8)
@@ -36,11 +28,8 @@ $(McrTagsYmlTagGroup:3.1-alpine3.16-arm64v8)
 $(McrTagsYmlTagGroup:3.1-focal-arm64v8)
 $(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm32v7)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm32v7)
 $(McrTagsYmlTagGroup:6.0-jammy-arm32v7)
@@ -50,16 +39,12 @@ $(McrTagsYmlTagGroup:3.1-buster-slim-arm32v7)
 $(McrTagsYmlTagGroup:3.1-focal-arm32v7)
 $(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:7.0-nanoserver-ltsc2022)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-windowsservercore-ltsc2022)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-nanoserver-ltsc2022)
 $(McrTagsYmlTagGroup:6.0-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.1-nanoserver-ltsc2022)
 $(McrTagsYmlTagGroup:7.0-nanoserver-1809)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-windowsservercore-ltsc2019)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-nanoserver-1809)
 $(McrTagsYmlTagGroup:6.0-windowsservercore-ltsc2019)
 $(McrTagsYmlTagGroup:3.1-nanoserver-1809)

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -1,10 +1,7 @@
 $(McrTagsYmlRepo:sdk)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-amd64)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-amd64)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-amd64)
 $(McrTagsYmlTagGroup:6.0-jammy-amd64)
@@ -15,11 +12,8 @@ $(McrTagsYmlTagGroup:3.1-alpine3.16)
 $(McrTagsYmlTagGroup:3.1-focal)
 $(McrTagsYmlTagGroup:3.1-bionic)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm64v8)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm64v8)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm64v8)
 $(McrTagsYmlTagGroup:6.0-jammy-arm64v8)
@@ -29,11 +23,8 @@ $(McrTagsYmlTagGroup:3.1-buster-arm64v8)
 $(McrTagsYmlTagGroup:3.1-focal-arm64v8)
 $(McrTagsYmlTagGroup:3.1-bionic-arm64v8)
 $(McrTagsYmlTagGroup:7.0-bullseye-slim-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine3.16-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-jammy-arm32v7)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-bullseye-slim-arm32v7)
 $(McrTagsYmlTagGroup:6.0-alpine3.16-arm32v7)
 $(McrTagsYmlTagGroup:6.0-jammy-arm32v7)
@@ -43,16 +34,12 @@ $(McrTagsYmlTagGroup:3.1-buster-arm32v7)
 $(McrTagsYmlTagGroup:3.1-focal-arm32v7)
 $(McrTagsYmlTagGroup:3.1-bionic-arm32v7)
 $(McrTagsYmlTagGroup:7.0-nanoserver-ltsc2022)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-windowsservercore-ltsc2022)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-nanoserver-ltsc2022)
 $(McrTagsYmlTagGroup:6.0-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.1-nanoserver-ltsc2022)
 $(McrTagsYmlTagGroup:7.0-nanoserver-1809)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:7.0-windowsservercore-ltsc2019)
-    customSubTableTitle: .NET 7 Preview Tags
 $(McrTagsYmlTagGroup:6.0-nanoserver-1809)
 $(McrTagsYmlTagGroup:6.0-windowsservercore-ltsc2019)
 $(McrTagsYmlTagGroup:3.1-nanoserver-1809)

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -10,7 +10,7 @@
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`^
 elif match(SHORT_REPO, "monitor"):* `7` (RC)
   * `docker pull {{FULL_REPO}}:7`
-* `6` (Standard Support)
+* `6` (LTS)
   * `docker pull {{FULL_REPO}}:6`^
 else:* `7.0` (RC)
   * `docker pull {{FULL_REPO}}:7.0`

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -8,13 +8,11 @@
   * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
 * `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`^
-elif match(SHORT_REPO, "monitor"):{{if VARIABLES["branch"] = "nightly":* `7` (Preview)
+elif match(SHORT_REPO, "monitor"):* `7` (RC)
   * `docker pull {{FULL_REPO}}:7`
-* `6` (Preview)
+* `6` (Standard Support)
   * `docker pull {{FULL_REPO}}:6`^
-else:* `6` (Current)
-  * `docker pull {{FULL_REPO}}:6`}}^
-else:{{if VARIABLES["branch"] = "nightly":* `7.0` (Preview)
+else:* `7.0` (RC)
   * `docker pull {{FULL_REPO}}:7.0`
-}}* `6.0` (Current, LTS)
+* `6.0` (LTS)
   * `docker pull {{FULL_REPO}}:6.0`}}


### PR DESCRIPTION
This outlines our plans for classifying tags in the readmes for each .NET release:

* While a .NET version is in preview, its tags will be listed separately from the other supported versions in its own "Preview Tags" table.
* Once a .NET version has reached an RC release:
  * That separate table will now longer be used and the RC tags will be incorporated with the tags of the other supported versions.
  * The "Featured Tags" section will be updated to include the RC version.