### PR TITLE
Update image size baseline

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -261,7 +261,7 @@
     "src/monitor/7.0/ubuntu-chiseled/arm64v8": 127632309,
     "src/monitor/7.0/cbl-mariner/amd64": 220741666,
     "src/monitor/7.0/cbl-mariner/arm64v8": 217293451,
-    "src/monitor/7.0/cbl-mariner-distroless/amd64": 126119268,
+    "src/monitor/7.0/cbl-mariner-distroless/amd64": 132678720,
     "src/monitor/7.0/cbl-mariner-distroless/arm64v8": 133547868,
     "src/monitor/8.0/ubuntu-chiseled/amd64": 121260554,
     "src/monitor/8.0/ubuntu-chiseled/arm64v8": 128934532,


### PR DESCRIPTION
This change is due to an update in the size of the base Mariner distroless image from the addition of tzdata and certificates package.