### PR TITLE
Pass full SDK version from Get-DropVersions to UpdateDependencies tool

### DIFF
--- a/eng/Get-DropVersions.ps1
+++ b/eng/Get-DropVersions.ps1
@@ -84,7 +84,7 @@ function GetSdkVersionInfo([string]$sdkUrl) {
 
         return [PSCustomObject]@{
             CommitSha = $commitSha
-            Version = $shortVersion
+            Version = $fullVersion
             IsStableVersion = $isStableVersion
             Rid = $rid
         }


### PR DESCRIPTION
This was a regression in https://github.com/dotnet/dotnet-docker/pull/4941, instead of what I did there we should actually pass the full SDK version and let update-dependencies decide whether or not we should trim that based on the stable version argument. This is needed to unblock internal dependency flow.