### PR TITLE
Fix alpine custom build leg groups to match other extra/aot images

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1000,8 +1000,8 @@
               },
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
+                  "name": "test-dependencies",
+                  "type": "Integral",
                   "dependencies": [
                     "$(Repo:sdk):8.0-alpine3.18-amd64"
                   ]
@@ -1022,8 +1022,8 @@
               "variant": "v7",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
+                  "name": "test-dependencies",
+                  "type": "Integral",
                   "dependencies": [
                     "$(Repo:sdk):8.0-alpine3.18-arm32v7"
                   ]
@@ -1044,8 +1044,8 @@
               "variant": "v8",
               "customBuildLegGroups": [
                 {
-                  "name": "pr-build",
-                  "type": "Supplemental",
+                  "name": "test-dependencies",
+                  "type": "Integral",
                   "dependencies": [
                     "$(Repo:sdk):8.0-alpine3.18-arm64v8"
                   ]


### PR DESCRIPTION
These were left out of https://github.com/dotnet/dotnet-docker/pull/4857 by error.