### PR TITLE
Update Related Repos header name

### DIFF
--- a/.mar/portal/README.aspnet.portal.md
+++ b/.mar/portal/README.aspnet.portal.md
@@ -11,7 +11,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 * `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/aspnet:6.0`
 
-## Related Repos
+## Related Repositories
 
 .NET:
 

--- a/.mar/portal/README.monitor.portal.md
+++ b/.mar/portal/README.monitor.portal.md
@@ -13,7 +13,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 * `6` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/monitor:6`
 
-## Related Repos
+## Related Repositories
 
 .NET:
 

--- a/.mar/portal/README.runtime-deps.portal.md
+++ b/.mar/portal/README.runtime-deps.portal.md
@@ -11,7 +11,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 * `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime-deps:6.0`
 
-## Related Repos
+## Related Repositories
 
 .NET:
 

--- a/.mar/portal/README.runtime.portal.md
+++ b/.mar/portal/README.runtime.portal.md
@@ -11,7 +11,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 * `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime:6.0`
 
-## Related Repos
+## Related Repositories
 
 .NET:
 

--- a/.mar/portal/README.samples.portal.md
+++ b/.mar/portal/README.samples.portal.md
@@ -11,7 +11,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 * `aspnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile)
   * `docker pull mcr.microsoft.com/dotnet/samples:aspnetapp`
 
-## Related Repos
+## Related Repositories
 
 .NET:
 

--- a/.mar/portal/README.sdk.portal.md
+++ b/.mar/portal/README.sdk.portal.md
@@ -17,7 +17,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 * `6.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/sdk:6.0`
 
-## Related Repos
+## Related Repositories
 
 .NET:
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -29,7 +29,7 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
-# Related Repos
+# Related Repositories
 
 .NET:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
-# Related Repos
+# Related Repositories
 
 .NET:
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -23,7 +23,7 @@ You can run a container with a pre-built [.NET Docker Image](https://hub.docker.
 
 See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
 
-# Related Repos
+# Related Repositories
 
 .NET:
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -17,7 +17,7 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 * [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian-x64-slim) builds and runs an application as a self-contained application.
 
-# Related Repos
+# Related Repositories
 
 .NET:
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -25,7 +25,7 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/samples
 ```
 
-# Related Repos
+# Related Repositories
 
 .NET:
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -39,7 +39,7 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
-# Related Repos
+# Related Repositories
 
 .NET:
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -34,7 +34,7 @@ The following samples show how to develop, build and test .NET applications with
 * [Test .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-tests-in-sdk-container.md)
 * [Run .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-in-sdk-container.md)
 
-# Related Repos
+# Related Repositories
 
 .NET:
 

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -2,7 +2,7 @@
     _ ARGS:
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme
-}}{{ARGS["top-header"]}} Related Repos
+}}{{ARGS["top-header"]}} Related Repositories
 
 .NET:
 


### PR DESCRIPTION
This new name matches the naming for the [MAR portal guidelines](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-management-and-platforms/containers-bburns/microsoft-container-registry/microsoft-artifact-registry-also-known-as-microsoft-container-registry-docs/onboardingdocs/documentationstandards).

Fixes #4161