### PR TITLE
Only update one .NET Monitor version in update dependencies pipeline

### DIFF
--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -16,17 +16,6 @@ stages:
     displayName: Update Dependencies (dotnet/dotnet-monitor)
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
-    strategy:
-      matrix:
-        Update6:
-          MajorMinorVersion: 6.$(monitor6MinorVersion)
-          ChannelQuality: $(monitor6Quality)
-        Update7:
-          MajorMinorVersion: 7.$(monitor7MinorVersion)
-          ChannelQuality: $(monitor7Quality)
-        Update8:
-          MajorMinorVersion: 8.$(monitor8MinorVersion)
-          ChannelQuality: $(monitor8Quality)
     steps:
     - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -Channel $(MajorMinorVersion)/$(ChannelQuality)
       displayName: Get Versions


### PR DESCRIPTION
This change simplifies the update dependencies pipeline for .NET Monitor to only scan for updates for the version configured by the `MajorMinorVersion` and `ChannelQuality` pipeline variables, which will be set to `8.0` and `daily` respectively.

Post-merge, the [Azure DevOps pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1207&_a=summary) will be updated to reflect the variable changes.

Addresses the first issue in #4314

cc @dotnet/dotnet-monitor