### PR TITLE
dotnet-monitor: Set default GC mode

### DIFF
--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -79,6 +79,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/eng/dockerfile-templates/monitor/Dockerfile
+++ b/eng/dockerfile-templates/monitor/Dockerfile
@@ -73,14 +73,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/alpine/amd64/Dockerfile
+++ b/src/monitor/6.2/alpine/amd64/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.2/alpine/arm64v8/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/amd64/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/amd64/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.2/cbl-mariner/arm64v8/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/alpine/amd64/Dockerfile
+++ b/src/monitor/6.3/alpine/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/alpine/amd64/Dockerfile
+++ b/src/monitor/6.3/alpine/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/alpine/amd64/Dockerfile
+++ b/src/monitor/6.3/alpine/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-alpine3.16-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.3/alpine/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-alpine3.16-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.3/alpine/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/alpine/arm64v8/Dockerfile
+++ b/src/monitor/6.3/alpine/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-alpine3.16-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN wget -O dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner-distroless/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner-distroless/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner-distroless/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/6.3/cbl-mariner/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-cbl-mariner2.0-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-jammy-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-jammy-amd64 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-jammy-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \

--- a/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile
@@ -6,7 +6,7 @@ FROM $SDK_REPO:6.0.402-jammy-arm64v8 AS installer
 
 # Install .NET Monitor
 ENV DOTNET_MONITOR_VERSION=6.3.0
-RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/6.3.0-rtm.22479.7/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetcli.azureedge.net/dotnet/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
     && dotnetmonitor_sha512='d31780f4adab2ce7e4073d4dc3570cca80ae4d2e4f73a714bb485a8e3ed3601deec6eb6612731854e7da00f2b5e28593e7055ef457568ac8dc60f60807390a25' \
     && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
     && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net6.0 --no-cache \
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/alpine/amd64/Dockerfile
+++ b/src/monitor/7.0/alpine/amd64/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/alpine/arm64v8/Dockerfile
+++ b/src/monitor/7.0/alpine/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/alpine/arm64v8/Dockerfile
+++ b/src/monitor/7.0/alpine/arm64v8/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/amd64/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
+++ b/src/monitor/7.0/cbl-mariner/arm64v8/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -47,14 +47,14 @@ ENV \
     DefaultProcess__Filters__0__Value=1 \
     # Remove Unix Domain Socket before starting diagnostic port server
     DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Logging: JSON format so that analytic platforms can get discrete entry information
     Logging__Console__FormatterName=json \
     # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -53,6 +53,8 @@ ENV \
     Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
     # Logging: Write timestamps using UTC offset (+0:00)
     Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
     # Add dotnet-monitor path to front of PATH for easier, prioritized execution
     PATH="/app:${PATH}"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -133,6 +133,8 @@ namespace Microsoft.DotNet.Docker.Tests
             variables.Add(new EnvironmentVariableInfo("DefaultProcess__Filters__0__Value", "1"));
             // Existing (orphaned) diagnostic port should be delete before starting server
             variables.Add(new EnvironmentVariableInfo("DiagnosticPort__DeleteEndpointOnStartup", "true"));
+            // GC mode should be set to Server
+            variables.Add(new EnvironmentVariableInfo("DOTNET_gcServer", "1"));
             // Console logger format should be JSON and output UTC timestamps without timezone information
             variables.Add(new EnvironmentVariableInfo("Logging__Console__FormatterName", "json"));
             variables.Add(new EnvironmentVariableInfo("Logging__Console__FormatterOptions__TimestampFormat", "yyyy-MM-ddTHH:mm:ss.fffffffZ"));


### PR DESCRIPTION
This PR explicitly sets the default GC mode for `dotnet monitor` images to Server. This PR **does not** change the default behavior of any of the images as this is their current default, and instead ensures that future images keep their current behavior going forward as we change `dotnet monitor`'s GC defaults for other environments.

cc @dotnet/dotnet-monitor 