### PR TITLE
Split .NET Monitor 8 image into base and extensions

### DIFF
--- a/.mar/portal/README.monitor-base.portal.md
+++ b/.mar/portal/README.monitor-base.portal.md
@@ -4,20 +4,18 @@
 
 **The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/monitor/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+**See [dotnet](https://mcr.microsoft.com/product/dotnet/monitor/base/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
 
-This image contains the .NET Monitor tool.
+This image contains the .NET Monitor Base installation.
 
-Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
+Use this image as a base image for building a .NET Monitor image with extensions.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
 ## Featured Tags
 
-* `7` (Standard Support)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:7`
-* `6` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor:6`
+* `8` (Long-Term Support)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor/base:8`
 
 ## Related Repositories
 
@@ -28,7 +26,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor/base](https://mcr.microsoft.com/product/dotnet/nightly/monitor/base/about): .NET Monitor Base (Preview)
+* [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
 
 .NET Framework:
 
@@ -39,11 +37,14 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-### Container sample: Run the tool
+### Building a Custom .NET Monitor Image
 
-You can run a container with a pre-built [.NET Docker Image](https://mcr.microsoft.com/product/dotnet/monitor/about), based on the dotnet-monitor global tool.
+The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 
-See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
+* [CBL Mariner Distroless - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile)
+* [CBL Mariner Distroless - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile)
+* [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
+* [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)
 
 ## Support
 

--- a/.mar/portal/README.monitor-base.portal.md
+++ b/.mar/portal/README.monitor-base.portal.md
@@ -14,8 +14,8 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `8` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor/base:8`
+* `8` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor/base:8-preview`
 
 ## Related Repositories
 
@@ -41,8 +41,6 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 
-* [CBL Mariner Distroless - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile)
-* [CBL Mariner Distroless - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile)
 * [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
 * [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -6,8 +6,8 @@
 
 # Featured Tags
 
-* `8` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor/base:8`
+* `8` (Preview)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor/base:8-preview`
 
 # About
 
@@ -25,8 +25,6 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 
-* [CBL Mariner Distroless - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile)
-* [CBL Mariner Distroless - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile)
 * [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
 * [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -1,0 +1,93 @@
+**IMPORTANT**
+
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+
+**See [dotnet](https://hub.docker.com/_/microsoft-dotnet-monitor-base/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+
+# Featured Tags
+
+* `8` (Long-Term Support)
+  * `docker pull mcr.microsoft.com/dotnet/nightly/monitor/base:8`
+
+# About
+
+This image contains the .NET Monitor Base installation.
+
+Use this image as a base image for building a .NET Monitor image with extensions.
+
+Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+# Usage
+
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+
+## Building a Custom .NET Monitor Image
+
+The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
+
+* [CBL Mariner Distroless - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile)
+* [CBL Mariner Distroless - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile)
+* [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
+* [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)
+
+# Related Repositories
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+
+.NET Framework:
+
+* [dotnet/framework](https://hub.docker.com/_/microsoft-dotnet-framework/): .NET Framework, ASP.NET and WCF
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+# Full Tag Listing
+
+## Linux amd64 Tags
+##### .NET Monitor 8 Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.0.0-preview.4-ubuntu-chiseled-amd64, 8.0-preview-ubuntu-chiseled-amd64, 8-preview-ubuntu-chiseled-amd64, 8.0.0-preview.4-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-preview.4, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+
+## Linux arm64 Tags
+##### .NET Monitor 8 Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.0.0-preview.4-ubuntu-chiseled-arm64v8, 8.0-preview-ubuntu-chiseled-arm64v8, 8-preview-ubuntu-chiseled-arm64v8, 8.0.0-preview.4-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-preview.4, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+
+You can retrieve a list of all available tags for dotnet/nightly/monitor/base at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/base/tags/list.
+<!--End of generated tags-->
+
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
+
+# Support
+
+## Lifecycle
+
+* [Microsoft Support for .NET](https://github.com/dotnet/core/blob/main/microsoft-support.md)
+* [Supported Container Platforms Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-platforms.md)
+* [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)
+
+## Image Update Policy
+
+* We update the supported .NET images within 12 hours of any updates to their base images (e.g. debian:buster-slim, windows/nanoserver:ltsc2022, buildpack-deps:bionic-scm, etc.).
+* We publish .NET images as part of releasing new versions of .NET including major/minor and servicing.
+
+## Feedback
+
+* [File an issue](https://github.com/dotnet/dotnet-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+# License
+
+* Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+* [.NET license](https://github.com/dotnet/dotnet-docker/blob/main/LICENSE)
+* [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md)
+* [Windows base image license](https://docs.microsoft.com/virtualization/windowscontainers/images-eula) (only applies to Windows containers)
+* [Pricing and licensing for Windows Server 2019](https://www.microsoft.com/cloud-platform/windows-server-pricing)

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -39,6 +39,7 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 * [dotnet/nightly/aspnet](https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor/base](https://hub.docker.com/_/microsoft-dotnet-nightly-monitor-base/): .NET Monitor Base (Preview)
 
 .NET Framework:
 
@@ -60,7 +61,7 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor 8 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-preview.3-ubuntu-chiseled-amd64, 8.0-preview-ubuntu-chiseled-amd64, 8-preview-ubuntu-chiseled-amd64, 8.0.0-preview.3-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-preview.3, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+8.0.0-preview.4-ubuntu-chiseled-amd64, 8.0-preview-ubuntu-chiseled-amd64, 8-preview-ubuntu-chiseled-amd64, 8.0.0-preview.4-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-preview.4, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
@@ -75,7 +76,7 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor 8 Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-preview.3-ubuntu-chiseled-arm64v8, 8.0-preview-ubuntu-chiseled-arm64v8, 8-preview-ubuntu-chiseled-arm64v8, 8.0.0-preview.3-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-preview.3, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+8.0.0-preview.4-ubuntu-chiseled-arm64v8, 8.0-preview-ubuntu-chiseled-arm64v8, 8-preview-ubuntu-chiseled-arm64v8, 8.0.0-preview.4-ubuntu-chiseled, 8.0-preview-ubuntu-chiseled, 8-preview-ubuntu-chiseled, 8.0.0-preview.4, 8.0-preview, 8-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -68,6 +68,13 @@ if ($RuntimeVersion) {
 
 if ($MonitorVersion) {
     $updateDepsArgs += @("--product-version", "monitor=$MonitorVersion")
+
+    $productMajorVersion = $ProductVersion.Split('.', 2)[0]
+    if ($productMajorVersion -ge 8) {
+        $updateDepsArgs += @("--product-version", "monitor-base=$MonitorVersion")
+        $updateDepsArgs += @("--product-version", "monitor-ext-azureblobstorage=$MonitorVersion")
+        $updateDepsArgs += @("--product-version", "monitor-ext-s3storage=$MonitorVersion")
+    }
 }
 
 if ($ComputeShas) {

--- a/eng/dockerfile-templates/Dockerfile.linux.install-files
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-files
@@ -20,4 +20,5 @@ else:{{if ARGS["create-install-dir"]:mkdir -p {{ARGS["install-dir"]}} \
         "file": file["filename"],
         "dest-dir": ARGS["install-dir"],
         "extract-paths": file["extract-paths"]
-    ])}}}}}}
+    ])}}{{if i < len(ARGS["files"]) - 1: \
+}}}}}}

--- a/eng/dockerfile-templates/monitor-base/Dockerfile.envs
+++ b/eng/dockerfile-templates/monitor-base/Dockerfile.envs
@@ -1,0 +1,20 @@
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"

--- a/eng/dockerfile-templates/monitor-base/Dockerfile.linux
+++ b/eng/dockerfile-templates/monitor-base/Dockerfile.linux
@@ -1,0 +1,33 @@
+{{
+    _ .NET major version matches the major version of dotnet-monitor ^
+    set dotnetMajor to split(PRODUCT_VERSION, ".")[0] ^
+    set dotnetMajorMinor to cat(dotnetMajor, ".0") ^
+    set monitorMajor to split(PRODUCT_VERSION, ".")[0] ^
+    set isMariner to find(OS_VERSION, "mariner") >= 0 ^
+    set aspnetBaseTag to
+        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
+    set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
+    set installerImageTag to when(isMariner,
+        cat("mcr.microsoft.com/cbl-mariner/base/core:", OS_VERSION_NUMBER),
+        cat(ARCH_VERSIONED, "/buildpack-deps:", osVersionBase, "-curl"))
+}}ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM {{installerImageTag}} AS installer
+{{if isMariner:
+{{InsertTemplate("../Dockerfile.linux.distroless-mariner-installer-prereqs")}}
+}}
+# Retrieve .NET Monitor Base
+{{InsertTemplate("Dockerfile.linux.install-monitor-base")}}
+
+
+# .NET Monitor Base image
+FROM {{aspnetBaseTag}}
+
+WORKDIR /app
+COPY --from=installer /app .
+
+{{InsertTemplate("Dockerfile.envs")}}
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/eng/dockerfile-templates/monitor-base/Dockerfile.linux.install-monitor-base
+++ b/eng/dockerfile-templates/monitor-base/Dockerfile.linux.install-monitor-base
@@ -1,0 +1,25 @@
+{{
+    set monitorMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
+    set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
+    set monitorVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|", monitorVersionVariable)] ^
+    _ When build and product versions are the same and they are stable versions, use account from main branch e.g. dotnetcli
+      Otherwise, use the account that is associated with the current branch. ^
+    set urlBranch to when(find(monitorVersion, "-") >= 0 || buildVersion != monitorVersion, VARIABLES["branch"], "main") ^
+    set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$dotnet_monitor_version') ^
+    set monitorBaseUrl to cat(VARIABLES[cat("base-url|", monitorMajorMinor, "-monitor|", urlBranch)], "/diagnostics/monitor/", versionFolder, "/") ^
+    set files to [
+        [
+            "filename": "dotnet-monitor-base.tar.gz",
+            "url": cat(monitorBaseUrl, "dotnet-monitor-base-$dotnet_monitor_version-linux-", ARCH_SHORT, ".tar.gz"),
+            "sha": VARIABLES[join(["monitor-base", monitorMajorMinor, "linux", ARCH_SHORT, "sha"], "|")],
+            "sha-var-name": "dotnet_monitor_base_sha512"
+        ]
+    ]
+}}RUN dotnet_monitor_version={{monitorVersion}} \
+    && {{InsertTemplate("../Dockerfile.linux.download-and-install",
+        [
+            "files": files,
+            "install-dir": "/app",
+            "create-install-dir": "true"
+        ], "    ")}}

--- a/eng/dockerfile-templates/monitor/Dockerfile.entrypoint.monitorV8
+++ b/eng/dockerfile-templates/monitor/Dockerfile.entrypoint.monitorV8
@@ -1,2 +1,0 @@
-ENTRYPOINT [ "dotnet-monitor" ]
-CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/eng/dockerfile-templates/monitor/Dockerfile.linux.extensions
+++ b/eng/dockerfile-templates/monitor/Dockerfile.linux.extensions
@@ -20,7 +20,7 @@ FROM {{installerImageTag}} AS installer
 {{if isMariner:
 {{InsertTemplate("../Dockerfile.linux.distroless-mariner-installer-prereqs")}}
 }}
-# Retrieve .NET Monitor
+# Retrieve .NET Monitor extensions
 {{InsertTemplate("Dockerfile.linux.install-extensions")}}
 
 

--- a/eng/dockerfile-templates/monitor/Dockerfile.linux.extensions
+++ b/eng/dockerfile-templates/monitor/Dockerfile.linux.extensions
@@ -1,0 +1,30 @@
+{{
+    _ .NET major version matches the major version of dotnet-monitor ^
+    set dotnetMajor to split(PRODUCT_VERSION, ".")[0] ^
+    set dotnetMajorMinor to cat(dotnetMajor, ".0") ^
+    set monitorMajor to split(PRODUCT_VERSION, ".")[0] ^
+    set isMariner to find(OS_VERSION, "mariner") >= 0 ^
+    set monitorBaseTagOs to when(isMariner,
+        "cbl-mariner-distroless",
+        "ubuntu-chiseled") ^
+    set monitorBaseTag to
+        cat("$REPO:", VARIABLES[cat("monitor|", dotnetMajorMinor, "|product-version")], "-", monitorBaseTagOs, ARCH_TAG_SUFFIX) ^
+    set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
+    set installerImageTag to when(isMariner,
+        cat("mcr.microsoft.com/cbl-mariner/base/core:", OS_VERSION_NUMBER),
+        cat(ARCH_VERSIONED, "/buildpack-deps:", osVersionBase, "-curl"))
+}}ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM {{installerImageTag}} AS installer
+{{if isMariner:
+{{InsertTemplate("../Dockerfile.linux.distroless-mariner-installer-prereqs")}}
+}}
+# Retrieve .NET Monitor
+{{InsertTemplate("Dockerfile.linux.install-extensions")}}
+
+
+# .NET Monitor image
+FROM {{monitorBaseTag}}
+
+COPY --from=installer ["/app", "/app"]

--- a/eng/dockerfile-templates/monitor/Dockerfile.linux.install-extensions
+++ b/eng/dockerfile-templates/monitor/Dockerfile.linux.install-extensions
@@ -1,0 +1,31 @@
+{{
+    set monitorMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
+    set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
+    set monitorVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|", monitorVersionVariable)] ^
+    _ When build and product versions are the same and they are stable versions, use account from main branch e.g. dotnetcli
+      Otherwise, use the account that is associated with the current branch. ^
+    set urlBranch to when(find(monitorVersion, "-") >= 0 || buildVersion != monitorVersion, VARIABLES["branch"], "main") ^
+    set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$dotnet_monitor_extension_version') ^
+    set monitorBaseUrl to cat(VARIABLES[cat("base-url|", monitorMajorMinor, "-monitor|", urlBranch)], "/diagnostics/monitor/", versionFolder, "/") ^
+    set files to [
+        [
+            "filename": "dotnet-monitor-egress-azureblobstorage.tar.gz",
+            "url": cat(monitorBaseUrl, "dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-", ARCH_SHORT, ".tar.gz"),
+            "sha": VARIABLES[join(["monitor-ext-azureblobstorage", monitorMajorMinor, "linux", ARCH_SHORT, "sha"], "|")],
+            "sha-var-name": "dotnet_monitor_extension_sha512"
+        ],
+        [
+            "filename": "dotnet-monitor-egress-s3storage.tar.gz",
+            "url": cat(monitorBaseUrl, "dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-", ARCH_SHORT, ".tar.gz"),
+            "sha": VARIABLES[join(["monitor-ext-s3storage", monitorMajorMinor, "linux", ARCH_SHORT, "sha"], "|")],
+            "sha-var-name": "dotnet_monitor_extension_sha512"
+        ]
+    ]
+}}RUN dotnet_monitor_extension_version={{monitorVersion}} \
+    && {{InsertTemplate("../Dockerfile.linux.download-and-install",
+        [
+            "files": files,
+            "install-dir": "/app",
+            "create-install-dir": "true"
+        ], "    ")}}

--- a/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
@@ -1,0 +1,5 @@
+$(McrTagsYmlRepo:monitor-base)
+$(McrTagsYmlTagGroup:8.0-preview-ubuntu-chiseled-amd64)
+    customSubTableTitle: .NET Monitor 8 Preview Tags
+$(McrTagsYmlTagGroup:8.0-preview-ubuntu-chiseled-arm64v8)
+    customSubTableTitle: .NET Monitor 8 Preview Tags

--- a/eng/readme-templates/About.md
+++ b/eng/readme-templates/About.md
@@ -1,13 +1,16 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
-      readme-host: Moniker of the site that will host the readme
+      readme-host: Moniker of the site that will host the readme ^
+    set templateQualifier to when(IS_PRODUCT_FAMILY,
+        "product-family",
+        when(PARENT_REPO = "monitor", cat("monitor-", SHORT_REPO), SHORT_REPO))
 }}{{ARGS["top-header"]}} About
 {{if ARGS["readme-host"] = "mar":{{InsertTemplate("Announcement.md",
   [
     "leading-line-break": "true",
     "readme-host": ARGS["readme-host"]
   ])}}}}
-{{InsertTemplate(join(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."))}}
+{{InsertTemplate(join(["About", templateQualifier, "md"], "."))}}
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/eng/readme-templates/About.monitor-base.md
+++ b/eng/readme-templates/About.monitor-base.md
@@ -1,0 +1,3 @@
+This image contains the .NET Monitor Base installation.
+
+Use this image as a base image for building a .NET Monitor image with extensions.

--- a/eng/readme-templates/Announcement.md
+++ b/eng/readme-templates/Announcement.md
@@ -3,12 +3,13 @@
       leading-line-break: Indicates whether to include a leading line break
       trailing-line-break: Indicates whether to include a trailing line break
       readme-host: Moniker of the site that will host the readme ^
-    set nonNightlyRepo to when(IS_PRODUCT_FAMILY, "dotnet", join(split(REPO, "/nightly"), ""))
-}}{{if match(PARENT_REPO, "nightly") || VARIABLES["branch"] = "nightly"
+    set nonNightlyRepo to when(IS_PRODUCT_FAMILY, "dotnet", join(split(REPO, "/nightly"), "")) ^
+    set isNightlyRepo to match(split(REPO, "/")[1], "nightly")
+}}{{if isNightlyRepo || VARIABLES["branch"] = "nightly"
 :{{if ARGS["leading-line-break"]:
 }}**IMPORTANT**
 
-**The images from the dotnet/{{if IS_PRODUCT_FAMILY:nightly^else:{{PARENT_REPO}}}} repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
+**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
 
 **See [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": nonNightlyRepo ])}}) for images with official releases of [.NET](https://github.com/dotnet/core).**
 {{if ARGS["trailing-line-break"]:

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -12,6 +12,8 @@ elif match(SHORT_REPO, "monitor"):* `7` (Standard Support)
   * `docker pull {{FULL_REPO}}:7`
 * `6` (Long-Term Support)
   * `docker pull {{FULL_REPO}}:6`^
+elif match(REPO, "monitor/base"):* `8` (Long-Term Support)
+  * `docker pull {{FULL_REPO}}:8`^
 else:* `7.0` (Standard Support)
   * `docker pull {{FULL_REPO}}:7.0`
 * `6.0` (Long-Term Support)

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -1,6 +1,7 @@
 {{
     _ ARGS:
-      top-header: The string to use as the top-level header.
+      top-header: The string to use as the top-level header. ^
+    set isNightlyRepo to match(split(REPO, "/")[1], "nightly")
 }}{{ARGS["top-header"]}} Featured Tags
 
 {{if match(SHORT_REPO, "samples")
@@ -12,8 +13,8 @@ elif match(SHORT_REPO, "monitor"):* `7` (Standard Support)
   * `docker pull {{FULL_REPO}}:7`
 * `6` (Long-Term Support)
   * `docker pull {{FULL_REPO}}:6`^
-elif match(REPO, "monitor/base"):* `8` (Long-Term Support)
-  * `docker pull {{FULL_REPO}}:8`^
+elif match(REPO, "monitor/base") && isNightlyRepo:* `8` (Preview)
+  * `docker pull {{FULL_REPO}}:8-preview`^
 else:* `7.0` (Standard Support)
   * `docker pull {{FULL_REPO}}:7.0`
 * `6.0` (Long-Term Support)

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -1,7 +1,6 @@
 {{
     _ ARGS:
-      top-header: The string to use as the top-level header. ^
-    set isNightlyRepo to match(split(REPO, "/")[1], "nightly")
+      top-header: The string to use as the top-level header.
 }}{{ARGS["top-header"]}} Featured Tags
 
 {{if match(SHORT_REPO, "samples")
@@ -13,7 +12,7 @@ elif match(SHORT_REPO, "monitor"):* `7` (Standard Support)
   * `docker pull {{FULL_REPO}}:7`
 * `6` (Long-Term Support)
   * `docker pull {{FULL_REPO}}:6`^
-elif match(REPO, "monitor/base") && isNightlyRepo:* `8` (Preview)
+elif match(REPO, "monitor/base"):* `8` (Preview)
   * `docker pull {{FULL_REPO}}:8-preview`^
 else:* `7.0` (Standard Support)
   * `docker pull {{FULL_REPO}}:7.0`

--- a/eng/readme-templates/Get-GeneratedReadmes.ps1
+++ b/eng/readme-templates/Get-GeneratedReadmes.ps1
@@ -24,6 +24,7 @@ $onDockerfilesGenerated = {
         CopyReadme $ContainerName "README.aspnet.md"
         CopyReadme $ContainerName "README.md"
         CopyReadme $ContainerName "README.monitor.md"
+        CopyReadme $ContainerName "README.monitor-base.md"
         CopyReadme $ContainerName "README.runtime-deps.md"
         CopyReadme $ContainerName "README.runtime.md"
         CopyReadme $ContainerName "README.samples.md"
@@ -31,6 +32,7 @@ $onDockerfilesGenerated = {
 
         CopyReadme $ContainerName ".mar/portal/README.aspnet.portal.md"
         CopyReadme $ContainerName ".mar/portal/README.monitor.portal.md"
+        CopyReadme $ContainerName ".mar/portal/README.monitor-base.portal.md"
         CopyReadme $ContainerName ".mar/portal/README.runtime-deps.portal.md"
         CopyReadme $ContainerName ".mar/portal/README.runtime.portal.md"
         CopyReadme $ContainerName ".mar/portal/README.samples.portal.md"

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -2,7 +2,8 @@
   set commonArgs to [
     "top-header": "#"
     "readme-host": "dockerhub"
-  ]
+  ] ^
+  set isNightlyRepo to match(split(REPO, "/")[1], "nightly")
 }}{{InsertTemplate("Announcement.md", union(commonArgs, [ "trailing-line-break": "true" ]))}}{{
 if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 }}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":# Featured Repos
@@ -30,7 +31,7 @@ if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 {{if !IS_PRODUCT_FAMILY:
 # Full Tag Listing
 <!--End of generated tags-->
-{{if SHORT_REPO != "monitor":For tags contained in the old dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}} repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core{{if (PARENT_REPO = "nightly"):-nightly}}/{{SHORT_REPO}}/tags/list.
+{{if find(split(REPO, "/"), "monitor") < 0:For tags contained in the old dotnet/core{{if isNightlyRepo:-nightly}}/{{SHORT_REPO}} repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core{{if isNightlyRepo:-nightly}}/{{SHORT_REPO}}/tags/list.
 
 }}*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 }}

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -1,35 +1,40 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
-      readme-host: Moniker of the site that will host the readme
+      readme-host: Moniker of the site that will host the readme ^
+    set isNightlyRepo to match(split(REPO, "/")[1], "nightly")
 }}{{ARGS["top-header"]}} Related Repositories
 
 .NET:
 
 {{if (!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly") && ARGS["readme-host"] = "dockerhub"
     :* [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet", "is-product-family": "true" ])}}): .NET
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "sdk")
+}}{{if (!IS_PRODUCT_FAMILY && !isNightlyRepo && SHORT_REPO != "sdk")
     :* [dotnet/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/sdk" ])}}): .NET SDK
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "aspnet")
+}}{{if (!IS_PRODUCT_FAMILY && !isNightlyRepo && SHORT_REPO != "aspnet")
     :* [dotnet/aspnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/aspnet" ])}}): ASP.NET Core Runtime
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime")
+}}{{if (!IS_PRODUCT_FAMILY && !isNightlyRepo && SHORT_REPO != "runtime")
     :* [dotnet/runtime]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/runtime" ])}}): .NET Runtime
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "runtime-deps")
+}}{{if (!IS_PRODUCT_FAMILY && !isNightlyRepo && SHORT_REPO != "runtime-deps")
     :* [dotnet/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/runtime-deps" ])}}): .NET Runtime Dependencies
-}}{{if (PARENT_REPO = "dotnet" && SHORT_REPO != "monitor")
+}}{{if (!IS_PRODUCT_FAMILY && !isNightlyRepo && SHORT_REPO != "monitor")
     :* [dotnet/monitor]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/monitor" ])}}): .NET Monitor Tool
+}}{{if (!IS_PRODUCT_FAMILY && !isNightlyRepo && SHORT_REPO = "monitor")
+    :* [dotnet/monitor/base]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/monitor/base" ])}}): .NET Monitor Base
 }}{{if ((!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly") && SHORT_REPO != "samples")
     :* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/samples" ])}}): .NET Samples
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "sdk") || (PARENT_REPO = "dotnet" && SHORT_REPO = "sdk") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "sdk") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/sdk" ])}}): .NET SDK (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "aspnet") || (PARENT_REPO = "dotnet" && SHORT_REPO = "aspnet") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "aspnet") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/aspnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/aspnet" ])}}): ASP.NET Core Runtime (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "runtime") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/runtime]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime" ])}}): .NET Runtime (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "runtime-deps") || (PARENT_REPO = "dotnet" && SHORT_REPO = "runtime-deps") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "runtime-deps") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime-deps" ])}}): .NET Runtime Dependencies (Preview)
-}}{{if ((PARENT_REPO = "nightly" && SHORT_REPO != "monitor") || (PARENT_REPO = "dotnet" && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/monitor]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/monitor" ])}}): .NET Monitor Tool (Preview)
+}}{{if ((isNightlyRepo && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+    :* [dotnet/nightly/monitor/base]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/monitor/base" ])}}): .NET Monitor Base (Preview)
 }}
 .NET Framework:
 

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -33,7 +33,7 @@
     :* [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime-deps" ])}}): .NET Runtime Dependencies (Preview)
 }}{{if ((isNightlyRepo && SHORT_REPO != "monitor") || (!isNightlyRepo && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/monitor]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/monitor" ])}}): .NET Monitor Tool (Preview)
-}}{{if ((SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if (isNightlyRepo && SHORT_REPO = "monitor")
     :* [dotnet/nightly/monitor/base]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/monitor/base" ])}}): .NET Monitor Base (Preview)
 }}
 .NET Framework:

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -23,17 +23,17 @@
     :* [dotnet/monitor/base]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/monitor/base" ])}}): .NET Monitor Base
 }}{{if ((!IS_PRODUCT_FAMILY || VARIABLES["branch"] = "nightly") && SHORT_REPO != "samples")
     :* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/samples" ])}}): .NET Samples
-}}{{if ((isNightlyRepo && SHORT_REPO != "sdk") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "sdk") || (!isNightlyRepo && SHORT_REPO = "sdk") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/sdk" ])}}): .NET SDK (Preview)
-}}{{if ((isNightlyRepo && SHORT_REPO != "aspnet") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "aspnet") || (!isNightlyRepo && SHORT_REPO = "aspnet") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/aspnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/aspnet" ])}}): ASP.NET Core Runtime (Preview)
-}}{{if ((isNightlyRepo && SHORT_REPO != "runtime") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "runtime") || (!isNightlyRepo && SHORT_REPO = "runtime") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/runtime]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime" ])}}): .NET Runtime (Preview)
-}}{{if ((isNightlyRepo && SHORT_REPO != "runtime-deps") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "runtime-deps") || (!isNightlyRepo && SHORT_REPO = "runtime-deps") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime-deps" ])}}): .NET Runtime Dependencies (Preview)
-}}{{if ((isNightlyRepo && SHORT_REPO != "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((isNightlyRepo && SHORT_REPO != "monitor") || (!isNightlyRepo && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/monitor]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/monitor" ])}}): .NET Monitor Tool (Preview)
-}}{{if ((isNightlyRepo && SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
+}}{{if ((SHORT_REPO = "monitor") || (IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main"))
     :* [dotnet/nightly/monitor/base]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/monitor/base" ])}}): .NET Monitor Base (Preview)
 }}
 .NET Framework:

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -1,10 +1,13 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
-      readme-host: Moniker of the site that will host the readme
+      readme-host: Moniker of the site that will host the readme ^
+    set templateQualifier to when(IS_PRODUCT_FAMILY,
+        "product-family",
+        when(PARENT_REPO = "monitor", cat("monitor-", SHORT_REPO), SHORT_REPO))
 }}{{ARGS["top-header"]}} Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-{{InsertTemplate(join(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], "."),
+{{InsertTemplate(join(["Use", templateQualifier, "md"], "."),
   [ "top-header": ARGS["top-header"], "readme-host": ARGS["readme-host"]])}}

--- a/eng/readme-templates/Use.monitor-base.md
+++ b/eng/readme-templates/Use.monitor-base.md
@@ -6,7 +6,5 @@
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 
-* [CBL Mariner Distroless - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile)
-* [CBL Mariner Distroless - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile)
 * [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
 * [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)

--- a/eng/readme-templates/Use.monitor-base.md
+++ b/eng/readme-templates/Use.monitor-base.md
@@ -1,0 +1,12 @@
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
+}}{{ARGS["top-header"]}}# Building a Custom .NET Monitor Image
+
+The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
+
+* [CBL Mariner Distroless - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile)
+* [CBL Mariner Distroless - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile)
+* [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
+* [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -65,6 +65,9 @@ namespace Dotnet.Docker
                 { "powershell", new string[] { "https://pwshtool.blob.core.windows.net/tool/$VERSION_DIR/PowerShell.$OS.$ARCH.$VERSION_FILE.nupkg" } },
 
                 { "monitor", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
+                { "monitor-base", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-base-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
+                { "monitor-ext-azureblobstorage", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-egress-azureblobstorage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
+                { "monitor-ext-s3storage", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-egress-s3storage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
 
                 { "runtime", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-runtime-$VERSION_FILE$OPTIONAL_OS-{GetRuntimeSdkArchFormat()}.$ARCHIVE_EXT" } },
                 { "runtime-host", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-host-$VERSION_FILE-{GetRpmArchFormat()}.$ARCHIVE_EXT" } },

--- a/manifest.json
+++ b/manifest.json
@@ -5338,6 +5338,125 @@
       ]
     },
     {
+      "id": "monitor-base",
+      "name": "dotnet/nightly/monitor/base",
+      "readmes": [
+        {
+          "path": "README.monitor-base.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mar/portal/README.monitor-base.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
+      "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/monitor-base-tags.yml",
+      "images": [
+        {
+          "productVersion": "$(monitor|8.0|product-version)",
+          "sharedTags": {
+            "$(monitor|8.0|product-version)-ubuntu-chiseled": {},
+            "8.0-preview-ubuntu-chiseled": {},
+            "8-preview-ubuntu-chiseled": {},
+            "$(monitor|8.0|product-version)": {},
+            "8.0-preview": {},
+            "8-preview": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.0/ubuntu-chiseled/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.0|product-version)-ubuntu-chiseled-amd64": {},
+                "8.0-preview-ubuntu-chiseled-amd64": {},
+                "8-preview-ubuntu-chiseled-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.0/ubuntu-chiseled/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.0|product-version)-ubuntu-chiseled-arm64v8": {},
+                "8.0-preview-ubuntu-chiseled-arm64v8": {},
+                "8-preview-ubuntu-chiseled-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|8.0|product-version)",
+          "sharedTags": {
+            "$(monitor|8.0|product-version)-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8.0-preview-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8-preview-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.0/cbl-mariner-distroless/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.0|product-version)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8.0-preview-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8-preview-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                }
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.0/cbl-mariner-distroless/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.0|product-version)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "8.0-preview-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "8-preview-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "monitor",
       "name": "dotnet/nightly/monitor",
       "readmes": [
@@ -5938,10 +6057,10 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
+                "REPO": "$(Repo:monitor-base)"
               },
               "dockerfile": "src/monitor/8.0/ubuntu-chiseled/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
               "osVersion": "jammy-chiseled",
               "tags": {
@@ -5953,10 +6072,10 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
+                "REPO": "$(Repo:monitor-base)"
               },
               "dockerfile": "src/monitor/8.0/ubuntu-chiseled/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
               "osVersion": "jammy-chiseled",
               "tags": {
@@ -5984,10 +6103,10 @@
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
+                "REPO": "$(Repo:monitor-base)"
               },
               "dockerfile": "src/monitor/8.0/cbl-mariner-distroless/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
@@ -6005,10 +6124,10 @@
             {
               "architecture": "arm64",
               "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
+                "REPO": "$(Repo:monitor-base)"
               },
               "dockerfile": "src/monitor/8.0/cbl-mariner-distroless/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -97,10 +97,17 @@
     "monitor|7.1|linux|arm64|sha": "c3313bcad518e34210400c8d0bdd255150ee0f2976ff317ae4d703e82320fc1d659f3073462d3f10b258df2bc79230e818a442d1ebff4e43ebd86209a2ed172a",
     "monitor|7.1|product-version": "7.1.1",
 
-    "monitor|8.0|build-version": "8.0.0-preview.3.23180.9",
-    "monitor|8.0|linux|x64|sha": "e7f7220a3d0e268b4db12bfdf6e95a01a186ede1ea8aff2eedcae149f1c4369b80c7aaebacf5ac2b4b9fc612640a27a616890f07ff90a3fe6d95b84cfc99543f",
-    "monitor|8.0|linux|arm64|sha": "38a209cb6e5c2bdfa53c1470a5ad0e5f777c7b882826f426d406a2267699f5462118391d3430c3fbf3153f99e2aff12b401c6cc86e4ff85e05da66bd24492d8e",
-    "monitor|8.0|product-version": "8.0.0-preview.3",
+    "monitor|8.0|build-version": "8.0.0-preview.4.23207.3",
+    "monitor|8.0|product-version": "8.0.0-preview.4",
+
+    "monitor-base|8.0|linux|x64|sha": "3cec6d9902afeea454b2dde99bb0e24ec11882e554c70eb9a0394e4d644bce58af7fb13b4d2ac92a8e5af3120032d93d4f34ed551c5e85f65e00e0460b0c3084",
+    "monitor-base|8.0|linux|arm64|sha": "1bf77b8ca2cde1b89c51c49893a89c5cde4c994dc2df95c83c472cf9095dc540a6c920cdc6ba3346bc63b5c0a2c0cb1c1e86d7740850f994bf39dc0f6027c038",
+
+    "monitor-ext-azureblobstorage|8.0|linux|x64|sha": "3a96ad6ac0f795f2348966bc77f67f06489354ce19e803f3c02c55df651f3abf6e025161176e28e59a460fb0a409632d4488c189b5eb42a4bdf50e18e07eb4fe",
+    "monitor-ext-azureblobstorage|8.0|linux|arm64|sha": "c021b20983c18b7a0dfef0075578d915b78fb3dc25d08de9c8103976ab2c9fb1b2bc4e8588c9a52d506db8fd343c3415e6b7d59ea34e21c1072a6b1b2aa0791c",
+
+    "monitor-ext-s3storage|8.0|linux|x64|sha": "7b99de681c9efe8a69bab03571ebc210db9747067e1a2e621aa422d2058c528035a7deb02ef5016cb635a127bb3424d4b300c81b8cb260ce419f55fc4e9fbdfd",
+    "monitor-ext-s3storage|8.0|linux|arm64|sha": "45bd876739a241a41901bd3dd41960f3e51dbaeb662b3c86e028cad936883006b1accd7f5f628faffe883a0e4d64578bf0ce8f9e85268b4e7975d9c82b7275d4",
 
     "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha": "fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880",
 

--- a/src/monitor-base/8.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor-base/8.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz \
+    && dotnet_monitor_base_sha512='3cec6d9902afeea454b2dde99bb0e24ec11882e554c70eb9a0394e4d644bce58af7fb13b4d2ac92a8e5af3120032d93d4f34ed551c5e85f65e00e0460b0c3084' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-distroless-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor-base/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor-base/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz \
+    && dotnet_monitor_base_sha512='1bf77b8ca2cde1b89c51c49893a89c5cde4c994dc2df95c83c472cf9095dc540a6c920cdc6ba3346bc63b5c0a2c0cb1c1e86d7740850f994bf39dc0f6027c038' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-distroless-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz \
+    && dotnet_monitor_base_sha512='3cec6d9902afeea454b2dde99bb0e24ec11882e554c70eb9a0394e4d644bce58af7fb13b4d2ac92a8e5af3120032d93d4f34ed551c5e85f65e00e0460b0c3084' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-preview.4-jammy-chiseled-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz \
+    && dotnet_monitor_base_sha512='1bf77b8ca2cde1b89c51c49893a89c5cde4c994dc2df95c83c472cf9095dc540a6c920cdc6ba3346bc63b5c0a2c0cb1c1e86d7740850f994bf39dc0f6027c038' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-preview.4-jammy-chiseled-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -9,7 +9,7 @@ RUN tdnf install -y \
         tar \
     && tdnf clean all
 
-# Retrieve .NET Monitor
+# Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
     && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
     && dotnet_monitor_extension_sha512='3a96ad6ac0f795f2348966bc77f67f06489354ce19e803f3c02c55df651f3abf6e025161176e28e59a460fb0a409632d4488c189b5eb42a4bdf50e18e07eb4fe' \

--- a/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
@@ -10,41 +10,23 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor
-RUN dotnet_monitor_version=8.0.0-preview.3.23180.9 \
-    && curl -fSL --output dotnet-monitor.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-$dotnet_monitor_version-linux-x64.tar.gz \
-    && dotnet_monitor_sha512='e7f7220a3d0e268b4db12bfdf6e95a01a186ede1ea8aff2eedcae149f1c4369b80c7aaebacf5ac2b4b9fc612640a27a616890f07ff90a3fe6d95b84cfc99543f' \
-    && echo "$dotnet_monitor_sha512  dotnet-monitor.tar.gz" | sha512sum -c - \
+RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='3a96ad6ac0f795f2348966bc77f67f06489354ce19e803f3c02c55df651f3abf6e025161176e28e59a460fb0a409632d4488c189b5eb42a4bdf50e18e07eb4fe' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='7b99de681c9efe8a69bab03571ebc210db9747067e1a2e621aa422d2058c528035a7deb02ef5016cb635a127bb3424d4b300c81b8cb260ce419f55fc4e9fbdfd' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
     && mkdir -p /app \
-    && tar -oxzf dotnet-monitor.tar.gz -C /app \
-    && rm dotnet-monitor.tar.gz
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
 
 
 # .NET Monitor image
-FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-distroless-amd64
+FROM $REPO:8.0.0-preview.4-cbl-mariner-distroless-amd64
 
-WORKDIR /app
-COPY --from=installer /app .
-
-ENV \
-    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
-    ASPNETCORE_HTTP_PORTS= \
-    # Disable debugger and profiler diagnostics to avoid diagnosing self.
-    COMPlus_EnableDiagnostics=0 \
-    # Default Filter
-    DefaultProcess__Filters__0__Key=ProcessId \
-    DefaultProcess__Filters__0__Value=1 \
-    # Remove Unix Domain Socket before starting diagnostic port server
-    DiagnosticPort__DeleteEndpointOnStartup=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
-    # Logging: JSON format so that analytic platforms can get discrete entry information
-    Logging__Console__FormatterName=json \
-    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
-    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
-    # Logging: Write timestamps using UTC offset (+0:00)
-    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
-    PATH="/app:${PATH}"
-
-ENTRYPOINT [ "dotnet-monitor" ]
-CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -9,7 +9,7 @@ RUN tdnf install -y \
         tar \
     && tdnf clean all
 
-# Retrieve .NET Monitor
+# Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
     && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
     && dotnet_monitor_extension_sha512='c021b20983c18b7a0dfef0075578d915b78fb3dc25d08de9c8103976ab2c9fb1b2bc4e8588c9a52d506db8fd343c3415e6b7d59ea34e21c1072a6b1b2aa0791c' \

--- a/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
@@ -10,41 +10,23 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor
-RUN dotnet_monitor_version=8.0.0-preview.3.23180.9 \
-    && curl -fSL --output dotnet-monitor.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-$dotnet_monitor_version-linux-arm64.tar.gz \
-    && dotnet_monitor_sha512='38a209cb6e5c2bdfa53c1470a5ad0e5f777c7b882826f426d406a2267699f5462118391d3430c3fbf3153f99e2aff12b401c6cc86e4ff85e05da66bd24492d8e' \
-    && echo "$dotnet_monitor_sha512  dotnet-monitor.tar.gz" | sha512sum -c - \
+RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='c021b20983c18b7a0dfef0075578d915b78fb3dc25d08de9c8103976ab2c9fb1b2bc4e8588c9a52d506db8fd343c3415e6b7d59ea34e21c1072a6b1b2aa0791c' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='45bd876739a241a41901bd3dd41960f3e51dbaeb662b3c86e028cad936883006b1accd7f5f628faffe883a0e4d64578bf0ce8f9e85268b4e7975d9c82b7275d4' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
     && mkdir -p /app \
-    && tar -oxzf dotnet-monitor.tar.gz -C /app \
-    && rm dotnet-monitor.tar.gz
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
 
 
 # .NET Monitor image
-FROM $REPO:8.0.0-preview.4-cbl-mariner2.0-distroless-arm64v8
+FROM $REPO:8.0.0-preview.4-cbl-mariner-distroless-arm64v8
 
-WORKDIR /app
-COPY --from=installer /app .
-
-ENV \
-    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
-    ASPNETCORE_HTTP_PORTS= \
-    # Disable debugger and profiler diagnostics to avoid diagnosing self.
-    COMPlus_EnableDiagnostics=0 \
-    # Default Filter
-    DefaultProcess__Filters__0__Key=ProcessId \
-    DefaultProcess__Filters__0__Value=1 \
-    # Remove Unix Domain Socket before starting diagnostic port server
-    DiagnosticPort__DeleteEndpointOnStartup=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
-    # Logging: JSON format so that analytic platforms can get discrete entry information
-    Logging__Console__FormatterName=json \
-    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
-    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
-    # Logging: Write timestamps using UTC offset (+0:00)
-    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
-    PATH="/app:${PATH}"
-
-ENTRYPOINT [ "dotnet-monitor" ]
-CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile
@@ -3,7 +3,7 @@ ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 # Installer image
 FROM amd64/buildpack-deps:jammy-curl AS installer
 
-# Retrieve .NET Monitor
+# Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
     && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
     && dotnet_monitor_extension_sha512='3a96ad6ac0f795f2348966bc77f67f06489354ce19e803f3c02c55df651f3abf6e025161176e28e59a460fb0a409632d4488c189b5eb42a4bdf50e18e07eb4fe' \

--- a/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile
@@ -1,44 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
 FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor
-RUN dotnet_monitor_version=8.0.0-preview.3.23180.9 \
-    && curl -fSL --output dotnet-monitor.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-$dotnet_monitor_version-linux-x64.tar.gz \
-    && dotnet_monitor_sha512='e7f7220a3d0e268b4db12bfdf6e95a01a186ede1ea8aff2eedcae149f1c4369b80c7aaebacf5ac2b4b9fc612640a27a616890f07ff90a3fe6d95b84cfc99543f' \
-    && echo "$dotnet_monitor_sha512  dotnet-monitor.tar.gz" | sha512sum -c - \
+RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='3a96ad6ac0f795f2348966bc77f67f06489354ce19e803f3c02c55df651f3abf6e025161176e28e59a460fb0a409632d4488c189b5eb42a4bdf50e18e07eb4fe' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='7b99de681c9efe8a69bab03571ebc210db9747067e1a2e621aa422d2058c528035a7deb02ef5016cb635a127bb3424d4b300c81b8cb260ce419f55fc4e9fbdfd' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
     && mkdir -p /app \
-    && tar -oxzf dotnet-monitor.tar.gz -C /app \
-    && rm dotnet-monitor.tar.gz
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
 
 
 # .NET Monitor image
-FROM $REPO:8.0.0-preview.4-jammy-chiseled-amd64
+FROM $REPO:8.0.0-preview.4-ubuntu-chiseled-amd64
 
-WORKDIR /app
-COPY --from=installer /app .
-
-ENV \
-    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
-    ASPNETCORE_HTTP_PORTS= \
-    # Disable debugger and profiler diagnostics to avoid diagnosing self.
-    COMPlus_EnableDiagnostics=0 \
-    # Default Filter
-    DefaultProcess__Filters__0__Key=ProcessId \
-    DefaultProcess__Filters__0__Value=1 \
-    # Remove Unix Domain Socket before starting diagnostic port server
-    DiagnosticPort__DeleteEndpointOnStartup=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
-    # Logging: JSON format so that analytic platforms can get discrete entry information
-    Logging__Console__FormatterName=json \
-    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
-    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
-    # Logging: Write timestamps using UTC offset (+0:00)
-    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
-    PATH="/app:${PATH}"
-
-ENTRYPOINT [ "dotnet-monitor" ]
-CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -3,7 +3,7 @@ ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 # Installer image
 FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
-# Retrieve .NET Monitor
+# Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
     && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
     && dotnet_monitor_extension_sha512='c021b20983c18b7a0dfef0075578d915b78fb3dc25d08de9c8103976ab2c9fb1b2bc4e8588c9a52d506db8fd343c3415e6b7d59ea34e21c1072a6b1b2aa0791c' \

--- a/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile
@@ -1,44 +1,26 @@
-ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
 FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor
-RUN dotnet_monitor_version=8.0.0-preview.3.23180.9 \
-    && curl -fSL --output dotnet-monitor.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-$dotnet_monitor_version-linux-arm64.tar.gz \
-    && dotnet_monitor_sha512='38a209cb6e5c2bdfa53c1470a5ad0e5f777c7b882826f426d406a2267699f5462118391d3430c3fbf3153f99e2aff12b401c6cc86e4ff85e05da66bd24492d8e' \
-    && echo "$dotnet_monitor_sha512  dotnet-monitor.tar.gz" | sha512sum -c - \
+RUN dotnet_monitor_extension_version=8.0.0-preview.4.23207.3 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='c021b20983c18b7a0dfef0075578d915b78fb3dc25d08de9c8103976ab2c9fb1b2bc4e8588c9a52d506db8fd343c3415e6b7d59ea34e21c1072a6b1b2aa0791c' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='45bd876739a241a41901bd3dd41960f3e51dbaeb662b3c86e028cad936883006b1accd7f5f628faffe883a0e4d64578bf0ce8f9e85268b4e7975d9c82b7275d4' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
     && mkdir -p /app \
-    && tar -oxzf dotnet-monitor.tar.gz -C /app \
-    && rm dotnet-monitor.tar.gz
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
 
 
 # .NET Monitor image
-FROM $REPO:8.0.0-preview.4-jammy-chiseled-arm64v8
+FROM $REPO:8.0.0-preview.4-ubuntu-chiseled-arm64v8
 
-WORKDIR /app
-COPY --from=installer /app .
-
-ENV \
-    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
-    ASPNETCORE_HTTP_PORTS= \
-    # Disable debugger and profiler diagnostics to avoid diagnosing self.
-    COMPlus_EnableDiagnostics=0 \
-    # Default Filter
-    DefaultProcess__Filters__0__Key=ProcessId \
-    DefaultProcess__Filters__0__Value=1 \
-    # Remove Unix Domain Socket before starting diagnostic port server
-    DiagnosticPort__DeleteEndpointOnStartup=true \
-    # Server GC mode
-    DOTNET_gcServer=1 \
-    # Logging: JSON format so that analytic platforms can get discrete entry information
-    Logging__Console__FormatterName=json \
-    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
-    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
-    # Logging: Write timestamps using UTC offset (+0:00)
-    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
-    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
-    PATH="/app:${PATH}"
-
-ENTRYPOINT [ "dotnet-monitor" ]
-CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]
+COPY --from=installer ["/app", "/app"]

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -216,9 +216,13 @@
     "src/monitor/7.1/cbl-mariner/arm64v8": 217293451,
     "src/monitor/7.1/cbl-mariner-distroless/amd64": 132678720,
     "src/monitor/7.1/cbl-mariner-distroless/arm64v8": 133547868,
-    "src/monitor/8.0/ubuntu-chiseled/amd64": 121260554,
-    "src/monitor/8.0/ubuntu-chiseled/arm64v8": 128934532,
-    "src/monitor/8.0/cbl-mariner-distroless/amd64": 133235508,
-    "src/monitor/8.0/cbl-mariner-distroless/arm64v8": 140710709
+    "src/monitor/8.0/ubuntu-chiseled/amd64": 127821834,
+    "src/monitor/8.0/ubuntu-chiseled/arm64v8": 134958622,
+    "src/monitor/8.0/cbl-mariner-distroless/amd64": 141200979,
+    "src/monitor/8.0/cbl-mariner-distroless/arm64v8": 148117492,
+    "src/monitor-base/8.0/ubuntu-chiseled/amd64": 119965752,
+    "src/monitor-base/8.0/ubuntu-chiseled/arm64v8": 127102540,
+    "src/monitor-base/8.0/cbl-mariner-distroless/amd64": 133344897,
+    "src/monitor-base/8.0/cbl-mariner-distroless/arm64v8": 140261410
   }
 }


### PR DESCRIPTION
This change splits the .NET Monitor 8 image into two separate images:
- A base image that contains the base installation of the .NET Monitor tool, environment variables, and entrypoint specification. The repository for this image is `dotnet/monitor/base`.
- A deriving image that takes the base image and installs the .NET Monitor extensions into the tool. Currently, the only extensions included are the Azure Blob storage and S3 storage extensions. The repository for this image is `dotnet/monitor`. It provides equivalent functionality compared to the prior 8.0 Preview images.

This split allows others to more easily produce a custom .NET Monitor image with a custom list of extensions installed on top of it without having to reimplement the entire image.

The image size baseline for the amd64 images were determined by building the images and inspecting their sizes. The arm64v8 image size baselines were calculated by using the relative difference between the amd64 images and applying those same offsets.

Other changes include replacing most of the template code that compares PARENT_REPO to `dotnet` and `nightly` with code that looks for these values at specific offsets. The problem with the prior implementation is that the new base image repository is `dotnet/nightly/monitor/base`, so its PARENT_REPO is `monitor` and its SHORT_REPO is `base`.

cc @dotnet/dotnet-monitor