### PR TITLE
Update expected packages for distroless Mariner

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 "openssl",
                 "openssl-libs",
                 "prebuilt-ca-certificates",
-                "prebuilt-ca-certificates-base",
+                "tzdata",
                 "zlib"
             };
 


### PR DESCRIPTION
The latest servicing version of Mariner has caused a change in the expected packages that exist. We verify these expected packages for the distroless version and this new version has caused `tzdata` to be added and `prebuilt-ca-certificates-base` to be removed. This doesn't seem right and I'll continue to investigate what happened and log issues if necessary. But these changes update the tests to reflect the current status and unblock the build.