### PR TITLE
Force upgrade of .NET runtime deps in alpine images

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-pkgs
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-pkgs
@@ -18,7 +18,7 @@
     }}
 }}{{
 if isDnf:dnf install -y{{ARGS["pkg-mgr-opts"]}} \^
-elif isApk:apk add --no-cache{{ARGS["pkg-mgr-opts"]}} \^
+elif isApk:apk add --upgrade --no-cache{{ARGS["pkg-mgr-opts"]}} \^
 elif isTdnf:tdnf install -y{{ARGS["pkg-mgr-opts"]}} \^
 else:apt-get update \
     &&{{if ARGS["noninteractive"]: DEBIAN_FRONTEND=noninteractive}} apt-get install -y --no-install-recommends{{ARGS["pkg-mgr-opts"]}} \}}{{

--- a/src/runtime-deps/6.0/alpine3.17/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.17/amd64/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/6.0/alpine3.17/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.17/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/6.0/alpine3.17/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.17/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/6.0/alpine3.18/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.18/amd64/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/6.0/alpine3.18/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.18/arm32v7/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/6.0/alpine3.18/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/alpine3.18/arm64v8/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/8.0/alpine3.18/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/amd64/Dockerfile
@@ -10,7 +10,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/8.0/alpine3.18/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/arm32v7/Dockerfile
@@ -10,7 +10,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/runtime-deps/8.0/alpine3.18/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/alpine3.18/arm64v8/Dockerfile
@@ -10,7 +10,7 @@ ENV \
     # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         ca-certificates \
         \
         # .NET dependencies

--- a/src/sdk/6.0/alpine3.17/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.17/amd64/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.17
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/6.0/alpine3.17/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.17/arm32v7/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.17-arm32
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/6.0/alpine3.17/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.17/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.17-arm64
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/6.0/alpine3.18/amd64/Dockerfile
+++ b/src/sdk/6.0/alpine3.18/amd64/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/6.0/alpine3.18/arm32v7/Dockerfile
+++ b/src/sdk/6.0/alpine3.18/arm32v7/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18-arm32
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/6.0/alpine3.18/arm64v8/Dockerfile
+++ b/src/sdk/6.0/alpine3.18/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18-arm64
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/7.0/alpine3.17/amd64/Dockerfile
+++ b/src/sdk/7.0/alpine3.17/amd64/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.17
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/7.0/alpine3.17/arm32v7/Dockerfile
+++ b/src/sdk/7.0/alpine3.17/arm32v7/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.17-arm32
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/7.0/alpine3.17/arm64v8/Dockerfile
+++ b/src/sdk/7.0/alpine3.17/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.17-arm64
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/7.0/alpine3.18/amd64/Dockerfile
+++ b/src/sdk/7.0/alpine3.18/amd64/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/7.0/alpine3.18/arm32v7/Dockerfile
+++ b/src/sdk/7.0/alpine3.18/arm32v7/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18-arm32
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/7.0/alpine3.18/arm64v8/Dockerfile
+++ b/src/sdk/7.0/alpine3.18/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18-arm64
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/8.0/alpine3.18/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.18/amd64/Dockerfile
@@ -17,7 +17,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/8.0/alpine3.18/arm32v7/Dockerfile
+++ b/src/sdk/8.0/alpine3.18/arm32v7/Dockerfile
@@ -17,7 +17,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18-arm32
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \

--- a/src/sdk/8.0/alpine3.18/arm64v8/Dockerfile
+++ b/src/sdk/8.0/alpine3.18/arm64v8/Dockerfile
@@ -17,7 +17,7 @@ ENV \
     # PowerShell telemetry for docker image usage
     POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.18-arm64
 
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         curl \
         icu-data-full \
         icu-libs \


### PR DESCRIPTION
fixes #4776 

At present (for runtime-deps\6.0\alpine3.18\amd64) this causes a size increase of 12.3 -> 17.4 MB because `libcrypto3` and `libssl3` are updated.