### PR TITLE
Test .NET Monitor with samples regardless of mode and distrolessness

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.Docker.Tests
         /// <summary>
         /// Creates a file system volume that is backed by memory instead of disk.
         /// </summary>
-        public string CreateTmpfsVolume(string name, bool ownedByDistrolessUser = false)
+        public string CreateTmpfsVolume(string name, string ownerIdentifier = null)
         {
             // Create volume using the local driver (the default driver),
             // which accepts options similar to the 'mount' command.
@@ -278,9 +278,9 @@ namespace Microsoft.DotNet.Docker.Tests
             // - make this volume an in-memory file system with a unique device name (type=tmpfs, device={guid}}).
             // - to set the owner of the root of the file system (o=uid=101).
             string optionalArgs = string.Empty;
-            if (ownedByDistrolessUser)
+            if (!string.IsNullOrEmpty(ownerIdentifier))
             {
-                optionalArgs += " --opt o=uid=101";
+                optionalArgs += $" --opt o=uid={ownerIdentifier}";
             }
             string device = Guid.NewGuid().ToString("D");
             return ExecuteWithLogging($"volume create --opt type=tmpfs --opt device={device}{optionalArgs} {name}");

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.Docker.Tests
         /// <summary>
         /// Creates a file system volume that is backed by memory instead of disk.
         /// </summary>
-        public string CreateTmpfsVolume(string name, string ownerIdentifier = null)
+        public string CreateTmpfsVolume(string name, int? ownerUid = null)
         {
             // Create volume using the local driver (the default driver),
             // which accepts options similar to the 'mount' command.
@@ -278,9 +278,9 @@ namespace Microsoft.DotNet.Docker.Tests
             // - make this volume an in-memory file system with a unique device name (type=tmpfs, device={guid}}).
             // - to set the owner of the root of the file system (o=uid=101).
             string optionalArgs = string.Empty;
-            if (!string.IsNullOrEmpty(ownerIdentifier))
+            if (ownerUid.HasValue)
             {
-                optionalArgs += $" --opt o=uid={ownerIdentifier}";
+                optionalArgs += $" --opt o=uid={ownerUid.Value}";
             }
             string device = Guid.NewGuid().ToString("D");
             return ExecuteWithLogging($"volume create --opt type=tmpfs --opt device={device}{optionalArgs} {name}");

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
@@ -62,9 +62,9 @@ namespace Microsoft.DotNet.Docker.Tests
             return this;
         }
 
-        public DockerRunArgsBuilder AsUser(string userIdentifier)
+        public DockerRunArgsBuilder AsUser(int uid)
         {
-            _builder.AppendFormat(CultureInfo.InvariantCulture, "-u {0}", userIdentifier);
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "-u {0} ", uid);
             return this;
         }
     }

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerRunArgsBuilder.cs
@@ -61,5 +61,11 @@ namespace Microsoft.DotNet.Docker.Tests
             _builder.AppendFormat(CultureInfo.InvariantCulture, "-v {0}:{1} ", name, path);
             return this;
         }
+
+        public DockerRunArgsBuilder AsUser(string userIdentifier)
+        {
+            _builder.AppendFormat(CultureInfo.InvariantCulture, "-u {0}", userIdentifier);
+            return this;
+        }
     }
 }


### PR DESCRIPTION
The .NET Monitor tests were filtering .NET Monitor and sample image combinations based on the "distrolessness" of each image where only distroless was being tested with distroless and non-distroless tested with non-distroless. This doesn't cover the real possibility that customers are running their apps as a different user as compared to the .NET Monitor image; this is especially true of the .NET Monitor 8 images which are all distroless and exclusively use a non-root user.

I've removed this filter to allow all combinations and updated the volume creation to determine the least-privileged user of the two images to be used as the owner of the volumes and defer to the sample image user if there is a tie; this would be the guidance for our customers who have mixed user usage of containers in their deployments.