### PR TITLE
Update Windows image size baselines

### DIFF
--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -2,43 +2,43 @@
   "dotnet/nightly/runtime": {
     "src/runtime/6.0/nanoserver-1809/amd64": 339178589,
     "src/runtime/6.0/nanoserver-ltsc2022/amd64": 369353141,
-    "src/runtime/6.0/windowsservercore-ltsc2019/amd64": 4732678338,
-    "src/runtime/6.0/windowsservercore-ltsc2022/amd64": 3943838372,
+    "src/runtime/6.0/windowsservercore-ltsc2019/amd64": 3745603648,
+    "src/runtime/6.0/windowsservercore-ltsc2022/amd64": 3152002804,
     "src/runtime/7.0/nanoserver-1809/amd64": 328470826,
     "src/runtime/7.0/nanoserver-ltsc2022/amd64": 367604122,
-    "src/runtime/7.0/windowsservercore-ltsc2019/amd64": 4733882179,
-    "src/runtime/7.0/windowsservercore-ltsc2022/amd64": 3944434697,
+    "src/runtime/7.0/windowsservercore-ltsc2019/amd64": 3746963797,
+    "src/runtime/7.0/windowsservercore-ltsc2022/amd64": 3152737117,
     "src/runtime/8.0/nanoserver-1809/amd64": 332610335,
     "src/runtime/8.0/nanoserver-ltsc2022/amd64": 370748495,
-    "src/runtime/8.0/windowsservercore-ltsc2019/amd64": 4730605392,
-    "src/runtime/8.0/windowsservercore-ltsc2022/amd64": 3943617568
+    "src/runtime/8.0/windowsservercore-ltsc2019/amd64": 3744075205,
+    "src/runtime/8.0/windowsservercore-ltsc2022/amd64": 3150089685
   },
   "dotnet/nightly/aspnet": {
     "src/aspnet/6.0/nanoserver-1809/amd64": 362186301,
     "src/aspnet/6.0/nanoserver-ltsc2022/amd64": 391627241,
-    "src/aspnet/6.0/windowsservercore-ltsc2019/amd64": 4761399575,
-    "src/aspnet/6.0/windowsservercore-ltsc2022/amd64": 3979824632,
+    "src/aspnet/6.0/windowsservercore-ltsc2019/amd64": 3774345382,
+    "src/aspnet/6.0/windowsservercore-ltsc2022/amd64": 3183798598,
     "src/aspnet/7.0/nanoserver-1809/amd64": 349969843,
     "src/aspnet/7.0/nanoserver-ltsc2022/amd64": 389103139,
-    "src/aspnet/7.0/windowsservercore-ltsc2019/amd64": 4765654099,
-    "src/aspnet/7.0/windowsservercore-ltsc2022/amd64": 3983454128,
+    "src/aspnet/7.0/windowsservercore-ltsc2019/amd64": 3778746655,
+    "src/aspnet/7.0/windowsservercore-ltsc2022/amd64": 3187573999,
     "src/aspnet/8.0/nanoserver-1809/amd64": 357313558,
     "src/aspnet/8.0/nanoserver-ltsc2022/amd64": 395451718,
-    "src/aspnet/8.0/windowsservercore-ltsc2019/amd64": 4761173182,
-    "src/aspnet/8.0/windowsservercore-ltsc2022/amd64": 3982354000
+    "src/aspnet/8.0/windowsservercore-ltsc2019/amd64": 3775435641,
+    "src/aspnet/8.0/windowsservercore-ltsc2022/amd64": 3184454893
   },
   "dotnet/nightly/sdk": {
     "src/sdk/6.0/nanoserver-1809/amd64": 964537766,
     "src/sdk/6.0/nanoserver-ltsc2022/amd64": 1006844828,
-    "src/sdk/6.0/windowsservercore-ltsc2019/amd64": 5186501449,
-    "src/sdk/6.0/windowsservercore-ltsc2022/amd64": 4650233783,
+    "src/sdk/6.0/windowsservercore-ltsc2019/amd64": 4432623743,
+    "src/sdk/6.0/windowsservercore-ltsc2022/amd64": 3851001933,
     "src/sdk/7.0/nanoserver-1809/amd64": 1100784131,
     "src/sdk/7.0/nanoserver-ltsc2022/amd64": 1114152303,
-    "src/sdk/7.0/windowsservercore-ltsc2019/amd64": 5254946180,
-    "src/sdk/7.0/windowsservercore-ltsc2022/amd64": 4726532816,
+    "src/sdk/7.0/windowsservercore-ltsc2019/amd64": 4542131032,
+    "src/sdk/7.0/windowsservercore-ltsc2022/amd64": 3962555788,
     "src/sdk/8.0/nanoserver-1809/amd64": 1112868757,
     "src/sdk/8.0/nanoserver-ltsc2022/amd64": 1145212794,
-    "src/sdk/8.0/windowsservercore-ltsc2019/amd64": 5472371517,
-    "src/sdk/8.0/windowsservercore-ltsc2022/amd64": 4923239401
+    "src/sdk/8.0/windowsservercore-ltsc2019/amd64": 4538129093,
+    "src/sdk/8.0/windowsservercore-ltsc2022/amd64": 3959037745
   }
 }


### PR DESCRIPTION
Windowsservercore removed the servicing layer from their images.