### PR TITLE
Allow using local checksums table file for looking up checksums

### DIFF
--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -49,7 +49,11 @@ param(
 
     # SAS query string used to access files in the checksum blob container
     [string]
-    $ChecksumSasQueryString
+    $ChecksumSasQueryString,
+
+    # File containing checksums for each product asset; used to override the behavior of locating the checksums from blob storage accounts.
+    [string]
+    $ChecksumsFile
 )
 
 $updateDepsArgs = @($ProductVersion)
@@ -87,6 +91,10 @@ if ($BinarySasQueryString) {
 
 if ($ChecksumSasQueryString) {
     $updateDepsArgs += "--checksum-sas=$ChecksumSasQueryString"
+}
+
+if ($ChecksumsFile) {
+    $updateDepsArgs += "--checksums-file=$ChecksumsFile"
 }
 
 if ($UseStableBranding) {

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
 
 using System.Collections.Generic;
 using System.CommandLine;
@@ -29,9 +30,10 @@ namespace Dotnet.Docker
         public bool UseStableBranding { get; }
         public bool UpdateOnly => Email == null || Password == null || User == null || TargetBranch == null;
         public bool IsInternal => !string.IsNullOrEmpty(BinarySasQueryString) || !string.IsNullOrEmpty(ChecksumSasQueryString);
+        public string ChecksumsFile { get; }
 
         public Options(string dockerfileVersion, string[] productVersion, string versionSourceName, string email, string password, string user,
-            bool computeShas, bool stableBranding, string binarySas, string checksumSas, string sourceBranch, string targetBranch, string org, string project, string repo)
+            bool computeShas, bool stableBranding, string binarySas, string checksumSas, string sourceBranch, string targetBranch, string org, string project, string repo, string checksumsFile)
         {
             DockerfileVersion = dockerfileVersion;
             ProductVersions = productVersion
@@ -42,6 +44,7 @@ namespace Dotnet.Docker
             Password = password;
             User = user;
             ComputeChecksums = computeShas;
+            ChecksumsFile = checksumsFile;
             UseStableBranding = stableBranding;
             BinarySasQueryString = binarySas;
             ChecksumSasQueryString = checksumSas;
@@ -83,6 +86,7 @@ namespace Dotnet.Docker
                 new Option<string>("--org", "Name of the AzDO organization"),
                 new Option<string>("--project", "Name of the AzDO project"),
                 new Option<string>("--repo", "Name of the AzDO repo"),
+                new Option<string>("--checksums-file", "File containing a list of checksums for each product asset")
             };
     }
 }


### PR DESCRIPTION
These changes allow using a locally available checksums table file instead of requiring the checksums to be publicly available on a blob storage account. I refactored the existing code to maintain the caching and validation behavior but allow for supplying a separate source of checksum information (in this case, the local file system).