### PR TITLE
Revert Image Builder update

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2233114
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2230260
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-bullseye-slim-docker-testrunner


### PR DESCRIPTION
There's some weird behavior in the build that's blocking the release. I suspect it's due to the Image Builder update.