### PR TITLE
Remove libintl from .NET 8.0 Alpine runtime-deps images

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -9,14 +9,23 @@
     set isDistrolessMariner to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) ^
     set dotnetDepsComment to "# .NET dependencies" ^
     set pkgs to when(isAlpine,
-        [
-            "krb5-libs",
-            "libgcc",
-            "libintl",
-            cat("libssl", VARIABLES[cat("libssl|", OS_VERSION_BASE)]),
-            "libstdc++",
-            "zlib"
-        ],
+        when (dotnetVersion = "6.0" || dotnetVersion = "7.0",
+            [
+                "krb5-libs",
+                "libgcc",
+                "libintl",
+                cat("libssl", VARIABLES[cat("libssl|", OS_VERSION_BASE)]),
+                "libstdc++",
+                "zlib"
+            ],
+            [
+                "krb5-libs",
+                "libgcc",
+                cat("libssl", VARIABLES[cat("libssl|", OS_VERSION_BASE)]),
+                "libstdc++",
+                "zlib"
+            ]
+        ),
         when(isMariner,
             when(isDistrolessMariner && find(OS_VERSION, "1.0") < 0,
                 [

--- a/src/runtime-deps/8.0/alpine3.17/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.17/amd64/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --no-cache \
         # .NET dependencies
         krb5-libs \
         libgcc \
-        libintl \
         libssl3 \
         libstdc++ \
         zlib

--- a/src/runtime-deps/8.0/alpine3.17/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.17/arm32v7/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --no-cache \
         # .NET dependencies
         krb5-libs \
         libgcc \
-        libintl \
         libssl3 \
         libstdc++ \
         zlib

--- a/src/runtime-deps/8.0/alpine3.17/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.17/arm64v8/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --no-cache \
         # .NET dependencies
         krb5-libs \
         libgcc \
-        libintl \
         libssl3 \
         libstdc++ \
         zlib

--- a/src/runtime-deps/8.0/alpine3.18/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/amd64/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --no-cache \
         # .NET dependencies
         krb5-libs \
         libgcc \
-        libintl \
         libssl3 \
         libstdc++ \
         zlib

--- a/src/runtime-deps/8.0/alpine3.18/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/arm32v7/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --no-cache \
         # .NET dependencies
         krb5-libs \
         libgcc \
-        libintl \
         libssl3 \
         libstdc++ \
         zlib

--- a/src/runtime-deps/8.0/alpine3.18/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/arm64v8/Dockerfile
@@ -16,7 +16,6 @@ RUN apk add --no-cache \
         # .NET dependencies
         krb5-libs \
         libgcc \
-        libintl \
         libssl3 \
         libstdc++ \
         zlib


### PR DESCRIPTION
Fixes #4627 