### PR TITLE
Use Set-DotnetVersions for updating .NET Monitor

### DIFF
--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -95,7 +95,7 @@ if ($UseStableBranding) {
 
 $versionSourceName = switch ($PSCmdlet.ParameterSetName) {
     "DotnetInstaller" { "dotnet/installer" }
-    "DotnetMonitor" { "dotnet/dotnet-monitor" }
+    "DotnetMonitor" { "dotnet/dotnet-monitor/$ProductVersion" }
     default { Write-Error -Message "Unknown version source" -ErrorAction Stop }
 }
 

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -29,9 +29,16 @@ stages:
     - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -BuildVersionFilePath "$(Pipeline.Workspace)/dotnet-monitor/Build_Info/dotnet-monitor.nupkg.buildversion"
       displayName: Get Versions
     - powershell: |
-        $customArgs = "$(monitorMajorMinorVersion) --product-version monitor=$(monitorVer) --version-source-name dotnet/dotnet-monitor/$(monitorMajorMinorVersion) --stable-branding=$(stableBranding)"
+        $scriptArgs = @{
+          ProductVersion = "$(monitorMajorMinorVersion)"
+          MonitorVersion = "$(monitorVer)"
+          AzdoVariableName = 'updateDepsArgs'
+          UseStableBranding = [bool]::Parse("$(stableBranding)")
+        }
 
-        $customArgsArray = @($customArgs)
+        $(engPath)/Set-DotnetVersions.ps1 @scriptArgs
+
+        $customArgsArray = @($updateDepsArgs)
         echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
       displayName: Set Custom Args
     - template: steps/update-dependencies.yml

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -37,8 +37,9 @@ stages:
         }
 
         $(engPath)/Set-DotnetVersions.ps1 @scriptArgs
-
-        $customArgsArray = @($updateDepsArgs)
+      displayName: Get update-dependencies args
+    - powershell: |
+        $customArgsArray = @("$(updateDepsArgs)")
         echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
       displayName: Set Custom Args
     - template: steps/update-dependencies.yml


### PR DESCRIPTION
The Set-DotnetVersions.ps1 script understands how to break out the "monitor" product into separate subproducts for 8.0 and going forward. The update-dependencies-monitor.yml pipeline was constructing its own command line arguments to pass to the update-dependencies tool as wasn't updated to understand the subproduct notion.

This changes the update-dependencies-monitor.yml pipeline to use the Set-DotnetVersions.ps1 script so that consistent .NET Monitor product versioning behavior is used and maintained in one place.