### PR TITLE
.NET Monitor 7.3 Ubuntu Chiseled images

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -52,8 +52,9 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.3.0-alpine-amd64, 7.3-alpine-amd64, 7-alpine-amd64, 7.3.0-alpine, 7.3-alpine, 7-alpine, 7.3.0, 7.3, 7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/alpine/amd64/Dockerfile) | Alpine 3.18
+7.3.0-ubuntu-chiseled-amd64, 7.3-ubuntu-chiseled-amd64, 7-ubuntu-chiseled-amd64, 7.3.0-ubuntu-chiseled, 7.3-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 7.2.1-alpine-amd64, 7.2-alpine-amd64, 7.2.1-alpine, 7.2-alpine, 7.2.1, 7.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.2/alpine/amd64/Dockerfile) | Alpine 3.18
-7.2.1-ubuntu-chiseled-amd64, 7.2-ubuntu-chiseled-amd64, 7-ubuntu-chiseled-amd64, 7.2.1-ubuntu-chiseled, 7.2-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.2/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+7.2.1-ubuntu-chiseled-amd64, 7.2-ubuntu-chiseled-amd64, 7.2.1-ubuntu-chiseled, 7.2-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.2/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 7.1.3-alpine-amd64, 7.1-alpine-amd64, 7.1.3-alpine, 7.1-alpine, 7.1.3, 7.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.1/alpine/amd64/Dockerfile) | Alpine 3.18
 7.1.3-ubuntu-chiseled-amd64, 7.1-ubuntu-chiseled-amd64, 7.1.3-ubuntu-chiseled, 7.1-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.3.2-alpine-amd64, 6.3-alpine-amd64, 6-alpine-amd64, 6.3.2-alpine, 6.3-alpine, 6-alpine, 6.3.2, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/amd64/Dockerfile) | Alpine 3.18
@@ -68,8 +69,9 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 7.3.0-alpine-arm64v8, 7.3-alpine-arm64v8, 7-alpine-arm64v8, 7.3.0-alpine, 7.3-alpine, 7-alpine, 7.3.0, 7.3, 7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/alpine/arm64v8/Dockerfile) | Alpine 3.18
+7.3.0-ubuntu-chiseled-arm64v8, 7.3-ubuntu-chiseled-arm64v8, 7-ubuntu-chiseled-arm64v8, 7.3.0-ubuntu-chiseled, 7.3-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 7.2.1-alpine-arm64v8, 7.2-alpine-arm64v8, 7.2.1-alpine, 7.2-alpine, 7.2.1, 7.2 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.2/alpine/arm64v8/Dockerfile) | Alpine 3.18
-7.2.1-ubuntu-chiseled-arm64v8, 7.2-ubuntu-chiseled-arm64v8, 7-ubuntu-chiseled-arm64v8, 7.2.1-ubuntu-chiseled, 7.2-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.2/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+7.2.1-ubuntu-chiseled-arm64v8, 7.2-ubuntu-chiseled-arm64v8, 7.2.1-ubuntu-chiseled, 7.2-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.2/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 7.1.3-alpine-arm64v8, 7.1-alpine-arm64v8, 7.1.3-alpine, 7.1-alpine, 7.1.3, 7.1 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.1/alpine/arm64v8/Dockerfile) | Alpine 3.18
 7.1.3-ubuntu-chiseled-arm64v8, 7.1-ubuntu-chiseled-arm64v8, 7.1.3-ubuntu-chiseled, 7.1-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.3.2-alpine-arm64v8, 6.3-alpine-arm64v8, 6-alpine-arm64v8, 6.3.2-alpine, 6.3-alpine, 6-alpine, 6.3.2, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/arm64v8/Dockerfile) | Alpine 3.18

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -5,6 +5,8 @@ $(McrTagsYmlTagGroup:8.0-preview-ubuntu-chiseled-arm64v8)
     customSubTableTitle: .NET Monitor 8 Preview Tags
 $(McrTagsYmlTagGroup:7.3-alpine-amd64)
 $(McrTagsYmlTagGroup:7.3-alpine-arm64v8)
+$(McrTagsYmlTagGroup:7.3-ubuntu-chiseled-amd64)
+$(McrTagsYmlTagGroup:7.3-ubuntu-chiseled-arm64v8)
 $(McrTagsYmlTagGroup:7.2-alpine-amd64)
 $(McrTagsYmlTagGroup:7.2-alpine-arm64v8)
 $(McrTagsYmlTagGroup:7.2-ubuntu-chiseled-amd64)

--- a/manifest.json
+++ b/manifest.json
@@ -6867,8 +6867,7 @@
           "productVersion": "$(monitor|7.2|product-version)",
           "sharedTags": {
             "$(monitor|7.2|product-version)-ubuntu-chiseled": {},
-            "7.2-ubuntu-chiseled": {},
-            "7-ubuntu-chiseled": {}
+            "7.2-ubuntu-chiseled": {}
           },
           "platforms": [
             {
@@ -6881,8 +6880,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|7.2|product-version)-ubuntu-chiseled-amd64": {},
-                "7.2-ubuntu-chiseled-amd64": {},
-                "7-ubuntu-chiseled-amd64": {}
+                "7.2-ubuntu-chiseled-amd64": {}
               }
             },
             {
@@ -6896,8 +6894,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|7.2|product-version)-ubuntu-chiseled-arm64v8": {},
-                "7.2-ubuntu-chiseled-arm64v8": {},
-                "7-ubuntu-chiseled-arm64v8": {}
+                "7.2-ubuntu-chiseled-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -7039,6 +7036,46 @@
                 "$(monitor|7.3|product-version)-alpine-arm64v8": {},
                 "7.3-alpine-arm64v8": {},
                 "7-alpine-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|7.3|product-version)",
+          "sharedTags": {
+            "$(monitor|7.3|product-version)-ubuntu-chiseled": {},
+            "7.3-ubuntu-chiseled": {},
+            "7-ubuntu-chiseled": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor/7.3/ubuntu-chiseled/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|7.3|product-version)-ubuntu-chiseled-amd64": {},
+                "7.3-ubuntu-chiseled-amd64": {},
+                "7-ubuntu-chiseled-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor/7.3/ubuntu-chiseled/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|7.3|product-version)-ubuntu-chiseled-arm64v8": {},
+                "7.3-ubuntu-chiseled-arm64v8": {},
+                "7-ubuntu-chiseled-arm64v8": {}
               },
               "variant": "v8"
             }

--- a/src/monitor/7.3/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/7.3/ubuntu-chiseled/amd64/Dockerfile
@@ -1,0 +1,45 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor
+RUN dotnet_monitor_version=7.3.0 \
+    && curl -fSL --output dotnet-monitor.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/7.3.0-rtm.23376.3/dotnet-monitor-$dotnet_monitor_version-linux-x64.tar.gz \
+    && dotnet_monitor_sha512='f157f5812e0200742adb32d70b10ed880bee69dd1e08104d7f498fb436e96ac44fee6be0b058f8d0774a0ccd7702463dd7ca9c14b79ab9b0280f56d13f97fec1' \
+    && echo "$dotnet_monitor_sha512  dotnet-monitor.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor.tar.gz -C /app \
+    && rm dotnet-monitor.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:7.0.9-jammy-chiseled-amd64
+
+COPY --from=installer ["/app", "/app"] 
+
+WORKDIR /app
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/7.3/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/7.3/ubuntu-chiseled/arm64v8/Dockerfile
@@ -1,0 +1,45 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor
+RUN dotnet_monitor_version=7.3.0 \
+    && curl -fSL --output dotnet-monitor.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/7.3.0-rtm.23376.3/dotnet-monitor-$dotnet_monitor_version-linux-arm64.tar.gz \
+    && dotnet_monitor_sha512='371bee3f206c8835c0a1ce48b8ccb559d512eff22b10c6ace49aa649b3ef8e13b262368c506d7d2c7ae341eeb70049ff01ed09f87db098911eeb4fbfecbf8164' \
+    && echo "$dotnet_monitor_sha512  dotnet-monitor.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor.tar.gz -C /app \
+    && rm dotnet-monitor.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:7.0.9-jammy-chiseled-arm64v8
+
+COPY --from=installer ["/app", "/app"] 
+
+WORKDIR /app
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -171,6 +171,8 @@ namespace Microsoft.DotNet.Docker.Tests
             new ProductImageData { Version = V7_2, VersionFamily = V7_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64 },
             new ProductImageData { Version = V7_3, VersionFamily = V7_0, OS = OS.Alpine318,           OSTag = OS.Alpine,            Arch = Arch.Amd64 },
             new ProductImageData { Version = V7_3, VersionFamily = V7_0, OS = OS.Alpine318,           OSTag = OS.Alpine,            Arch = Arch.Arm64 },
+            new ProductImageData { Version = V7_3, VersionFamily = V7_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Amd64 },
+            new ProductImageData { Version = V7_3, VersionFamily = V7_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Arm64 },
             new ProductImageData { Version = V7_3, VersionFamily = V7_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Amd64 },
             new ProductImageData { Version = V7_3, VersionFamily = V7_0, OS = OS.Mariner20,           OSTag = OS.Mariner,           Arch = Arch.Arm64 },
             new ProductImageData { Version = V7_3, VersionFamily = V7_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Amd64 },

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -268,6 +268,8 @@
     "src/monitor/7.2/cbl-mariner-distroless/arm64v8": 145441793,
     "src/monitor/7.3/alpine/amd64": 128250369,
     "src/monitor/7.3/alpine/arm64v8": 141137686,
+    "src/monitor/7.3/ubuntu-chiseled/amd64": 125167820,
+    "src/monitor/7.3/ubuntu-chiseled/arm64v8": 132889434,
     "src/monitor/7.3/cbl-mariner/amd64": 219210220,
     "src/monitor/7.3/cbl-mariner/arm64v8": 224001932,
     "src/monitor/7.3/cbl-mariner-distroless/amd64": 138412478,


### PR DESCRIPTION
Add the .NET Monitor 7.3 Ubuntu Chiseled images separately from the other 7.3 images to facilitate easier merge to main branch. These images should remain only in the nightly branch until Ubuntu Chiseled images are supported for .NET 7 based images.

Follow up from #4786

cc @dotnet/dotnet-monitor