### PR TITLE
Doc updates for .NET 7 release

### DIFF
--- a/.mar/portal/README.aspnet.portal.md
+++ b/.mar/portal/README.aspnet.portal.md
@@ -12,9 +12,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
 
 ## Related Repos

--- a/.mar/portal/README.monitor.portal.md
+++ b/.mar/portal/README.monitor.portal.md
@@ -14,9 +14,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7` (RC)
+* `7` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
-* `6` (LTS)
+* `6` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 ## Related Repos

--- a/.mar/portal/README.runtime-deps.portal.md
+++ b/.mar/portal/README.runtime-deps.portal.md
@@ -12,9 +12,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
 
 ## Related Repos

--- a/.mar/portal/README.runtime.portal.md
+++ b/.mar/portal/README.runtime.portal.md
@@ -12,9 +12,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
 
 ## Related Repos

--- a/.mar/portal/README.sdk.portal.md
+++ b/.mar/portal/README.sdk.portal.md
@@ -18,9 +18,9 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
 
 ## Related Repos

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:6.0`
 
 # About

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7` (RC)
+* `7` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
-* `6` (LTS)
+* `6` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
 
 # About

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0`
 
 # About

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:6.0`
 
 # About

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -6,9 +6,9 @@
 
 # Featured Tags
 
-* `7.0` (RC)
+* `7.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:6.0`
 
 # About

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -8,11 +8,11 @@
   * `docker pull mcr.microsoft.com/dotnet/samples:dotnetapp`
 * `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`^
-elif match(SHORT_REPO, "monitor"):* `7` (RC)
+elif match(SHORT_REPO, "monitor"):* `7` (Standard Support)
   * `docker pull {{FULL_REPO}}:7`
-* `6` (LTS)
+* `6` (Long-Term Support)
   * `docker pull {{FULL_REPO}}:6`^
-else:* `7.0` (RC)
+else:* `7.0` (Standard Support)
   * `docker pull {{FULL_REPO}}:7.0`
-* `6.0` (LTS)
+* `6.0` (Long-Term Support)
   * `docker pull {{FULL_REPO}}:6.0`}}

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64
@@ -12,7 +12,7 @@ RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false --no-res
 
 # final stage/image
 # Relies on 7.0 multi-arch tag to pick the same Windows version as the host. 
-# Alternatively, a release specific tag can be used, like: `6.0-nanoserver-ltsc2022`
+# Alternatively, a release specific tag can be used, like: `7.0-nanoserver-ltsc2022`
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 WORKDIR /app
 COPY --from=build /app ./

--- a/samples/complexapp/README.md
+++ b/samples/complexapp/README.md
@@ -71,8 +71,8 @@ The following example demonstrates targeting the `test` stage with the `--target
 ```console
 PS C:\git\dotnet-docker\samples\complexapp> docker build --pull --target test -t complexapp-test .
 Sending build context to Docker daemon  12.81MB
-Step 1/15 : FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-6.0: Pulling from dotnet/sdk
+Step 1/15 : FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+7.0: Pulling from dotnet/sdk
 Successfully built f98c5453be3d
 Successfully tagged complexapp-test:latest
 SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
@@ -85,8 +85,8 @@ PS C:\git\dotnet-docker\samples\complexapp> docker run --rm -v $pwd\TestResults:
   2 of 3 projects are up-to-date for restore.
   libbar -> /source/libbar/bin/Debug/netstandard2.0/libbar.dll
   libfoo -> /source/libfoo/bin/Debug/netstandard2.0/libfoo.dll
-  tests -> /source/tests/bin/Debug/net6.0/tests.dll
-Test run for /source/tests/bin/Debug/net6.0/tests.dll (.NETCoreApp,Version=v6.0)
+  tests -> /source/tests/bin/Debug/net7.0/tests.dll
+Test run for /source/tests/bin/Debug/net7.0/tests.dll (.NETCoreApp,Version=v7.0)
 Microsoft (R) Test Execution Command Line Tool Version 17.0.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
 
@@ -94,7 +94,7 @@ Starting test execution, please wait...
 A total of 1 test files matched the specified pattern.
 Results File: /source/tests/TestResults/_886d04dbf347_2020-11-02_18_30_59.trx
 
-Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 2 ms - /source/tests/bin/Debug/net6.0/tests.dll (net6.0)
+Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 2 ms - /source/tests/bin/Debug/net7.0/tests.dll (net7.0)
 
 PS C:\git\dotnet-docker\samples\complexapp> dir .\TestResults\
 
@@ -156,10 +156,10 @@ You will see that tests are run while building the image, as you can see in the 
 ```console
 > docker build --pull -t complexapp .
 Sending build context to Docker daemon  12.79MB
-Step 1/24 : FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-6.0: Pulling from dotnet/sdk
+Step 1/24 : FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+7.0: Pulling from dotnet/sdk
 Digest: sha256:02606610ffd96978da91adeac1b73af9ac536b85a3034b061d0c7d8d9fcd6790
-Status: Image is up to date for mcr.microsoft.com/dotnet/sdk:6.0
+Status: Image is up to date for mcr.microsoft.com/dotnet/sdk:7.0
  ---> 9817c25953a8
 Step 17/24 : RUN dotnet test --logger:trx
  ---> Running in 4678e2e6456d
@@ -168,8 +168,8 @@ Step 17/24 : RUN dotnet test --logger:trx
   2 of 3 projects are up-to-date for restore.
   libbar -> /source/libbar/bin/Debug/netstandard2.0/libbar.dll
   libfoo -> /source/libfoo/bin/Debug/netstandard2.0/libfoo.dll
-  tests -> /source/tests/bin/Debug/net6.0/tests.dll
-Test run for /source/tests/bin/Debug/net6.0/tests.dll (.NETCoreApp,Version=v6.0)
+  tests -> /source/tests/bin/Debug/net7.0/tests.dll
+Test run for /source/tests/bin/Debug/net7.0/tests.dll (.NETCoreApp,Version=v7.0)
 Microsoft (R) Test Execution Command Line Tool Version 17.0.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
 
@@ -177,7 +177,7 @@ Starting test execution, please wait...
 A total of 1 test files matched the specified pattern.
 Results File: /source/tests/TestResults/_886d04dbf347_2021-09-02_18_30_59.trx
 
-Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 2 ms - /source/tests/bin/Debug/net6.0/tests.dll (net6.0)
+Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 2 ms - /source/tests/bin/Debug/net7.0/tests.dll (net7.0)
 Removing intermediate container 4678e2e6456d
  ---> 6deeeacdaaf2
 Step 24/24 : ENTRYPOINT ["dotnet","complexapp.dll"]

--- a/samples/dotnetapp/README.md
+++ b/samples/dotnetapp/README.md
@@ -34,7 +34,7 @@ dotnetapp           latest              baee380605f4        14 seconds ago      
 The logic to build the image is described in the [Dockerfile](Dockerfile), which follows.
 
 ```Dockerfile
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -46,13 +46,13 @@ COPY . .
 RUN dotnet publish -c Release -o /app --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM mcr.microsoft.com/dotnet/runtime:7.0
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "dotnetapp.dll"]
 ```
 
-The `sdk:6.0` and `runtime:6.0` tags are both multi-arch tags that will result in an image that is compatible for the given chip and OS. These simple tags (only contain a version number) are great to get started with Docker because they adapt to your environment. We recommend using an OS-specific tag for the runtime for production applications to ensure that you always get the OS you expect. This level of specification isn't needed for the SDK in most cases.
+The `sdk:7.0` and `runtime:7.0` tags are both multi-arch tags that will result in an image that is compatible for the given chip and OS. These simple tags (only contain a version number) are great to get started with Docker because they adapt to your environment. We recommend using an OS-specific tag for the runtime for production applications to ensure that you always get the OS you expect. This level of specification isn't needed for the SDK in most cases.
 
 This Dockerfile copies and restores the project file as the first step so that the results of those commands can be cached for subsequent builds since project file edits are less common than source code edits. Editing a `.cs` file, for example, does not invalidate the layer created by copying and restoring project file, which makes subsequent docker builds much faster.
 
@@ -60,7 +60,7 @@ This Dockerfile copies and restores the project file as the first step so that t
 
 ## Build an image for Alpine, Debian or Ubuntu
 
-.NET multi-platform tags result in Debian-based images, for Linux. For example, you will pull a Debian-based image if you use a simple version-based tag, such as `6.0`, as opposed to a distro-specific tag like `6.0-alpine`.
+.NET multi-platform tags result in Debian-based images, for Linux. For example, you will pull a Debian-based image if you use a simple version-based tag, such as `7.0`, as opposed to a distro-specific tag like `7.0-alpine`.
 
 This sample includes Dockerfile examples that explicitly target Alpine, Debian and Ubuntu. Docker makes it easy to use alternate Dockerfiles by using the `-f` argument.
 
@@ -132,12 +132,12 @@ docker images dotnetapp
 The `Dockerfile.nanoserver-x64` Dockerfile targets a version-specific tag, which will result in a Nano Server version that targets a specific Windows version (and will only work on Windows hosts of the same version or higher). You can update the following the tag to a different version, as needed.
 
 ```console
-FROM mcr.microsoft.com/dotnet/runtime:6.0-nanoserver-ltsc2022
+FROM mcr.microsoft.com/dotnet/runtime:7.0-nanoserver-ltsc2022
 ```
 
 ## Build an image for ARM32 and ARM64
 
-By default, distro-specific .NET tags target x64, such as `6.0-alpine` or `6.0-focal`. You need to use an architecture-specific tag if you want to target ARM. Note that for Alpine, .NET is only supported on ARM64 and x64, and not ARM32.
+By default, distro-specific .NET tags target x64, such as `7.0-alpine` or `7.0-focal`. You need to use an architecture-specific tag if you want to target ARM. Note that for Alpine, .NET is only supported on ARM64 and x64, and not ARM32.
 
 > Note: Docker documentation sometimes refers to ARM32 as `armhf` and ARM64 as `aarch64`.
 

--- a/samples/run-tests-in-sdk-container.md
+++ b/samples/run-tests-in-sdk-container.md
@@ -36,15 +36,15 @@ You can run `dotnet test` within a .NET SDK container using the following patter
   Restored /app/tests/tests.csproj (in 8.25 sec).
   libfoo -> /app/libfoo/bin/Debug/netstandard2.0/libfoo.dll
   libbar -> /app/libbar/bin/Debug/netstandard2.0/libbar.dll
-  tests -> /app/tests/bin/Debug/net6.0/tests.dll
-Test run for /app/tests/bin/Debug/net6.0/tests.dll (.NETCoreApp,Version=v6.0)
+  tests -> /app/tests/bin/Debug/net7.0/tests.dll
+Test run for /app/tests/bin/Debug/net7.0/tests.dll (.NETCoreApp,Version=v7.0)
 Microsoft (R) Test Execution Command Line Tool Version 16.8.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
 
 Starting test execution, please wait...
 A total of 1 test files matched the specified pattern.
 
-Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 2 ms - /app/tests/bin/Debug/net6.0/tests.dll (net6.0)
+Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 2 ms - /app/tests/bin/Debug/net7.0/tests.dll (net7.0)
  ```
 
 In this example, the tests (and any other required code) are [volume mounted](https://docs.docker.com/engine/admin/volumes/volumes/) into the countainer, and `dotnet test` is run from the `tests` directory (`-w` sets the working directory). Test results can be read from the console or from logs, which can be written to disk with the `--logger:trx` flag.


### PR DESCRIPTION
This makes miscellaneous updates to the docs so that they're updated appropriately for the .NET 7 release.

Regarding the change of `LTS` to `Long-Term Support`, this is the change that's being adopted for official .NET docs with the introduction of the `Standard Support` support type. It makes the terms more consistent when they're shown together.