### PR TITLE
Use default shell for non-root user in non-distroless images

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.distroless-user
@@ -16,7 +16,8 @@
     "name": ARGS["name"],
     "uid": ARGS["uid"],
     "gid": ARGS["gid"],
-    "no-create-home": ARGS["no-create-home"]
+    "no-create-home": ARGS["no-create-home"],
+    "no-shell": "true"
 ])}} \{{if !ARGS["no-create-home"]:
     && install -d -m 0755 -o {{ARGS["uid"]}} -g {{ARGS["gid"]}} "{{ARGS["staging-dir"]}}/home/{{ARGS["name"]}}" \}}{{
     if ARGS["exclusive"]:{{if ARGS["create-dir"]:

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.non-root-user
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.non-root-user
@@ -4,7 +4,8 @@
         name: Name of the user/group to create
         uid: ID of the user to be created
         gid: ID of the group to be created
-        no-create-home (optional): Indicates whether a home directory should be created for the user ^
+        no-create-home (optional): Indicates whether a home directory should be created for the user
+        no-shell (optional): Indicates whether the shell should be set to /bin/false ^
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isDebian to find(OS_ARCH_HYPHENATED, "Debian") >= 0 ^
@@ -21,8 +22,8 @@
         {{ARGS["name"]}} \
     && {{if isDebian:useradd^else:adduser}} \
         --uid {{ARGS["uid"]}} \
-        {{if isAlpine:--ingroup={{ARGS["name"]}}^else:--gid {{ARGS["gid"]}}}} \
-        --shell /bin/false \{{if ARGS["no-create-home"]:
+        {{if isAlpine:--ingroup={{ARGS["name"]}}^else:--gid {{ARGS["gid"]}}}} \{{if ARGS["no-shell"]:
+        --shell /bin/false \}}{{if ARGS["no-create-home"]:
         --no-create-home \^elif dotnetVersion != "6.0" && dotnetVersion != "7.0" && (isMariner || isDebian):
         --create-home \}}
         --system \

--- a/src/runtime-deps/8.0/alpine3.17/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.17/amd64/Dockerfile
@@ -19,7 +19,6 @@ RUN addgroup \
     && adduser \
         --uid 101 \
         --ingroup=app \
-        --shell /bin/false \
         --system \
         app
 

--- a/src/runtime-deps/8.0/alpine3.17/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.17/arm32v7/Dockerfile
@@ -19,7 +19,6 @@ RUN addgroup \
     && adduser \
         --uid 101 \
         --ingroup=app \
-        --shell /bin/false \
         --system \
         app
 

--- a/src/runtime-deps/8.0/alpine3.17/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.17/arm64v8/Dockerfile
@@ -19,7 +19,6 @@ RUN addgroup \
     && adduser \
         --uid 101 \
         --ingroup=app \
-        --shell /bin/false \
         --system \
         app
 

--- a/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile
@@ -22,7 +22,6 @@ RUN groupadd \
     && useradd \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --create-home \
         --system \
         app

--- a/src/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -22,7 +22,6 @@ RUN groupadd \
     && useradd \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --create-home \
         --system \
         app

--- a/src/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -22,7 +22,6 @@ RUN groupadd \
     && useradd \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --create-home \
         --system \
         app

--- a/src/runtime-deps/8.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/cbl-mariner2.0/amd64/Dockerfile
@@ -23,7 +23,6 @@ RUN tdnf install -y \
     && adduser \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --create-home \
         --system \
         app \

--- a/src/runtime-deps/8.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -23,7 +23,6 @@ RUN tdnf install -y \
     && adduser \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --create-home \
         --system \
         app \

--- a/src/runtime-deps/8.0/jammy/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy/amd64/Dockerfile
@@ -22,7 +22,6 @@ RUN groupadd \
     && adduser \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --system \
         app
 

--- a/src/runtime-deps/8.0/jammy/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy/arm32v7/Dockerfile
@@ -22,7 +22,6 @@ RUN groupadd \
     && adduser \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --system \
         app
 

--- a/src/runtime-deps/8.0/jammy/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy/arm64v8/Dockerfile
@@ -22,7 +22,6 @@ RUN groupadd \
     && adduser \
         --uid 101 \
         --gid 101 \
-        --shell /bin/false \
         --system \
         app
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-docker/issues/4467