### PR TITLE
Add SqlClient info to globalization doc

### DIFF
--- a/samples/enable-globalization.md
+++ b/samples/enable-globalization.md
@@ -23,7 +23,18 @@ In many scenarios, globalization support with ICU is required, for example, to c
 
 Images that do not include ICU enable [Globalization Invariant Mode](https://aka.ms/dotnet/globalization/invariant), which provides more basic globalization behaviors in absence of using ICU.
 
-Some users want to add ICU to one of the image types that doesn't include it. It is counter-productive to remove ICU from an image that already includes it.
+Some users want to add ICU to one of the image types that doesn't include it. It is counter-productive to remove ICU from an image that already includes it; it doesn't actually reduce the size of the image since it's stored in an earlier layer which cannot be changed.
+
+### Use of `Microsoft.Data.SqlClient` requires ICU to be installed
+
+When using `Microsoft.Data.SqlClient` or Entity Framework Core without ICU installed, the following exception may be thrown when attempting to connect to a database:
+
+```
+System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name')
+en-us is an invalid culture identifier.
+```
+
+This is by design. `Microsoft.Data.SqlClient` requires ICU to be installed. See https://github.com/dotnet/SqlClient/issues/220 for more information.
 
 ### Alpine images
 


### PR DESCRIPTION
Updates the globalization doc to make customers aware of the lack of invariant mode support from SqlClient (see https://github.com/dotnet/SqlClient/issues/220).