### PR TITLE
Enable .NET Monitor updates from dotnetstage storage account

### DIFF
--- a/eng/Get-DropVersions.ps1
+++ b/eng/Get-DropVersions.ps1
@@ -208,6 +208,7 @@ foreach ($sdkVersionInfo in $SdkVersionInfos) {
         RuntimeVersion = $runtimeVersion
         AspnetVersion = $aspnetVersion
         StableBranding = $sdkVersionInfo.IsStableVersion
+        ComputeShas = $true
     }
 }
 

--- a/eng/Get-MonitorDropVersions.ps1
+++ b/eng/Get-MonitorDropVersions.ps1
@@ -20,6 +20,13 @@ $majorMinorVersion="$($versionSplit[0]).$($versionSplit[1])"
 
 $stableBranding = & $PSScriptRoot/Get-IsStableBranding.ps1 -Version $monitorVersion
 
-Write-Output "##vso[task.setvariable variable=monitorMajorMinorVersion]$majorMinorVersion"
-Write-Output "##vso[task.setvariable variable=monitorVer]$monitorVersion"
-Write-Output "##vso[task.setvariable variable=stableBranding]$stableBranding"
+$versionInfos = @(
+    @{
+        DockerfileVersion = $majorMinorVersion
+        MonitorVersion = $monitorVersion
+        StableBranding = $stableBranding
+        ComputeShas = $false
+    }
+)
+
+Write-Output "##vso[task.setvariable variable=versionInfos]$($versionInfos | ConvertTo-Json -Compress -AsArray)"

--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -1,12 +1,84 @@
 parameters:
-  # The customArgsArray parameter is used to specify the configuration for multiple Dockerfile versions.
+  # The versionInfosArray parameter is used to specify the configuration for multiple Dockerfile versions.
   # This allows for a single PR to be generated for different internal .NET build versions.
   # This is required in order to publish a single set of internal images when the PR is merged.
-  customArgsArray: ""
+  versionInfosArray: ""
 
   useInternalBuild: false
 
 steps:
+- powershell: |
+    $versionInfos = '${{ parameters.versionInfosArray }}' | ConvertFrom-Json
+
+    $index=0
+    foreach ($versionInfo in $versionInfos) {
+      $args = @{
+        ProductVersion = $versionInfo.DockerfileVersion
+        ComputeShas = $versionInfo.ComputeShas
+        AzdoVariableName = "updateDepsArgs-$index"
+        UseStableBranding = $versionInfo.StableBranding
+      }
+
+      if ($versionInfo.RuntimeVersion) {
+        $args += @{
+          RuntimeVersion = $versionInfo.RuntimeVersion
+        }
+      }
+
+      if ($versionInfo.AspnetVersion) {
+        $args += @{
+          AspnetVersion = $versionInfo.AspnetVersion
+        }
+      }
+
+      if ($versionInfo.SdkVersion) {
+        $args += @{
+          SdkVersion = $versionInfo.SdkVersion
+        }
+      }
+
+      if ($versionInfo.MonitorVersion) {
+        $args += @{
+          MonitorVersion = $versionInfo.MonitorVersion
+        }
+      }
+
+      if ("${{ parameters.useInternalBuild }}" -eq "true") {
+        if ($versionInfo.MonitorVersion) {
+          # .NET Monitor checksums are staged in the same account as the binaries
+          $args["ChecksumSasQueryString"] = '"$(dotnetstage-account-sas-read-token)"'
+        } else {
+          $args["ChecksumSasQueryString"] = '"$(dotnetchecksumsstage-account-sas-read-token)"'
+        }
+        $args["BinarySasQueryString"] = '"$(dotnetstage-account-sas-read-token)"'
+      }
+
+      Write-Host "Executing Set-DotnetVersions.ps1 for $($versionInfo.DockerfileVersion)"
+      $(engPath)/Set-DotnetVersions.ps1 @args
+      $index++
+    }
+  displayName: Get update-dependencies args
+- powershell: |
+    $branchPrefix = ""
+    if ("${{ parameters.useInternalBuild }}" -eq "true") {
+      $branchPrefix = "internal/release/"
+    }
+    $targetBranch = $branchPrefix + $(& $(engPath)/Get-Branch.ps1)
+
+    $customArgsArray = @()
+    $index=0
+
+    # Grab the variables that were set by the multiple calls to Set-DotnetVersions.ps1 and
+    # add them to an array. This allows us to pass args for multiple Dockerfile versions.
+    while ([Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index") -ne $null) {
+      $updateDepsArgs = [Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index")
+      $updateDepsArgs = "$updateDepsArgs --org dnceng --project $(System.TeamProject) --repo $(Build.Repository.Name) --target-branch $targetBranch"
+      $customArgsArray += $updateDepsArgs
+      $index++
+    }
+    
+    echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
+  displayName: Set Custom Args
 - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
   displayName: Build Update Dependencies Tool
 - script: docker run --name update-dependencies -d -t --entrypoint /bin/sh -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
@@ -23,7 +95,7 @@ steps:
     # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions
     # Ensure that the value is treated as an array by wrapping it in an array literal. This deals with the quirk of
     # how PowerShell treats a single item as a string instead of an array.
-    $customArgsArray = @('${{ parameters.customArgsArray }}' | ConvertFrom-Json)
+    $customArgsArray = @('$(customArgsArray)' | ConvertFrom-Json)
     foreach ($customArgs in $customArgsArray) {
       # If this is the last iteration, include the credentials to cause a PR to be generated
       if ($customArgs -eq $customArgsArray[-1]) {

--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -25,53 +25,7 @@ steps:
 
     $(engPath)/Get-DropVersions.ps1 @args
   displayName: Get Versions
-- powershell: |
-    $versionInfos = '$(versionInfos)' | ConvertFrom-Json
-
-    $index=0
-    foreach ($versionInfo in $versionInfos) {
-      $args = @{
-        ProductVersion = $versionInfo.DockerfileVersion
-        RuntimeVersion = $versionInfo.RuntimeVersion
-        AspnetVersion = $versionInfo.AspnetVersion
-        SdkVersion = $versionInfo.SdkVersion
-        ComputeShas = $true
-        AzdoVariableName = "updateDepsArgs-$index"
-        UseStableBranding = $versionInfo.StableBranding
-      }
-
-      if ("${{ parameters.useInternalBuild }}" -eq "true") {
-        $args["ChecksumSasQueryString"] = '"$(dotnetchecksumsstage-account-sas-read-token)"'
-        $args["BinarySasQueryString"] = '"$(dotnetstage-account-sas-read-token)"'
-      }
-
-      Write-Host "Executing Set-DotnetVersions.ps1 for $($versionInfo.DockerfileVersion)"
-      $(engPath)/Set-DotnetVersions.ps1 @args
-      $index++
-    }
-  displayName: Get update-dependencies args
-- powershell: |
-    $branchPrefix = ""
-    if ("${{ parameters.useInternalBuild }}" -eq "true") {
-      $branchPrefix = "internal/release/"
-    }
-    $targetBranch = $branchPrefix + $(& $(engPath)/Get-Branch.ps1)
-
-    $customArgsArray = @()
-    $index=0
-
-    # Grab the variables that were set by the multiple calls to Set-DotnetVersions.ps1 and
-    # add them to an array. This allows us to pass args for multiple Dockerfile versions.
-    while ([Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index") -ne $null) {
-      $updateDepsArgs = [Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index")
-      $updateDepsArgs = "$updateDepsArgs --org dnceng --project $(System.TeamProject) --repo $(Build.Repository.Name) --target-branch $targetBranch"
-      $customArgsArray += $updateDepsArgs
-      $index++
-    }
-    
-    echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
-  displayName: Set Custom Args
 - template: update-dependencies.yml
   parameters:
-    customArgsArray: "$(customArgsArray)"
+    versionInfosArray: "$(versionInfos)"
     useInternalBuild: ${{ parameters.useInternalBuild }}

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -13,8 +13,12 @@ resources:
       - real signed
 trigger: none
 pr: none
+
 variables:
 - template: ../common/templates/variables/dotnet/common.yml
+- group: DncEng-Partners-Tokens
+- group: DotNet-AllOrgs-Darc-Pats
+
 stages:
 - stage: Monitor
   jobs:
@@ -26,22 +30,17 @@ stages:
     - download: dotnet-monitor
       artifact: Build_Info
       displayName: "Download Build Info (Branch: $(resources.pipeline.dotnet-monitor.sourceBranch))"
+
     - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -BuildVersionFilePath "$(Pipeline.Workspace)/dotnet-monitor/Build_Info/dotnet-monitor.nupkg.buildversion"
       displayName: Get Versions
-    - powershell: |
-        $scriptArgs = @{
-          ProductVersion = "$(monitorMajorMinorVersion)"
-          MonitorVersion = "$(monitorVer)"
-          AzdoVariableName = 'updateDepsArgs'
-          UseStableBranding = [bool]::Parse("$(stableBranding)")
-        }
 
-        $(engPath)/Set-DotnetVersions.ps1 @scriptArgs
-      displayName: Get update-dependencies args
     - powershell: |
-        $customArgsArray = @("$(updateDepsArgs)")
-        echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
-      displayName: Set Custom Args
+        $isInternalBuild = '$(resources.pipeline.dotnet-monitor.sourceBranch)'.StartsWith('refs/heads/internal/release/')
+        echo "Is Internal Build: $isInternalBuild"
+        echo "##vso[task.setvariable variable=IsInternalBuild]$($isInternalBuild.ToString().ToLowerInvariant())"
+      displayName: Determine Build Type
+
     - template: steps/update-dependencies.yml
       parameters:
-        customArgsArray: $(customArgsArray)
+        versionInfosArray: "$(versionInfos)"
+        useInternalBuild: $(IsInternalBuild)

--- a/eng/update-dependencies/BaseUrlUpdater.cs
+++ b/eng/update-dependencies/BaseUrlUpdater.cs
@@ -42,14 +42,21 @@ internal class BaseUrlUpdater : FileRegexUpdater
 
         if (_options.IsInternal)
         {
-            if (!_options.ProductVersions.TryGetValue("sdk", out string? sdkVersion) || string.IsNullOrEmpty(sdkVersion))
+            if (_options.ProductVersions.ContainsKey("monitor"))
             {
-                throw new InvalidOperationException("The sdk version must be set in order to derive the build's blob storage location.");
+                unresolvedBaseUrl = "https://dotnetstage.blob.core.windows.net/dotnet-monitor";
             }
+            else
+            {
+                if (!_options.ProductVersions.TryGetValue("sdk", out string? sdkVersion) || string.IsNullOrEmpty(sdkVersion))
+                {
+                    throw new InvalidOperationException("The sdk version must be set in order to derive the build's blob storage location.");
+                }
 
-            sdkVersion = sdkVersion.Replace(".", "-");
+                sdkVersion = sdkVersion.Replace(".", "-");
 
-            unresolvedBaseUrl = $"https://dotnetstage.blob.core.windows.net/{sdkVersion}-internal";
+                unresolvedBaseUrl = $"https://dotnetstage.blob.core.windows.net/{sdkVersion}-internal";
+            }
         }
         else
         {

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
 
 using System;
 using System.Collections.Generic;
@@ -64,11 +65,38 @@ namespace Dotnet.Docker
             {
                 { "powershell", new string[] { "https://pwshtool.blob.core.windows.net/tool/$VERSION_DIR/PowerShell.$OS.$ARCH.$VERSION_FILE.nupkg" } },
 
-                { "monitor", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
-                { "monitor-base", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-base-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
-                { "monitor-ext-azureblobstorage", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-egress-azureblobstorage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
-                { "monitor-ext-s3storage", new string[] { $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-egress-s3storage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT" } },
-
+                {
+                    "monitor",
+                    new string[]
+                    {
+                        $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT",
+                        $"$DOTNET_BASE_URL/$VERSION_DIR/BlobAssets/dotnet-monitor-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"
+                    }
+                },
+                {
+                    "monitor-base",
+                    new string[]
+                    {
+                        $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-base-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT",
+                        $"$DOTNET_BASE_URL/$VERSION_DIR/BlobAssets/dotnet-monitor-base-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"
+                    }
+                },
+                {
+                    "monitor-ext-azureblobstorage",
+                    new string[]
+                    {
+                        $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-egress-azureblobstorage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT",
+                        $"$DOTNET_BASE_URL/$VERSION_DIR/BlobAssets/dotnet-monitor-egress-azureblobstorage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"
+                    }
+                },
+                {
+                    "monitor-ext-s3storage",
+                    new string[]
+                    {
+                        $"$DOTNET_BASE_URL/diagnostics/monitor/$VERSION_DIR/dotnet-monitor-egress-s3storage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT",
+                        $"$DOTNET_BASE_URL/$VERSION_DIR/BlobAssets/dotnet-monitor-egress-s3storage-$VERSION_FILE-$OS-$ARCH.$ARCHIVE_EXT"
+                    }
+                },
                 { "runtime", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-runtime-$VERSION_FILE$OPTIONAL_OS-{GetRuntimeSdkArchFormat()}.$ARCHIVE_EXT" } },
                 { "runtime-host", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-host-$VERSION_FILE-{GetRpmArchFormat()}.$ARCHIVE_EXT" } },
                 { "runtime-hostfxr", new string[] { $"$DOTNET_BASE_URL/Runtime/$VERSION_DIR/dotnet-hostfxr-$VERSION_FILE-{GetRpmArchFormat()}.$ARCHIVE_EXT" } },
@@ -326,14 +354,9 @@ namespace Dotnet.Docker
             return sha;
         }
 
-        private static bool IsInternalUrl(string url)
+        private string ApplySasQueryStringIfNecessary(string url, string sasQueryString)
         {
-            return url.Contains("internal");
-        }
-
-        private static string ApplySasQueryStringIfNecessary(string url, string sasQueryString)
-        {
-            if (IsInternalUrl(url))
+            if (_options.IsInternal)
             {
                 return url + sasQueryString;
             }
@@ -350,6 +373,7 @@ namespace Dotnet.Docker
                 .Replace("/dotnetcli", "/dotnetclichecksums")
                 .Replace("/internal/", "/internal-checksums/")
                 .Replace("/public/", "/public-checksums/")
+                .Replace("/BlobAssets/", "/ChecksumAssets/")
                 .Replace("azureedge.net", "blob.core.windows.net")
                 + shaExt;
 


### PR DESCRIPTION
These changes allow generating an dependency update PR into the internal project based on an internal build of .NET Monitor.

Overview of changes:
- Move all common update-dependencies pipeline logic into the `eng/pipelines/steps/update-dependencies.yml` pipeline step template. This allows sharing of the aggregation and internal vs public logic between the SDK products and .NET Monitor.
- Update the `Get-*DropVersion.ps1` scripts to conform to the merged pipeline logic for updating dependencies.
- Update the `update-dependencies` tool to handle internal builds of .NET Monitor that have been staged to the dotnetstage storage account. The .NET Monitor binaries and checksums are staged into a different container with a different layout compared to the SDK files.

Example .NET Monitor layout:
- `https://dotnetstage.blob.core.windows.net/dotnet-monitor/<build_version>/BlobAssets/dotnet-monitor-base-8.0.0-linux-x64.tar.gz`
- `https://dotnetstage.blob.core.windows.net/dotnet-monitor/<build_version>/ChecksumAssets/dotnet-monitor-base-8.0.0-linux-x64.tar.gz.sha512`

cc @dotnet/dotnet-monitor 