### PR TITLE
Pin .NET Monitor base image versions

### DIFF
--- a/eng/dockerfile-templates/monitor-base/Dockerfile.linux
+++ b/eng/dockerfile-templates/monitor-base/Dockerfile.linux
@@ -5,7 +5,7 @@
     set monitorMajor to split(PRODUCT_VERSION, ".")[0] ^
     set isMariner to find(OS_VERSION, "mariner") >= 0 ^
     set aspnetBaseTag to
-        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
+        cat("$REPO:", VARIABLES[cat("dotnet-prev|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
     set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
     set installerImageTag to when(isMariner,
         cat("mcr.microsoft.com/cbl-mariner/base/core:", OS_VERSION_NUMBER),

--- a/eng/dockerfile-templates/monitor/Dockerfile.linux
+++ b/eng/dockerfile-templates/monitor/Dockerfile.linux
@@ -8,7 +8,7 @@
     set isDistroless to find(OS_VERSION, "distroless") >= 0 || find(OS_VERSION, "chiseled") >= 0 ^
     set isSingleStage to isAlpine ^
     set aspnetBaseTag to
-        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
+        cat("$REPO:", VARIABLES[cat("dotnet-prev|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
     set osVersionBase to when(isDistroless, match(OS_VERSION, ".+(?=.*-)")[0], OS_VERSION_BASE) ^
     set installerImageTag to when(isMariner,
         cat("mcr.microsoft.com/cbl-mariner/base/core:", OS_VERSION_NUMBER),

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -70,6 +70,10 @@
     "chisel|6.0|ref": "commit:121a047c83d6c028d3772a825206c8b22a7bca3e",
     "chisel|8.0|ref": "commit:121a047c83d6c028d3772a825206c8b22a7bca3e",
 
+    "dotnet-prev|6.0|product-version": "6.0.21",
+    "dotnet-prev|7.0|product-version": "7.0.10",
+    "dotnet-prev|8.0|product-version": "8.0.0-preview.7",
+
     "dotnet|6.0|product-version": "6.0.21",
     "dotnet|7.0|product-version": "7.0.10",
     "dotnet|8.0|product-version": "8.0.0-preview.7",


### PR DESCRIPTION
Pin the base image versions of the .NET Monitor images to allow easier separate update of the .NET Monitor images