### PR TITLE
Use pipeline resources when updating .NET Monitor dependencies

### DIFF
--- a/eng/Get-MonitorDropVersions.ps1
+++ b/eng/Get-MonitorDropVersions.ps1
@@ -6,24 +6,14 @@ Returns the various component versions of the latest .NET Monitor build.
 #>
 [cmdletbinding()]
 param(
-    # The release channel to use for determining the latest .NET Monitor build.
-    [Parameter(Mandatory=$true, ParameterSetName="WithChannel")]
-    [string]
-    $Channel,
-
     # A file containing the latest .NET Monitor build version.
-    [Parameter(Mandatory=$true, ParameterSetName="WithBuildVersionFile")]
+    [Parameter(Mandatory=$true)]
     [ValidateScript({if (-not (Test-Path -PathType Leaf -Path $(Resolve-Path $_).Path)) { throw "Could not find file $_"} $true})]
     [string]
     $BuildVersionFilePath
 )
 
-if ($Channel) {
-    $url = "https://aka.ms/dotnet/diagnostics/monitor$Channel/dotnet-monitor.nupkg.buildversion"
-    $monitorVersion = $(Invoke-RestMethod $url).Trim()
-} else {
-    $monitorVersion = $(Get-Content $BuildVersionFilePath).Trim()
-}
+$monitorVersion = $(Get-Content $BuildVersionFilePath).Trim()
 
 $versionSplit=$monitorVersion.Split('.', 3)
 $majorMinorVersion="$($versionSplit[0]).$($versionSplit[1])"

--- a/eng/Get-MonitorDropVersions.ps1
+++ b/eng/Get-MonitorDropVersions.ps1
@@ -7,15 +7,29 @@ Returns the various component versions of the latest .NET Monitor build.
 [cmdletbinding()]
 param(
     # The release channel to use for determining the latest .NET Monitor build.
-    [Parameter(Mandatory)]
+    [Parameter(Mandatory=$true, ParameterSetName="WithChannel")]
     [string]
-    $Channel
+    $Channel,
+
+    # A file containing the latest .NET Monitor build version.
+    [Parameter(Mandatory=$true, ParameterSetName="WithBuildVersionFile")]
+    [ValidateScript({if (-not (Test-Path -PathType Leaf -Path $(Resolve-Path $_).Path)) { throw "Could not find file $_"} $true})]
+    [string]
+    $BuildVersionFilePath
 )
 
-$url = "https://aka.ms/dotnet/diagnostics/monitor$Channel/dotnet-monitor.nupkg.buildversion"
-$monitorVersion = $(Invoke-RestMethod $url).Trim()
+if ($Channel) {
+    $url = "https://aka.ms/dotnet/diagnostics/monitor$Channel/dotnet-monitor.nupkg.buildversion"
+    $monitorVersion = $(Invoke-RestMethod $url).Trim()
+} else {
+    $monitorVersion = $(Get-Content $BuildVersionFilePath).Trim()
+}
+
+$versionSplit=$monitorVersion.Split('.', 3)
+$majorMinorVersion="$($versionSplit[0]).$($versionSplit[1])"
 
 $stableBranding = & $PSScriptRoot/Get-IsStableBranding.ps1 -Version $monitorVersion
 
+Write-Output "##vso[task.setvariable variable=monitorMajorMinorVersion]$majorMinorVersion"
 Write-Output "##vso[task.setvariable variable=monitorVer]$monitorVersion"
 Write-Output "##vso[task.setvariable variable=stableBranding]$stableBranding"

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -36,7 +36,7 @@ stages:
     - download: dotnet-monitor
       artifact: Build_Info
       displayName: "Download Build Info (Branch: $(resources.pipeline.dotnet-monitor.sourceBranch))"
-    - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -BuildVersionFilePath "$(Pipeline.Workspace)/dotnet-monitor/Build_Info/buildversion"
+    - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -BuildVersionFilePath "$(Pipeline.Workspace)/dotnet-monitor/Build_Info/dotnet-monitor.nupkg.buildversion"
       displayName: Get Versions
     - powershell: |
         $customArgs = "$(monitorMajorMinorVersion) --product-version monitor=$(monitorVer) --version-source-name dotnet/dotnet-monitor/$(monitorMajorMinorVersion) --stable-branding=$(stableBranding)"

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -37,7 +37,7 @@ stages:
       artifact: Build_Info
       displayName: "Download Build Info (Branch: $(resources.pipeline.dotnet-monitor.sourceBranch))"
     - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -BuildVersionFilePath "$(Pipeline.Workspace)/dotnet-monitor/Build_Info/buildversion"
-      displayName: Get Versions (Resource Trigger)
+      displayName: Get Versions
     - powershell: |
         $customArgs = "$(monitorMajorMinorVersion) --product-version monitor=$(monitorVer) --version-source-name dotnet/dotnet-monitor/$(monitorMajorMinorVersion) --stable-branding=$(stableBranding)"
 

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -2,7 +2,7 @@ resources:
   pipelines:
     - pipeline: dotnet-monitor
       source: dotnet-dotnet-monitor
-      branch: main # Default used by the schedule or manual invocations. Triggers it will use triggering branch instead.
+      branch: main # Default used by the schedule or manual invocations. When triggered it will use triggering branch instead.
       tags:
       - real signed
       trigger:

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -1,3 +1,19 @@
+resources:
+  pipelines:
+    - pipeline: dotnet-monitor
+      source: dotnet-dotnet-monitor
+      branch: main # Default used by the schedule or manual invocations. Triggers it will use triggering branch instead.
+      tags:
+      - real signed
+      trigger:
+        branches:
+          include:
+          - release/*
+          - internal/release/*
+        tags:
+        - update-docker
+        - real signed
+        - MonitorRelease
 trigger: none
 pr: none
 schedules:
@@ -17,11 +33,14 @@ stages:
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
-    - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -Channel $(MajorMinorVersion)/$(ChannelQuality)
-      displayName: Get Versions
+    - download: dotnet-monitor
+      artifact: Build_Info
+      displayName: "Download Build Info (Branch: $(resources.pipeline.dotnet-monitor.sourceBranch))"
+    - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -BuildVersionFilePath "$(Pipeline.Workspace)/dotnet-monitor/Build_Info/buildversion"
+      displayName: Get Versions (Resource Trigger)
     - powershell: |
-        $customArgs = "$(MajorMinorVersion) --product-version monitor=$(monitorVer) --version-source-name dotnet/dotnet-monitor/$(MajorMinorVersion) --stable-branding=$(stableBranding)"
-        
+        $customArgs = "$(monitorMajorMinorVersion) --product-version monitor=$(monitorVer) --version-source-name dotnet/dotnet-monitor/$(monitorMajorMinorVersion) --stable-branding=$(stableBranding)"
+
         $customArgsArray = @($customArgs)
         echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
       displayName: Set Custom Args


### PR DESCRIPTION
This PR changes the .NET Monitor update dependencies pipeline in two ways:
1. Automatically run when there is a .NET Monitor release build completed which we have marked as needing to be updated in docker.
2. When running on the nightly schedule, pull version information from the latest .NET Monitor nightly build instead of relying on the Channel variables. This allows us to remove the `MajorMinorVersion` and `ChannelQuality` pipeline variables, and use the same logic as the above triggered runs.

- Post-merge, the [Azure DevOps pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1207&_a=summary) will be updated to reflect the variable changes.
- Addresses the second issue in: https://github.com/dotnet/dotnet-docker/issues/4314

/cc @dotnet/dotnet-monitor 