### PR TITLE
Update samples for user and cgroup info 

### DIFF
--- a/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
+++ b/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
@@ -7,7 +7,7 @@ public struct EnvironmentInfo
         GCMemoryInfo gcInfo = GC.GetGCMemoryInfo();
         TotalAvailableMemoryBytes = gcInfo.TotalAvailableMemoryBytes;
 
-        if (!RuntimeInformation.OSDescription.StartsWith("Linux"))
+        if (!OperatingSystem.IsLinux())
         {
             return;
         }
@@ -37,10 +37,10 @@ public struct EnvironmentInfo
     public long MemoryLimit { get; init; }
     public long MemoryUsage { get; init; }
 
-    private long GetBestValue(string[] paths)
+    private static long GetBestValue(string[] paths)
     {
         string value = string.Empty;
-        foreach(string path in paths)
+        foreach (string path in paths)
         {
             if (Path.Exists(path))
             {

--- a/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
+++ b/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
@@ -1,32 +1,59 @@
 using System.Runtime.InteropServices;
 
-public class EnvironmentInfo
+public struct EnvironmentInfo
 {
     public EnvironmentInfo()
     {
-        RuntimeVersion = RuntimeInformation.FrameworkDescription;
-        OSVersion = RuntimeInformation.OSDescription;
-        OSArchitecture = RuntimeInformation.OSArchitecture.ToString();
-        ProcessorCount = Environment.ProcessorCount;
         GCMemoryInfo gcInfo = GC.GetGCMemoryInfo();
         TotalAvailableMemoryBytes = gcInfo.TotalAvailableMemoryBytes;
-        bool hasCgroup = RuntimeInformation.OSDescription.StartsWith("Linux") && Directory.Exists("/sys/fs/cgroup/memory");
 
-        if (hasCgroup)
+        if (!RuntimeInformation.OSDescription.StartsWith("Linux"))
         {
-            string limit = System.IO.File.ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0];
-            string usage = System.IO.File.ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0];
-            MemoryLimit = long.Parse(limit);
-            MemoryUsage = long.Parse(usage);
+            return;
         }
+
+        string[] memoryLimits = new string[] 
+        {
+            "/sys/fs/cgroup/memory.max",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+        };
+
+        string[] currentMemory = new string[] 
+        {
+            "/sys/fs/cgroup/memory.current",
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes",
+        };
+
+        MemoryLimit = GetBestValue(memoryLimits);
+        MemoryUsage = GetBestValue(currentMemory);
     }
 
-    public string RuntimeVersion { get; set; }
-    public string OSVersion { get; set; }
-    public string OSArchitecture { get; set; }
-    public int ProcessorCount { get; set; }
-    public long TotalAvailableMemoryBytes {get; set;}
-    public long MemoryLimit {get; set;}
-    public long MemoryUsage {get; set;}
+    public string RuntimeVersion => RuntimeInformation.FrameworkDescription;
+    public string OSVersion => RuntimeInformation.OSDescription;
+    public string OSArchitecture => RuntimeInformation.OSArchitecture.ToString();
+    public string User => Environment.UserName;
+    public int ProcessorCount => Environment.ProcessorCount;
+    public long TotalAvailableMemoryBytes { get; init; }
+    public long MemoryLimit { get; init; }
+    public long MemoryUsage { get; init; }
 
+    private long GetBestValue(string[] paths)
+    {
+        string value = string.Empty;
+        foreach(string path in paths)
+        {
+            if (Path.Exists(path))
+            {
+                value = File.ReadAllText(path);
+                break;
+            }
+        }
+
+        if (int.TryParse(value, out int result))
+        {
+            return result;
+        }
+
+        return 0;
+    }
 }

--- a/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
+++ b/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
@@ -33,9 +33,9 @@ public struct EnvironmentInfo
     public string OSArchitecture => RuntimeInformation.OSArchitecture.ToString();
     public string User => Environment.UserName;
     public int ProcessorCount => Environment.ProcessorCount;
-    public long TotalAvailableMemoryBytes { get; init; }
-    public long MemoryLimit { get; init; }
-    public long MemoryUsage { get; init; }
+    public long TotalAvailableMemoryBytes { get; }
+    public long MemoryLimit { get; }
+    public long MemoryUsage { get; }
 
     private static long GetBestValue(string[] paths)
     {

--- a/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
+++ b/samples/aspnetapp/aspnetapp/EnvironmentInfo.cs
@@ -12,20 +12,20 @@ public struct EnvironmentInfo
             return;
         }
 
-        string[] memoryLimits = new string[] 
+        string[] memoryLimitPaths = new string[] 
         {
             "/sys/fs/cgroup/memory.max",
             "/sys/fs/cgroup/memory/memory.limit_in_bytes",
         };
 
-        string[] currentMemory = new string[] 
+        string[] currentMemoryPaths = new string[] 
         {
             "/sys/fs/cgroup/memory.current",
             "/sys/fs/cgroup/memory/memory.usage_in_bytes",
         };
 
-        MemoryLimit = GetBestValue(memoryLimits);
-        MemoryUsage = GetBestValue(currentMemory);
+        MemoryLimit = GetBestValue(memoryLimitPaths);
+        MemoryUsage = GetBestValue(currentMemoryPaths);
     }
 
     public string RuntimeVersion => RuntimeInformation.FrameworkDescription;

--- a/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
+++ b/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
@@ -2,26 +2,12 @@
 @using System.IO
 @using System.Diagnostics
 @{
-    ViewData["Title"] = "Home page";
-    var hostName = System.Net.Dns.GetHostName();
+    ViewData["Title"] = "Welcome to .NET";
+    string hostName = System.Net.Dns.GetHostName();
     var ipList = await System.Net.Dns.GetHostAddressesAsync(hostName);
-
+    EnvironmentInfo env = new();
     const long Mebi = 1024 * 1024;
     const long Gibi = Mebi * 1024;
-    GCMemoryInfo gcInfo = GC.GetGCMemoryInfo();
-    string totalAvailableMemory = GetInBestUnit(gcInfo.TotalAvailableMemoryBytes);
-
-    bool cgroup = RuntimeInformation.OSDescription.StartsWith("Linux") && Directory.Exists("/sys/fs/cgroup/memory");
-    string memoryUsage = string.Empty;
-    string memoryLimit = string.Empty;
-
-    if (cgroup)
-    {
-        string usage = System.IO.File.ReadAllLines("/sys/fs/cgroup/memory/memory.usage_in_bytes")[0];
-        string limit = System.IO.File.ReadAllLines("/sys/fs/cgroup/memory/memory.limit_in_bytes")[0];
-        memoryUsage = GetInBestUnit(long.Parse(usage));
-        memoryLimit = GetInBestUnit(long.Parse(limit));
-    }
 }
 
 <div class="text-center">
@@ -51,20 +37,24 @@
             <td>@(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") is null ? "false" : "true")</td>
         </tr>
         <tr>
-            <td>Memory, total available GC memory</td>
-            <td>@totalAvailableMemory</td>
+            <td>User</td>
+            <td>@(Environment.UserName)</td>
         </tr>
-        @if (cgroup)
+        @if (env.MemoryLimit > 0)
         {
             <tr>
-                <td>cgroup memory usage</td>
-                <td>@memoryUsage</td>
+                <td>cgroup memory limit</td>
+                <td>@env.MemoryLimit (@GetInBestUnit(@env.MemoryLimit))</td>
             </tr>
             <tr>
-                <td>cgroup memory limit</td>
-                <td>@memoryLimit</td>
+                <td>cgroup memory usage</td>
+                <td>@env.MemoryUsage (@GetInBestUnit(@env.MemoryUsage))</td>
             </tr>
         }
+        <tr>
+            <td>Memory, total available GC memory</td>
+            <td>@env.TotalAvailableMemoryBytes (@GetInBestUnit(@env.TotalAvailableMemoryBytes))</td>
+        </tr>
         <tr>
             <td>Host name</td>
             <td>@hostName</td>
@@ -95,12 +85,12 @@
         else if (size < Gibi)
         {
             decimal mebibytes = Decimal.Divide(size, Mebi);
-            return $"{mebibytes:F} MiB";
+            return $"{mebibytes:N2} MiB";
         }
         else
         {
             decimal gibibytes = Decimal.Divide(size, Gibi);
-            return $"{gibibytes:F} GiB";
+            return $"{gibibytes:N2} GiB";
         }
     }
 }

--- a/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
+++ b/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
@@ -44,7 +44,7 @@
         {
             <tr>
                 <td>cgroup memory limit</td>
-                <td>@env.MemoryLimit (@GetInBestUnit(@env.MemoryLimit))</td>
+                <td>@env.MemoryLimit (@GetInBestUnit(env.MemoryLimit))</td>
             </tr>
             <tr>
                 <td>cgroup memory usage</td>

--- a/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
+++ b/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
@@ -48,12 +48,12 @@
             </tr>
             <tr>
                 <td>cgroup memory usage</td>
-                <td>@env.MemoryUsage (@GetInBestUnit(@env.MemoryUsage))</td>
+                <td>@env.MemoryUsage (@GetInBestUnit(env.MemoryUsage))</td>
             </tr>
         }
         <tr>
             <td>Memory, total available GC memory</td>
-            <td>@env.TotalAvailableMemoryBytes (@GetInBestUnit(@env.TotalAvailableMemoryBytes))</td>
+            <td>@env.TotalAvailableMemoryBytes (@GetInBestUnit(env.TotalAvailableMemoryBytes))</td>
         </tr>
         <tr>
             <td>Host name</td>

--- a/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
+++ b/samples/aspnetapp/aspnetapp/Views/Home/Index.cshtml
@@ -84,12 +84,12 @@
         }
         else if (size < Gibi)
         {
-            decimal mebibytes = Decimal.Divide(size, Mebi);
+            double mebibytes = (double)size / Mebi;
             return $"{mebibytes:N2} MiB";
         }
         else
         {
-            decimal gibibytes = Decimal.Divide(size, Gibi);
+            double gibibytes = (double)size / Gibi;
             return $"{gibibytes:N2} GiB";
         }
     }

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -80,7 +80,7 @@ if (OperatingSystem.IsLinux())
     {
         WriteLine($"cgroup memory limit: {memoryLimit} ({GetInBestUnit(memoryLimit)})");
         WriteLine($"cgroup memory usage: {currentMemory} ({GetInBestUnit(currentMemory)})");
-        WriteLine($"GC Hard limit %:  {(double)totalMemoryBytes/memoryLimit * 100:N0}");
+        WriteLine($"GC Hard limit %: {(double)totalMemoryBytes/memoryLimit * 100:N0}");
     }
 }
 

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -92,12 +92,12 @@ string GetInBestUnit(long size)
     }
     else if (size < Gibi)
     {
-        decimal mebibytes = Decimal.Divide(size, Mebi);
+        double mebibytes = (double)(size / Mebi);
         return $"{mebibytes:F} MiB";
     }
     else
     {
-        decimal gibibytes = Decimal.Divide(size, Gibi);
+        double gibibytes = (double)(size / Gibi);
         return $"{gibibytes:F} GiB";
     }
 }

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -70,7 +70,7 @@ string[] currentMemoryPaths = new string[]
 };
 
 // cgroup information
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+if (OperatingSystem.IsLinux())
 {
     // get memory cgroup information
     long memoryLimit = GetBestValue(memoryLimitPaths);
@@ -80,7 +80,7 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
     {
         WriteLine($"cgroup memory limit: {memoryLimit} ({GetInBestUnit(memoryLimit)})");
         WriteLine($"cgroup memory usage: {currentMemory} ({GetInBestUnit(currentMemory)})");
-        WriteLine($"GC Hard limit %:  {decimal.Divide(totalMemoryBytes,memoryLimit) * 100}");
+        WriteLine($"GC Hard limit %:  {(double)totalMemoryBytes/memoryLimit * 100:N0}");
     }
 }
 
@@ -105,7 +105,7 @@ string GetInBestUnit(long size)
 long GetBestValue(string[] paths)
 {
     string value = string.Empty;
-    foreach(string path in paths)
+    foreach (string path in paths)
     {
         if (Path.Exists(path))
         {

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -7,18 +7,17 @@ using static System.Console;
 // Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
 // Ascii text: https://ascii.co.uk/text (Univers font)
 
-string nl = Environment.NewLine;
+WriteLine($"""
+         88                                                    
+         88              ,d                             ,d     
+         88              88                             88     
+ ,adPPYb,88  ,adPPYba, MM88MMM 8b,dPPYba,   ,adPPYba, MM88MMM  
+a8"    `Y88 a8"     "8a  88    88P'   `"8a a8P_____88   88     
+8b       88 8b       d8  88    88       88 8PP!!!!!!!   88     
+"8a,   ,d88 "8a,   ,a8"  88,   88       88 "8b,   ,aa   88,    
+ `"8bbdP"Y8  `"YbbdP"'   "Y888 88       88  `"Ybbd8"'   "Y888  
 
-WriteLine(
-$"         42{nl}" +
-$"         42              ,d                             ,d{nl}" +
-$"         42              42                             42{nl}" +
-$" ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM{nl}" +
-$"a8\"    `Y42 a8\"     \"8a  42    42P\'   `\"8a a8P_____42   42{nl}" +
-$"8b       42 8b       d8  42    42       42 8PP\"\"\"\"\"\"\"   42{nl}" +
-$"\"8a,   ,d42 \"8a,   ,a8\"  42,   42       42 \"8b,   ,aa   42,{nl}" +
-$" `\"8bbdP\"Y8  `\"YbbdP\"\'   \"Y428 42       42  `\"Ybbd8\"\'   \"Y428{nl}");
-
+""");
 
 // .NET information
 WriteLine(RuntimeInformation.FrameworkDescription);

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -52,6 +52,7 @@ GCMemoryInfo gcInfo = GC.GetGCMemoryInfo();
 long totalMemoryBytes = gcInfo.TotalAvailableMemoryBytes;
 
 // Environment information
+WriteLine($"{nameof(Environment.UserName)}: {Environment.UserName}");
 WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {RuntimeInformation.OSArchitecture}");
 WriteLine($"{nameof(Environment.ProcessorCount)}: {Environment.ProcessorCount}");
 WriteLine($"{nameof(GCMemoryInfo.TotalAvailableMemoryBytes)}: {totalMemoryBytes} ({GetInBestUnit(totalMemoryBytes)})");

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -8,14 +8,14 @@ using static System.Console;
 // Ascii text: https://ascii.co.uk/text (Univers font)
 
 WriteLine("""
-         88                                                    
-         88              ,d                             ,d     
-         88              88                             88     
- ,adPPYb,88  ,adPPYba, MM88MMM 8b,dPPYba,   ,adPPYba, MM88MMM  
-a8"    `Y88 a8"     "8a  88    88P'   `"8a a8P_____88   88     
-8b       88 8b       d8  88    88       88 8PP!!!!!!!   88     
-"8a,   ,d88 "8a,   ,a8"  88,   88       88 "8b,   ,aa   88,    
- `"8bbdP"Y8  `"YbbdP"'   "Y888 88       88  `"Ybbd8"'   "Y888  
+         42                                                    
+         42              ,d                             ,d     
+         42              42                             42     
+ ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM  
+a8"    `Y42 a8"     "8a  42    42P'   `"8a a8P_____42   42     
+8b       42 8b       d8  42    42       42 8PP!!!!!!!   42     
+"8a,   ,d42 "8a,   ,a8"  42,   42       42 "8b,   ,aa   42,    
+ `"8bbdP"Y8  `"YbbdP"'   "Y428 42       42  `"Ybbd8"'   "Y428  
 
 """);
 

--- a/samples/dotnetapp/Program.cs
+++ b/samples/dotnetapp/Program.cs
@@ -7,7 +7,7 @@ using static System.Console;
 // Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
 // Ascii text: https://ascii.co.uk/text (Univers font)
 
-WriteLine($"""
+WriteLine("""
          88                                                    
          88              ,d                             ,d     
          88              88                             88     


### PR DESCRIPTION
I noticed that our samples were stale w/rt cgroups. They are using cgroup v1, but the primary distros we're using are cgroup v2.  I'm not sure if this is exclusively a host/kernel topic or requires guest/userland support. The change should work either way. The current samples don't work correctly anymore because of this and likely haven't for some time.

I also added the user. That'll be useful for our rootless work.

Some quick evidence:

```bash
% docker run --rm -m 50mb -it --entrypoint bash dotnetapp
root@44ead91c120f:/app# stat -fc %T /sys/fs/cgroup/
cgroup2fs
```

This is what our `dotnetapp` sample does today:

```bash
% docker run --rm -m 50mb mcr.microsoft.com/dotnet/samples:dotnetapp
         42
         42              ,d                             ,d
         42              42                             42
 ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM
a8"    `Y42 a8"     "8a  42    42P'   `"8a a8P_____42   42
8b       42 8b       d8  42    42       42 8PP"""""""   42
"8a,   ,d42 "8a,   ,a8"  42,   42       42 "8b,   ,aa   42,
 `"8bbdP"Y8  `"YbbdP"'   "Y428 42       42  `"Ybbd8"'   "Y428

.NET 7.0.0
Alpine Linux v3.16

OSArchitecture: Arm64
ProcessorCount: 4
TotalAvailableMemoryBytes: 37.50 MiB
```

Notice that the container is memory limited but that information isn't showed. It's because all the logic of the sample is oriented around cgroup v1, but the environment it is running in is cgroup v2.

Let's do the same thing with the code in this PR.

```bash
% docker run --rm -m 50mb dotnetapp
         42
         42              ,d                             ,d
         42              42                             42
 ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM
a8"    `Y42 a8"     "8a  42    42P'   `"8a a8P_____42   42
8b       42 8b       d8  42    42       42 8PP"""""""   42
"8a,   ,d42 "8a,   ,a8"  42,   42       42 "8b,   ,aa   42,
 `"8bbdP"Y8  `"YbbdP"'   "Y428 42       42  `"Ybbd8"'   "Y428

.NET 7.0.0
Linux 5.15.49-linuxkit #1 SMP PREEMPT Tue Sep 13 07:51:32 UTC 2022

UserName: app
OSArchitecture: Arm64
ProcessorCount: 4
TotalAvailableMemoryBytes: 39321600 (37.50 MiB)
cgroup memory limit: 52428800 (50.00 MiB)
cgroup memory usage: 5718016 (5.45 MiB)
GC Hard limit %:  75.00
```

See that user is `app`. That's using our Chiseled images. Otherwise, you'd see `root`.

The code to show the cgroup information was always there, but the logic around it was (or became) wrong.

https://github.com/dotnet/dotnet-docker/blob/9b731e901dd4a343fc30da7b8b3ab7d305a4aff9/samples/dotnetapp/Program.cs#L61-L63

Related info:

- https://github.com/dotnet/coreclr/pull/25906
- https://github.com/dask/distributed/pull/7051
- https://stackoverflow.com/questions/65646317/sys-fs-cgroup-memory-memory-limit-in-bytes-not-present-in-fedora-33
- https://unix.stackexchange.com/questions/471476/how-do-i-check-cgroup-v2-is-installed-on-my-machine