### PR TITLE
Install tarball in Mariner instead of RPM package

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux
@@ -7,7 +7,8 @@
     set isDistrolessMariner to isMariner && isDistroless ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
-    set isSingleStage to (dotnetVersion = "3.1" || isAlpine || isFullMariner) && !isInternal ^
+    set isRpmInstall to isFullMariner && (dotnetVersion = "3.1" || dotnetVersion = "6.0") ^
+    set isSingleStage to (dotnetVersion = "3.1" || isAlpine || isRpmInstall) && !isInternal ^
     set archTagSuffix to when(dotnetVersion != "3.1" || ARCH_VERSIONED != "amd64", ARCH_TAG_SUFFIX, "") ^
     set runtimeBaseTag to
         cat("$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", OS_VERSION, archTagSuffix) ^
@@ -35,7 +36,8 @@
 {{InsertTemplate("Dockerfile.linux.install-aspnet",
     [
         "install-method": "download-and-install",
-        "use-local-version-var": dotnetVersion = "3.1"
+        "use-local-version-var": dotnetVersion = "3.1",
+        "is-rpm-install": isRpmInstall
     ])}}^else:
 {{
 
@@ -48,14 +50,20 @@ FROM {{installerImageTag}} AS installer
 ARG SAS_QUERY_STRING
 }}{{if isDistrolessMariner:
 {{InsertTemplate("../Dockerfile.linux.distroless-mariner-installer-prereqs")}}
+^elif isFullMariner && !isRpmInstall:
+RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
+    [
+        "pkgs": ["tar"]
+    ])}}
 }}
 # Retrieve ASP.NET Core
 {{InsertTemplate("Dockerfile.linux.install-aspnet",
     [
-        "install-method": when(isInternal && isFullMariner, "download", "download-and-install"),
+        "install-method": when(isInternal && isRpmInstall, "download", "download-and-install"),
         "use-local-version-var": "true",
         "is-internal": isInternal,
-        "url-suffix": when(isInternal, "$SAS_QUERY_STRING", "")
+        "url-suffix": when(isInternal, "$SAS_QUERY_STRING", ""),
+        "is-rpm-install": isRpmInstall
     ])}}
 
 
@@ -63,12 +71,13 @@ ARG SAS_QUERY_STRING
 FROM {{runtimeBaseTag}}
 
 {{InsertTemplate("Dockerfile.envs")}}
-{{if isInternal && isFullMariner:
+{{if isInternal && isRpmInstall:
 {{InsertTemplate("Dockerfile.linux.install-aspnet",
     [
         "install-method": "copy-and-install",
         "is-internal": isInternal,
         "url-suffix": when(isInternal, "$SAS_QUERY_STRING", ""),
-        "installer-stage": "installer"
+        "installer-stage": "installer",
+        "is-rpm-install": isRpmInstall
     ])}}^else:
 COPY --from=installer ["{{copyFromSrcPath}}", "{{copyFromDstPath}}"]}}}}

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
@@ -5,17 +5,17 @@
             instead of referencing the environment variable.
         - is-internal (optional): Whether the Dockerfile is targeting an internal build of the product.
         - url-suffix (optional): Suffix string to append the end of the URL.
-        - installer-stage (optional): Name of the Dockerfile stage responsible for installation ^
+        - installer-stage (optional): Name of the Dockerfile stage responsible for installation
+        - is-rpm-install (optional): Whether to install RPM versus tarball ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isFullMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
     set isDistroless to find(OS_VERSION, "distroless") >= 0 || find(OS_VERSION, "chiseled") >= 0 ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
-    set useRpm to isFullMariner ^
-    set filePlatform to when(useRpm, "", when(isAlpine, "-linux-musl", "-linux")) ^
-    set varPlatform to when(useRpm, "linux-rpm", when(isAlpine, "linux-musl", "linux")) ^
-    set fileExt to when(useRpm, "rpm", "tar.gz") ^
-    set destDir to when((isAlpine || dotnetVersion = "3.1" || isFullMariner) && !ARGS["is-internal"],
+    set filePlatform to when(ARGS["is-rpm-install"], "", when(isAlpine, "-linux-musl", "-linux")) ^
+    set varPlatform to when(ARGS["is-rpm-install"], "linux-rpm", when(isAlpine, "linux-musl", "linux")) ^
+    set fileExt to when(ARGS["is-rpm-install"], "rpm", "tar.gz") ^
+    set destDir to when((isAlpine || dotnetVersion = "3.1" || ARGS["is-rpm-install"]) && !ARGS["is-internal"],
         "/usr/share/dotnet",
         when(isDistroless, "/dotnet", "")) ^
     set aspnetVersionDir to when(ARGS["use-local-version-var"],
@@ -29,7 +29,7 @@
     set aspnetVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         aspnetVersionDir) ^
-    set fileArch to when(useRpm && ARCH_SHORT = "arm64", "aarch64", ARCH_SHORT) ^
+    set fileArch to when(ARGS["is-rpm-install"] && ARCH_SHORT = "arm64", "aarch64", ARCH_SHORT) ^
     set url to cat(
         VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])],
         "/aspnetcore/Runtime/", aspnetVersionDir, "/aspnetcore-runtime-", aspnetVersionFile,

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -16,12 +16,13 @@
                     "mcr.microsoft.com/cbl-mariner/base/core",
                     "<NOT-IMPLEMENTED>")))) ^
     set baseImageTag to when(isAlpine || isMariner, OS_VERSION_NUMBER, OS_VERSION) ^
-    set isSingleStage to !(isMariner && isInternal) ^
+    set isRpmInstall to isMariner && (dotnetVersion = "3.1" || dotnetVersion = "6.0") ^
+    set isSingleStage to !(isRpmInstall && isInternal) ^
     set urlSuffix to when(isInternal, "$SAS_QUERY_STRING", "") ^
     set rpmFilename to "dotnet-runtime-deps.rpm"
 }}{{
     if !isSingleStage:# Installer image
-}}FROM {{baseImageRepo}}:{{baseImageTag}}{{if !isSingleStage: AS installer}}{{ if isInternal && isMariner:
+}}FROM {{baseImageRepo}}:{{baseImageTag}}{{if !isSingleStage: AS installer}}{{ if isInternal && isRpmInstall:
 
 ARG SAS_QUERY_STRING
 
@@ -31,10 +32,10 @@ RUN {{InsertTemplate("Dockerfile.download-runtime-deps-pkg",
         "filename": rpmFilename,
         "is-internal": isInternal
     ], "    ")}}}}
-{{if isMariner && isInternal:FROM {{baseImageRepo}}:{{baseImageTag}}
+{{if isRpmInstall && isInternal:FROM {{baseImageRepo}}:{{baseImageTag}}
 }}
 RUN {{InsertTemplate("../Dockerfile.linux.install-deps")}}
-{{ if isMariner:
+{{ if isRpmInstall:
 {{if isInternal:{{InsertTemplate("../Dockerfile.linux.copy-files",
 [
     "files": [

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -7,7 +7,8 @@
     set isDistrolessMariner to isMariner && isDistroless ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
-    set isSingleStage to (dotnetVersion = "3.1" || isAlpine || isFullMariner) && !isInternal ^
+    set isRpmInstall to isFullMariner && (dotnetVersion = "3.1" || dotnetVersion = "6.0") ^
+    set isSingleStage to (dotnetVersion = "3.1" || isAlpine || isRpmInstall) && !isInternal ^
     set archTagSuffix to when(dotnetVersion != "3.1" || ARCH_VERSIONED != "amd64", ARCH_TAG_SUFFIX, "") ^
     set runtimeDepsBaseTag to cat(
         "$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", OS_VERSION, archTagSuffix) ^
@@ -25,7 +26,7 @@ _ SINGLE STAGE
 }}FROM {{runtimeDepsBaseTag}}
 {{if isAlpine:
 {{InsertTemplate("../Dockerfile.alpine.invariant-mode")}}
-^elif dotnetVersion = "3.1" && !isFullMariner:
+^elif (dotnetVersion = "3.1" && !isFullMariner):
 RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
     [
         "pkgs": ["curl"]
@@ -38,8 +39,9 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
     [
         "install-method": "download-and-install",
         "dest-dir": "/usr/share/dotnet",
-        "add-symlink": !isFullMariner,
-        "use-local-version-var": dotnetVersion = "3.1"
+        "add-symlink": !isRpmInstall,
+        "use-local-version-var": dotnetVersion = "3.1",
+        "is-rpm-install": isRpmInstall
     ])}}^
 else:{{
 
@@ -53,15 +55,21 @@ FROM {{installerImageTag}} AS installer
 ARG SAS_QUERY_STRING
 }}{{ if isDistrolessMariner:
 {{InsertTemplate("../Dockerfile.linux.distroless-mariner-installer-prereqs")}}
+^elif isFullMariner && !isRpmInstall:
+RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
+    [
+        "pkgs": ["tar"]
+    ])}}
 }}
 # Retrieve .NET Runtime
 {{InsertTemplate("Dockerfile.linux.install-runtime",
     [
-        "install-method": when(isInternal && isFullMariner, "download", "download-and-install"),
+        "install-method": when(isInternal && isRpmInstall, "download", "download-and-install"),
         "dest-dir": when(isDistroless, "/usr/share/dotnet", "/dotnet"),
         "use-local-version-var": "true",
         "is-internal": isInternal,
-        "url-suffix": when(isInternal, "$SAS_QUERY_STRING", "")
+        "url-suffix": when(isInternal, "$SAS_QUERY_STRING", ""),
+        "is-rpm-install": isRpmInstall
     ])}}{{ if isDistroless:
 
 RUN mkdir /dotnet-symlink \
@@ -72,21 +80,22 @@ RUN mkdir /dotnet-symlink \
 FROM {{runtimeDepsBaseTag}}
 
 {{InsertTemplate("Dockerfile.envs")}}
-{{ if isInternal && isFullMariner:
+{{ if isInternal && isRpmInstall:
 {{InsertTemplate("Dockerfile.linux.install-runtime",
     [
         "install-method": "copy-and-install",
         "dest-dir": when(isDistroless, "/usr/share/dotnet", "/dotnet"),
         "is-internal": isInternal,
         "url-suffix": when(isInternal, "$SAS_QUERY_STRING", ""),
-        "installer-stage": "installer"
+        "installer-stage": "installer",
+        "is-rpm-install": isRpmInstall
     ])}}}}{{ if isDistroless:
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]{{ if !isMariner || (dotnetVersion != "3.1" && dotnetVersion != "6.0"):
 
 ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]}}^
-elif !(isInternal && isFullMariner):
+elif !(isInternal && isRpmInstall):
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
 RUN {{InsertTemplate("Dockerfile.linux.symlink")}}}}}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
@@ -7,7 +7,8 @@
             instead of referencing the environment variable.
         is-internal (optional): Whether the Dockerfile is targeting an internal build of the product.
         url-suffix (optional): Suffix string to append the end of the URL.
-        installer-stage (optional): Name of the Dockerfile stage responsible for installation ^
+        installer-stage (optional): Name of the Dockerfile stage responsible for installation
+        is-rpm-install (optional): Whether to install RPM versus tarball ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
@@ -57,7 +58,7 @@
             "sha-var-name": "dotnet_sha512"
         ]
     ] ^
-    set files to when(isFullMariner, rpms, tarballs) ^
+    set files to when(ARGS["is-rpm-install"], rpms, tarballs) ^
     set copyEnabled to ARGS["install-method"] = "copy-and-install" ^
     set downloadEnabled to ARGS["install-method"] = "download" || ARGS["install-method"] = "download-and-install" ^
     set installEnabled to ARGS["install-method"] = "download-and-install" || ARGS["install-method"] = "copy-and-install"
@@ -76,6 +77,6 @@ if copyEnabled:{{InsertTemplate("../Dockerfile.linux.copy-files",
             "skip-download": !downloadEnabled,
             "skip-install": !installEnabled,
             "install-dir": ARGS["dest-dir"],
-            "create-install-dir": !isFullMariner || ARGS["is-internal"]
+            "create-install-dir": !ARGS["is-rpm-install"] || ARGS["is-internal"]
         ], "    ")}}{{if ARGS["add-symlink"]: \
     && {{InsertTemplate("Dockerfile.linux.symlink")}}}}

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -5,6 +5,7 @@
     set isFullMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
+    set isRpmInstall to isFullMariner && (dotnetVersion = "3.1" || dotnetVersion = "6.0") ^
     set isBasedOnBuildpackDeps to (dotnetVersion = "3.1" && !(isAlpine || isMariner)) ^
     set archTagSuffix to when(dotnetVersion != "3.1", ARCH_TAG_SUFFIX, "") ^
     set baseImageTag to when(isBasedOnBuildpackDeps,
@@ -37,14 +38,20 @@
 FROM {{internalInstallerBase}} AS installer
 
 ARG SAS_QUERY_STRING
-
+{{if isFullMariner && !isRpmInstall:
+RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
+    [
+        "pkgs": ["tar"]
+    ])}}
+}}
 {{InsertTemplate("Dockerfile.linux.install-sdk",
     [
-        "install-method": when(isFullMariner, "download", "download-and-install"),
+        "install-method": when(isRpmInstall, "download", "download-and-install"),
         "based-on-buildpack-deps": isBasedOnBuildpackDeps,
         "use-local-version-var": (dotnetVersion = "3.1"),
         "is-internal": isInternal,
-        "url-suffix": "$SAS_QUERY_STRING"
+        "url-suffix": "$SAS_QUERY_STRING",
+        "is-rpm-install": isRpmInstall
     ])}}
 
 
@@ -67,12 +74,13 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 RUN {{InsertTemplate("../Dockerfile.linux.install-deps", ["isSdk": "true"])}}
 }}
 {{if isInternal:{{
-if isFullMariner:{{InsertTemplate("Dockerfile.linux.install-sdk",
+if isRpmInstall:{{InsertTemplate("Dockerfile.linux.install-sdk",
     [
         "install-method": "copy-and-install",
         "is-internal": isInternal,
         "url-suffix": "$SAS_QUERY_STRING",
-        "installer-stage": "installer"
+        "installer-stage": "installer",
+        "is-rpm-install": isRpmInstall
     ])}}^
 else:COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]{{
 if isBasedOnBuildpackDeps:
@@ -84,7 +92,8 @@ else:{{InsertTemplate("Dockerfile.linux.install-sdk",
     [
         "install-method": "download-and-install",
         "based-on-buildpack-deps": isBasedOnBuildpackDeps,
-        "use-local-version-var": (dotnetVersion = "3.1")
+        "use-local-version-var": (dotnetVersion = "3.1"),
+        "is-rpm-install": isRpmInstall
     ])}}}}{{if !isAlpine || ARCH_SHORT = "x64":
 
 {{InsertTemplate("Dockerfile.linux.install-powershell")}}}}

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
@@ -6,7 +6,8 @@
             referencing the environment variable.
         is-internal (optional): Whether the Dockerfile is targeting an internal build of the product.
         url-suffix (optional): Suffix string to append the end of the URL.
-        installer-stage (optional): Name of the Dockerfile stage responsible for installation ^
+        installer-stage (optional): Name of the Dockerfile stage responsible for installation
+        is-rpm-install (optional): Whether to install RPM versus tarball ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
@@ -111,7 +112,7 @@
                     ]))
         ]
     ] ^
-    set files to when(isFullMariner, rpms, tarballs) ^
+    set files to when(ARGS["is-rpm-install"], rpms, tarballs) ^
     set copyEnabled to ARGS["install-method"] = "copy-and-install" ^
     set downloadEnabled to ARGS["install-method"] = "download" || ARGS["install-method"] = "download-and-install" ^
     set installEnabled to ARGS["install-method"] = "download-and-install" || ARGS["install-method"] = "copy-and-install"
@@ -135,6 +136,6 @@ if isFullMariner:    dotnet_version={{VARIABLES[cat("runtime|", dotnetVersion, "
         "skip-install": !installEnabled,
         "install-dir": installDir,
         "create-install-dir": !isFullMariner
-    ], "    ")}}{{if !ARGS["is-internal"] || (isFullMariner && installEnabled):{{if ARGS["based-on-buildpack-deps"]: \
+    ], "    ")}}{{if !ARGS["is-internal"] || (ARGS["is-rpm-install"] && installEnabled):{{if ARGS["based-on-buildpack-deps"]: \
     && ln -s {{installDir}}/dotnet /usr/bin/dotnet}} \
     {{InsertTemplate("Dockerfile.linux.first-run", ["append-cmd": "true"], "    ")}}}}

--- a/src/aspnet/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -1,12 +1,25 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-amd64 AS installer
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=7.0.0-rc.2.22476.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+    && aspnetcore_sha512='1941cd6ea3bea31d970029c34acf0d60b63d1e7fba39086be1a79177a6f87f2b0300bf4008e96a5235d52bc74a41503b21b088143cd306058d42dd3ce8252af0' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
 FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=7.0.0-rc.2.22476.2
 
-# Install ASP.NET Core
-RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-x64.rpm \
-    && aspnetcore_sha512='1c13045edfa319bdee564c7fabdb66e30935b51172c579ec2ea4ccd6f5c86b760a9b311184ea98ceb4a35db8dee776f659fb281b390c93f1638addf343b22394' \
-    && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
-    && tdnf install -y --disablerepo=* aspnetcore.rpm \
-    && rm aspnetcore.rpm
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/aspnet/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/aspnet/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -1,12 +1,25 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-arm64v8 AS installer
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=7.0.0-rc.2.22476.2 \
+    && curl -fSL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+    && aspnetcore_sha512='24fb13ed26a44d6fba86a2058839026ec81868143a5b7af7857b75a004b0c64eea9a3e544f9e0774b761f9c911608ac74237b2d63ba6799718d12915d5d32df4' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
 FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=7.0.0-rc.2.22476.2
 
-# Install ASP.NET Core
-RUN curl -fSL --output aspnetcore.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-aarch64.rpm \
-    && aspnetcore_sha512='7c0c28f581d2aa8be3a329eb938efea0a0922bc7d68daf0e7f8cc8ff299b6d5f3a138c9162df9f07067905c7737ed8a1a213b3e33d401b98efbe2eabfb80b757' \
-    && echo "$aspnetcore_sha512  aspnetcore.rpm" | sha512sum -c - \
-    && tdnf install -y --disablerepo=* aspnetcore.rpm \
-    && rm aspnetcore.rpm
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/src/runtime-deps/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -13,14 +13,6 @@ RUN tdnf install -y \
         zlib \
     && tdnf clean all
 
-# Install dotnet-runtime-deps package
-RUN dotnet_version=7.0.0-rc.2.22472.3 \
-    && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.2-x64.rpm \
-    && dotnet_sha512='682df20f01a341c0d9d983824c7e2a08603a8316bfb882624d98fa27cb9a749bfe31adcbd22f1ddac334d1a19ffbe0c090d0995811a5ea37a13dfff56972f15f' \
-    && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
-    && tdnf install -y --disablerepo=* dotnet-runtime-deps.rpm \
-    && rm dotnet-runtime-deps.rpm
-
 ENV \
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 \

--- a/src/runtime-deps/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -13,14 +13,6 @@ RUN tdnf install -y \
         zlib \
     && tdnf clean all
 
-# Install dotnet-runtime-deps package
-RUN dotnet_version=7.0.0-rc.2.22472.3 \
-    && curl -fSL --output dotnet-runtime-deps.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-deps-$dotnet_version-cm.2-aarch64.rpm \
-    && dotnet_sha512='fad0aa94b13acbdf2d91164a002b49f692b9ee41a3ce0dde9395fbfef5067e13a61dc0d31073381e4c198f7b8041608b849d062a376b2273678b9c70d7b5a776' \
-    && echo "$dotnet_sha512  dotnet-runtime-deps.rpm" | sha512sum -c - \
-    && tdnf install -y --disablerepo=* dotnet-runtime-deps.rpm \
-    && rm dotnet-runtime-deps.rpm
-
 ENV \
     # Configure web servers to bind to port 80 when present
     ASPNETCORE_URLS=http://+:80 \

--- a/src/runtime/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -1,21 +1,28 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-amd64 AS installer
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=7.0.0-rc.2.22472.3 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+    && dotnet_sha512='2294605e371ec575e59baa1eacf973d7dd6761d5d161f4988ed6c51d5db2795a4dc95709d6eaf38ddb2caee6f0551225b49be5cbe42233c2ffae3a0f63d4412c' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
 FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=7.0.0-rc.2.22472.3
 
-# Install .NET Runtime
-RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-x64.rpm \
-    && dotnet_sha512='3f26f508100ec4d6b6c7c031e1f83373208324ffd6d708d5793c576920caab1d7e9c5d4d76ae7cacd299e43a8522167a293f9b0107550ab70e2910278a521fdc' \
-    && echo "$dotnet_sha512  dotnet-host.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output dotnet-hostfxr.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-hostfxr-$DOTNET_VERSION-x64.rpm \
-    && dotnet_sha512='ee538acb48c4a0b9f3b5ef3b20d754e48a96c5e7c4064536a6a8f13a5a49a905c0017b9264792013430460d304535d92f4f4a0c7c8b6085a4d4b662c827269f9' \
-    && echo "$dotnet_sha512  dotnet-hostfxr.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output dotnet-runtime.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-x64.rpm \
-    && dotnet_sha512='94a198d725b3e6a4b6777f206c61c67466e3788c2b72a4caacf2f996592122d5750dc0f46918f7f61c19569dd2712d36dc2432bff460f1221fbaf9e64fa7f24c' \
-    && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
-    \
-    && tdnf install -y --disablerepo=* dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
-    && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/runtime/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -1,21 +1,28 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-arm64v8 AS installer
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=7.0.0-rc.2.22472.3 \
+    && curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+    && dotnet_sha512='cc1f37687745a3aed3c161415fa57dd8f151f515fb2a030c6b2e600942d188837398038d81654a1137bfafc5e1733e351e7c8ea04678cd2457d6620a3381826b' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
 FROM $REPO:7.0.0-rc.2-cbl-mariner2.0-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=7.0.0-rc.2.22472.3
 
-# Install .NET Runtime
-RUN curl -fSL --output dotnet-host.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-host-$DOTNET_VERSION-aarch64.rpm \
-    && dotnet_sha512='3e271773c4b1086054bc48ee36ce0a08b8dc89dd6cff97b6ae4395b2107820ad216f88616ddd8c966a7db9eb5fef555f57366c8e92cb91d0c06756fa5f5f27e6' \
-    && echo "$dotnet_sha512  dotnet-host.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output dotnet-hostfxr.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-hostfxr-$DOTNET_VERSION-aarch64.rpm \
-    && dotnet_sha512='70c6f9fe900b7aec800546a94c921781be918d7f8f82ae69889473176ff9979b39ddf722f6506169c6ba8846321abf398c6b5a316613f434c6ce1520763aedd2' \
-    && echo "$dotnet_sha512  dotnet-hostfxr.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output dotnet-runtime.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-aarch64.rpm \
-    && dotnet_sha512='8db36736ad90a89389ca26bca4be4426fce3ce21c2125d316848e9898e84e2d85c3246db8469c6259e978764964f57cd7c764d811698e911117aedcab8263634' \
-    && echo "$dotnet_sha512  dotnet-runtime.rpm" | sha512sum -c - \
-    \
-    && tdnf install -y --disablerepo=* dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm \
-    && rm dotnet-host.rpm dotnet-hostfxr.rpm dotnet-runtime.rpm
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/sdk/7.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/7.0/cbl-mariner2.0/amd64/Dockerfile
@@ -23,28 +23,11 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -fSL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-x64.rpm \
-    && dotnet_sha512='4aac5c68077fca9afdd7ea1c49f780718a68d1cf04ce3afd2f797f391444c0c7c945e50a7ed0b7902e73aa8fc1b274362d08256627c719c08536d4ee9024fa7c' \
-    && echo "$dotnet_sha512  dotnet.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output apphost.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-apphost-pack-$DOTNET_VERSION-x64.rpm \
-    && dotnet_sha512='cae2f4d2362ce0fdd58ef91e524d6264f9078c2cd55476604a762a202df50fd2c2242821dd8ea1ea952a9d3ab34ccc636d89bf5a70d4b7d8e239b789a38acba6' \
-    && echo "$dotnet_sha512  apphost.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-rc.2.22472.3/dotnet-targeting-pack-7.0.0-rc.2.22472.3-x64.rpm \
-    && dotnet_sha512='7736109e0916ac65200ce3216979ad090cd26528255fff6652d9a8f87096b05f9401335881b5b67df033a4621422c37bb11e40fc1ba6eedeac71d83ab50419a3' \
-    && echo "$dotnet_sha512  targeting-pack.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output aspnetcore-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-rc.2.22476.2/aspnetcore-targeting-pack-7.0.0-rc.2.22476.2-x64.rpm \
-    && dotnet_sha512='109c4455ad1aafd368b6c0e089dc0c830920143af4d8684c25e28e6bca24e00c345eaaa530007ee11146dc9ff1c0f13f11374628bd2a45ae7ed1b29cfcc1d7a0' \
-    && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output netstandard-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.0/netstandard-targeting-pack-2.1.0-x64.rpm \
-    && dotnet_sha512='fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880' \
-    && echo "$dotnet_sha512  netstandard-targeting-pack.rpm" | sha512sum -c - \
-    \
-    && tdnf install -y --disablerepo=* dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
-    && rm dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm netstandard-targeting-pack.rpm \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+    && dotnet_sha512='22db5d1d16f6fcedfc46f87896920425b5d9b61d09c47d254d6ac731c6d853657882b21faf21f313ed20b33e6331d01b9f723b2c586f0e0cf5acc5ed570b0260' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 

--- a/src/sdk/7.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/7.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -23,24 +23,11 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -fSL --output dotnet.rpm https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-aarch64.rpm \
-    && dotnet_sha512='3971b8307375803db19911fe9123f60770e2f3a68852e1596058d5c7ce89e11aafb97ae9c7a5792484af1c473b35d0506ef1a22d24dcb5008aac3540b8801897' \
-    && echo "$dotnet_sha512  dotnet.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output apphost.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-apphost-pack-$DOTNET_VERSION-aarch64.rpm \
-    && dotnet_sha512='47ef401ddcfc098f07829cddeac714bdbff17ff48ab34adb8ecda0f7477d240e1ade0191286eb4cb1e32761a6ac34de4d200983df3633a14e1cf2797fd799ddb' \
-    && echo "$dotnet_sha512  apphost.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/Runtime/7.0.0-rc.2.22472.3/dotnet-targeting-pack-7.0.0-rc.2.22472.3-aarch64.rpm \
-    && dotnet_sha512='86a38e25498a6f247bb276acebbf4d52cde207c5337b249578e81ec8e75a5739744409217cebe4aff16a6c1d0f170b2db2ba248de16e6ff1334b7d527178f01c' \
-    && echo "$dotnet_sha512  targeting-pack.rpm" | sha512sum -c - \
-    \
-    && curl -fSL --output aspnetcore-targeting-pack.rpm https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/7.0.0-rc.2.22476.2/aspnetcore-targeting-pack-7.0.0-rc.2.22476.2-aarch64.rpm \
-    && dotnet_sha512='f852f930b64c44e9fdc68474809265b5d50ecaacdd6dd04e65ec93407fa3728c6a89e94bccaddada253d8b0228978bfc8c6a68a434f5649104f7f164aa38a999' \
-    && echo "$dotnet_sha512  aspnetcore-targeting-pack.rpm" | sha512sum -c - \
-    \
-    && tdnf install -y --disablerepo=* dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
-    && rm dotnet.rpm apphost.rpm targeting-pack.rpm aspnetcore-targeting-pack.rpm \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz \
+    && dotnet_sha512='bd5f6fc2bc6783bcf71b4a5c274b2e710336fc031c2577f5ccdb9be2679ce8b15e40fb8e631e2dd18b2359396107fe44d867d341f6fc5daae165f8f238adee17' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPackageInstallation(ProductImageData imageData)
         {
-            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless)
+            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless || imageData.Version.Major > 6)
             {
                 return;
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPackageInstallation(ProductImageData imageData)
         {
-            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless)
+            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless || imageData.Version.Major > 6)
             {
                 return;
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPackageInstallation(ProductImageData imageData)
         {
-            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless)
+            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless || imageData.Version.Major > 6)
             {
                 return;
             }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyPackageInstallation(ProductImageData imageData)
         {
-            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless)
+            if (!imageData.OS.Contains("cbl-mariner") || imageData.IsDistroless || imageData.Version.Major > 6)
             {
                 return;
             }


### PR DESCRIPTION
Updates the Mariner Dockerfiles for .NET 7 so that they install .NET from a tarball instead of RPM package.

Since Mariner 2.0 doesn't have `tar` installed by default, the Dockerfiles have also been updated to install that when necessary. Since `tar` is getting installed to do the install, a multi-stage Dockerfile is used to avoid `tar` showing up in the final image (except for the sdk where we do want `tar` installed).

Tests have also been updated to skip RPM package verification for .NET 7 and higher.

Fixes #4157