### PR TITLE
Include OS release info in Chiseled Ubuntu images

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -25,7 +25,7 @@ param(
 )
 
 if (($Mode -eq "BuildAndTest" -or $Mode -eq "Test") -and $TestCategories.Contains("pre-build")) {
-    & ./tests/run-tests.ps1 -TestCategories "pre-build"
+    & ./tests/run-tests.ps1 -TestCategories "pre-build" -Version "*"
 }
 
 if ($Mode -eq "BuildAndTest" -or $Mode -eq "Build") {

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -31,6 +31,7 @@ RUN {{InsertTemplate("Dockerfile.linux.distroless-user",
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
 RUN chisel cut --release "ubuntu-{{osVersionNumber}}" --root /rootfs \
         base-files_base \
+        base-files_release-info \
         ca-certificates_data \
         libc6_libs \
         libgcc-s1_libs \

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -29,6 +29,7 @@ RUN groupadd \
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
 RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
         base-files_base \
+        base-files_release-info \
         ca-certificates_data \
         libc6_libs \
         libgcc-s1_libs \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -29,6 +29,7 @@ RUN groupadd \
 COPY --from=chisel /opt/chisel/chisel /usr/bin/
 RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
         base-files_base \
+        base-files_release-info \
         ca-certificates_data \
         libc6_libs \
         libgcc-s1_libs \

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 SyftImage, "distroless-packages", $"packages docker:{imageName} -o json", useMountedDockerSocket: true);
 
             string[] expectedPackages;
-            if (imageData.OS.Contains(OS.MarinerDistroless))
+            if (imageData.OS.Contains(OS.Mariner))
             {
                 expectedPackages = new[]
                 {

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -92,12 +92,6 @@ namespace Microsoft.DotNet.Docker.Tests
                 return;
             }
 
-            if (imageData.OS == OS.JammyChiseled)
-            {
-                OutputHelper.WriteLine("Scanning support not implemented for Chiseled Ubuntu images.");
-                return;
-            }
-
             const string SyftImage = "anchore/syft";
             DockerHelper.Pull(SyftImage);
 
@@ -105,22 +99,35 @@ namespace Microsoft.DotNet.Docker.Tests
             string output = DockerHelper.Run(
                 SyftImage, "distroless-packages", $"packages docker:{imageName} -o json", useMountedDockerSocket: true);
 
-            string[] expectedPackages = new[]
+            string[] expectedPackages;
+            if (imageData.OS.Contains(OS.MarinerDistroless))
             {
-                "distroless-packages-minimal",
-                "e2fsprogs-libs",
-                "filesystem",
-                "glibc",
-                "krb5",
-                "libgcc",
-                "libstdc++",
-                "mariner-release",
-                "openssl",
-                "openssl-libs",
-                "prebuilt-ca-certificates",
-                "prebuilt-ca-certificates-base",
-                "zlib"
-            };
+                expectedPackages = new[]
+                {
+                    "distroless-packages-minimal",
+                    "e2fsprogs-libs",
+                    "filesystem",
+                    "glibc",
+                    "krb5",
+                    "libgcc",
+                    "libstdc++",
+                    "mariner-release",
+                    "openssl",
+                    "openssl-libs",
+                    "prebuilt-ca-certificates",
+                    "prebuilt-ca-certificates-base",
+                    "zlib"
+                };
+            }
+            else if (imageData.OS == OS.JammyChiseled)
+            {
+                OutputHelper.WriteLine("Package scanning support not implemented for Chiseled Ubuntu images.");
+                expectedPackages = Array.Empty<string>();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
 
             JsonNode node = JsonNode.Parse(output);
             if (node is null)
@@ -133,6 +140,10 @@ namespace Microsoft.DotNet.Docker.Tests
                 .ToArray();
 
             Assert.Equal(expectedPackages, actualPackages);
+
+            // Verify the OS release info is available
+            JsonObject distro = (JsonObject)node["distro"];
+            Assert.NotEmpty((string)distro["version"]);
         }
 
         internal static string[] GetExpectedRpmPackagesInstalled(ProductImageData imageData) =>


### PR DESCRIPTION
This mirrors the changes that were made in https://github.com/ubuntu-rocks/dotnet/pull/81. It includes OS release info to the Chiseled Ubuntu images (e.g. the `/etc/os-release` file). This allows image scanning tools that look for this OS info to be able to correctly identify the type of OS for these Chiseled Ubuntu images.

For example, before these changes [Syft](https://github.com/anchore/syft) would not be able to identify the OS:

```bash
> syft packages --output json -q mcr.microsoft.com/dotnet/nightly/runtime-deps:7.0-jammy-chiseled | jq -r .distro
{}
```

But with these changes it will output this instead:

```json
{
  "prettyName": "Ubuntu 22.04.1 LTS",
  "name": "Ubuntu",
  "id": "ubuntu",
  "idLike": [
   "debian"
  ],
  "version": "22.04.1 LTS (Jammy Jellyfish)",
  "versionID": "22.04",
  "versionCodename": "jammy",
  "homeURL": "https://www.ubuntu.com/",
  "supportURL": "https://help.ubuntu.com/",
  "bugReportURL": "https://bugs.launchpad.net/ubuntu/",
  "privacyPolicyURL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
}
```