### PR TITLE
Remove unnecessary custom build leg groups that were causing errors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -925,18 +925,10 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-amd64"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-aot-amd64",
-                    "$(Repo:runtime-deps):8.0-alpine3.18-amd64"
+                    "$(Repo:sdk):8.0-alpine3.18-aot-amd64"
                   ]
                 }
               ]
@@ -955,18 +947,10 @@
               "variant": "v7",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-arm32v7"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-aot-arm64v8",
-                    "$(Repo:runtime-deps):8.0-alpine3.18-arm32v7"
+                    "$(Repo:sdk):8.0-alpine3.18-aot-arm64v8"
                   ]
                 }
               ]
@@ -985,18 +969,10 @@
               "variant": "v8",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-arm64v8"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-aot-arm64v8",
-                    "$(Repo:runtime-deps):8.0-alpine3.18-arm64v8"
+                    "$(Repo:sdk):8.0-alpine3.18-aot-arm64v8"
                   ]
                 }
               ]
@@ -1028,14 +1004,6 @@
                   "dependencies": [
                     "$(Repo:sdk):8.0-alpine3.18-amd64"
                   ]
-                },
-                {
-                  "name": "test-dependencies",
-                  "type": "Integral",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-amd64",
-                    "$(Repo:runtime-deps):8.0-alpine3.18-amd64"
-                  ]
                 }
               ]
             },
@@ -1058,14 +1026,6 @@
                   "dependencies": [
                     "$(Repo:sdk):8.0-alpine3.18-arm32v7"
                   ]
-                },
-                {
-                  "name": "test-dependencies",
-                  "type": "Integral",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-arm64v8",
-                    "$(Repo:runtime-deps):8.0-alpine3.18-arm64v8"
-                  ]
                 }
               ]
             },
@@ -1087,14 +1047,6 @@
                   "type": "Supplemental",
                   "dependencies": [
                     "$(Repo:sdk):8.0-alpine3.18-arm64v8"
-                  ]
-                },
-                {
-                  "name": "test-dependencies",
-                  "type": "Integral",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-alpine3.18-arm64v8",
-                    "$(Repo:runtime-deps):8.0-alpine3.18-arm32v7"
                   ]
                 }
               ]
@@ -1232,18 +1184,10 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-amd64"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-aot-amd64",
-                    "$(Repo:runtime-deps):8.0-jammy-chiseled-amd64"
+                    "$(Repo:sdk):8.0-jammy-aot-amd64"
                   ]
                 }
               ]
@@ -1261,18 +1205,10 @@
               "variant": "v8",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-arm64v8"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-aot-arm64v8",
-                    "$(Repo:runtime-deps):8.0-jammy-chiseled-arm64v8"
+                    "$(Repo:sdk):8.0-jammy-aot-arm64v8"
                   ]
                 }
               ]
@@ -1290,18 +1226,10 @@
               "variant": "v7",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-arm32v7"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-aot-arm64v8",
-                    "$(Repo:runtime-deps):8.0-jammy-chiseled-arm32v7"
+                    "$(Repo:sdk):8.0-jammy-aot-arm64v8"
                   ]
                 }
               ]
@@ -1326,18 +1254,10 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-amd64"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-amd64",
-                    "$(Repo:runtime-deps):8.0-jammy-chiseled-amd64"
+                    "$(Repo:sdk):8.0-jammy-amd64"
                   ]
                 }
               ]
@@ -1355,18 +1275,10 @@
               "variant": "v8",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-arm64v8"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-arm64v8",
-                    "$(Repo:runtime-deps):8.0-jammy-chiseled-arm64v8"
+                    "$(Repo:sdk):8.0-jammy-arm64v8"
                   ]
                 }
               ]
@@ -1384,18 +1296,10 @@
               "variant": "v7",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-arm32v7"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-jammy-arm64v8",
-                    "$(Repo:runtime-deps):8.0-jammy-chiseled-arm32v7"
+                    "$(Repo:sdk):8.0-jammy-arm64v8"
                   ]
                 }
               ]
@@ -1556,18 +1460,10 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-amd64"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-aot-amd64",
-                    "$(Repo:runtime-deps):8.0-cbl-mariner2.0-amd64"
+                    "$(Repo:sdk):8.0-cbl-mariner2.0-aot-amd64"
                   ]
                 }
               ]
@@ -1592,18 +1488,10 @@
               "variant": "v8",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-arm64v8"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-aot-arm64v8",
-                    "$(Repo:runtime-deps):8.0-cbl-mariner2.0-distroless-arm64v8"
+                    "$(Repo:sdk):8.0-cbl-mariner2.0-aot-arm64v8"
                   ]
                 }
               ]
@@ -1642,18 +1530,10 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-amd64"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-amd64",
-                    "$(Repo:runtime-deps):8.0-cbl-mariner2.0-distroless-amd64"
+                    "$(Repo:sdk):8.0-cbl-mariner2.0-amd64"
                   ]
                 }
               ]
@@ -1678,18 +1558,10 @@
               "variant": "v8",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
-                  "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-arm64v8"
-                  ]
-                },
-                {
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
-                    "$(Repo:sdk):8.0-cbl-mariner2.0-arm64v8",
-                    "$(Repo:runtime-deps):8.0-cbl-mariner2.0-distroless-arm64v8"
+                    "$(Repo:sdk):8.0-cbl-mariner2.0-arm64v8"
                   ]
                 }
               ]

--- a/manifest.json
+++ b/manifest.json
@@ -950,6 +950,7 @@
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
+                    "$(Repo:sdk):8.0-alpine3.18-arm32v7",
                     "$(Repo:sdk):8.0-alpine3.18-aot-arm64v8"
                   ]
                 }
@@ -1208,6 +1209,7 @@
                   "name": "test-dependencies",
                   "type": "Integral",
                   "dependencies": [
+                    "$(Repo:sdk):8.0-jammy-arm32v7",
                     "$(Repo:sdk):8.0-jammy-aot-arm64v8"
                   ]
                 }


### PR DESCRIPTION
This still fixes the root cause issue that prompted https://github.com/dotnet/dotnet-docker/pull/4856, but prevents the internal build (`PlatformDependencyGraph` matrix) from complaining that we have dependencies on multiple Dockerfile graphs.