### PR TITLE
Add openssl1.1-compat to update-dependencies Dockerfile

### DIFF
--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -22,7 +22,8 @@ FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine
 
 # install Docker
 RUN apk add --no-cache \
-        docker
+        docker \
+        openssl1.1-compat
 
 # copy update-dependencies
 WORKDIR /update-dependencies


### PR DESCRIPTION
Similar to https://github.com/dotnet/docker-tools/pull/1106, update-dependencies depends on libgit2sharp, which needs openssl 1.1 instead of openssl 3 in Alpine 3.17.