### PR TITLE
Use dotnetstage storage account for internal builds

### DIFF
--- a/eng/Get-DropVersions.ps1
+++ b/eng/Get-DropVersions.ps1
@@ -54,15 +54,16 @@ function GetCommitSha([string]$sdkVersion, [string]$queryString, [switch]$useSta
         $sdkStableVersion = $sdkVersion
     }
 
+    $zipFile = "dotnet-sdk-$sdkStableVersion-win-x64.zip"
+
     if ($UseInternalBuild) {
-        $blobContainer = "internal"
+        $sdkUrl = "https://dotnetstage.blob.core.windows.net/internal/Sdk/$sdkVersion/$zipFile$queryString"
     }
     else {
-        $blobContainer = "public"
+        $sdkUrl = "https://dotnetbuilds.blob.core.windows.net/public/Sdk/$sdkVersion/$zipFile"
     }
-    
+
     # Download the SDK
-    $sdkUrl = "https://dotnetbuilds.blob.core.windows.net/$blobContainer/Sdk/$sdkVersion/dotnet-sdk-$sdkStableVersion-win-x64.zip$queryString"
     Write-Host "Downloading SDK from $sdkUrl"
     $sdkOutPath = "$tempDir/sdk.zip"
     Invoke-WebRequest -Uri $sdkUrl -OutFile $sdkOutPath

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -34,13 +34,7 @@ stages:
     - powershell: |
         $imageBuilderBuildArgs = "$(imageBuilderBuildArgs)"
         if ("$(publishRepoPrefix)".Contains("internal/")) {
-          if ("$env:ENABLEINTERNAL3_1" -eq "true") {
-            $sasQueryString = "$(dotnetclimsrc-read-sas-token)"
-          }
-          else {
-            $sasQueryString = "$(dotnetbuilds-internal-container-read-token)"
-          }
-          
+          $sasQueryString = "$(dotnetstage-account-sas-read-token)"
           $imageBuilderBuildArgs += " --build-arg SAS_QUERY_STRING='$sasQueryString'"
         }
         echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"

--- a/eng/pipelines/steps/set-custom-test-variables.yml
+++ b/eng/pipelines/steps/set-custom-test-variables.yml
@@ -5,12 +5,7 @@ steps:
     $testInit=""
 
     if ("$(publishRepoPrefix)".Contains("internal/")) {
-      if ("$env:ENABLEINTERNAL3_1" -eq "true") {
-        $sasQueryString = "$(dotnetclimsrc-read-sas-token)"
-      }
-      else {
-        $sasQueryString = "$(dotnetbuilds-internal-container-read-token)"
-      }
+      $sasQueryString = "$(dotnetstage-account-sas-read-token)"
 
       if ($Env:AGENT_OS -eq 'Linux') {
         $testRunnerOptions="$testRunnerOptions -e SAS_QUERY_STRING='$sasQueryString' -e NUGET_FEED_PASSWORD='$(dn-bot-dnceng-artifact-feeds-rw)'"

--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -19,7 +19,7 @@ steps:
 
     if ("${{ parameters.useInternalBuild }}" -eq "true") {
       $args["UseInternalBuild"] = $true
-      $args["BlobStorageSasQueryString"] = "$(dotnetbuilds-internal-container-read-token)"
+      $args["BlobStorageSasQueryString"] = "$(dotnetstage-account-sas-read-token)"
       $args["AzdoVersionsRepoInfoAccessToken"] = "$(dn-bot-devdiv-dnceng-rw-code-pat)"
     }
 
@@ -41,8 +41,8 @@ steps:
       }
 
       if ("${{ parameters.useInternalBuild }}" -eq "true") {
-        $args["BinarySasQueryString"] = '"$(dotnetbuilds-internal-container-read-token)"'
-        $args["ChecksumSasQueryString"] = '"$(dotnetbuilds-internal-checksums-container-read-token)"'
+        $args["ChecksumSasQueryString"] = '"$(dotnetchecksumsstage-account-sas-read-token)"'
+        $args["BinarySasQueryString"] = '"$(dotnetstage-account-sas-read-token)"'
       }
 
       Write-Host "Executing Set-DotnetVersions.ps1 for $($versionInfo.DockerfileVersion)"

--- a/eng/pipelines/update-dependencies-internal.yml
+++ b/eng/pipelines/update-dependencies-internal.yml
@@ -3,7 +3,7 @@ pr: none
 
 variables:
 - template: ../common/templates/variables/dotnet/common.yml
-- group: DotNetBuilds storage account read tokens
+- group: DncEng-Partners-Tokens
 - group: DotNet-AllOrgs-Darc-Pats
 stages:
 - stage: DotNet

--- a/eng/pipelines/variables/core.yml
+++ b/eng/pipelines/variables/core.yml
@@ -2,9 +2,7 @@ variables:
 - template: ../../common/templates/variables/dotnet/build-test-publish.yml
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNetBuilds storage account read tokens
   - group: AzureDevOps-Artifact-Feeds-Pats
-  - group: DotNet-MSRC-Storage # needed for .NET Core 3.1 internal builds
 
 - name: manifest
   value: manifest.json

--- a/eng/pipelines/variables/internal-core.yml
+++ b/eng/pipelines/variables/internal-core.yml
@@ -2,6 +2,7 @@
 
 variables:
 - template: core.yml
+- group: DncEng-Partners-Tokens
 
 # Since the images published by the pipeline are only available internally, configure variables so that image info
 # is published to an internal repo.

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -42,12 +42,12 @@
     "base-url|public|main": "https://dotnetcli.azureedge.net/dotnet",
     "base-url|public|nightly": "https://dotnetbuilds.azureedge.net/public",
     "base-url|internal|main": "https://dotnetclimsrc.blob.core.windows.net/dotnet",
-    "base-url|internal|nightly": "https://dotnetbuilds.blob.core.windows.net/internal",
+    "base-url|internal|nightly": "https://dotnetstage.blob.core.windows.net/internal",
 
     "base-url|public|maintenance|main": "$(base-url|public|main)",
     "base-url|public|maintenance|nightly": "https://dotnetcli.azureedge.net/dotnet",
-    "base-url|internal|maintenance|main": "https://dotnetbuilds.blob.core.windows.net/internal",
-    "base-url|internal|maintenance|nightly": "https://dotnetbuilds.blob.core.windows.net/internal",
+    "base-url|internal|maintenance|main": "https://dotnetstage.blob.core.windows.net/internal",
+    "base-url|internal|maintenance|nightly": "https://dotnetstage.blob.core.windows.net/internal",
 
     "base-url|public|maintenance-legacy|main": "$(base-url|public|maintenance|main)",
     "base-url|public|maintenance-legacy|nightly": "$(base-url|public|maintenance|nightly)",


### PR DESCRIPTION
Updates the infra to use the https://dotnetstage.blob.core.windows.net/internal blob container instead of https://dotnetbuilds.blob.core.windows.net/internal when targeting internal .NET builds. This is because the files in dotnetstage are fully signed.

Fixes https://github.com/dotnet/dotnet-docker/issues/4147