### PR TITLE
Update update-dependencies Dockerfile to .NET 8.0

### DIFF
--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -1,24 +1,21 @@
 # build image
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build-env
-
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
+ARG TARGETARCH
 WORKDIR /update-dependencies
-
-# Need to publish with version-specific RID. See https://github.com/libgit2/libgit2sharp/issues/1798
-ARG RID=alpine.3.14-x64
 
 # copy csproj and restore as distinct layers
 COPY eng/update-dependencies/*.csproj ./
 COPY NuGet.config ./
-RUN dotnet restore -r $RID
+RUN dotnet restore -r linux-musl-$TARGETARCH
 
 # copy everything else and build
 COPY eng/update-dependencies/. ./
 
-RUN dotnet publish -c Release -o out --no-restore
+RUN dotnet publish -r linux-musl-$TARGETARCH -c Release -o out --no-restore
 
 
 # runtime image
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine
 
 # install Docker
 RUN apk add --no-cache \


### PR DESCRIPTION
Context: this failing pipeline run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2298697&view=results [internal link]

I forgot to include this in https://github.com/dotnet/dotnet-docker/pull/4952.