### PR TITLE
Remove channel name concept from update-dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,10 @@ The following examples illustrate how to run `update-dependencies`:
     > ./eng/Set-DotnetVersions.ps1 -ProductVersion 3.1 -SdkVersion 3.1.302 -RuntimeVersion 3.1.6 -AspnetVersion 3.1.6
     ```
 
-- Update the .NET Monitor version
+- Update the .NET Monitor version (uses a helper script for running update-dependencies)
 
     ``` console
-    > dotnet run --project .\eng\update-dependencies\update-dependencies.csproj 6.0 --product-version monitor=6.0.0-rc.1.21515.7 --channel-name 6.0/rc.1
+    > ./eng/Set-DotnetVersions.ps1 -ProductVersion 6.0 -MonitorVersion 6.0.0-rc.1.21515.7
     ```
 
 - Update the PowerShell version used in the 6.0 images

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -31,7 +31,7 @@ stages:
     - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -Channel $(MajorMinorVersion)/$(ChannelQuality)
       displayName: Get Versions
     - powershell: |
-        $customArgs = "$(MajorMinorVersion) --product-version monitor=$(monitorVer) --channel-name $(MajorMinorVersion)/$(ChannelQuality) --version-source-name dotnet/dotnet-monitor/$(MajorMinorVersion) --stable-branding=$(stableBranding)"
+        $customArgs = "$(MajorMinorVersion) --product-version monitor=$(monitorVer) --version-source-name dotnet/dotnet-monitor/$(MajorMinorVersion) --stable-branding=$(stableBranding)"
         
         $customArgsArray = @($customArgs)
         echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -208,7 +208,6 @@ namespace Dotnet.Docker
                     .Replace("$ARCHIVE_EXT", archiveExt)
                     .Replace("$VERSION_DIR", versionDir)
                     .Replace("$VERSION_FILE", versionFile)
-                    .Replace("$CHANNEL_NAME", _options.ChannelName)
                     .Replace("$OS", _os)
                     .Replace("$OPTIONAL_OS", optionalOs)
                     .Replace("$ARCH", _arch)

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -14,7 +14,6 @@ namespace Dotnet.Docker
         public string ChecksumSasQueryString { get; }
         public bool ComputeChecksums { get; }
         public string DockerfileVersion { get; }
-        public string ChannelName { get; }
         public string Email { get; }
         public string Password { get; }
         public string GitHubProject => "dotnet-docker";
@@ -31,14 +30,13 @@ namespace Dotnet.Docker
         public bool UpdateOnly => Email == null || Password == null || User == null || TargetBranch == null;
         public bool IsInternal => !string.IsNullOrEmpty(BinarySasQueryString) || !string.IsNullOrEmpty(ChecksumSasQueryString);
 
-        public Options(string dockerfileVersion, string[] productVersion, string channelName, string versionSourceName, string email, string password, string user,
+        public Options(string dockerfileVersion, string[] productVersion, string versionSourceName, string email, string password, string user,
             bool computeShas, bool stableBranding, string binarySas, string checksumSas, string sourceBranch, string targetBranch, string org, string project, string repo)
         {
             DockerfileVersion = dockerfileVersion;
             ProductVersions = productVersion
                 .Select(pair => pair.Split(new char[] { '=' }, 2))
                 .ToDictionary(split => split[0].ToLower(), split => split.Skip(1).FirstOrDefault());
-            ChannelName = channelName;
             VersionSourceName = versionSourceName;
             Email = email;
             Password = password;
@@ -72,7 +70,6 @@ namespace Dotnet.Docker
             {
                 new Argument<string>("dockerfile-version", "Version of the Dockerfiles to update"),
                 new Option<string[]>("--product-version", "Product versions to update (<product-name>=<version>)"),
-                new Option<string>("--channel-name", "The name of the channel from which to find product files."),
                 new Option<string>("--version-source-name", "The name of the source from which the version information was acquired."),
                 new Option<string>("--email", "GitHub or AzDO email used to make PR (if not specified, a PR will not be created)"),
                 new Option<string>("--password", "GitHub or AzDO password used to make PR (if not specified, a PR will not be created)"),


### PR DESCRIPTION
The `--channel-name` option was introduced long ago when .NET Monitor could not be staged in the storage accounts the same way that the rest of the .NET assets were able to in the .NET 6 timeframe. Shortly after .NET 6 shipped, this was fixed so that .NET Monitor now conforms to the usual shipping mechanism via storage accounts. Thus, the channel name concept is no longer necessary; remove it to reduce the concept count.