### PR TITLE
Change Publish Output Option to PublishDir

### DIFF
--- a/documentation/scenarios/nuget-credentials.md
+++ b/documentation/scenarios/nuget-credentials.md
@@ -46,7 +46,7 @@ RUN dotnet restore
 
 # Copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o out  --no-restore
+RUN dotnet publish -c Release /p:PublishDir=out  --no-restore
 
 
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
@@ -105,7 +105,7 @@ RUN dotnet restore
 
 # Copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o out  --no-restore
+RUN dotnet publish -c Release /p:PublishDir=out  --no-restore
 
 
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
@@ -161,7 +161,7 @@ RUN dotnet restore
 
 # Copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o out --no-restore
+RUN dotnet publish -c Release /p:PublishDir=out --no-restore
 
 
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
@@ -198,7 +198,7 @@ RUN dotnet restore
 
 # Copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o out --no-restore
+RUN dotnet publish -c Release /p:PublishDir=out --no-restore
 
 
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
@@ -298,7 +298,7 @@ RUN --mount=type=secret,id=nugetconfig \
 
 # Copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o out --no-restore
+RUN dotnet publish -c Release /p:PublishDir=out --no-restore
 
 
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime

--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -14,7 +14,7 @@ RUN dotnet restore -r $RID
 # copy everything else and build
 COPY eng/update-dependencies/. ./
 
-RUN dotnet publish -c Release -o out --no-restore
+RUN dotnet publish -c Release /p:PublishDir=out --no-restore
 
 
 # runtime image

--- a/samples/aspnetapp/Dockerfile
+++ b/samples/aspnetapp/Dockerfile
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0

--- a/samples/aspnetapp/Dockerfile.alpine
+++ b/samples/aspnetapp/Dockerfile.alpine
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish --use-current-runtime -c Release --self-contained false --no-restore -o /app
+RUN dotnet publish --use-current-runtime -c Release --self-contained false --no-restore /p:PublishDir=/app
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-arm32
+++ b/samples/aspnetapp/Dockerfile.alpine-arm32
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm --self-contained false --no-restore
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-arm32-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-arm32-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-arm64
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm64 --self-contained false --no-restore
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-arm64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-arm64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm64 /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-icu
+++ b/samples/aspnetapp/Dockerfile.alpine-icu
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish --use-current-runtime -c Release --self-contained false --no-restore -o /app
+RUN dotnet publish --use-current-runtime -c Release --self-contained false --no-restore /p:PublishDir=/app
 
 # To learn about globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-non-root
+++ b/samples/aspnetapp/Dockerfile.alpine-non-root
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish --use-current-runtime -c Release --self-contained false --no-restore -o /app
+RUN dotnet publish --use-current-runtime -c Release --self-contained false --no-restore /p:PublishDir=/app
 
 
 # To enable globalization:

--- a/samples/aspnetapp/Dockerfile.alpine-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-slim
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app --use-current-runtime --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app --use-current-runtime --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-x64
+++ b/samples/aspnetapp/Dockerfile.alpine-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-x64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-musl-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-x64 --self-contained false --no-restore
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/aspnetapp/Dockerfile.alpine-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # To enable globalization:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md

--- a/samples/aspnetapp/Dockerfile.chiseled
+++ b/samples/aspnetapp/Dockerfile.chiseled
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/nightly/aspnet:7.0-jammy-chiseled

--- a/samples/aspnetapp/Dockerfile.debian-arm32
+++ b/samples/aspnetapp/Dockerfile.debian-arm32
@@ -8,7 +8,7 @@ RUN dotnet restore  -r linux-arm
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-arm --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-arm --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim-arm32v7

--- a/samples/aspnetapp/Dockerfile.debian-arm64
+++ b/samples/aspnetapp/Dockerfile.debian-arm64
@@ -8,7 +8,7 @@ RUN dotnet restore  -r linux-arm64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-arm64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-arm64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim-arm64v8

--- a/samples/aspnetapp/Dockerfile.debian-x64
+++ b/samples/aspnetapp/Dockerfile.debian-x64
@@ -8,7 +8,7 @@ RUN dotnet restore  -r linux-x64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim-amd64

--- a/samples/aspnetapp/Dockerfile.debian-x64-slim
+++ b/samples/aspnetapp/Dockerfile.debian-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore  -r linux-x64 /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-bullseye-slim-amd64

--- a/samples/aspnetapp/Dockerfile.nanoserver-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-slim
@@ -11,7 +11,7 @@ RUN dotnet restore --use-current-runtime /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app --use-current-runtime --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app --use-current-runtime --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/windows/nanoserver:$TAG

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64
@@ -8,7 +8,7 @@ RUN dotnet restore  -r win-x64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
 # Relies on 7.0 multi-arch tag to pick the same Windows version as the host. 

--- a/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/aspnetapp/Dockerfile.nanoserver-x64-slim
@@ -10,7 +10,7 @@ RUN dotnet restore  -r win-x64 /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-jammy-amd64

--- a/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/aspnetapp/Dockerfile.ubuntu-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-jammy-amd64

--- a/samples/aspnetapp/Dockerfile.windowsservercore-containeruser
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-containeruser
@@ -8,7 +8,7 @@ RUN dotnet restore  -r win-x64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained false --no-restore
 
 
 # final stage/image

--- a/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
@@ -16,24 +16,24 @@ RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained fal
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-windowsservercore-ltsc2022
 
 RUN powershell -Command `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    `
-    # Install IIS
-    Add-WindowsFeature Web-Server; `
-    Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    `
-    # Acquire ServiceMonitor
-    Invoke-WebRequest -OutFile C:\ServiceMonitor.exe -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe; `
-    `
-    # Install the ASP.NET Core Module
-    Invoke-WebRequest -OutFile c:\dotnet-hosting-win.exe https://aka.ms/dotnet/6.0/preview/dotnet-hosting-win.exe; `
-    $process = Start-Process -Filepath C:\dotnet-hosting-win.exe -ArgumentList  @('/install', '/q', '/norestart', 'OPT_NO_RUNTIME=1', 'OPT_NO_X86=1', 'OPT_NO_SHAREDFX=1') -Wait -PassThru ; `
-    if ($process.ExitCode -ne 0) { `
-    exit $process.ExitCode; `
-    } `
-    Remove-Item -Force C:\dotnet-hosting-win.exe; `
-    Remove-Item -Force -Recurse $Env:Temp\*
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Install IIS
+        Add-WindowsFeature Web-Server; `
+        Remove-Item -Recurse C:\inetpub\wwwroot\*; `
+        `
+        # Acquire ServiceMonitor
+        Invoke-WebRequest -OutFile C:\ServiceMonitor.exe -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe; `
+        `
+        # Install the ASP.NET Core Module
+        Invoke-WebRequest -OutFile c:\dotnet-hosting-win.exe https://aka.ms/dotnet/6.0/preview/dotnet-hosting-win.exe; `
+        $process = Start-Process -Filepath C:\dotnet-hosting-win.exe -ArgumentList  @('/install', '/q', '/norestart', 'OPT_NO_RUNTIME=1', 'OPT_NO_X86=1', 'OPT_NO_SHAREDFX=1') -Wait -PassThru ; `
+        if ($process.ExitCode -ne 0) { `
+            exit $process.ExitCode; `
+        } `
+        Remove-Item -Force C:\dotnet-hosting-win.exe; `
+        Remove-Item -Force -Recurse $Env:Temp\*
 
 WORKDIR /inetpub/wwwroot
 COPY --from=build /app .

--- a/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-iis-x64
@@ -10,30 +10,30 @@ RUN dotnet restore -r win-x64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-windowsservercore-ltsc2022
 
 RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        `
-        # Install IIS
-        Add-WindowsFeature Web-Server; `
-        Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        `
-        # Acquire ServiceMonitor
-        Invoke-WebRequest -OutFile C:\ServiceMonitor.exe -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe; `
-        `
-        # Install the ASP.NET Core Module
-        Invoke-WebRequest -OutFile c:\dotnet-hosting-win.exe https://aka.ms/dotnet/6.0/preview/dotnet-hosting-win.exe; `
-        $process = Start-Process -Filepath C:\dotnet-hosting-win.exe -ArgumentList  @('/install', '/q', '/norestart', 'OPT_NO_RUNTIME=1', 'OPT_NO_X86=1', 'OPT_NO_SHAREDFX=1') -Wait -PassThru ; `
-        if ($process.ExitCode -ne 0) { `
-            exit $process.ExitCode; `
-        } `
-        Remove-Item -Force C:\dotnet-hosting-win.exe; `
-        Remove-Item -Force -Recurse $Env:Temp\*
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    `
+    # Install IIS
+    Add-WindowsFeature Web-Server; `
+    Remove-Item -Recurse C:\inetpub\wwwroot\*; `
+    `
+    # Acquire ServiceMonitor
+    Invoke-WebRequest -OutFile C:\ServiceMonitor.exe -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe; `
+    `
+    # Install the ASP.NET Core Module
+    Invoke-WebRequest -OutFile c:\dotnet-hosting-win.exe https://aka.ms/dotnet/6.0/preview/dotnet-hosting-win.exe; `
+    $process = Start-Process -Filepath C:\dotnet-hosting-win.exe -ArgumentList  @('/install', '/q', '/norestart', 'OPT_NO_RUNTIME=1', 'OPT_NO_X86=1', 'OPT_NO_SHAREDFX=1') -Wait -PassThru ; `
+    if ($process.ExitCode -ne 0) { `
+    exit $process.ExitCode; `
+    } `
+    Remove-Item -Force C:\dotnet-hosting-win.exe; `
+    Remove-Item -Force -Recurse $Env:Temp\*
 
 WORKDIR /inetpub/wwwroot
 COPY --from=build /app .

--- a/samples/aspnetapp/Dockerfile.windowsservercore-x64
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r win-x64
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-windowsservercore-ltsc2022 AS runtime

--- a/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/aspnetapp/Dockerfile.windowsservercore-x64-slim
@@ -10,7 +10,7 @@ RUN dotnet restore -r win-x64 /p:PublishReadyToRun=true
 
 # copy everything else and build app
 COPY aspnetapp/. .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS runtime

--- a/samples/build-in-sdk-container.md
+++ b/samples/build-in-sdk-container.md
@@ -21,7 +21,7 @@ docker pull mcr.microsoft.com/dotnet/sdk:7.0
 ## Linux
 
 ```console
-docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out
+docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release /p:PublishDir=out
 ```
 
 You can see the built binaries with the following command:
@@ -34,7 +34,7 @@ dotnetapp  dotnetapp.deps.json  dotnetapp.dll  dotnetapp.pdb  dotnetapp.runtimec
 ## macOS
 
 ```console
-docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out -r osx-x64 --self-contained false
+docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release /p:PublishDir=out -r osx-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:
@@ -51,7 +51,7 @@ dotnetapp.dll
 The following example uses PowerShell.
 
 ```console
-docker run --rm -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out -r win-x64 --self-contained false
+docker run --rm -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release /p:PublishDir=out -r win-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:
@@ -76,7 +76,7 @@ Mode                 LastWriteTime         Length Name
 The following example uses PowerShell.
 
 ```console
-docker run --rm -v ${pwd}:c:\app -w c:\app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out
+docker run --rm -v ${pwd}:c:\app -w c:\app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release /p:PublishDir=out
 ```
 
 You can see the built binaries with the following command:
@@ -103,7 +103,7 @@ You may want the build output to be written to a separate location than the sour
 The following example demonstrates doing that on macOS:
 
 ```console
-docker run --rm -v ~/dotnetapp:/out -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o /out -r osx-x64 --self-contained false
+docker run --rm -v ~/dotnetapp:/out -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release /p:PublishDir=/out -r osx-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:
@@ -119,7 +119,7 @@ The following PowerShell example demonstrates doing that on Windows (using Linux
 
 ```console
 mkdir C:\dotnetapp
-docker run --rm -v C:\dotnetapp:c:\app\out -v ${pwd}:c:\app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out -r win-x64 --self-contained false
+docker run --rm -v C:\dotnetapp:c:\app\out -v ${pwd}:c:\app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release /p:PublishDir=out -r win-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:

--- a/samples/complexapp/Dockerfile
+++ b/samples/complexapp/Dockerfile
@@ -29,7 +29,7 @@ RUN dotnet build --no-restore
 ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore", "--no-build"]
 
 FROM build AS publish
-RUN dotnet publish -c Release --no-build -o /app
+RUN dotnet publish -c Release --no-build /p:PublishDir=/app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0

--- a/samples/dotnetapp/Dockerfile
+++ b/samples/dotnetapp/Dockerfile
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0

--- a/samples/dotnetapp/Dockerfile.alpine-arm32
+++ b/samples/dotnetapp/Dockerfile.alpine-arm32
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine-arm32v7

--- a/samples/dotnetapp/Dockerfile.alpine-arm32-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-arm32-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm /p:PublishReadyToRun=true
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine-arm32v7

--- a/samples/dotnetapp/Dockerfile.alpine-arm64
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine-arm64v8

--- a/samples/dotnetapp/Dockerfile.alpine-arm64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-arm64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-arm64 /p:PublishReadyToRun=true
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-musl-arm64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-arm64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine-arm64v8

--- a/samples/dotnetapp/Dockerfile.alpine-x64
+++ b/samples/dotnetapp/Dockerfile.alpine-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-musl-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine-amd64

--- a/samples/dotnetapp/Dockerfile.alpine-x64-slim
+++ b/samples/dotnetapp/Dockerfile.alpine-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-musl-x64 /p:PublishReadyToRun=true
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine-amd64

--- a/samples/dotnetapp/Dockerfile.chiseled
+++ b/samples/dotnetapp/Dockerfile.chiseled
@@ -8,7 +8,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/nightly/runtime:7.0-jammy-chiseled

--- a/samples/dotnetapp/Dockerfile.debian-arm32
+++ b/samples/dotnetapp/Dockerfile.debian-arm32
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-arm
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-arm --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-arm --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-bullseye-slim-arm32v7

--- a/samples/dotnetapp/Dockerfile.debian-arm64
+++ b/samples/dotnetapp/Dockerfile.debian-arm64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-arm64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-arm64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-arm64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-bullseye-slim-arm64v8

--- a/samples/dotnetapp/Dockerfile.debian-x64
+++ b/samples/dotnetapp/Dockerfile.debian-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-bullseye-slim-amd64

--- a/samples/dotnetapp/Dockerfile.debian-x64-slim
+++ b/samples/dotnetapp/Dockerfile.debian-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-bullseye-slim-amd64

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r win-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
 # Relies on 7.0 multi-arch tag to pick the same Windows version as the host. 

--- a/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
+++ b/samples/dotnetapp/Dockerfile.nanoserver-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r win-x64 /p:PublishReadyToRun=true
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/samples/dotnetapp/Dockerfile.ubuntu-arm32
+++ b/samples/dotnetapp/Dockerfile.ubuntu-arm32
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-arm
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-arm --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-arm --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-jammy-arm32v7

--- a/samples/dotnetapp/Dockerfile.ubuntu-arm64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-arm64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-arm64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-arm64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-arm64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-jammy-arm64v8

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-jammy-amd64

--- a/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
+++ b/samples/dotnetapp/Dockerfile.ubuntu-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r linux-x64 /p:PublishReadyToRun=true
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r linux-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-jammy-amd64

--- a/samples/dotnetapp/Dockerfile.windowsservercore-x64
+++ b/samples/dotnetapp/Dockerfile.windowsservercore-x64
@@ -8,7 +8,7 @@ RUN dotnet restore -r win-x64
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0-windowsservercore-ltsc2022

--- a/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
+++ b/samples/dotnetapp/Dockerfile.windowsservercore-x64-slim
@@ -8,7 +8,7 @@ RUN dotnet restore -r win-x64 /p:PublishReadyToRun=true
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
+RUN dotnet publish -c Release /p:PublishDir=/app -r win-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true /p:PublishSingleFile=true
 
 # final stage/image
 FROM mcr.microsoft.com/windows/servercore:ltsc2022

--- a/samples/dotnetapp/README.md
+++ b/samples/dotnetapp/README.md
@@ -43,7 +43,7 @@ RUN dotnet restore
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:7.0

--- a/samples/globalapp/Dockerfile
+++ b/samples/globalapp/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore --use-current-runtime
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c Release -o /app --use-current-runtime --self-contained false --no-restore
+RUN dotnet publish -c Release /p:PublishDir=/app --use-current-runtime --self-contained false --no-restore
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/runtime:$TAG

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
@@ -35,7 +35,7 @@ ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 
 FROM build as publish_fx_dependent
-RUN dotnet publish --no-restore -c Release -o out
+RUN dotnet publish --no-restore -c Release /p:PublishDir=out
 
 
 FROM $runtime_image AS fx_dependent_app
@@ -50,7 +50,7 @@ ENTRYPOINT ["dotnet", "app.dll"]
 
 FROM build as publish_self_contained
 ARG rid
-RUN dotnet publish -r $rid -c Release -o out
+RUN dotnet publish -r $rid -c Release /p:PublishDir=out
 
 
 FROM $runtime_deps_image AS self_contained_app

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
@@ -34,7 +34,7 @@ ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 
 FROM build as publish_fx_dependent
-RUN dotnet publish --no-restore -c Release -o out
+RUN dotnet publish --no-restore -c Release /p:PublishDir=out
 
 
 FROM $runtime_image AS fx_dependent_app


### PR DESCRIPTION
Since the release of the **.NET 7.0.200 SDK** the `--output` Option is no longer supported for Build Related Commands.
I have created this PR to replace the `--output {OUTPUT_DIR}` with `/p:PublishDir={OUTPUT_DIR}` in the Dockerfile's and Documentation per the Microsoft Documentation mentioned above.

I believe this to be a cause of issue #4462 as reverting to a pre **.NET 7.0.100 SDK** solved there issue.