### PR TITLE
Update aspnetapp samples port

### DIFF
--- a/samples/aspnetapp/README.md
+++ b/samples/aspnetapp/README.md
@@ -9,7 +9,7 @@ This sample demonstrates how to build container images for ASP.NET Core web apps
 You can start by launching a sample from our [container registry](https://mcr.microsoft.com/) and access it in your web browser at `http://localhost:8000`.
 
 ```console
-docker run --rm -it -p 8000:8080 mcr.microsoft.com/dotnet/samples:aspnetapp
+docker run --rm -it -p 8000:8080 -e ASPNETCORE_HTTP_PORTS=8080 mcr.microsoft.com/dotnet/samples:aspnetapp
 ```
 
 You can also call an endpoint that the app exposes:
@@ -39,7 +39,7 @@ Supported with .NET Core 1.0+
 ASPNETCORE_URLS=http://+:80 
 ```
 
-Note: `ASPNETCORE_URLS` overwrites `ASPNETCORE_HTTP_PORTS`` if set.
+Note: `ASPNETCORE_URLS` overwrites `ASPNETCORE_HTTP_PORTS` if set.
 
 These environment variables are used in [.NET 8](https://github.com/dotnet/dotnet-docker/blob/6da64f31944bb16ecde5495b6a53fc170fbe100d/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile#L7C5-L7C31) and [.NET 6](https://github.com/dotnet/dotnet-docker/blob/6da64f31944bb16ecde5495b6a53fc170fbe100d/src/runtime-deps/6.0/bookworm-slim/amd64/Dockerfile#L5) Dockerfiles, respectively.
 
@@ -49,13 +49,13 @@ You can built an image using one of the provided Dockerfiles.
 
 ```console
 docker build --pull -t aspnetapp .
-docker run --rm -it -p 8000:8080 aspnetapp
+docker run --rm -it -p 8000:8080 -e ASPNETCORE_HTTP_PORTS=8080 aspnetapp
 ```
 
 You should see the following console output as the application starts:
 
 ```console
-> docker run --rm -it -p 8000:8080 aspnetapp
+> docker run --rm -it -p 8000:8080 -e ASPNETCORE_HTTP_PORTS=8080 aspnetapp
 info: Microsoft.Hosting.Lifetime[14]
       Now listening on: http://[::]:8080
 info: Microsoft.Hosting.Lifetime[0]

--- a/samples/releasesapi/README.md
+++ b/samples/releasesapi/README.md
@@ -12,7 +12,7 @@ You can build and run the sample:
 
 ```bash
 docker build --pull -t app .
-docker run --rm -it -p 8000:8080 app
+docker run --rm -it -p 8000:8080 -e ASPNETCORE_HTTP_PORTS=8080 app
 ```
 
 It exposes two endpoints:


### PR DESCRIPTION
Fixes a formatting issue with the markdown for `ASPNETCORE_HTTP_PORTS`.

Also explicitly sets `ASPNETCORE_HTTP_PORTS` when calling `docker run`. I feel it's a best practice to be explicit about what port the container runs with rather than assuming. Had users done this prior to .NET 8 with `ASPNETCORE_URLS`, they wouldn't be broken by the port change from 80 to 8080.