### PR TITLE
Add documentation for image variants

### DIFF
--- a/.mar/portal/README.aspnet.portal.md
+++ b/.mar/portal/README.aspnet.portal.md
@@ -62,6 +62,50 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
+### Tag Formatting
+
+#### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+#### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+#### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+### Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
+#### `composite`
+
+Compared to the default ASP.NET images, ASP.NET Composite images provide a smaller image size on disk as well as performance improvements for framework-dependent ASP.NET apps by performing some cross-assembly optimizations and between the .NET and ASP.NET runtimes.
+However, this means that apps run on the ASP.NET Composite runtime cannot use handpicked custom versions of .NET or ASP.NET assemblies that are built into the image.
+
+Example tags:
+
+- `8.0.0-jammy-chiseled-composite`
+- `8.0-alpine3.18-composite` 
+
 ## Support
 
 ### Lifecycle

--- a/.mar/portal/README.monitor-base.portal.md
+++ b/.mar/portal/README.monitor-base.portal.md
@@ -45,6 +45,40 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 * [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
 * [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)
 
+### Tag Formatting
+
+#### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+#### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+#### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+### Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 ## Support
 
 ### Lifecycle

--- a/.mar/portal/README.monitor.portal.md
+++ b/.mar/portal/README.monitor.portal.md
@@ -49,6 +49,40 @@ You can run a container with a pre-built [.NET Docker Image](https://mcr.microso
 
 See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
 
+### Tag Formatting
+
+#### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+#### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+#### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+### Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 ## Support
 
 ### Lifecycle

--- a/.mar/portal/README.runtime-deps.portal.md
+++ b/.mar/portal/README.runtime-deps.portal.md
@@ -42,6 +42,63 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 * [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian-x64-slim) builds and runs an application as a self-contained application.
 
+### Tag Formatting
+
+#### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+#### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+#### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+### Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
+#### `extra`
+
+The `extra` image variant is offered alongside our size-focused base images for self-contained or single file apps that depend on globalization functionality.
+Extra images contain everything that the default images do, plus `icu` and `tzdata`.
+
+Example tags:
+- `8.0-jammy-chiseled-extra`
+- `8.0.0-alpine3.18-extra`
+
+#### (Preview) `aot`
+
+`aot` images provide an optimized deployment size for [native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) compiled .NET apps.
+Native AOT has the lowest size, startup time, and memory footprint of all .NET deployment models.
+Please see ["Limiatations of Native AOT deployment"](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot#limitations-of-native-aot-deployment) to see if your app might be compatible.
+
+Example tags:
+- `8.0-jammy-chiseled-aot`
+- `8.0.0-alpine3.18-aot`
+
+**Note:** `aot` images are only available as a preview in the [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about) and [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about) repos.
+Native AOT compiled apps will function exactly the same on the existing `runtime-deps` (non-`aot`) images, but with a larger deployment size.
+Please try these new, smaller images out and give us feedback!
+
 ## Support
 
 ### Lifecycle

--- a/.mar/portal/README.runtime.portal.md
+++ b/.mar/portal/README.runtime.portal.md
@@ -50,6 +50,40 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/samples
 ```
 
+### Tag Formatting
+
+#### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+#### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+#### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+### Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 ## Support
 
 ### Lifecycle

--- a/.mar/portal/README.samples.portal.md
+++ b/.mar/portal/README.samples.portal.md
@@ -63,6 +63,40 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
+### Tag Formatting
+
+#### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+#### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+#### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+### Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 ## Support
 
 These sample images are not intended for production use and may be subject to breaking changes or removal at any time. They are provided as a starting point for developers to experiment with and learn about .NET in a containerized environment.

--- a/.mar/portal/README.sdk.portal.md
+++ b/.mar/portal/README.sdk.portal.md
@@ -52,6 +52,54 @@ The following samples show how to develop, build and test .NET applications with
 * [Test .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-tests-in-sdk-container.md)
 * [Run .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-in-sdk-container.md)
 
+### Tag Formatting
+
+#### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+#### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+#### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+### Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
+#### (Preview) `aot`
+
+`aot` images provide an optimized deployment size for [native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) compiled .NET apps.
+Native AOT has the lowest size, startup time, and memory footprint of all .NET deployment models.
+Please see ["Limiatations of Native AOT deployment"](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot#limitations-of-native-aot-deployment) to see if your app might be compatible.
+
+Example tags:
+- `8.0.100-jammy-aot`
+- `8.0-alpine3.18-aot`
+
+**Note:** `aot` images are only available as a preview in the [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about) and [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about) repos.
+Native AOT compiled apps will function exactly the same on the existing `runtime-deps` (non-`aot`) images, but with a larger deployment size.
+Please try these new, smaller images out and give us feedback!
+
 ## Support
 
 ### Lifecycle

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -46,6 +46,50 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
+### `composite`
+
+Compared to the default ASP.NET images, ASP.NET Composite images provide a smaller image size on disk as well as performance improvements for framework-dependent ASP.NET apps by performing some cross-assembly optimizations and between the .NET and ASP.NET runtimes.
+However, this means that apps run on the ASP.NET Composite runtime cannot use handpicked custom versions of .NET or ASP.NET assemblies that are built into the image.
+
+Example tags:
+
+- `8.0.0-jammy-chiseled-composite`
+- `8.0-alpine3.18-composite` 
+
 # Related Repositories
 
 .NET:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 # Related Repositories
 
 .NET:

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -29,6 +29,40 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 * [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
 * [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 # Related Repositories
 
 .NET:

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -32,6 +32,40 @@ You can run a container with a pre-built [.NET Docker Image](https://hub.docker.
 
 See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 # Related Repositories
 
 .NET:

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -26,6 +26,63 @@ The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samp
 
 * [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian-x64-slim) builds and runs an application as a self-contained application.
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
+### `extra`
+
+The `extra` image variant is offered alongside our size-focused base images for self-contained or single file apps that depend on globalization functionality.
+Extra images contain everything that the default images do, plus `icu` and `tzdata`.
+
+Example tags:
+- `8.0-jammy-chiseled-extra`
+- `8.0.0-alpine3.18-extra`
+
+### (Preview) `aot`
+
+`aot` images provide an optimized deployment size for [native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) compiled .NET apps.
+Native AOT has the lowest size, startup time, and memory footprint of all .NET deployment models.
+Please see ["Limiatations of Native AOT deployment"](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot#limitations-of-native-aot-deployment) to see if your app might be compatible.
+
+Example tags:
+- `8.0-jammy-chiseled-aot`
+- `8.0.0-alpine3.18-aot`
+
+**Note:** `aot` images are only available as a preview in the [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/) and [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/) repos.
+Native AOT compiled apps will function exactly the same on the existing `runtime-deps` (non-`aot`) images, but with a larger deployment size.
+Please try these new, smaller images out and give us feedback!
+
 # Related Repositories
 
 .NET:

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -34,6 +34,40 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/samples
 ```
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 # Related Repositories
 
 .NET:

--- a/README.samples.md
+++ b/README.samples.md
@@ -48,6 +48,40 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](https://github.com/dotnet/dotnet-docker/blob/main/samples/host-aspnetcore-https.md) to use HTTPS with this image.
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
 # Related Repositories
 
 .NET:

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -36,6 +36,54 @@ The following samples show how to develop, build and test .NET applications with
 * [Test .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-tests-in-sdk-container.md)
 * [Run .NET Applications with SDK Container](https://github.com/dotnet/dotnet-docker/blob/main/samples/run-in-sdk-container.md)
 
+## Tag Formatting
+
+### .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+### Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+### Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+## Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.
+
+### (Preview) `aot`
+
+`aot` images provide an optimized deployment size for [native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) compiled .NET apps.
+Native AOT has the lowest size, startup time, and memory footprint of all .NET deployment models.
+Please see ["Limiatations of Native AOT deployment"](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot#limitations-of-native-aot-deployment) to see if your app might be compatible.
+
+Example tags:
+- `8.0.100-jammy-aot`
+- `8.0-alpine3.18-aot`
+
+**Note:** `aot` images are only available as a preview in the [dotnet/nightly/sdk](https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/) and [dotnet/nightly/runtime-deps](https://hub.docker.com/_/microsoft-dotnet-nightly-runtime-deps/) repos.
+Native AOT compiled apps will function exactly the same on the existing `runtime-deps` (non-`aot`) images, but with a larger deployment size.
+Please try these new, smaller images out and give us feedback!
+
 # Related Repositories
 
 .NET:

--- a/eng/readme-templates/About.variants.md
+++ b/eng/readme-templates/About.variants.md
@@ -1,0 +1,75 @@
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme ^
+    set repo to when(IS_PRODUCT_FAMILY,
+        "product-family",
+        when(PARENT_REPO = "monitor", cat("monitor-", SHORT_REPO), SHORT_REPO))
+}}{{ARGS["top-header"]}}# Tag Formatting
+
+{{ARGS["top-header"]}}## .NET Versions
+
+All .NET container images have both "fixed version" and "floating version" tags.
+Floating version tags will always reference the latest version of a specific .NET major version, while fixed version tags will always only reference a specific patch version.
+For all tags below, `<.NET Version>` can be substituted for either `<Major.Minor>` or `<Major.Minor.Patch>`, for example: `7.0` or `7.0.12`.
+
+{{ARGS["top-header"]}}## Single-platform tags
+
+These "fixed version" tags reference an image with a specific .NET version for a specific operating system and architecture.
+
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+- `<.NET Version>-<OS>-<Architecture>`
+- `<.NET Version>-<OS>-<variant>-<Architecture>`
+
+{{ARGS["top-header"]}}## Multi-platform tags
+
+These tags reference images for [multiple platforms](https://docs.docker.com/build/building/multi-platform/).
+
+- `<.NET Version>`
+    - The version-only floating tag refers to the latest Debian version available at the .NET Major Version's release.
+- `<.NET Version>-<OS>`
+- `<.NET Version>-<OS>-<variant>`
+
+{{ARGS["top-header"]}}# Image Variants
+
+By default, Ubuntu and Debian images for .NET 8 will have both `icu` and `tzdata` installed.
+
+Our Alpine and Ubuntu Chiseled images are focused on size.
+These images do not and will not include `icu` or `tzdata`, meaning that these images only work iwth apps that are configured for [globalization-invariant mode](https://learn.microsoft.com/dotnet/core/runtime-config/globalization).
+Apps that require globalization support can use the `extra` image variant.{{if repo = "runtime-deps":
+
+{{ARGS["top-header"]}}## `extra`
+
+The `extra` image variant is offered alongside our size-focused base images for self-contained or single file apps that depend on globalization functionality.
+Extra images contain everything that the default images do, plus `icu` and `tzdata`.
+
+Example tags:
+- `8.0-jammy-chiseled-extra`
+- `8.0.0-alpine3.18-extra`}}{{if repo = "aspnet":
+
+{{ARGS["top-header"]}}## `composite`
+
+Compared to the default ASP.NET images, ASP.NET Composite images provide a smaller image size on disk as well as performance improvements for framework-dependent ASP.NET apps by performing some cross-assembly optimizations and between the .NET and ASP.NET runtimes.
+However, this means that apps run on the ASP.NET Composite runtime cannot use handpicked custom versions of .NET or ASP.NET assemblies that are built into the image.
+
+Example tags:
+
+- `8.0.0-jammy-chiseled-composite`
+- `8.0-alpine3.18-composite` }}{{if or(repo = "runtime-deps", repo = "sdk"):
+
+{{ARGS["top-header"]}}## (Preview) `aot`
+
+`aot` images provide an optimized deployment size for [native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) compiled .NET apps.
+Native AOT has the lowest size, startup time, and memory footprint of all .NET deployment models.
+Please see ["Limiatations of Native AOT deployment"](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot#limitations-of-native-aot-deployment) to see if your app might be compatible.
+
+Example tags:{{if repo = "runtime-deps":
+- `8.0-jammy-chiseled-aot`
+- `8.0.0-alpine3.18-aot`^else:
+- `8.0.100-jammy-aot`
+- `8.0-alpine3.18-aot`}}
+
+**Note:** `aot` images are only available as a preview in the [dotnet/nightly/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/sdk" ])}}) and [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly/runtime-deps" ])}}) repos.
+Native AOT compiled apps will function exactly the same on the existing `runtime-deps` (non-`aot`) images, but with a larger deployment size.
+Please try these new, smaller images out and give us feedback!}}

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -8,4 +8,6 @@
 
 {{InsertTemplate("Use.md", commonArgs)}}
 
+{{InsertTemplate("About.variants.md", commonArgs)}}
+
 {{InsertTemplate("Support.md", commonArgs)}}

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -27,6 +27,8 @@ if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 
 {{InsertTemplate("Use.md", commonArgs)}}
 
+{{InsertTemplate("About.variants.md", commonArgs)}}
+
 {{InsertTemplate("RelatedRepos.md", commonArgs)}}
 {{if !IS_PRODUCT_FAMILY:
 # Full Tag Listing


### PR DESCRIPTION
TODO:
- Display all variants on main README.
- Clean up "Image Variants" section wording for repos with no variants (runtime, monitor?)