### PR TITLE
Add .NET Monitor 8 Dockerfiles

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -50,20 +50,30 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-7.0.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.1-alpine, 7.0-alpine, 7-alpine, 7.0.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.17
+7.0.1-alpine-amd64, 7.0-alpine-amd64, 7-alpine-amd64, 7.0.1-alpine, 7.0-alpine, 7-alpine, 7.0.1, 7.0, 7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/amd64/Dockerfile) | Alpine 3.17
 7.0.1-ubuntu-chiseled-amd64, 7.0-ubuntu-chiseled-amd64, 7-ubuntu-chiseled-amd64, 7.0.1-ubuntu-chiseled, 7.0-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.3.1-alpine-amd64, 6.3-alpine-amd64, 6-alpine-amd64, 6.3.1-alpine, 6.3-alpine, 6-alpine, 6.3.1, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/amd64/Dockerfile) | Alpine 3.17
 6.3.1-ubuntu-chiseled-amd64, 6.3-ubuntu-chiseled-amd64, 6-ubuntu-chiseled-amd64, 6.3.1-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.2.2-alpine-amd64, 6.2-alpine-amd64, 6.2.2-alpine, 6.2-alpine, 6.2.2, 6.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/amd64/Dockerfile) | Alpine 3.17
 
+##### .NET Monitor 8 Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.0.0-alpha.1-ubuntu-chiseled-amd64, 8.0-preview-ubuntu-chiseled-amd64, 8-preview-ubuntu-chiseled-amd64, 8.0.0-alpha.1-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-alpha.1, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-7.0.1-alpine-arm64v8, 7.0-alpine-arm64v8, 7-alpine-arm64v8, 7.0.1-alpine, 7.0-alpine, 7-alpine, 7.0.1, 7.0, 7, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/arm64v8/Dockerfile) | Alpine 3.17
+7.0.1-alpine-arm64v8, 7.0-alpine-arm64v8, 7-alpine-arm64v8, 7.0.1-alpine, 7.0-alpine, 7-alpine, 7.0.1, 7.0, 7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/alpine/arm64v8/Dockerfile) | Alpine 3.17
 7.0.1-ubuntu-chiseled-arm64v8, 7.0-ubuntu-chiseled-arm64v8, 7-ubuntu-chiseled-arm64v8, 7.0.1-ubuntu-chiseled, 7.0-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.3.1-alpine-arm64v8, 6.3-alpine-arm64v8, 6-alpine-arm64v8, 6.3.1-alpine, 6.3-alpine, 6-alpine, 6.3.1, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/arm64v8/Dockerfile) | Alpine 3.17
 6.3.1-ubuntu-chiseled-arm64v8, 6.3-ubuntu-chiseled-arm64v8, 6-ubuntu-chiseled-arm64v8, 6.3.1-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.2.2-alpine-arm64v8, 6.2-alpine-arm64v8, 6.2.2-alpine, 6.2-alpine, 6.2.2, 6.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.2/alpine/arm64v8/Dockerfile) | Alpine 3.17
+
+##### .NET Monitor 8 Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.0.0-alpha.1-ubuntu-chiseled-arm64v8, 8.0-preview-ubuntu-chiseled-arm64v8, 8-preview-ubuntu-chiseled-arm64v8, 8.0.0-alpha.1-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-alpha.1, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/dockerfile-templates/monitor/Dockerfile.entrypoint.monitorV8
+++ b/eng/dockerfile-templates/monitor/Dockerfile.entrypoint.monitorV8
@@ -1,0 +1,2 @@
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -1,4 +1,8 @@
 $(McrTagsYmlRepo:monitor)
+$(McrTagsYmlTagGroup:8.0-preview-ubuntu-chiseled-amd64)
+    customSubTableTitle: .NET Monitor 8 Preview Tags
+$(McrTagsYmlTagGroup:8.0-preview-ubuntu-chiseled-arm64v8)
+    customSubTableTitle: .NET Monitor 8 Preview Tags
 $(McrTagsYmlTagGroup:7.0-alpine-amd64)
 $(McrTagsYmlTagGroup:7.0-alpine-arm64v8)
 $(McrTagsYmlTagGroup:7.0-ubuntu-chiseled-amd64)

--- a/manifest.json
+++ b/manifest.json
@@ -7507,8 +7507,7 @@
             "7-alpine": {},
             "$(monitor|7.0|product-version)": {},
             "7.0": {},
-            "7": {},
-            "latest": {}
+            "7": {}
           },
           "platforms": [
             {
@@ -7700,6 +7699,112 @@
                   "docType": "Undocumented"
                 },
                 "7-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|8.0|product-version)",
+          "sharedTags": {
+            "$(monitor|8.0|product-version)-ubuntu-chiseled": {},
+            "8.0-preview-ubuntu-chiseled": {},
+            "8-preview-ubuntu-chiseled": {},
+            "$(monitor|8.0|product-version)": {},
+            "8.0-preview": {},
+            "8-preview": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/8.0/ubuntu-chiseled/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.0|product-version)-ubuntu-chiseled-amd64": {},
+                "8.0-preview-ubuntu-chiseled-amd64": {},
+                "8-preview-ubuntu-chiseled-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/8.0/ubuntu-chiseled/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.0|product-version)-ubuntu-chiseled-arm64v8": {},
+                "8.0-preview-ubuntu-chiseled-arm64v8": {},
+                "8-preview-ubuntu-chiseled-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|8.0|product-version)",
+          "sharedTags": {
+            "$(monitor|8.0|product-version)-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8.0-preview-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8-preview-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/8.0/cbl-mariner-distroless/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.0|product-version)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8.0-preview-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8-preview-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                }
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "ASPNET_REPO": "$(Repo:aspnet)",
+                "SDK_REPO": "$(Repo:sdk)"
+              },
+              "dockerfile": "src/monitor/8.0/cbl-mariner-distroless/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.0|product-version)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "8.0-preview-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "8-preview-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 }
               },

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -77,6 +77,8 @@
     "base-url|6.3-monitor|nightly": "$(base-url|public|nightly)",
     "base-url|7.0-monitor|main": "$(base-url|public|main)",
     "base-url|7.0-monitor|nightly": "$(base-url|public|nightly)",
+    "base-url|8.0-monitor|main": "$(base-url|public|main)",
+    "base-url|8.0-monitor|nightly": "$(base-url|public|nightly)",
 
     "dotnet|3.1|product-version": "3.1.31",
     "dotnet|6.0|product-version": "6.0.11",
@@ -111,6 +113,10 @@
     "monitor|7.0|build-version": "7.0.1-servicing.22601.8",
     "monitor|7.0|product-version": "7.0.1",
     "monitor|7.0|sha": "c316a859eb8d024c765b024bfb4a92b6aedfb5cc02d0751f73e826e2bc20f2ab5c1ed8c4d6b481b6b757fc58d35423668f9087f9d4cfb1acd7ab8dced1412c03",
+
+    "monitor|8.0|build-version": "8.0.0-alpha.1.22606.5",
+    "monitor|8.0|product-version": "8.0.0-alpha.1",
+    "monitor|8.0|sha": "7d0ebc07ec62072fd43bdcf0b7abac54eb0bb9793798518b9f3f958cc8ac78a878fc0910c9585535f865447b306f3d3948cc9f4ff7c524f4108ca42344c5bac9",
 
     "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha": "fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880",
 

--- a/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -1,0 +1,62 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:8.0.100-alpha.1-cbl-mariner2.0-amd64 AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION=8.0.0-alpha.1.22606.5
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='7d0ebc07ec62072fd43bdcf0b7abac54eb0bb9793798518b9f3f958cc8ac78a878fc0910c9585535f865447b306f3d3948cc9f4ff7c524f4108ca42344c5bac9' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net8.0 --no-cache \
+    # To reduce image size, remove all non-net8.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net8.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net8[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:8.0.0-alpha.1-cbl-mariner2.0-distroless-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -1,0 +1,62 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:8.0.100-alpha.1-cbl-mariner2.0-arm64v8 AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION=8.0.0-alpha.1.22606.5
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='7d0ebc07ec62072fd43bdcf0b7abac54eb0bb9793798518b9f3f958cc8ac78a878fc0910c9585535f865447b306f3d3948cc9f4ff7c524f4108ca42344c5bac9' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net8.0 --no-cache \
+    # To reduce image size, remove all non-net8.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net8.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net8[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:8.0.0-alpha.1-cbl-mariner2.0-distroless-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile
@@ -1,0 +1,62 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:8.0.100-alpha.1-jammy-amd64 AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION=8.0.0-alpha.1.22606.5
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='7d0ebc07ec62072fd43bdcf0b7abac54eb0bb9793798518b9f3f958cc8ac78a878fc0910c9585535f865447b306f3d3948cc9f4ff7c524f4108ca42344c5bac9' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net8.0 --no-cache \
+    # To reduce image size, remove all non-net8.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net8.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net8[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the x64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-arm64|linux-musl-arm64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:8.0.0-alpha.1-jammy-chiseled-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -1,0 +1,62 @@
+ARG ASPNET_REPO=mcr.microsoft.com/dotnet/aspnet
+ARG SDK_REPO=mcr.microsoft.com/dotnet/sdk
+
+# Installer image
+FROM $SDK_REPO:8.0.100-alpha.1-jammy-arm64v8 AS installer
+
+# Install .NET Monitor
+ENV DOTNET_MONITOR_VERSION=8.0.0-alpha.1.22606.5
+RUN curl -fSL --output dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$DOTNET_MONITOR_VERSION/dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg \
+    && dotnetmonitor_sha512='7d0ebc07ec62072fd43bdcf0b7abac54eb0bb9793798518b9f3f958cc8ac78a878fc0910c9585535f865447b306f3d3948cc9f4ff7c524f4108ca42344c5bac9' \
+    && echo "$dotnetmonitor_sha512  dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg" | sha512sum -c - \
+    && dotnet tool install dotnet-monitor --tool-path /app --add-source / --version $DOTNET_MONITOR_VERSION --framework net8.0 --no-cache \
+    # To reduce image size, remove all non-net8.0 TFMs
+    # To do this safely, we need to first find everything that dotnet tool installed named "dotnet-monitor".
+    # The /dotnet-monitor/ folder exists under .store which is not a stable constant to rely on. The result is multi stage search:
+    # 1. Find any files in /app
+    # 2. Match anything that is under a *folder* called 'dotnet-monitor'
+    # 3. Match anything from step 2 that isn't in a '/tools/net8.0' folder (/tools is the folder we use in a nuget file that is stable)
+    # 4. Delete everything from step 3
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -v -i '.*/tools/net8[.]0' | xargs rm -rf \
+    # To reduce image size further, remove the non-linux assemblies
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(win|osx)' | xargs rm -rf \
+    # To reduce image size further, remove linux assemblies that do not match the arm64 architecture
+    && find /app -type f -print | grep -i '.*/dotnet-monitor/.*' | grep -i -E '/(runtimes|shared|shims)/(linux-x64|linux-musl-x64)' | xargs rm -rf \
+    # To reduce image size further, remove symbol files
+    && find /app -type f \( -name *.pdb -o -name *.dbg \) -print | xargs rm -rf \
+    # Remove all the empty directories left by the previous step
+    && find /app -type d -empty -delete \
+    # Allow other users to run the tool
+    && chmod 755 /app/dotnet-monitor \
+    && rm dotnet-monitor.$DOTNET_MONITOR_VERSION.nupkg
+
+
+# Monitor image
+FROM $ASPNET_REPO:8.0.0-alpha.1-jammy-chiseled-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -167,6 +167,10 @@ namespace Microsoft.DotNet.Docker.Tests
             new ProductImageData { Version = V7_0, VersionFamily = V7_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Arm64 },
             new ProductImageData { Version = V7_0, VersionFamily = V7_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Amd64 },
             new ProductImageData { Version = V7_0, VersionFamily = V7_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64 },
+            new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Amd64 },
+            new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Arm64 },
+            new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64 },
         };
 
         private static readonly ProductImageData[] s_windowsMonitorTestData =

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -262,6 +262,10 @@
     "src/monitor/7.0/cbl-mariner/amd64": 220741666,
     "src/monitor/7.0/cbl-mariner/arm64v8": 217293451,
     "src/monitor/7.0/cbl-mariner-distroless/amd64": 126119268,
-    "src/monitor/7.0/cbl-mariner-distroless/arm64v8": 133547868
+    "src/monitor/7.0/cbl-mariner-distroless/arm64v8": 133547868,
+    "src/monitor/8.0/ubuntu-chiseled/amd64": 121260554,
+    "src/monitor/8.0/ubuntu-chiseled/arm64v8": 128934532,
+    "src/monitor/8.0/cbl-mariner-distroless/amd64": 133235508,
+    "src/monitor/8.0/cbl-mariner-distroless/arm64v8": 140710709
   }
 }


### PR DESCRIPTION
For .NET Monitor 8, the initial offering will be to only provide distroless and chiseled images. These images will follow the same tagging policy introduced for .NET 8.

cc @dotnet/dotnet-monitor