### PR TITLE
Update .NET 7.0 SDK image sizes

### DIFF
--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -200,7 +200,7 @@
     "src/sdk/7.0/jammy/arm32v7": 769433765,
     "src/sdk/7.0/jammy/arm64v8": 835695289,
     "src/sdk/7.0/cbl-mariner2.0/amd64": 1078836148,
-    "src/sdk/7.0/cbl-mariner2.0/arm64v8": 1062704610,
+    "src/sdk/7.0/cbl-mariner2.0/arm64v8": 1140953546,
     "src/sdk/8.0/bookworm-slim/amd64": 823543661,
     "src/sdk/8.0/bookworm-slim/arm32v7": 776844580,
     "src/sdk/8.0/bookworm-slim/arm64v8": 880785194,

--- a/tests/performance/ImageSize.nightly.windows.json
+++ b/tests/performance/ImageSize.nightly.windows.json
@@ -33,7 +33,7 @@
     "src/sdk/6.0/windowsservercore-ltsc2019/amd64": 5248928501,
     "src/sdk/6.0/windowsservercore-ltsc2022/amd64": 4813068796,
     "src/sdk/7.0/nanoserver-1809/amd64": 1100784131,
-    "src/sdk/7.0/nanoserver-ltsc2022/amd64": 1114152303,
+    "src/sdk/7.0/nanoserver-ltsc2022/amd64": 1177815943,
     "src/sdk/7.0/windowsservercore-ltsc2019/amd64": 5402484736,
     "src/sdk/7.0/windowsservercore-ltsc2022/amd64": 4969131289,
     "src/sdk/8.0/nanoserver-1809/amd64": 1112868757,


### PR DESCRIPTION
There were a couple of .NET 7.0.400 SDK images left out from https://github.com/dotnet/dotnet-docker/pull/4831 that have now crossed the size increase threshold.