### PR TITLE
Use alpine RID to workaround libgit2sharp load issue

### DIFF
--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -1,17 +1,22 @@
 # build image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
 ARG TARGETARCH
+# The rid must be version-specific to workaround a libgit2sharp issue (see https://github.com/dotnet/dotnet-docker/pull/2111)
+ARG RID=alpine.3.18-$TARGETARCH
 WORKDIR /update-dependencies
 
 # copy csproj and restore as distinct layers
 COPY eng/update-dependencies/*.csproj ./
 COPY NuGet.config ./
-RUN dotnet restore -r linux-musl-$TARGETARCH
+
+# Set UseRidGraph=true to enable non-portable RIDs: https://aka.ms/netsdk1083
+RUN dotnet restore -r $RID /p:UseRidGraph=true
 
 # copy everything else and build
 COPY eng/update-dependencies/. ./
 
-RUN dotnet publish -r linux-musl-$TARGETARCH -c Release -o out --no-restore
+# Set UseRidGraph=true to enable non-portable RIDs: https://aka.ms/netsdk1083
+RUN dotnet publish -r $RID /p:UseRidGraph=true -c Release -o out --no-restore
 
 
 # runtime image


### PR DESCRIPTION
This works around an issue where the libgit2 library cannot be located when used by the update-dependencies tool. This prevents the successful creation of dependency update PRs that target the internal branches.

This workaround was previously used to avoid this issue but was regressed as part of #4959. This fix restores the functionality used prior to the regression, but accounts for slight differences in using the `$TARGETARCH` variable and project upgrade to .NET 8 (which impacted the RID graph availability for non-portable RIDs).