### PR TITLE
Update pool for builds targeting internal .NET builds

### DIFF
--- a/eng/pipelines/dotnet-core-internal-nightly.yml
+++ b/eng/pipelines/dotnet-core-internal-nightly.yml
@@ -44,3 +44,6 @@ stages:
   parameters:
     internalProjectName: ${{ variables.internalProjectName }}
     publicProjectName: ${{ variables.publicProjectName }}
+    linuxAmd64Pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/pull/4106, this should also be applied to the pipeline which publishes images for internal .NET builds.