### PR TITLE
Add missing build-base package from Alpine AOT SDK

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.aot
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.aot
@@ -14,6 +14,7 @@
 
     set pkgs to when(isAlpine,
         [
+            "build-base",
             "clang",
             "zlib-dev"
         ],

--- a/src/sdk/8.0/alpine3.18-aot/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.18-aot/amd64/Dockerfile
@@ -3,5 +3,6 @@ ARG REPO=mcr.microsoft.com/dotnet/sdk
 FROM $REPO:8.0.100-rc.1-alpine3.18-amd64
 
 RUN apk add --upgrade --no-cache \
+        build-base \
         clang \
         zlib-dev

--- a/src/sdk/8.0/alpine3.18-aot/arm64v8/Dockerfile
+++ b/src/sdk/8.0/alpine3.18-aot/arm64v8/Dockerfile
@@ -3,5 +3,6 @@ ARG REPO=mcr.microsoft.com/dotnet/sdk
 FROM $REPO:8.0.100-rc.1-alpine3.18-arm64v8
 
 RUN apk add --upgrade --no-cache \
+        build-base \
         clang \
         zlib-dev


### PR DESCRIPTION
I discovered this during testing and this should go in before RC1. I missed a library in Alpine that is specified in the AOT samples from https://github.com/dotnet/dotnet-docker/pull/4742.