### PR TITLE
Specify platform for tests to pull the correct images on arm32

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageScenarioVerifier.cs
@@ -249,6 +249,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     tag: tag,
                     target: stageTarget,
                     contextDir: contextDir,
+                    platform: _imageData.Platform,
                     buildArgs: buildArgs.ToArray());
             }
             finally
@@ -330,6 +331,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 name: containerName,
                 command: $"dotnet new {String.Join(' ', args)}",
                 workdir: ProjectContainerDir,
+                optionalRunArgs: $"--platform {_imageData.Platform}",
                 skipAutoCleanup: true);
 
             _dockerHelper.Copy($"{containerName}:{ProjectContainerDir}", destinationPath);


### PR DESCRIPTION
Port of https://github.com/dotnet/dotnet-docker/pull/4948/commits/f5b05e4a44dab896846f5cf1594d037bf9768dce to main according to https://github.com/dotnet/dotnet-docker/issues/4950#issuecomment-1771504201.

Fixes https://github.com/dotnet/dotnet-docker/issues/4950