### PR TITLE
Enable image scanning for Ubuntu Chiseled

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -6,16 +6,21 @@
     set gid to uid
 }}FROM {{ARCH_VERSIONED}}/golang:1.18 as chisel
 
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
+    && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
+
 WORKDIR /opt/chisel
+
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
 
 FROM {{ARCH_VERSIONED}}/ubuntu:{{osVersionBase}} as builder
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN {{InsertTemplate("Dockerfile.linux.non-root-user-staged", [
         "staging-dir": "/rootfs",
@@ -27,27 +32,30 @@ RUN {{InsertTemplate("Dockerfile.linux.non-root-user-staged", [
         "create-home": "true"
     ])}}
 
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-RUN chisel cut --release "ubuntu-{{osVersionNumber}}" --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libc6_libs \
-        libgcc-s1_libs \
-        libssl3_libs \
-        libstdc++6_libs \
-        zlib1g_libs
+COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release "ubuntu-{{osVersionNumber}}" --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
 
 
 FROM scratch
 
 COPY --from=builder /rootfs /
 
-# Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown={{uid}}:{{gid}} /rootfs/home/{{username}} /home/{{username}}
-
 {{InsertTemplate("../Dockerfile.common-dotnet-envs", [
     "uid": uid
 ])}}
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/{{username}} /home/{{username}}
 
 USER $APP_UID

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -4,7 +4,12 @@
     set username to "app" ^
     set uid to 64198 ^
     set gid to uid
-}}FROM {{ARCH_VERSIONED}}/golang:1.18 as chisel
+}}FROM {{ARCH_VERSIONED}}/golang:1.20 as chisel
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
     && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
@@ -12,15 +17,9 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel 
 WORKDIR /opt/chisel
 
 RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
-
-FROM {{ARCH_VERSIONED}}/ubuntu:{{osVersionBase}} as builder
-
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        file
+    && go build ./cmd/chisel \
+    && cp /opt/chisel/chisel /usr/bin/ \
+    && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN {{InsertTemplate("Dockerfile.linux.non-root-user-staged", [
         "staging-dir": "/rootfs",
@@ -31,8 +30,6 @@ RUN {{InsertTemplate("Dockerfile.linux.non-root-user-staged", [
         "gid": gid,
         "create-home": "true"
     ])}}
-
-COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN mkdir -p /rootfs/var/lib/dpkg/ \
     && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
@@ -49,13 +46,13 @@ RUN mkdir -p /rootfs/var/lib/dpkg/ \
 
 FROM scratch
 
-COPY --from=builder /rootfs /
+COPY --from=chisel /rootfs /
 
 {{InsertTemplate("../Dockerfile.common-dotnet-envs", [
     "uid": uid
 ])}}
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/{{username}} /home/{{username}}
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/{{username}} /home/{{username}}
 
 USER $APP_UID

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,9 @@
-FROM amd64/golang:1.18 as chisel
+FROM amd64/golang:1.20 as chisel
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
     && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
@@ -6,15 +11,9 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel 
 WORKDIR /opt/chisel
 
 RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
-
-FROM amd64/ubuntu:jammy as builder
-
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        file
+    && go build ./cmd/chisel \
+    && cp /opt/chisel/chisel /usr/bin/ \
+    && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
         --gid=64198 \
@@ -29,8 +28,6 @@ RUN groupadd \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
-
-COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN mkdir -p /rootfs/var/lib/dpkg/ \
     && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
@@ -47,7 +44,7 @@ RUN mkdir -p /rootfs/var/lib/dpkg/ \
 
 FROM scratch
 
-COPY --from=builder /rootfs /
+COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
@@ -60,6 +57,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -1,15 +1,20 @@
 FROM amd64/golang:1.18 as chisel
 
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
+    && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
+
 WORKDIR /opt/chisel
+
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
 
 FROM amd64/ubuntu:jammy as builder
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN groupadd \
         --gid=64198 \
@@ -25,24 +30,24 @@ RUN groupadd \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libc6_libs \
-        libgcc-s1_libs \
-        libssl3_libs \
-        libstdc++6_libs \
-        zlib1g_libs
+COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release "ubuntu-22.04" --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
 
 
 FROM scratch
 
 COPY --from=builder /rootfs /
-
-# Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=64198:64198 /rootfs/home/app /home/app
 
 ENV \
     # UID of the non-root user 'app'
@@ -53,5 +58,8 @@ ENV \
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,9 @@
-FROM arm32v7/golang:1.18 as chisel
+FROM arm32v7/golang:1.20 as chisel
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
     && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
@@ -6,15 +11,9 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel 
 WORKDIR /opt/chisel
 
 RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
-
-FROM arm32v7/ubuntu:jammy as builder
-
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        file
+    && go build ./cmd/chisel \
+    && cp /opt/chisel/chisel /usr/bin/ \
+    && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
         --gid=64198 \
@@ -29,8 +28,6 @@ RUN groupadd \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
-
-COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN mkdir -p /rootfs/var/lib/dpkg/ \
     && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
@@ -47,7 +44,7 @@ RUN mkdir -p /rootfs/var/lib/dpkg/ \
 
 FROM scratch
 
-COPY --from=builder /rootfs /
+COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
@@ -60,6 +57,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,15 +1,20 @@
 FROM arm32v7/golang:1.18 as chisel
 
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
+    && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
+
 WORKDIR /opt/chisel
+
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
 
 FROM arm32v7/ubuntu:jammy as builder
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN groupadd \
         --gid=64198 \
@@ -25,24 +30,24 @@ RUN groupadd \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libc6_libs \
-        libgcc-s1_libs \
-        libssl3_libs \
-        libstdc++6_libs \
-        zlib1g_libs
+COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release "ubuntu-22.04" --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
 
 
 FROM scratch
 
 COPY --from=builder /rootfs /
-
-# Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=64198:64198 /rootfs/home/app /home/app
 
 ENV \
     # UID of the non-root user 'app'
@@ -53,5 +58,8 @@ ENV \
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,15 +1,20 @@
 FROM arm64v8/golang:1.18 as chisel
 
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
+    && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
+
 WORKDIR /opt/chisel
+
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
 
 FROM arm64v8/ubuntu:jammy as builder
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN groupadd \
         --gid=64198 \
@@ -25,24 +30,24 @@ RUN groupadd \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libc6_libs \
-        libgcc-s1_libs \
-        libssl3_libs \
-        libstdc++6_libs \
-        zlib1g_libs
+COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release "ubuntu-22.04" --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
 
 
 FROM scratch
 
 COPY --from=builder /rootfs /
-
-# Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=64198:64198 /rootfs/home/app /home/app
 
 ENV \
     # UID of the non-root user 'app'
@@ -53,5 +58,8 @@ ENV \
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,9 @@
-FROM arm64v8/golang:1.18 as chisel
+FROM arm64v8/golang:1.20 as chisel
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
     && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
@@ -6,15 +11,9 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel 
 WORKDIR /opt/chisel
 
 RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
-
-FROM arm64v8/ubuntu:jammy as builder
-
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        file
+    && go build ./cmd/chisel \
+    && cp /opt/chisel/chisel /usr/bin/ \
+    && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
         --gid=64198 \
@@ -29,8 +28,6 @@ RUN groupadd \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
-
-COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN mkdir -p /rootfs/var/lib/dpkg/ \
     && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
@@ -47,7 +44,7 @@ RUN mkdir -p /rootfs/var/lib/dpkg/ \
 
 FROM scratch
 
-COPY --from=builder /rootfs /
+COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
@@ -60,6 +57,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,9 @@
-FROM amd64/golang:1.18 as chisel
+FROM amd64/golang:1.20 as chisel
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
     && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
@@ -6,15 +11,9 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel 
 WORKDIR /opt/chisel
 
 RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
-
-FROM amd64/ubuntu:jammy as builder
-
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        file
+    && go build ./cmd/chisel \
+    && cp /opt/chisel/chisel /usr/bin/ \
+    && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
         --gid=64198 \
@@ -29,8 +28,6 @@ RUN groupadd \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
-
-COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN mkdir -p /rootfs/var/lib/dpkg/ \
     && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
@@ -47,7 +44,7 @@ RUN mkdir -p /rootfs/var/lib/dpkg/ \
 
 FROM scratch
 
-COPY --from=builder /rootfs /
+COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
@@ -60,6 +57,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
@@ -1,15 +1,20 @@
 FROM amd64/golang:1.18 as chisel
 
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
+    && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
+
 WORKDIR /opt/chisel
+
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
 
 FROM amd64/ubuntu:jammy as builder
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN groupadd \
         --gid=64198 \
@@ -25,24 +30,24 @@ RUN groupadd \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libc6_libs \
-        libgcc-s1_libs \
-        libssl3_libs \
-        libstdc++6_libs \
-        zlib1g_libs
+COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release "ubuntu-22.04" --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
 
 
 FROM scratch
 
 COPY --from=builder /rootfs /
-
-# Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=64198:64198 /rootfs/home/app /home/app
 
 ENV \
     # UID of the non-root user 'app'
@@ -53,5 +58,8 @@ ENV \
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,9 @@
-FROM arm32v7/golang:1.18 as chisel
+FROM arm32v7/golang:1.20 as chisel
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
     && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
@@ -6,15 +11,9 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel 
 WORKDIR /opt/chisel
 
 RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
-
-FROM arm32v7/ubuntu:jammy as builder
-
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        file
+    && go build ./cmd/chisel \
+    && cp /opt/chisel/chisel /usr/bin/ \
+    && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
         --gid=64198 \
@@ -29,8 +28,6 @@ RUN groupadd \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
-
-COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN mkdir -p /rootfs/var/lib/dpkg/ \
     && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
@@ -47,7 +44,7 @@ RUN mkdir -p /rootfs/var/lib/dpkg/ \
 
 FROM scratch
 
-COPY --from=builder /rootfs /
+COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
@@ -60,6 +57,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,15 +1,20 @@
 FROM arm32v7/golang:1.18 as chisel
 
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
+    && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
+
 WORKDIR /opt/chisel
+
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
 
 FROM arm32v7/ubuntu:jammy as builder
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN groupadd \
         --gid=64198 \
@@ -25,24 +30,24 @@ RUN groupadd \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libc6_libs \
-        libgcc-s1_libs \
-        libssl3_libs \
-        libstdc++6_libs \
-        zlib1g_libs
+COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release "ubuntu-22.04" --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
 
 
 FROM scratch
 
 COPY --from=builder /rootfs /
-
-# Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=64198:64198 /rootfs/home/app /home/app
 
 ENV \
     # UID of the non-root user 'app'
@@ -53,5 +58,8 @@ ENV \
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,15 +1,20 @@
 FROM arm64v8/golang:1.18 as chisel
 
-RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
+RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
+    && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
+
 WORKDIR /opt/chisel
+
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
 
 FROM arm64v8/ubuntu:jammy as builder
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN groupadd \
         --gid=64198 \
@@ -25,24 +30,24 @@ RUN groupadd \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
 
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-RUN chisel cut --release "ubuntu-22.04" --root /rootfs \
-        base-files_base \
-        base-files_release-info \
-        ca-certificates_data \
-        libc6_libs \
-        libgcc-s1_libs \
-        libssl3_libs \
-        libstdc++6_libs \
-        zlib1g_libs
+COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release "ubuntu-22.04" --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
 
 
 FROM scratch
 
 COPY --from=builder /rootfs /
-
-# Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=64198:64198 /rootfs/home/app /home/app
 
 ENV \
     # UID of the non-root user 'app'
@@ -53,5 +58,8 @@ ENV \
     DOTNET_RUNNING_IN_CONTAINER=true \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,9 @@
-FROM arm64v8/golang:1.18 as chisel
+FROM arm64v8/golang:1.20 as chisel
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        file
 
 RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel \
     && git clone --depth 1 -b main https://github.com/canonical/rocks-toolbox /opt/rocks-toolbox
@@ -6,15 +11,9 @@ RUN git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel 
 WORKDIR /opt/chisel
 
 RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
-
-FROM arm64v8/ubuntu:jammy as builder
-
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        file
+    && go build ./cmd/chisel \
+    && cp /opt/chisel/chisel /usr/bin/ \
+    && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
         --gid=64198 \
@@ -29,8 +28,6 @@ RUN groupadd \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
-
-COPY --from=chisel /opt/chisel/chisel /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN mkdir -p /rootfs/var/lib/dpkg/ \
     && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
@@ -47,7 +44,7 @@ RUN mkdir -p /rootfs/var/lib/dpkg/ \
 
 FROM scratch
 
-COPY --from=builder /rootfs /
+COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
@@ -60,6 +57,6 @@ ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=builder --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
 
 USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -121,8 +121,16 @@ namespace Microsoft.DotNet.Docker.Tests
             }
             else if (imageData.OS == OS.JammyChiseled)
             {
-                OutputHelper.WriteLine("Package scanning support not implemented for Chiseled Ubuntu images.");
-                expectedPackages = Array.Empty<string>();
+                expectedPackages = new[]
+                {
+                    "base-files",
+                    "ca-certificates",
+                    "libc6",
+                    "libgcc-s1",
+                    "libssl3",
+                    "libstdc++6",
+                    "zlib1g"
+                };
             }
             else
             {


### PR DESCRIPTION
Fixes #4667 

- Enable image scanning
- Enable image scanning test
- Tested against `syft` and `Trivy`:

```pwsh
PS> docker run --rm -v //var/run/docker.sock:/var/run/docker.sock anchore/syft chiseled
NAME             VERSION                   TYPE 
base-files       12ubuntu4.3               deb
ca-certificates  20230311ubuntu0.22.04.1   deb
libc6            2.35-0ubuntu3.1           deb
libgcc-s1        12.1.0-2ubuntu1~22.04     deb
libssl3          3.0.2-0ubuntu1.10         deb
libstdc++6       12.1.0-2ubuntu1~22.04     deb
zlib1g           1:1.2.11.dfsg-2ubuntu9.2  deb
```

It seems to have way fewer packages than CBL Mariner distroless.

Since we seem to be okay pulling directly from `main` in the `canonical/chisel` repo, I followed the same pattern for `rocks-toolbox`. If we want to take more precautions with this repo I would consider adding a `rocks-toolbox` sha/version/branch entry to `manifest.versions.json`.