### PR TITLE
Use build-specific blob container for internal builds

### DIFF
--- a/eng/Get-DropVersions.ps1
+++ b/eng/Get-DropVersions.ps1
@@ -56,8 +56,10 @@ function GetCommitSha([string]$sdkVersion, [string]$queryString, [switch]$useSta
 
     $zipFile = "dotnet-sdk-$sdkStableVersion-win-x64.zip"
 
+    $containerVersion = $sdkVersion.Replace(".", "-")
+
     if ($UseInternalBuild) {
-        $sdkUrl = "https://dotnetstage.blob.core.windows.net/internal/Sdk/$sdkVersion/$zipFile$queryString"
+        $sdkUrl = "https://dotnetstage.blob.core.windows.net/$containerVersion-internal/Sdk/$sdkVersion/$zipFile$queryString"
     }
     else {
         $sdkUrl = "https://dotnetbuilds.blob.core.windows.net/public/Sdk/$sdkVersion/$zipFile"

--- a/eng/update-dependencies/BaseUrlUpdater.cs
+++ b/eng/update-dependencies/BaseUrlUpdater.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.VersionTools.Dependencies;
@@ -27,7 +28,8 @@ internal class BaseUrlUpdater : FileRegexUpdater
             $"(?<{BaseUrlGroupName}>.+)");
         _options = options;
 
-        _manifestVariables = (JObject)ManifestHelper.LoadManifest(UpdateDependencies.VersionsFilename)["variables"];
+        _manifestVariables = (JObject?)ManifestHelper.LoadManifest(UpdateDependencies.VersionsFilename)["variables"] ??
+            throw new InvalidOperationException($"'{UpdateDependencies.VersionsFilename}' property missing in '{UpdateDependencies.VersionsFilename}'"); ;
     }
 
     protected override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)
@@ -35,15 +37,24 @@ internal class BaseUrlUpdater : FileRegexUpdater
         usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
 
         string baseUrlVersionVarName = ManifestHelper.GetBaseUrlVariableName(_options.DockerfileVersion, _options.SourceBranch, _options.VersionSourceName);
-        string unresolvedBaseUrl = _manifestVariables[baseUrlVersionVarName].ToString();
+        string unresolvedBaseUrl = _manifestVariables[baseUrlVersionVarName]?.ToString() ??
+            throw new InvalidOperationException($"Variable with name '{baseUrlVersionVarName}' is missing.");
 
         if (_options.IsInternal)
         {
-            unresolvedBaseUrl = unresolvedBaseUrl.Replace("public", "internal");
+            if (!_options.ProductVersions.TryGetValue("sdk", out string? sdkVersion) || string.IsNullOrEmpty(sdkVersion))
+            {
+                throw new InvalidOperationException("The sdk version must be set in order to derive the build's blob storage location.");
+            }
+
+            sdkVersion = sdkVersion.Replace(".", "-");
+
+            unresolvedBaseUrl = $"https://dotnetstage.blob.core.windows.net/{sdkVersion}-internal";
         }
         else
         {
-            unresolvedBaseUrl = unresolvedBaseUrl.Replace("internal", "public");
+            // Modifying the URL from internal to public is not suppported because it's not possible to know
+            // what common variable it was originally referencing when it was last public.
         }
 
         return unresolvedBaseUrl;

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -329,7 +329,7 @@ namespace Dotnet.Docker
 
         private static bool IsInternalUrl(string url)
         {
-            return url.Contains("msrc") || url.Contains("/internal");
+            return url.Contains("internal");
         }
 
         private static string ApplySasQueryStringIfNecessary(string url, string sasQueryString)

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -41,18 +41,12 @@
 
     "base-url|public|main": "https://dotnetcli.azureedge.net/dotnet",
     "base-url|public|nightly": "https://dotnetbuilds.azureedge.net/public",
-    "base-url|internal|main": "https://dotnetclimsrc.blob.core.windows.net/dotnet",
-    "base-url|internal|nightly": "https://dotnetstage.blob.core.windows.net/internal",
 
     "base-url|public|maintenance|main": "$(base-url|public|main)",
     "base-url|public|maintenance|nightly": "https://dotnetcli.azureedge.net/dotnet",
-    "base-url|internal|maintenance|main": "https://dotnetstage.blob.core.windows.net/internal",
-    "base-url|internal|maintenance|nightly": "https://dotnetstage.blob.core.windows.net/internal",
 
     "base-url|public|maintenance-legacy|main": "$(base-url|public|maintenance|main)",
     "base-url|public|maintenance-legacy|nightly": "$(base-url|public|maintenance|nightly)",
-    "base-url|internal|maintenance-legacy|main": "$(base-url|internal|main)",
-    "base-url|internal|maintenance-legacy|nightly": "https://dotnetclimsrc.blob.core.windows.net/dotnet",
 
     "base-url|3.1|main": "$(base-url|public|maintenance-legacy|main)",
     "base-url|3.1|nightly": "$(base-url|public|maintenance-legacy|nightly)",


### PR DESCRIPTION
With these changes, update-dependencies will set the `base-url|<version>|nightly` variable to an explicit URL rather than a variable. This allows the URL to be build-specific.

Fixes #4151 