### PR TITLE
[Do not merge][nightly] Reproduce BuildKit caching issues with new ImageBuilder version

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -13,10 +13,10 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
+  condition: and(${{ parameters.matrix }}, not(canceled()))
   dependsOn:
-  - PreBuildValidation
-  - CopyBaseImages
+  # - PreBuildValidation
+  # - CopyBaseImages
   - GenerateBuildMatrix
   pool: ${{ parameters.pool }}
   strategy:
@@ -172,7 +172,7 @@ jobs:
             -PackageVersion '$(Build.BuildNumber)' `
             -ManifestDirPath $sbomChildDir `
             -DockerImagesToScan $_ `
-            -Verbosity Information 
+            -Verbosity Information
         }
       displayName: Generate SBOMs
       condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -8,7 +8,7 @@ parameters:
   customTestInitSteps: []
   customPublishInitSteps: []
   customPublishVariables: []
-  
+
   linuxAmdBuildJobTimeout: 60
   linuxArmBuildJobTimeout: 60
   windowsAmdBuildJobTimeout: 60
@@ -46,31 +46,31 @@ stages:
 - stage: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  - template: ../jobs/test-images-linux-client.yml
-    parameters:
-      name: PreBuildValidation
-      pool: ${{ parameters.linuxAmd64Pool }}
-      testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
-      preBuildValidation: true
-      internalProjectName: ${{ parameters.internalProjectName }}
-      customInitSteps:
-        - ${{ parameters.customTestInitSteps }}
-        # These variables are normally set by the matrix. Since this test job is not generated
-        # by a matrix, we need to set them manually. They can be set to empty values since their
-        # values aren't actually used for the pre-build tests.
-        - powershell: |
-            echo "##vso[task.setvariable variable=productVersion]"
-            echo "##vso[task.setvariable variable=imageBuilderPaths]"
-            echo "##vso[task.setvariable variable=osVersions]"
-            echo "##vso[task.setvariable variable=architecture]"
-          displayName: Initialize Test Variables
-  - template: ../jobs/copy-base-images.yml
-    parameters:
-      name: CopyBaseImages
-      pool: ${{ parameters.linuxAmd64Pool }}
-      additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
-      publicProjectName: ${{ parameters.publicProjectName }}
-      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
+  # - template: ../jobs/test-images-linux-client.yml
+  #   parameters:
+  #     name: PreBuildValidation
+  #     pool: ${{ parameters.linuxAmd64Pool }}
+  #     testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
+  #     preBuildValidation: true
+  #     internalProjectName: ${{ parameters.internalProjectName }}
+  #     customInitSteps:
+  #       - ${{ parameters.customTestInitSteps }}
+  #       # These variables are normally set by the matrix. Since this test job is not generated
+  #       # by a matrix, we need to set them manually. They can be set to empty values since their
+  #       # values aren't actually used for the pre-build tests.
+  #       - powershell: |
+  #           echo "##vso[task.setvariable variable=productVersion]"
+  #           echo "##vso[task.setvariable variable=imageBuilderPaths]"
+  #           echo "##vso[task.setvariable variable=osVersions]"
+  #           echo "##vso[task.setvariable variable=architecture]"
+  #         displayName: Initialize Test Variables
+  # - template: ../jobs/copy-base-images.yml
+  #   parameters:
+  #     name: CopyBaseImages
+  #     pool: ${{ parameters.linuxAmd64Pool }}
+  #     additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
+  #     publicProjectName: ${{ parameters.publicProjectName }}
+  #     customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
   - template: ../jobs/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}

--- a/manifest.json
+++ b/manifest.json
@@ -851,7 +851,7 @@
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
-                "$(dotnet|8.0|product-version)-bookworm-slim-arm64v8": {},
+                "$(dotnet|8.0|product-version)-bookworm-slim-arm64v8-foo": {},
                 "8.0-bookworm-slim-arm64v8": {}
               },
               "variant": "v8"

--- a/src/runtime/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/runtime/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -14,7 +14,9 @@ RUN dotnet_version=8.0.0-rc.1.23381.3 \
 
 
 # .NET runtime image
-FROM $REPO:8.0.0-rc.1-bookworm-slim-arm64v8
+FROM $REPO:8.0.0-rc.1-bookworm-slim-arm64v8-foo
+
+RUN echo "Hello, your cache is invalid."
 
 # .NET Runtime version
 ENV DOTNET_VERSION=8.0.0-rc.1.23381.3


### PR DESCRIPTION
Trying to reproduce the same thing as in #4813, but this time after base images are updated to be arm64/ with no variant.