### PR TITLE
Vulnerability doc improvements

### DIFF
--- a/documentation/vulnerability-reporting.md
+++ b/documentation/vulnerability-reporting.md
@@ -1,9 +1,7 @@
 # Container Vulnerability Workflow
 
-This documented is intended to help guide you to the appropriate course of action when encountering reported vulnerabilities in the .NET container images.
+This document is intended to help guide you to the appropriate course of action when encountering reported vulnerabilities in the .NET container images.
 Please follow this guidance to determine the steps to take before logging an issue.
-The flowchart below describes a series of questions to help determine the state of the image being reported upon.
-By answering each question, it will eventually direct you to the action to help resolve your vulnerabilities.
 
 Prerequisites:
 
@@ -15,13 +13,20 @@ Prerequisites:
   * For Linux images, it's also important to [know the Linux distro and version](#how-can-i-determine-the-os-version-of-a-linux-image) (e.g. `Debian Bullseye`, `Alpine 3.17`, `Ubuntu Jammy`)
 * If you're using Docker Desktop for Windows and investigating a vulnerability in a Linux image, [change your settings](https://docs.docker.com/desktop/settings/windows/) to target Linux containers.
 
+The flowchart below describes a series of questions to help determine the state of the image being reported upon.
+By answering each question, it will eventually direct you to the action to help resolve your vulnerabilities.
+The flowchart is meant to be a visual representation of the workflow.
+Below the flowchart are the details of each question and the actions to take.
+Each question in the details section includes a "Response" header that contains links to help guide you through the workflow based on your responses.
+You may begin with the first question at "[A. Is your scanner targeting the latest version of your image?](#a-is-your-scanner-targeting-the-latest-version-of-your-image)"
+
 ```mermaid
 flowchart
     ScanningLatest{A. Is your scanner<br>targeting the latest<br>version of your image?} --> |No|RescanLatest[B. Scan your<br>latest image]
     ScanningLatest --> |Yes|BuiltOnSupportedBase{C. Is your image<br>built from a supported<br>.NET image?}
     BuiltOnSupportedBase --> |No|UpdateBaseImageTag[D. Update base image tag<br>to supported image]
     BuiltOnSupportedBase --> |Yes|BuiltOnLatestBase{E. Is your image<br>built from the latest<br>.NET image?}
-    BuiltOnLatestBase --> |No|RebuildImageBase[F. Rebuild your image<br>to get latest base]
+    BuiltOnLatestBase --> |No|RebuildImageBase[F. Rebuild your image<br>to get the latest base]
     BuiltOnLatestBase --> |Yes|IsDotnetVuln{G. Is .NET the source<br>of the vulnerability?}
     IsDotnetVuln --> |No|PlatformType{H. Which OS<br>platform is<br>this for?}
     IsDotnetVuln --> |Yes|LogDotnetDocker[R. Log an issue at<br>dotnet/dotnet-docker]
@@ -35,25 +40,6 @@ flowchart
     InstalledByDotnet --> |Yes|HiSeverity{P. Is it High/Critical<br>severity?}
     HiSeverity --> |No|WaitForDotnetServicing[Q. Wait for the next .NET<br>servicing release]
     HiSeverity --> |Yes|LogDotnetDocker
-    click ScanningLatest "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?a-is-your-scanner-targeting-the-latest-version-of-your-image"
-    click RescanLatest "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?b-scan-your-latest-image"
-    click BuiltOnSupportedBase "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?c-is-your-image-built-from-a-supported-net-tag"
-    click UpdateBaseImageTag "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?d-update-base-image-tag-to-supported-image"
-    click BuiltOnLatestBase "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?e-is-your-image-built-from-the-latest-net-image"
-    click RebuildImageBase "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?f-rebuild-your-image-to-get-latest-base"
-    click IsDotnetVuln "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?g-is-net-the-source-of-the-vulnerability"
-    click PlatformType "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?h-which-os-platform-is-this-for"
-    click LinuxFixAvailability "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?j-is-a-fix-available-for-the-package-from-the-linux-distro"
-    click WaitForFix "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?k-wait-for-a-fix-to-be-available-from-the-linux-distro"
-    click InLinuxBaseImage "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?l-is-the-package-in-the-linux-distro-base-image"
-    click WaitForLinuxBaseUpdate "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?m-upgrade-packages-or-wait-for-an-updated-linux-distro-base-image"
-    click InstalledByDotnet "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?n-is-the-package-installed-by-net"
-    click HiSeverity "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?p-is-it-highcritical-severity"
-    click RebuildImagePackage "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?o-rebuild-your-image-to-get-the-latest-package"
-    click WindowsVulnSource "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?o-what-is-the-source-of-the-vulnerability"
-    click WaitForDotnetServicing "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?q-wait-for-the-next-net-servicing-release"
-    click LogDotnetDocker "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?r-log-an-issue-at-dotnetdotnet-docker"
-    click WindowsVuln "https://github.com/dotnet/dotnet-docker/blob/main/documentation/vulnerability-reporting.md?i-log-an-issue-at-microsoftwindows-containers"
 ```
 
 ## Flowchart Details
@@ -117,6 +103,11 @@ osVersion="<windows-version>" # Only used for Windows containers (e.g. "10.0.203
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentation/scripts/resolve-image-digest.ps1'))) $myImage -Os $os -Architecture $arch -OsVersion $osVersion
 ```
 
+#### Response
+
+* `Yes`: go to "[B. Scan your latest image](#b-scan-your-latest-image)"
+* `No`: go to "[C. Is your image built from a supported .NET tag?](#c-is-your-image-built-from-a-supported-net-tag)"
+
 ### B. Scan your latest image
 
 Rerun the scan of your image using your scanning tool. Ensure you get the latest version of the image by running `docker pull <image-tag>`
@@ -146,6 +137,11 @@ $dotnetImage="<insert-dotnet-image-tag>" # example: mcr.microsoft.com/dotnet/asp
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentation/scripts/check-tag-support.ps1'))) $dotnetImage
 ```
+
+#### Response
+
+* `Yes`: go to "[E. Is your image built from the latest .NET image?](#e-is-your-image-built-from-the-latest-net-image)"
+* `No`: go to "[D. Update base image tag to supported image](#d-update-base-image-tag-to-supported-image)"
 
 ### D. Update base image tag to supported image
 
@@ -190,7 +186,12 @@ $dotnetBaseImage="<insert-dotnet-image-tag>" # example: mcr.microsoft.com/dotnet
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentation/scripts/check-latest-base.ps1'))) $myImage $dotnetBaseImage
 ```
 
-### F. Rebuild your image to get latest base
+#### Response
+
+* `True`/`Yes`: go to "[G. Is .NET the source of the vulnerability?](#g-is-net-the-source-of-the-vulnerability)"
+* `False`/`No`: go to "[F. Rebuild your image to get the latest base](#f-rebuild-your-image-to-get-the-latest-base)"
+
+### F. Rebuild your image to get the latest base
 
 Since your image is out of date with the latest version of the .NET image, rebuilding it will ensure it's up-to-date.
 Be sure that your workflow explicitly pulls the .NET image tag rather than using a potentially cached version of it.
@@ -215,9 +216,19 @@ For example:
 To determine whether .NET binaries are the source of the vulnerability, look at the title and description of the vulnerability.
 If it contains ".NET", "ASP.NET", or something related to .NET, assume this is a .NET vulnerability.
 
+#### Response
+
+* `Yes`: go to "[R. Log an issue at dotnet/dotnet-docker](#r-log-an-issue-at-dotnetdotnet-docker)"
+* `No`: go to "[H. Which OS platform is this for?](#h-which-os-platform-is-this-for)"
+
 ### H. Which OS platform is this for?
 
 See [How can I determine whether my image is based on Linux or Windows?](#how-can-i-determine-whether-my-image-is-based-on-linux-or-windows).
+
+#### Response
+
+* `Windows`: go to "[I. Log an issue at microsoft/Windows-Containers](#i-log-an-issue-at-microsoftwindows-containers)"
+* `Linux`: go to "[J. Is a fix available for the package from the Linux distro?](#j-is-a-fix-available-for-the-package-from-the-linux-distro)"
 
 ### I. Log an issue at microsoft/Windows-Containers
 
@@ -279,6 +290,11 @@ You'll want to track them all in the rest of this workflow.
 It's possible that packages are listed as upgradable but not actually relevant to the vulnerability.
 Those are unrelated packages that happen to contain the same name as the vulnerable package and they can be disregarded.
 
+#### Response
+
+* `Yes`: go to "[L. Is the package in the Linux distro base image?](#l-is-the-package-in-the-linux-distro-base-image)"
+* `No`: go to "[K. Wait for a fix to be available from the Linux distro](#k-wait-for-a-fix-to-be-available-from-the-linux-distro)"
+
 ### K. Wait for a fix to be available from the Linux distro
 
 .NET is dependent on the Linux distribution maintainers to produce fixed versions of the packages that are contained in the .NET container images.
@@ -311,6 +327,11 @@ $imageName="<insert-linux-base-image-name>" # example: amd64/debian:bullseye-sli
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentation/scripts/check-package-install.ps1'))) $packageName $imageName
 ```
+
+#### Response
+
+* `Yes`: go to "[M. Upgrade packages or wait for an updated Linux distro base image](#m-upgrade-packages-or-wait-for-an-updated-linux-distro-base-image)"
+* `No`: go to "[N. Is the package installed by .NET?](#n-is-the-package-installed-by-net)"
 
 ### M. Upgrade packages or wait for an updated Linux distro base image
 
@@ -362,6 +383,11 @@ $imageName="<insert-linux-base-image-name>" # example: mcr.microsoft.com/dotnet/
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentation/scripts/check-package-install.ps1'))) $packageName $imageName
 ```
 
+#### Response
+
+* `Yes`: go to "[P. Is it High/Critical severity?](#p-is-it-highcritical-severity)"
+* `No`: go to "[O. Rebuild your image to get the latest package](#o-rebuild-your-image-to-get-the-latest-package)"
+
 ### O. Rebuild your image to get the latest package
 
 Because the package is not installed by the Linux distro base image or .NET, it must be installed by your Dockerfile.
@@ -375,6 +401,11 @@ The severity of a vulnerability is indicated by its Common Vulnerability Scoring
 To find this score, search for the CVE at the [CVE site](https://www.cve.org/SiteSearch).
 The score will consist of both a number and a label.
 Note whether the label indicates "High" or "Critical".
+
+#### Response
+
+* `Yes`: go to "[R. Log an issue at dotnet/dotnet-docker](#r-log-an-issue-at-dotnetdotnet-docker)"
+* `No`: go to "[Q. Wait for the next .NET servicing release](#q-wait-for-the-next-net-servicing-release)"
 
 ### Q. Wait for the next .NET servicing release
 


### PR DESCRIPTION
The vulnerability doc intended to use the `click` functionality of mermaid to provide hyperlink behavior to the elements in the flowchart. This doesn't work as intended. When clicking such a link, it appears that the mermaid renderer attempts to open the link in the mermaid "box" rather than on the main browser. It then shows an error that says "This content is blocked. Contact the site owner to fix the issue".

So I've removed the use of those `click` definitions. Without that, the document lacks a good experience to walk through the flowchart. To improve things, I've updated each details section of the doc that represents a flowchart question so that it will now include hyperlinks to each of the possible responses. This allows the reader to guide themselves via the details section rather than the flowchart graphic. The graphic is kept as a visualization of the overall process.