### PR TITLE
Update non-root UID to avoid warning in Debian

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -27,7 +27,7 @@
     set rpmFilename to "dotnet-runtime-deps.rpm" ^
     set utilPkgs to when(isMariner && nonRootUserSupported, ["shadow-utils"], []) ^
     set username to "app" ^
-    set uid to 64198 ^
+    set uid to 1654 ^
     set gid to uid ^
     set nonRootUserComment to "# Create a non-root user and group"
 }}FROM {{baseImageRepo}}:{{baseImageTag}}{{if isMultiStage: AS {{firstStageName}}}}{{if isRpmInstall && isInternal:

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -2,7 +2,7 @@
     set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
     set osVersionNumber to split(OS_ARCH_HYPHENATED, "-")[1] ^
     set username to "app" ^
-    set uid to 64198 ^
+    set uid to 1654 ^
     set gid to uid
 }}FROM {{ARCH_VERSIONED}}/golang:1.20 as chisel
 

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
@@ -8,7 +8,7 @@
         when(find(OS_VERSION, "1.0") >= 0,
             1000,
             101),
-        64198) ^
+        1654) ^
     set gid to uid ^
     set createUserHome to dotnetVersion != "6.0"
 }}# Installer image

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -16,14 +16,14 @@ RUN go generate internal/deb/version.go \
     && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/rootfs/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
@@ -48,7 +48,7 @@ COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
@@ -16,14 +16,14 @@ RUN go generate internal/deb/version.go \
     && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/rootfs/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
@@ -48,7 +48,7 @@ COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -16,14 +16,14 @@ RUN go generate internal/deb/version.go \
     && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/rootfs/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
@@ -48,7 +48,7 @@ COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_URLS=http://+:8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/alpine3.18/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM amd64/alpine:3.18
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/alpine3.18/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/arm32v7/Dockerfile
@@ -2,7 +2,7 @@ FROM arm32v7/alpine:3.18
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/alpine3.18/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ FROM arm64v8/alpine:3.18
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM amd64/debian:bookworm-slim
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -2,7 +2,7 @@ FROM arm32v7/debian:bookworm-slim
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ FROM arm64v8/debian:bookworm-slim
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile
@@ -31,15 +31,15 @@ RUN tmpManifestPath="/tmp/rpmmanifest" \
 
 # Create a non-root user and group
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         --create-home \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/staging/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
@@ -59,7 +59,7 @@ FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container
@@ -70,6 +70,6 @@ ENV \
 COPY --from=installer /staging/ /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=installer --chown=64198:64198 /staging/home/app /home/app
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
 
 USER app

--- a/src/runtime-deps/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile
@@ -31,15 +31,15 @@ RUN tmpManifestPath="/tmp/rpmmanifest" \
 
 # Create a non-root user and group
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         --create-home \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/staging/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
     && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
@@ -59,7 +59,7 @@ FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container
@@ -70,6 +70,6 @@ ENV \
 COPY --from=installer /staging/ /
 
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=installer --chown=64198:64198 /staging/home/app /home/app
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
 
 USER app

--- a/src/runtime-deps/8.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/cbl-mariner2.0/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS base
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS base
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
@@ -16,14 +16,14 @@ RUN go generate internal/deb/version.go \
     && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/rootfs/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
@@ -48,7 +48,7 @@ COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -16,14 +16,14 @@ RUN go generate internal/deb/version.go \
     && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/rootfs/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
@@ -48,7 +48,7 @@ COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -16,14 +16,14 @@ RUN go generate internal/deb/version.go \
     && cp /opt/rocks-toolbox/chisel-wrapper /usr/bin/
 
 RUN groupadd \
-        --gid=64198 \
+        --gid=1654 \
         app \
     && useradd -l \
-        --uid=64198 \
-        --gid=64198 \
+        --uid=1654 \
+        --gid=1654 \
         --shell /bin/false \
         app \
-    && install -d -m 0755 -o 64198 -g 64198 "/rootfs/home/app" \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
     && mkdir -p "/rootfs/etc" \
     && rootOrAppRegex='^\(root\|app\):' \
     && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
@@ -48,7 +48,7 @@ COPY --from=chisel /rootfs /
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/jammy/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu.azurecr.io/ubuntu:jammy
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/jammy/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy/arm32v7/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu.azurecr.io/ubuntu:jammy
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/src/runtime-deps/8.0/jammy/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu.azurecr.io/ubuntu:jammy
 
 ENV \
     # UID of the non-root user 'app'
-    APP_UID=64198 \
+    APP_UID=1654 \
     # Configure web servers to bind to port 8080 when present
     ASPNETCORE_HTTP_PORTS=8080 \
     # Enable detection of running in a container

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public string OS { get; set; }
         public bool IsDistroless => OS.Contains("distroless") || OS.Contains("chiseled");
         public virtual int DefaultPort => IsDistroless ? 8080 : 80;
-        public virtual int? NonRootUID => IsWindows ? null : 64198;
+        public virtual int? NonRootUID => IsWindows ? null : 1654;
 
         private static readonly Lazy<JObject> s_imageInfoData;
 

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -157,7 +157,10 @@ namespace Microsoft.DotNet.Docker.Tests
 
             int uid = int.Parse(uidString);
 
-            Assert.True(uid > 10000);
+            // UIDs below 1000 are reserved for system accounts
+            Assert.True(uid >= 1000);
+            // Debian has a UID_MAX of 60000
+            Assert.True(uid <= 60000);
         }
 
         private IEnumerable<string> GetInstalledRpmPackages(ProductImageData imageData)


### PR DESCRIPTION
Fixes #4693 

UID is `1654` according to https://github.com/dotnet/dotnet-docker/issues/4693#issuecomment-1612002902