### PR TITLE
Add more flexible Dockerfile

### DIFF
--- a/samples/aspnetapp/Dockerfile.debian
+++ b/samples/aspnetapp/Dockerfile.debian
@@ -1,0 +1,20 @@
+# https://hub.docker.com/_/microsoft-dotnet
+ARG RID=linux-x64
+ARG ARCH=amd64
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+ARG RID
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY aspnetapp/*.csproj .
+RUN dotnet restore -r $RID
+
+# copy everything else and build app
+COPY aspnetapp/. .
+RUN dotnet publish -c Release -o /app -r $RID --self-contained false --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim-$ARCH
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT ["./aspnetapp"]


### PR DESCRIPTION
This Dockerfile has two basic modes:

For x64, by default:

```bash
docker build -t aspnetapp -f Dockerfile.debian .
```

For Arm64:

```bash
docker build -t aspnetapp -f Dockerfile.debian --build-arg ARCH=arm64v8 --build-arg RID=linux-arm64 .
```

This isn't super pretty, but it works. Also, this is showing the model. Clearly, you can pivot between x64 and Arm64 being the default.

One option is to make one symbol work for both ARCH and RID. That's part of what makes this super ugly. I think the easiest thing might be to push `x64` and `arm64` tags to align with our RIDs, as they are `amd64` and `arm64v8`, today.