### PR TITLE
Format remote branch name generated by update-deps

### DIFF
--- a/eng/update-dependencies/UpdateDependencies.cs
+++ b/eng/update-dependencies/UpdateDependencies.cs
@@ -123,13 +123,14 @@ namespace Dotnet.Docker
                 Enumerable.Empty<string>());
         }
 
+        // Replace slashes with hyphens for use in naming the branch
+        private static string FormatBranchName(string branchName) => branchName.Replace('/', '-');
+
         private static async Task CreatePullRequestAsync()
         {
             string commitMessage = $"[{Options.TargetBranch}] Update dependencies from {Options.VersionSourceName}";
 
-            // Replace slashes with hyphens for use in naming the branch
-            string versionSourceNameForBranch = Options.VersionSourceName.Replace("/", "-");
-            string branchSuffix = $"UpdateDependencies-{Options.TargetBranch}-From-{versionSourceNameForBranch}";
+            string branchSuffix = FormatBranchName($"UpdateDependencies-{Options.TargetBranch}-From-{Options.VersionSourceName}");
             PullRequestOptions prOptions = new()
             {
                 BranchNamingStrategy = new SingleBranchNamingStrategy(branchSuffix)
@@ -175,7 +176,7 @@ namespace Dotnet.Docker
             {
                 // Push the commit to AzDO
                 string username = Options.Email.Substring(0, Options.Email.IndexOf('@'));
-                string remoteBranch = prOptions.BranchNamingStrategy.Prefix($"users/{username}/{Options.TargetBranch}");
+                string remoteBranch = prOptions.BranchNamingStrategy.Prefix($"users/{username}/{FormatBranchName(Options.TargetBranch)}");
                 string pushRefSpec = $@"refs/heads/{remoteBranch}";
 
                 Trace.WriteLine($"Pushing to {remoteBranch}");


### PR DESCRIPTION
The name of the remote branch of the PR generated by the update-dependencies tool is very deeply nested and also causes an internal branch policy to be applied which prevents the branch from being deleted when the PR is completed.

These changes update the generated name to avoid both these issues by replace `/` with `-`.

As an example, the branch name currently generated for PRs of internal builds is `users/dotnet-docker-bot/internal/release/nightly-UpdateDependencies-internal/release/nightly-From-dotnet-installer`. In Git tools which provide folders based on the branch name, this gets displayed as:

```
users
  /dotnet-docker-bot
    /internal
      /release
        /nightly-UpdateDependencies-internal
          /release
            /nightly-From-dotnet-installer
```

With these changes, the branch name would be `users/dotnet-docker-bot/internal-release-nightly-UpdateDependencies-internal-release-nightly-From-dotnet-installer`:

```
users
  /dotnet-docker-bot
    /internal-release-nightly-UpdateDependencies-internal-release-nightly-From-dotnet-installer
```