### PR TITLE
Clarify WSC version support in doc

### DIFF
--- a/documentation/supported-platforms.md
+++ b/documentation/supported-platforms.md
@@ -21,7 +21,7 @@ Pre-release versions of the supported distros will be made available within the 
 The official .NET images support Nano Server as well as LTS versions of Windows Server Core for .NET 5.0 and higher. Nano Server is the best Windows SKU to run .NET apps from a performance perspective. In order for Nano Server to perform well and remain lightweight, it doesn't have support for every scenario. In case your scenario isn't supported by Nano Server, you may need to use one of the .NET images based on Windows Server Core. For scenarios where the official .NET images don't meet your needs, you will need to manage your own custom .NET images based on [Windows Server Core](https://hub.docker.com/_/microsoft-windows-servercore) or [Windows](https://hub.docker.com/_/microsoft-windows).
 
 - Nano Server - support all supported versions with each .NET version.
-- Windows Server Core - support all LTS versions starting with .NET 5.0.
+- Windows Server Core - support all LTS versions (Windows Server 2019 and above) starting with .NET 5.0.
 
 ## Architectures
 


### PR DESCRIPTION
Based on this [comment](https://github.com/dotnet/dotnet-docker/issues/2438#issuecomment-1399179170), I've clarified the documentation to indicate that we're only supporting Windows Server Core 2019 and above.