### PR TITLE
Use release tag to update rocks-toolbox

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.git-clone
+++ b/eng/dockerfile-templates/Dockerfile.git-clone
@@ -8,7 +8,6 @@
         dir: The directory to clone the repository into ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
-
     set ref to token(ARGS["ref"], ":", 1) ^
     set isTag to token(ARGS["ref"], ":", 0) = "tag"
 

--- a/eng/dockerfile-templates/Dockerfile.git-clone
+++ b/eng/dockerfile-templates/Dockerfile.git-clone
@@ -7,7 +7,6 @@
              Formatted as "<ref type>:<ref>"
         dir: The directory to clone the repository into ^
 
-    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set ref to token(ARGS["ref"], ":", 1) ^
     set isTag to token(ARGS["ref"], ":", 0) = "tag"
 

--- a/eng/dockerfile-templates/Dockerfile.git-clone
+++ b/eng/dockerfile-templates/Dockerfile.git-clone
@@ -4,8 +4,11 @@
     ARGS:
         url: The git repository URL
         ref: The commit hash, branch, or tag to checkout
-        dir: The directory to clone the repository into
+        dir: The directory to clone the repository into ^
 
-}}git clone --no-checkout {{ARGS["url"]}} {{ARGS["dir"]}} \
+    set is_tag to len(ARGS["ref"]) < 40
+
+}}{{if is_tag:git clone --branch {{ARGS["ref"]}} --depth 1 {{ARGS["url"]}} {{ARGS["dir"]}}^
+else:git clone --no-checkout {{ARGS["url"]}} {{ARGS["dir"]}} \
 && cd {{ARGS["dir"]}} \
-&& git checkout {{ARGS["ref"]}}
+&& git checkout {{ARGS["ref"]}}}}

--- a/eng/dockerfile-templates/Dockerfile.git-clone
+++ b/eng/dockerfile-templates/Dockerfile.git-clone
@@ -4,10 +4,15 @@
     ARGS:
         url: The git repository URL
         ref: The commit hash, branch, or tag to checkout
-        dir: The directory to clone the repository into
-        is-tag (optional): Whether to perform a shallow clone for a tag only
+             Formatted as "<ref type>:<ref>"
+        dir: The directory to clone the repository into ^
 
-}}{{if ARGS["is-tag"]:git clone --branch {{ARGS["ref"]}} --depth 1 {{ARGS["url"]}} {{ARGS["dir"]}}^
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+
+    set ref to token(ARGS["ref"], ":", 1) ^
+    set isTag to token(ARGS["ref"], ":", 0) = "tag"
+
+}}{{if isTag:git clone --branch {{ref}} --depth 1 {{ARGS["url"]}} {{ARGS["dir"]}}^
 else:git clone --no-checkout {{ARGS["url"]}} {{ARGS["dir"]}} \
 && cd {{ARGS["dir"]}} \
-&& git checkout {{ARGS["ref"]}}}}
+&& git checkout {{ref}}}}

--- a/eng/dockerfile-templates/Dockerfile.git-clone
+++ b/eng/dockerfile-templates/Dockerfile.git-clone
@@ -4,11 +4,10 @@
     ARGS:
         url: The git repository URL
         ref: The commit hash, branch, or tag to checkout
-        dir: The directory to clone the repository into ^
+        dir: The directory to clone the repository into
+        is-tag (optional): Whether to perform a shallow clone for a tag only
 
-    set is_tag to len(ARGS["ref"]) < 40
-
-}}{{if is_tag:git clone --branch {{ARGS["ref"]}} --depth 1 {{ARGS["url"]}} {{ARGS["dir"]}}^
+}}{{if ARGS["is-tag"]:git clone --branch {{ARGS["ref"]}} --depth 1 {{ARGS["url"]}} {{ARGS["dir"]}}^
 else:git clone --no-checkout {{ARGS["url"]}} {{ARGS["dir"]}} \
 && cd {{ARGS["dir"]}} \
 && git checkout {{ARGS["ref"]}}}}

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -5,15 +5,11 @@
 
     set chiselDir to "/opt/chisel" ^
     set chiselUrl to VARIABLES[cat("chisel|", dotnetVersion, "|url")] ^
-    set chiselRefVar to VARIABLES[cat("chisel|", dotnetVersion, "|ref")] ^
-    set chiselRef to token(chiselRefVar, ":", 1) ^
-    set chiselRefIsTag to token(chiselRefVar, ":", 0) = "tag" ^
+    set chiselRef to VARIABLES[cat("chisel|", dotnetVersion, "|ref")] ^
 
     set rocksToolboxDir to "/opt/rocks-toolbox" ^
     set rocksToolboxUrl to VARIABLES[cat("rocks-toolbox|", dotnetVersion, "|url")] ^
-    set rocksToolboxRefVar to VARIABLES[cat("rocks-toolbox|", dotnetVersion, "|ref")] ^
-    set rocksToolboxRef to token(rocksToolboxRefVar, ":", 1) ^
-    set rocksToolboxRefIsTag to token(rocksToolboxRefVar, ":", 0) = "tag" ^
+    set rocksToolboxRef to VARIABLES[cat("rocks-toolbox|", dotnetVersion, "|ref")] ^
 
     set username to "app" ^
     set uid to 1654 ^
@@ -28,15 +24,13 @@ RUN apt-get update \
 RUN {{InsertTemplate("../Dockerfile.git-clone", [
         "url": chiselUrl,
         "ref": chiselRef,
-        "dir": chiselDir,
-        "is-tag": chiselRefIsTag
+        "dir": chiselDir
     ], "    ")}} \
     \
     && {{InsertTemplate("../Dockerfile.git-clone", [
         "url": rocksToolboxUrl,
         "ref": rocksToolboxRef,
-        "dir": rocksToolboxDir,
-        "is-tag": rocksToolboxRefIsTag
+        "dir": rocksToolboxDir
     ], "    ")}}
 
 WORKDIR {{chiselDir}}

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -2,12 +2,19 @@
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
     set osVersionNumber to split(OS_ARCH_HYPHENATED, "-")[1] ^
+
     set chiselDir to "/opt/chisel" ^
     set chiselUrl to VARIABLES[cat("chisel|", dotnetVersion, "|url")] ^
-    set chiselRef to VARIABLES[cat("chisel|", dotnetVersion, "|ref")] ^
+    set chiselRefVar to VARIABLES[cat("chisel|", dotnetVersion, "|ref")] ^
+    set chiselRef to token(chiselRefVar, ":", 1) ^
+    set chiselRefIsTag to token(chiselRefVar, ":", 0) = "tag" ^
+
     set rocksToolboxDir to "/opt/rocks-toolbox" ^
     set rocksToolboxUrl to VARIABLES[cat("rocks-toolbox|", dotnetVersion, "|url")] ^
-    set rocksToolboxRef to VARIABLES[cat("rocks-toolbox|", dotnetVersion, "|ref")] ^
+    set rocksToolboxRefVar to VARIABLES[cat("rocks-toolbox|", dotnetVersion, "|ref")] ^
+    set rocksToolboxRef to token(rocksToolboxRefVar, ":", 1) ^
+    set rocksToolboxRefIsTag to token(rocksToolboxRefVar, ":", 0) = "tag" ^
+
     set username to "app" ^
     set uid to 1654 ^
     set gid to uid
@@ -21,13 +28,15 @@ RUN apt-get update \
 RUN {{InsertTemplate("../Dockerfile.git-clone", [
         "url": chiselUrl,
         "ref": chiselRef,
-        "dir": chiselDir
+        "dir": chiselDir,
+        "is-tag": chiselRefIsTag
     ], "    ")}} \
     \
     && {{InsertTemplate("../Dockerfile.git-clone", [
         "url": rocksToolboxUrl,
         "ref": rocksToolboxRef,
-        "dir": rocksToolboxDir
+        "dir": rocksToolboxDir,
+        "is-tag": rocksToolboxRefIsTag
     ], "    ")}}
 
 WORKDIR {{chiselDir}}

--- a/eng/update-dependencies/ChiselRefUpdater.cs
+++ b/eng/update-dependencies/ChiselRefUpdater.cs
@@ -7,5 +7,5 @@ namespace Dotnet.Docker;
 internal class ChiselRefUpdater : ChiselToolUpdater
 {
     public ChiselRefUpdater(string repoRoot, string dockerfileVersion, string newRef)
-        : base(repoRoot, $"chisel|{dockerfileVersion}|ref", dockerfileVersion, newRef) { }
+        : base(repoRoot, $"chisel|{dockerfileVersion}|ref", dockerfileVersion, false, newRef) { }
 }

--- a/eng/update-dependencies/ChiselToolUpdater.cs
+++ b/eng/update-dependencies/ChiselToolUpdater.cs
@@ -13,10 +13,11 @@ internal class ChiselToolUpdater : VariableUpdaterBase
     private readonly string _dockerfileVersion;
     private readonly string _newValue;
 
-    public ChiselToolUpdater(string repoRoot, string variableName, string dockerfileVersion, string newRef) : base(repoRoot, variableName)
+    public ChiselToolUpdater(string repoRoot, string variableName, string dockerfileVersion, bool isTag, string newRef) : base(repoRoot, variableName)
     {
         _dockerfileVersion = dockerfileVersion;
-        _newValue = newRef;
+        string prefix = isTag ? "tag" : "commit";
+        _newValue = $"{prefix}:{newRef}";
     }
 
     protected sealed override string TryGetDesiredValue(IEnumerable<IDependencyInfo> dependencyInfos, out IEnumerable<IDependencyInfo> usedDependencyInfos)

--- a/eng/update-dependencies/GitHubHelper.cs
+++ b/eng/update-dependencies/GitHubHelper.cs
@@ -23,6 +23,12 @@ public static class GitHubHelper
         s_httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Dotnet.Docker.UpdateDependencies", "1.0"));
     }
 
+    public static async Task<string> GetLatestReleaseTagAsync(string owner, string repo)
+    {
+        JObject releaseResponse = await GetLatestReleaseAsync(owner, repo);
+        return releaseResponse.GetRequiredToken<JValue>("tag_name").ToString();
+    }
+
     public static async Task<JObject> GetLatestReleaseAsync(string owner, string repo)
     {
         string request = $"/repos/{owner}/{repo}/releases/latest";

--- a/eng/update-dependencies/RocksToolboxRefUpdater.cs
+++ b/eng/update-dependencies/RocksToolboxRefUpdater.cs
@@ -7,5 +7,5 @@ namespace Dotnet.Docker;
 internal class RocksToolboxRefUpdater : ChiselToolUpdater
 {
     public RocksToolboxRefUpdater(string repoRoot, string dockerfileVersion, string newRef)
-        : base(repoRoot, $"rocks-toolbox|{dockerfileVersion}|ref", dockerfileVersion, newRef) { }
+        : base(repoRoot, $"rocks-toolbox|{dockerfileVersion}|ref", dockerfileVersion, true, newRef) { }
 }

--- a/eng/update-dependencies/UpdateDependencies.cs
+++ b/eng/update-dependencies/UpdateDependencies.cs
@@ -410,7 +410,7 @@ namespace Dotnet.Docker
 
             JObject minGitRelease = await GitHubHelper.GetLatestReleaseAsync("git-for-windows", "git");
             string chiselRef = await GitHubHelper.GetLatestCommitAsync("canonical", "chisel", "main");
-            string rocksToolboxRef = await GitHubHelper.GetLatestCommitAsync("canonical", "rocks-toolbox", "main");
+            string rocksToolboxRef = await GitHubHelper.GetLatestReleaseTagAsync("canonical", "rocks-toolbox");
 
             List<IDependencyUpdater> updaters = new()
             {

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -149,8 +149,8 @@
 
     "rocks-toolbox|6.0|url": "https://github.com/canonical/rocks-toolbox",
     "rocks-toolbox|8.0|url": "$(rocks-toolbox|6.0|url)",
-    "rocks-toolbox|6.0|ref": "e92d18b733647e77b6829968c91f8a16d25c1f2d",
-    "rocks-toolbox|8.0|ref": "fae9d8fa9de58459ade1ad8b67a75614eb2f659a",
+    "rocks-toolbox|6.0|ref": "commit:e92d18b733647e77b6829968c91f8a16d25c1f2d",
+    "rocks-toolbox|8.0|ref": "commit:fae9d8fa9de58459ade1ad8b67a75614eb2f659a",
 
     "runtime|6.0|build-version": "6.0.20",
     "runtime|6.0|targeting-pack-version": "$(runtime|6.0|build-version)",

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -65,8 +65,8 @@
 
     "chisel|6.0|url": "https://github.com/canonical/chisel",
     "chisel|8.0|url": "$(chisel|6.0|url)",
-    "chisel|6.0|ref": "00f796f17323422704241517aa0386ded5e0fba1",
-    "chisel|8.0|ref": "00f796f17323422704241517aa0386ded5e0fba1",
+    "chisel|6.0|ref": "commit:00f796f17323422704241517aa0386ded5e0fba1",
+    "chisel|8.0|ref": "commit:00f796f17323422704241517aa0386ded5e0fba1",
 
     "dotnet|6.0|product-version": "6.0.20",
     "dotnet|7.0|product-version": "7.0.9",


### PR DESCRIPTION
Fixes #4745 

The next time the update-dependencies tool runs, it should update the rocks-toolbox ref to a tag, and then change the way the tag is cloned in the Dockerfile.