### PR TITLE
Update Azure Artifacts docker sample for Windows

### DIFF
--- a/documentation/scenarios/nuget-credentials.md
+++ b/documentation/scenarios/nuget-credentials.md
@@ -179,13 +179,13 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Change user to workaround https://github.com/microsoft/artifacts-credprovider/issues/201
-USER ContainerAdministrator
 # Install the cred provider
-RUN Invoke-WebRequest https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1 -OutFile installcredprovider.ps1; `
+# In order to install as ContainerUser an explicit temp directory must be created
+WORKDIR /temp
+ENV TMP=C:\temp
+RUN Invoke-WebRequest https://aka.ms/install-artifacts-credprovider.ps1 -OutFile installcredprovider.ps1; `
     .\installcredprovider.ps1; `
     del installcredprovider.ps1
-USER ContainerUser
 
 WORKDIR /app
 

--- a/documentation/scenarios/nuget-credentials.md
+++ b/documentation/scenarios/nuget-credentials.md
@@ -180,7 +180,7 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install the cred provider
-# In order to install as ContainerUser an explicit temp directory must be created
+# By default, Nano Server runs as ContainerUser. In order to install the cred provider as ContainerUser, an explicit temp directory must be created
 WORKDIR /temp
 ENV TMP=C:\temp
 RUN Invoke-WebRequest https://aka.ms/install-artifacts-credprovider.ps1 -OutFile installcredprovider.ps1; `


### PR DESCRIPTION
The Windows sample for Azure Artifacts either got stale or never worked as specified, as the credential provider install did so as the wrong user, preventing dotnet restore from succeeding.

Updating the sample to use an explicit temp directory as Windows Nano Server doesn't have a good location for unelevated temp files. This is done in the build layer so therefore doesn't end up in the final image that contains the published build.