### PR TITLE
Upgrade to libssl3 for Alpine 3.17

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -13,7 +13,7 @@
             "krb5-libs",
             "libgcc",
             "libintl",
-            "libssl1.1",
+            cat("libssl", VARIABLES[cat("libssl|", OS_VERSION_BASE)]),
             "libstdc++",
             "zlib"
         ],

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -89,6 +89,8 @@
     "libicu|focal": 66,
     "libicu|jammy": 70,
 
+    "libssl|alpine3.16": "1.1",
+    "libssl|alpine3.17": "3",
     "libssl|bionic": "1.1",
     "libssl|bullseye": "1.1",
     "libssl|buster": "1.1",

--- a/src/runtime-deps/6.0/alpine3.17/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.17/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
         krb5-libs \
         libgcc \
         libintl \
-        libssl1.1 \
+        libssl3 \
         libstdc++ \
         zlib
 

--- a/src/runtime-deps/6.0/alpine3.17/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.17/arm32v7/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
         krb5-libs \
         libgcc \
         libintl \
-        libssl1.1 \
+        libssl3 \
         libstdc++ \
         zlib
 

--- a/src/runtime-deps/6.0/alpine3.17/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.17/arm64v8/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
         krb5-libs \
         libgcc \
         libintl \
-        libssl1.1 \
+        libssl3 \
         libstdc++ \
         zlib
 


### PR DESCRIPTION
While OpenSSL 1.1 is available in Alpine 3.17, [OpenSSL 3.0 is the default version](https://alpinelinux.org/posts/Alpine-3.17.0-released.html). We should reflect that default version with the version of libssl that is installed.

These changes upgrade the version of libssl from 1.1 to 3.0 for the Alpine 3.17 Dockerfiles.