### PR TITLE
Add Dockerfiles for Linux .NET Composite Images

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
@@ -7,52 +7,47 @@
     set isDistrolessMariner to isMariner && isDistroless ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
-    set isRpmInstall to isFullMariner && dotnetVersion = "6.0" ^
+    set isRpmInstall to false ^
     set isSingleStage to (isAlpine || isRpmInstall) && !isInternal ^
-    set runtimeBaseTag to
-        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
-    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set runtimeDepsBaseTag to cat(
+        "$REPO:", VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
     set osVersionBase to when(isDistroless, match(OS_VERSION, ".+(?=.*-)")[0], OS_VERSION_BASE) ^
     set installerImageTag to when(isDistrolessMariner,
         cat("mcr.microsoft.com/cbl-mariner/base/core:", OS_VERSION_NUMBER),
         when(isAlpine || isFullMariner,
-            runtimeBaseTag,
-            cat(ARCH_VERSIONED, "/buildpack-deps:", osVersionBase, "-curl"))) ^
-    set copyFromSrcPath to when(isDistroless, "/dotnet", "/shared/Microsoft.AspNetCore.App") ^
-    set copyFromDstPath to when(isDistroless, "/usr/share/dotnet", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App")
-}}ARG REPO=mcr.microsoft.com/dotnet/{{
-    if dotnetVersion = "6.0" || dotnetVersion = "7.0":{{
-        echo "runtime"
-    }}^
-    else:{{
-        echo "runtime-deps"
-    }}}}{{if isSingleStage:
+            runtimeDepsBaseTag,
+            cat(ARCH_VERSIONED, "/buildpack-deps:", osVersionBase, "-curl")))
+}}ARG REPO=mcr.microsoft.com/dotnet/runtime-deps{{if isSingleStage:
 {{
 
-    _ SINGLE STAGE
+_ SINGLE STAGE
 
-}}FROM {{runtimeBaseTag}}
+}}FROM {{runtimeDepsBaseTag}}
 {{if isAlpine:
 {{InsertTemplate("../Dockerfile.alpine.invariant-mode")}}
 }}
 {{InsertTemplate("Dockerfile.envs")}}
 
-# Install ASP.NET Core
-{{InsertTemplate("Dockerfile.linux.install-aspnet",
+# Install ASP.NET composite runtime
+{{InsertTemplate("../runtime/Dockerfile.linux.install-runtime",
     [
         "install-method": "download-and-install",
-        "is-rpm-install": isRpmInstall
-    ])}}^else:
-{{
+        "dest-dir": "/usr/share/dotnet",
+        "add-symlink": !isRpmInstall,
+        "is-rpm-install": isRpmInstall,
+        "is-composite-runtime": "true"
+    ])}}^
+else:{{
 
-    _ MULTI STAGE
+_ MULTI STAGE
 
 }}
+
 # Installer image
 FROM {{installerImageTag}} AS installer
 {{if isInternal:
 ARG SAS_QUERY_STRING
-}}{{if isDistrolessMariner:
+}}{{ if isDistrolessMariner:
 {{InsertTemplate("../Dockerfile.linux.distroless-mariner-installer-prereqs")}}
 ^elif isFullMariner && !isRpmInstall:
 RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
@@ -60,28 +55,43 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
         "pkgs": ["tar"]
     ])}}
 }}
-# Retrieve ASP.NET Core
-{{InsertTemplate("Dockerfile.linux.install-aspnet",
+# Retrieve ASP.NET composite runtime
+{{InsertTemplate("../runtime/Dockerfile.linux.install-runtime",
     [
         "install-method": when(isInternal && isRpmInstall, "download", "download-and-install"),
+        "dest-dir": when(isDistroless, "/usr/share/dotnet", "/dotnet"),
         "use-local-version-var": "true",
         "is-internal": isInternal,
         "url-suffix": when(isInternal, "$SAS_QUERY_STRING", ""),
-        "is-rpm-install": isRpmInstall
-    ])}}
+        "is-rpm-install": isRpmInstall,
+        "is-composite-runtime": "true"
+    ])}}{{ if isDistroless:
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet}}
 
 
-# ASP.NET Core image
-FROM {{runtimeBaseTag}}
+# ASP.NET composite runtime image
+FROM {{runtimeDepsBaseTag}}
 
+{{InsertTemplate("../runtime/Dockerfile.envs")}}
 {{InsertTemplate("Dockerfile.envs")}}
-{{if isInternal && isRpmInstall:
-{{InsertTemplate("Dockerfile.linux.install-aspnet",
+{{ if isInternal && isRpmInstall:
+{{InsertTemplate("../runtime/Dockerfile.linux.install-runtime",
     [
         "install-method": "copy-and-install",
+        "dest-dir": when(isDistroless, "/usr/share/dotnet", "/dotnet"),
         "is-internal": isInternal,
         "url-suffix": when(isInternal, "$SAS_QUERY_STRING", ""),
         "installer-stage": "installer",
         "is-rpm-install": isRpmInstall
-    ])}}^else:
-COPY --from=installer ["{{copyFromSrcPath}}", "{{copyFromDstPath}}"]}}}}
+    ])}}}}{{ if isDistroless:
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]{{ if !isMariner || dotnetVersion != "6.0":
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]}}^
+elif !(isInternal && isRpmInstall):
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN {{InsertTemplate("../runtime/Dockerfile.linux.symlink")}}}}}}

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
@@ -6,7 +6,8 @@
         - is-internal (optional): Whether the Dockerfile is targeting an internal build of the product.
         - url-suffix (optional): Suffix string to append the end of the URL.
         - installer-stage (optional): Name of the Dockerfile stage responsible for installation
-        - is-rpm-install (optional): Whether to install RPM versus tarball ^
+        - is-rpm-install (optional): Whether to install RPM versus tarball
+        - is-composite-install (optional): Whether to install aspnetcore composite version^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isFullMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
@@ -15,9 +16,11 @@
     set filePlatform to when(ARGS["is-rpm-install"], "", when(isAlpine, "-linux-musl", "-linux")) ^
     set varPlatform to when(ARGS["is-rpm-install"], "linux-rpm", when(isAlpine, "linux-musl", "linux")) ^
     set fileExt to when(ARGS["is-rpm-install"], "rpm", "tar.gz") ^
-    set destDir to when((isAlpine || ARGS["is-rpm-install"]) && !ARGS["is-internal"],
-        "/usr/share/dotnet",
-        when(isDistroless, "/dotnet", "")) ^
+    set destDir to when(dotnetVersion != "6.0" && dotnetVersion != "7.0",
+        "/dotnet",
+        when((isAlpine || ARGS["is-rpm-install"]) && !ARGS["is-internal"],
+            "/usr/share/dotnet",
+            when(isDistroless, "/dotnet", ""))) ^
     set aspnetVersionDir to when(ARGS["use-local-version-var"],
         "$aspnetcore_version",
         when(ARGS["is-internal"],

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
@@ -8,7 +8,8 @@
         is-internal (optional): Whether the Dockerfile is targeting an internal build of the product.
         url-suffix (optional): Suffix string to append the end of the URL.
         installer-stage (optional): Name of the Dockerfile stage responsible for installation
-        is-rpm-install (optional): Whether to install RPM versus tarball ^
+        is-rpm-install (optional): Whether to install RPM versus tarball
+        is-composite-runtime (optional): Whether to install ASP.NET Core composite runtime ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
@@ -19,15 +20,30 @@
         when(ARGS["is-internal"],
             VARIABLES[cat("runtime|", dotnetVersion, "|build-version")],
             "$DOTNET_VERSION")) ^
+    set aspnetVersionDir to when(ARGS["use-local-version-var"],
+        "$aspnetcore_version",
+        when(ARGS["is-internal"],
+            VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")],
+            "$ASPNET_VERSION")) ^
     set isInternalStableBranding to ARGS["is-internal"] &&
         (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
         find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
     set runtimeVersionFile to when(isInternalStableBranding,
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
         runtimeVersionDir) ^
-    set runtimeBaseUrl to cat(
-        VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])],
-        "/Runtime/", runtimeVersionDir, "/") ^
+    set aspnetVersionFile to when(isInternalStableBranding,
+        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
+        aspnetVersionDir) ^
+    set fileArch to when(ARGS["is-rpm-install"] && ARCH_SHORT = "arm64", "aarch64", ARCH_SHORT) ^
+    set fileExt to when(ARGS["is-rpm-install"], "rpm", "tar.gz") ^
+    set filePlatform to when(ARGS["is-rpm-install"], "", when(isAlpine, "-linux-musl", "-linux")) ^
+    set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
+    set runtimeBaseUrl to cat(baseUrl, "/Runtime/", runtimeVersionDir, "/") ^
+    set aspnetUrl to cat(baseUrl, "/aspnetcore/Runtime/", aspnetVersionDir, "/aspnetcore-runtime-composite-", aspnetVersionFile,
+        filePlatform, "-", fileArch, ".", fileExt, ARGS["url-suffix"]) ^
+    set localVersionVar to when(ARGS["is-composite-runtime"],
+        VARIABLES[cat("runtime|", dotnetVersion, "|build-version")],
+        VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]) ^
     set rpmFileArch to when(ARCH_SHORT = "arm64", "aarch64", ARCH_SHORT) ^
     set rpms to [
         [
@@ -49,15 +65,24 @@
             "sha-var-name": "dotnet_sha512"
         ]
     ] ^
-    set tarballs to [
+    set tarballs to when(ARGS["is-composite-runtime"],
         [
-            "filename": "dotnet.tar.gz",
-            "url": cat(runtimeBaseUrl, "dotnet-runtime-", runtimeVersionFile, "-", varPlatform, "-", ARCH_SHORT, ".tar.gz",
-                ARGS["url-suffix"]),
-            "sha": VARIABLES[join(["runtime", dotnetVersion, varPlatform, ARCH_SHORT, "sha"], "|")],
-            "sha-var-name": "dotnet_sha512"
-        ]
-    ] ^
+            [
+                "filename": "dotnet.tar.gz",
+                "url": aspnetUrl,
+                "sha": VARIABLES[join(["aspnet", dotnetVersion, varPlatform, ARCH_SHORT, "sha"], "|")],
+                "sha-var-name": "dotnet_sha512"
+            ]
+        ],
+        [
+            [
+                "filename": "dotnet.tar.gz",
+                "url": cat(runtimeBaseUrl, "dotnet-runtime-", runtimeVersionFile, "-", varPlatform, "-", ARCH_SHORT, ".tar.gz",
+                    ARGS["url-suffix"]),
+                "sha": VARIABLES[join(["runtime", dotnetVersion, varPlatform, ARCH_SHORT, "sha"], "|")],
+                "sha-var-name": "dotnet_sha512"
+            ]
+        ]) ^
     set files to when(ARGS["is-rpm-install"], rpms, tarballs) ^
     set copyEnabled to ARGS["install-method"] = "copy-and-install" ^
     set downloadEnabled to ARGS["install-method"] = "download" || ARGS["install-method"] = "download-and-install" ^
@@ -70,7 +95,8 @@ if copyEnabled:{{InsertTemplate("../Dockerfile.linux.copy-files",
         "destination": ""
     ])
 }}
-}}RUN {{if ARGS["use-local-version-var"]:dotnet_version={{VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]}} \
+}}RUN {{if ARGS["use-local-version-var"]:{{if ARGS["is-composite-runtime"]:aspnetcore_version={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}}^
+        else:dotnet_version={{VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]}}}} \
     && }}{{InsertTemplate("../Dockerfile.linux.download-and-install",
         [
             "files": files,

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -85,7 +85,7 @@ namespace Dotnet.Docker
                 { "runtime-deps-cm.1", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-runtime-deps-$VERSION_FILE-cm.1-{GetRpmArchFormat()}.$ARCHIVE_EXT" } },
                 { "runtime-deps-cm.2", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-runtime-deps-$VERSION_FILE-cm.2-{GetRpmArchFormat()}.$ARCHIVE_EXT" } },
 
-                { "aspnet", new string[] { $"$DOTNET_BASE_URL/aspnetcore/Runtime/$VERSION_DIR/aspnetcore-runtime-$VERSION_FILE$OPTIONAL_OS-{GetRuntimeSdkArchFormat()}.$ARCHIVE_EXT" } },
+                { "aspnet", new string[] { $"$DOTNET_BASE_URL/aspnetcore/Runtime/$VERSION_DIR/aspnetcore-runtime-$COMPOSITE_SUFFIX$VERSION_FILE$OPTIONAL_OS-{GetRuntimeSdkArchFormat()}.$ARCHIVE_EXT" } },
                 {
                     "aspnet-runtime-targeting-pack",
                     new string[]
@@ -207,6 +207,7 @@ namespace Dotnet.Docker
                     .Replace("$ARCHIVE_EXT", archiveExt)
                     .Replace("$VERSION_DIR", versionDir)
                     .Replace("$VERSION_FILE", versionFile)
+                    .Replace("$COMPOSITE_SUFFIX", _dockerfileVersion.Major != 6.0 && _dockerfileVersion.Major != 7.0 ? "composite-" : string.Empty)
                     .Replace("$OS", _os)
                     .Replace("$OPTIONAL_OS", optionalOs)
                     .Replace("$ARCH", _arch)

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -207,7 +207,7 @@ namespace Dotnet.Docker
                     .Replace("$ARCHIVE_EXT", archiveExt)
                     .Replace("$VERSION_DIR", versionDir)
                     .Replace("$VERSION_FILE", versionFile)
-                    .Replace("$COMPOSITE_SUFFIX", _dockerfileVersion.Major != 6.0 && _dockerfileVersion.Major != 7.0 ? "composite-" : string.Empty)
+                    .Replace("$COMPOSITE_SUFFIX", _dockerfileVersion.Major != 6.0 && _dockerfileVersion.Major != 7.0 && !_os.Contains("win") ? "composite-" : string.Empty)
                     .Replace("$OS", _os)
                     .Replace("$OPTIONAL_OS", optionalOs)
                     .Replace("$ARCH", _arch)

--- a/manifest.json
+++ b/manifest.json
@@ -3773,10 +3773,10 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/bookworm-slim/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
@@ -3787,10 +3787,10 @@
             {
               "architecture": "arm",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/bookworm-slim/arm32v7",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
@@ -3802,10 +3802,10 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/bookworm-slim/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
@@ -3826,10 +3826,10 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/bookworm-slim/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {}
@@ -3837,10 +3837,10 @@
             {
               "architecture": "arm",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/bookworm-slim/arm32v7",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {},
@@ -3849,10 +3849,10 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/bookworm-slim/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {},
@@ -3873,7 +3873,7 @@
                 "REPO": "$(Repo:runtime)"
               },
               "dockerfile": "src/aspnet/8.0/alpine3.17/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "alpine3.17",
               "tags": {
@@ -3888,7 +3888,7 @@
                 "REPO": "$(Repo:runtime)"
               },
               "dockerfile": "src/aspnet/8.0/alpine3.17/arm32v7",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "alpine3.17",
               "tags": {
@@ -3904,7 +3904,7 @@
                 "REPO": "$(Repo:runtime)"
               },
               "dockerfile": "src/aspnet/8.0/alpine3.17/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "alpine3.17",
               "tags": {
@@ -3925,10 +3925,10 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/jammy/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
@@ -3939,10 +3939,10 @@
             {
               "architecture": "arm",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/jammy/arm32v7",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
@@ -3954,10 +3954,10 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/jammy/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
@@ -3977,10 +3977,10 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/jammy-chiseled/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "jammy-chiseled",
               "tags": {
@@ -4000,10 +4000,10 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/jammy-chiseled/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "jammy-chiseled",
               "tags": {
@@ -4024,10 +4024,10 @@
             {
               "architecture": "arm",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/jammy-chiseled/arm32v7",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "jammy-chiseled",
               "tags": {
@@ -4063,10 +4063,10 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/cbl-mariner2.0/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
@@ -4084,10 +4084,10 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/cbl-mariner2.0/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
@@ -4124,7 +4124,7 @@
                 "REPO": "$(Repo:runtime)"
               },
               "dockerfile": "src/aspnet/8.0/cbl-mariner2.0-distroless/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
@@ -4154,7 +4154,7 @@
                 "REPO": "$(Repo:runtime)"
               },
               "dockerfile": "src/aspnet/8.0/cbl-mariner2.0-distroless/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {

--- a/manifest.json
+++ b/manifest.json
@@ -3870,7 +3870,7 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/alpine3.17/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
@@ -3885,7 +3885,7 @@
             {
               "architecture": "arm",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/alpine3.17/arm32v7",
               "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",
@@ -3901,7 +3901,7 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:runtime)"
+                "REPO": "$(Repo:runtime-deps)"
               },
               "dockerfile": "src/aspnet/8.0/alpine3.17/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile.linux-composite",

--- a/samples/aspnetapp/aspnetapp/NuGet.config
+++ b/samples/aspnetapp/aspnetapp/NuGet.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/aspnetapp/aspnetapp/aspnetapp.csproj
+++ b/samples/aspnetapp/aspnetapp/aspnetapp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>57393389627611478466</UserSecretsId>

--- a/src/aspnet/8.0/alpine3.17/amd64/Dockerfile
+++ b/src/aspnet/8.0/alpine3.17/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:8.0.0-preview.4-alpine3.17-amd64
 
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
@@ -7,9 +7,11 @@ FROM $REPO:8.0.0-preview.4-alpine3.17-amd64
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-# Install ASP.NET Core
-RUN wget -O aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='35ecceb0174f19ef8569ab90d8ec6b3bc3cc53c1b64ff7fd43f20e2b60d87b9063157d8527e40c4387ac5efc3a4a2728bf05d0266e3884b694b04e8e8b91a6ae' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+# Install ASP.NET composite runtime
+RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-composite-$ASPNET_VERSION-linux-musl-x64.tar.gz \
+    && dotnet_sha512='35ecceb0174f19ef8569ab90d8ec6b3bc3cc53c1b64ff7fd43f20e2b60d87b9063157d8527e40c4387ac5efc3a4a2728bf05d0266e3884b694b04e8e8b91a6ae' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/alpine3.17/arm32v7/Dockerfile
+++ b/src/aspnet/8.0/alpine3.17/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:8.0.0-preview.4-alpine3.17-arm32v7
 
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
@@ -7,9 +7,11 @@ FROM $REPO:8.0.0-preview.4-alpine3.17-arm32v7
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-# Install ASP.NET Core
-RUN wget -O aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm.tar.gz \
-    && aspnetcore_sha512='a3f6f10649acec2c8f3352acac7992437924bbe20451e2758cb6306427026ff55e1234c1f653e32086c6fd6300d94b97c719c9629051e0f2465786719c21e484' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+# Install ASP.NET composite runtime
+RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-composite-$ASPNET_VERSION-linux-musl-arm.tar.gz \
+    && dotnet_sha512='a3f6f10649acec2c8f3352acac7992437924bbe20451e2758cb6306427026ff55e1234c1f653e32086c6fd6300d94b97c719c9629051e0f2465786719c21e484' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/alpine3.17/arm64v8/Dockerfile
+++ b/src/aspnet/8.0/alpine3.17/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 FROM $REPO:8.0.0-preview.4-alpine3.17-arm64v8
 
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
@@ -7,9 +7,11 @@ FROM $REPO:8.0.0-preview.4-alpine3.17-arm64v8
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-# Install ASP.NET Core
-RUN wget -O aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
-    && aspnetcore_sha512='03c73748dccd0d9fd054f6059af8e9cad5aeef5420a06fa0fce3b977f36692f9447c0c4d8bbce2c3dc6c0d1d3b22dd3f5b32d267cf8a7b2d16d2066be63b617f' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+# Install ASP.NET composite runtime
+RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-composite-$ASPNET_VERSION-linux-musl-arm64.tar.gz \
+    && dotnet_sha512='03c73748dccd0d9fd054f6059af8e9cad5aeef5420a06fa0fce3b977f36692f9447c0c4d8bbce2c3dc6c0d1d3b22dd3f5b32d267cf8a7b2d16d2066be63b617f' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/aspnet/8.0/bookworm-slim/amd64/Dockerfile
@@ -1,21 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM amd64/buildpack-deps:bookworm-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-    && aspnetcore_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+    && dotnet_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-bookworm-slim-amd64
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/aspnet/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -1,21 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-    && aspnetcore_sha512='7b674a3a0f067b63c84e2d7d8a4f6df702b771ce4dd6635ddb13da0dab9147e782f84d59dd39701653630d257f80c235e7c0302b4a679ffa1ab092ac8d519e38' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
+    && dotnet_sha512='7b674a3a0f067b63c84e2d7d8a4f6df702b771ce4dd6635ddb13da0dab9147e782f84d59dd39701653630d257f80c235e7c0302b4a679ffa1ab092ac8d519e38' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-bookworm-slim-arm32v7
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/aspnet/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -1,21 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM arm64v8/buildpack-deps:bookworm-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-    && aspnetcore_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+    && dotnet_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-bookworm-slim-arm64v8
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
@@ -9,20 +9,29 @@ RUN tdnf install -y \
         tar \
     && tdnf clean all
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-    && aspnetcore_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && mkdir -p /dotnet \
-    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+    && dotnet_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-distroless-amd64
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/src/aspnet/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/aspnet/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
@@ -9,20 +9,29 @@ RUN tdnf install -y \
         tar \
     && tdnf clean all
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-    && aspnetcore_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && mkdir -p /dotnet \
-    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+    && dotnet_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-distroless-arm64v8
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/src/aspnet/8.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/aspnet/8.0/cbl-mariner2.0/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-amd64 AS installer
@@ -7,19 +7,24 @@ RUN tdnf install -y \
         tar \
     && tdnf clean all
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-    && aspnetcore_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+    && dotnet_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-amd64
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/aspnet/8.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-arm64v8 AS installer
@@ -7,19 +7,24 @@ RUN tdnf install -y \
         tar \
     && tdnf clean all
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-    && aspnetcore_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+    && dotnet_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-arm64v8
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/aspnet/8.0/jammy-chiseled/amd64/Dockerfile
@@ -1,22 +1,31 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM amd64/buildpack-deps:jammy-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-    && aspnetcore_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && mkdir -p /dotnet \
-    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+    && dotnet_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-jammy-chiseled-amd64
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/src/aspnet/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/aspnet/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,22 +1,31 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM arm32v7/buildpack-deps:jammy-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-    && aspnetcore_sha512='7b674a3a0f067b63c84e2d7d8a4f6df702b771ce4dd6635ddb13da0dab9147e782f84d59dd39701653630d257f80c235e7c0302b4a679ffa1ab092ac8d519e38' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && mkdir -p /dotnet \
-    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
+    && dotnet_sha512='7b674a3a0f067b63c84e2d7d8a4f6df702b771ce4dd6635ddb13da0dab9147e782f84d59dd39701653630d257f80c235e7c0302b4a679ffa1ab092ac8d519e38' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-jammy-chiseled-arm32v7
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/src/aspnet/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/aspnet/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,22 +1,31 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-    && aspnetcore_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && mkdir -p /dotnet \
-    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+    && dotnet_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-jammy-chiseled-arm64v8
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/src/aspnet/8.0/jammy/amd64/Dockerfile
+++ b/src/aspnet/8.0/jammy/amd64/Dockerfile
@@ -1,21 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM amd64/buildpack-deps:jammy-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-    && aspnetcore_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+    && dotnet_sha512='c1dc554665af00a931b882947d395eec4b92c95e4966a88e3993237e32d6f1147f34d2da560a93e7d5792239697f03bb7d3e80ef5fd10ff5cc6d5d973b0cd7dc' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-jammy-amd64
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/jammy/arm32v7/Dockerfile
+++ b/src/aspnet/8.0/jammy/arm32v7/Dockerfile
@@ -1,21 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM arm32v7/buildpack-deps:jammy-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-    && aspnetcore_sha512='7b674a3a0f067b63c84e2d7d8a4f6df702b771ce4dd6635ddb13da0dab9147e782f84d59dd39701653630d257f80c235e7c0302b4a679ffa1ab092ac8d519e38' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
+    && dotnet_sha512='7b674a3a0f067b63c84e2d7d8a4f6df702b771ce4dd6635ddb13da0dab9147e782f84d59dd39701653630d257f80c235e7c0302b4a679ffa1ab092ac8d519e38' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-jammy-arm32v7
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/src/aspnet/8.0/jammy/arm64v8/Dockerfile
+++ b/src/aspnet/8.0/jammy/arm64v8/Dockerfile
@@ -1,21 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
 FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
-# Retrieve ASP.NET Core
+# Retrieve ASP.NET composite runtime
 RUN aspnetcore_version=8.0.0-preview.4.23221.9 \
-    && curl -fSL --output aspnetcore.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-    && aspnetcore_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
+    && curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+    && dotnet_sha512='47a4c47e256bd0f15df8aa07f8765cf82f4e81e9b2e4214576800b81771877909e5b2ee149fc469e894d33f585d4ea0972afb29f6891a88dc1c65625ba85b4aa' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
 
 
-# ASP.NET Core image
+# ASP.NET composite runtime image
 FROM $REPO:8.0.0-preview.4-jammy-arm64v8
 
+# .NET Runtime version
+ENV DOTNET_VERSION=8.0.0-preview.4.23221.1
 # ASP.NET Core version
 ENV ASPNET_VERSION=8.0.0-preview.4.23221.9
 
-COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet


### PR DESCRIPTION
See discussion at https://github.com/dotnet/dotnet-docker/issues/4343

A few things:
- The musl changes have not flown in yet
- There are no updates to tests yet
- SDK images are based on aspnet-composite but will fail to build if sdk/aspnet's runtime is incoherent
- The Dockerfile.linux-composite template is copied mostly from the runtime template, so there's probably room to clean up some unnecessary conditions

I believe at this point the preview 3 build might be coherent, not sure how that will affect the SDK build.