### PR TITLE
Fix OS parameter usage in build script

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -47,7 +47,7 @@ if ($Mode -eq "BuildAndTest" -or $Mode -eq "Build") {
     # Build the sample images
     & ./eng/common/build.ps1 `
         -Version $Version `
-        -OSVersions @($OS) `
+        -OS @($OS) `
         -Architecture $Architecture `
         -Paths $Paths `
         -OptionalImageBuilderArgs $OptionalImageBuilderArgs `


### PR DESCRIPTION
This fixes the name of the OS parameter used when calling the /eng/common/build.ps1 script. It's name is `OS`, not `OSVersions`.