### PR TITLE
Fix exec: "./aspnetapp.dll": permission denied

### DIFF
--- a/samples/aspnetapp/Dockerfile.chiseled
+++ b/samples/aspnetapp/Dockerfile.chiseled
@@ -16,4 +16,4 @@ RUN dotnet publish --use-current-runtime --self-contained false --no-restore -o 
 FROM mcr.microsoft.com/dotnet/nightly/aspnet:7.0-jammy-chiseled
 WORKDIR /app
 COPY --from=build /app .
-ENTRYPOINT ["./aspnetapp.dll"]
+ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.debian
+++ b/samples/aspnetapp/Dockerfile.debian
@@ -16,4 +16,4 @@ RUN dotnet publish --use-current-runtime --self-contained false --no-restore -o 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
 WORKDIR /app
 COPY --from=build /app .
-ENTRYPOINT ["./aspnetapp.dll"]
+ENTRYPOINT ["./aspnetapp"]

--- a/samples/dotnetapp/Dockerfile.chiseled
+++ b/samples/dotnetapp/Dockerfile.chiseled
@@ -16,4 +16,4 @@ RUN dotnet publish --use-current-runtime --self-contained false --no-restore -o 
 FROM mcr.microsoft.com/dotnet/nightly/runtime:7.0-jammy-chiseled
 WORKDIR /app
 COPY --from=build /app .
-ENTRYPOINT ["dotnet", "dotnetapp.dll"]
+ENTRYPOINT ["./dotnetapp"]


### PR DESCRIPTION
With only "./aspnetapp.dll" as the entrypoint the resulting container image fails to run on arm64 Linux (most likely also on amd64) with:
```
exec: "./aspnetapp.dll": permission denied: unknown.
```