### PR TITLE
Only use pipeline trigger for all .NET Monitor updates

### DIFF
--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -1,28 +1,18 @@
 resources:
   pipelines:
-    - pipeline: dotnet-monitor
-      source: dotnet-dotnet-monitor
-      branch: main # Default used by the schedule or manual invocations. When triggered it will use triggering branch instead.
+  - pipeline: dotnet-monitor
+    source: dotnet-dotnet-monitor
+    trigger:
+      branches:
+        include:
+        - main
+        - release/*
+        - internal/release/*
       tags:
+      - update-docker
       - real signed
-      trigger:
-        branches:
-          include:
-          - release/*
-          - internal/release/*
-        tags:
-        - update-docker
-        - real signed
-        - MonitorRelease
 trigger: none
 pr: none
-schedules:
-- cron: "0 13 * * Mon-Fri"
-  displayName: M-F daily build
-  branches:
-    include:
-    - nightly
-  always: true
 variables:
 - template: ../common/templates/variables/dotnet/common.yml
 stages:


### PR DESCRIPTION
Currently, the update pipeline will run on a schedule that will automatically overwrite triggered updates from the release branches. This change make the nightly updates use the same trigger mechanism as the release branches to prevent this overwriting behavior. [Changes](https://github.com/dotnet/dotnet-monitor/pull/3523) are being made to the dotnet-dotnet-monitor pipeline (by only tagging main branch builds on a schedule) to make sure dotnet-docker only receives an automatic nightly update once per day.

cc @dotnet/dotnet-monitor