### PR TITLE
.NET Monitor 8.1

### DIFF
--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -62,7 +62,7 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-preview-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
@@ -72,7 +72,7 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-preview-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor/base at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/base/tags/list.
 <!--End of generated tags-->

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -57,12 +57,22 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-ubuntu-chiseled-amd64, 8.0-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8-ubuntu-chiseled, 8.0.0, 8.0, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+8.0.0-ubuntu-chiseled-amd64, 8.0-ubuntu-chiseled-amd64, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.0, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+
+##### .NET Monitor Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-ubuntu-chiseled-arm64v8, 8.0-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8-ubuntu-chiseled, 8.0.0, 8.0, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+8.0.0-ubuntu-chiseled-arm64v8, 8.0-ubuntu-chiseled-arm64v8, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.0, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+
+##### .NET Monitor Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor/base at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/base/tags/list.
 <!--End of generated tags-->

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -69,7 +69,7 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-preview-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
@@ -83,7 +83,7 @@ Tags | Dockerfile | OS Version
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-preview-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -60,20 +60,30 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-ubuntu-chiseled-amd64, 8.0-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8-ubuntu-chiseled, 8.0.0, 8.0, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+8.0.0-ubuntu-chiseled-amd64, 8.0-ubuntu-chiseled-amd64, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.0, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 7.3.2-alpine-amd64, 7.3-alpine-amd64, 7-alpine-amd64, 7.3.2-alpine, 7.3-alpine, 7-alpine, 7.3.2, 7.3, 7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/alpine/amd64/Dockerfile) | Alpine 3.18
 7.3.2-ubuntu-chiseled-amd64, 7.3-ubuntu-chiseled-amd64, 7-ubuntu-chiseled-amd64, 7.3.2-ubuntu-chiseled, 7.3-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.3.4-alpine-amd64, 6.3-alpine-amd64, 6-alpine-amd64, 6.3.4-alpine, 6.3-alpine, 6-alpine, 6.3.4, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/amd64/Dockerfile) | Alpine 3.18
 6.3.4-ubuntu-chiseled-amd64, 6.3-ubuntu-chiseled-amd64, 6-ubuntu-chiseled-amd64, 6.3.4-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 
+##### .NET Monitor Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-ubuntu-chiseled-arm64v8, 8.0-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8-ubuntu-chiseled, 8.0.0, 8.0, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+8.0.0-ubuntu-chiseled-arm64v8, 8.0-ubuntu-chiseled-arm64v8, 8.0.0-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.0, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 7.3.2-alpine-arm64v8, 7.3-alpine-arm64v8, 7-alpine-arm64v8, 7.3.2-alpine, 7.3-alpine, 7-alpine, 7.3.2, 7.3, 7 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/alpine/arm64v8/Dockerfile) | Alpine 3.18
 7.3.2-ubuntu-chiseled-arm64v8, 7.3-ubuntu-chiseled-arm64v8, 7-ubuntu-chiseled-arm64v8, 7.3.2-ubuntu-chiseled, 7.3-ubuntu-chiseled, 7-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/7.3/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.3.4-alpine-arm64v8, 6.3-alpine-arm64v8, 6-alpine-arm64v8, 6.3.4-alpine, 6.3-alpine, 6-alpine, 6.3.4, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/arm64v8/Dockerfile) | Alpine 3.18
 6.3.4-ubuntu-chiseled-arm64v8, 6.3-ubuntu-chiseled-arm64v8, 6-ubuntu-chiseled-arm64v8, 6.3.4-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+
+##### .NET Monitor Preview Tags
+Tags | Dockerfile | OS Version
+-----------| -------------| -------------
+8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1, 8, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/dockerfile-templates/monitor/Dockerfile.linux.extensions
+++ b/eng/dockerfile-templates/monitor/Dockerfile.linux.extensions
@@ -1,14 +1,12 @@
 {{
-    _ .NET major version matches the major version of dotnet-monitor ^
-    set dotnetMajor to split(PRODUCT_VERSION, ".")[0] ^
-    set dotnetMajorMinor to cat(dotnetMajor, ".0") ^
     set monitorMajor to split(PRODUCT_VERSION, ".")[0] ^
+    set monitorMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isMariner to find(OS_VERSION, "mariner") >= 0 ^
     set monitorBaseTagOs to when(isMariner,
         "cbl-mariner-distroless",
         "ubuntu-chiseled") ^
     set monitorBaseTag to
-        cat("$REPO:", VARIABLES[cat("monitor|", dotnetMajorMinor, "|product-version")], "-", monitorBaseTagOs, ARCH_TAG_SUFFIX) ^
+        cat("$REPO:", VARIABLES[cat("monitor|", monitorMajorMinor, "|product-version")], "-", monitorBaseTagOs, ARCH_TAG_SUFFIX) ^
     set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
     set installerImageTag to when(isMariner,
         cat("mcr.microsoft.com/cbl-mariner/base/core:", OS_VERSION_NUMBER),

--- a/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
@@ -1,3 +1,7 @@
 $(McrTagsYmlRepo:monitor-base)
+$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-amd64)
+    customSubTableTitle: .NET Monitor Preview Tags
+$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-arm64v8)
+    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-amd64)
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-arm64v8)

--- a/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
@@ -1,7 +1,7 @@
 $(McrTagsYmlRepo:monitor-base)
-$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-amd64)
+$(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-arm64v8)
+$(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-arm64v8)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-amd64)
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-arm64v8)

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -1,4 +1,8 @@
 $(McrTagsYmlRepo:monitor)
+$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-amd64)
+    customSubTableTitle: .NET Monitor Preview Tags
+$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-arm64v8)
+    customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-amd64)
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-arm64v8)
 $(McrTagsYmlTagGroup:7.3-alpine-amd64)

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -1,7 +1,7 @@
 $(McrTagsYmlRepo:monitor)
-$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-amd64)
+$(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:8.1-ubuntu-chiseled-arm64v8)
+$(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-arm64v8)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-amd64)
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-arm64v8)

--- a/manifest.json
+++ b/manifest.json
@@ -6983,10 +6983,10 @@
           "productVersion": "$(monitor|8.1|product-version)",
           "sharedTags": {
             "$(monitor|8.1|product-version)-ubuntu-chiseled": {},
-            "8.1-ubuntu-chiseled": {},
+            "8.1-preview-ubuntu-chiseled": {},
             "8-ubuntu-chiseled": {},
             "$(monitor|8.1|product-version)": {},
-            "8.1": {},
+            "8.1-preview": {},
             "8": {},
             "latest": {}
           },
@@ -7001,7 +7001,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.1|product-version)-ubuntu-chiseled-amd64": {},
-                "8.1-ubuntu-chiseled-amd64": {},
+                "8.1-preview-ubuntu-chiseled-amd64": {},
                 "8-ubuntu-chiseled-amd64": {}
               }
             },
@@ -7016,7 +7016,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.1|product-version)-ubuntu-chiseled-arm64v8": {},
-                "8.1-ubuntu-chiseled-arm64v8": {},
+                "8.1-preview-ubuntu-chiseled-arm64v8": {},
                 "8-ubuntu-chiseled-arm64v8": {}
               },
               "variant": "v8"
@@ -7029,7 +7029,7 @@
             "$(monitor|8.1|product-version)-cbl-mariner-distroless": {
               "docType": "Undocumented"
             },
-            "8.1-cbl-mariner-distroless": {
+            "8.1-preview-cbl-mariner-distroless": {
               "docType": "Undocumented"
             },
             "8-cbl-mariner-distroless": {
@@ -7049,7 +7049,7 @@
                 "$(monitor|8.1|product-version)-cbl-mariner-distroless-amd64": {
                   "docType": "Undocumented"
                 },
-                "8.1-cbl-mariner-distroless-amd64": {
+                "8.1-preview-cbl-mariner-distroless-amd64": {
                   "docType": "Undocumented"
                 },
                 "8-cbl-mariner-distroless-amd64": {
@@ -7070,7 +7070,7 @@
                 "$(monitor|8.1|product-version)-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 },
-                "8.1-cbl-mariner-distroless-arm64v8": {
+                "8.1-preview-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 },
                 "8-cbl-mariner-distroless-arm64v8": {

--- a/manifest.json
+++ b/manifest.json
@@ -6378,10 +6378,10 @@
           "productVersion": "$(monitor|8.1|product-version)",
           "sharedTags": {
             "$(monitor|8.1|product-version)-ubuntu-chiseled": {},
-            "8.1-ubuntu-chiseled": {},
+            "8.1-preview-ubuntu-chiseled": {},
             "8-ubuntu-chiseled": {},
             "$(monitor|8.1|product-version)": {},
-            "8.1": {},
+            "8.1-preview": {},
             "8": {},
             "latest": {}
           },
@@ -6396,7 +6396,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.1|product-version)-ubuntu-chiseled-amd64": {},
-                "8.1-ubuntu-chiseled-amd64": {},
+                "8.1-preview-ubuntu-chiseled-amd64": {},
                 "8-ubuntu-chiseled-amd64": {}
               }
             },
@@ -6411,7 +6411,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.1|product-version)-ubuntu-chiseled-arm64v8": {},
-                "8.1-ubuntu-chiseled-arm64v8": {},
+                "8.1-preview-ubuntu-chiseled-arm64v8": {},
                 "8-ubuntu-chiseled-arm64v8": {}
               },
               "variant": "v8"
@@ -6424,7 +6424,7 @@
             "$(monitor|8.1|product-version)-cbl-mariner-distroless": {
               "docType": "Undocumented"
             },
-            "8.1-cbl-mariner-distroless": {
+            "8.1-preview-cbl-mariner-distroless": {
               "docType": "Undocumented"
             },
             "8-cbl-mariner-distroless": {
@@ -6444,7 +6444,7 @@
                 "$(monitor|8.1|product-version)-cbl-mariner-distroless-amd64": {
                   "docType": "Undocumented"
                 },
-                "8.1-cbl-mariner-distroless-amd64": {
+                "8.1-preview-cbl-mariner-distroless-amd64": {
                   "docType": "Undocumented"
                 },
                 "8-cbl-mariner-distroless-amd64": {
@@ -6465,7 +6465,7 @@
                 "$(monitor|8.1|product-version)-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 },
-                "8.1-cbl-mariner-distroless-arm64v8": {
+                "8.1-preview-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 },
                 "8-cbl-mariner-distroless-arm64v8": {

--- a/manifest.json
+++ b/manifest.json
@@ -6291,11 +6291,8 @@
           "sharedTags": {
             "$(monitor|8.0|product-version)-ubuntu-chiseled": {},
             "8.0-ubuntu-chiseled": {},
-            "8-ubuntu-chiseled": {},
             "$(monitor|8.0|product-version)": {},
-            "8.0": {},
-            "8": {},
-            "latest": {}
+            "8.0": {}
           },
           "platforms": [
             {
@@ -6308,8 +6305,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.0|product-version)-ubuntu-chiseled-amd64": {},
-                "8.0-ubuntu-chiseled-amd64": {},
-                "8-ubuntu-chiseled-amd64": {}
+                "8.0-ubuntu-chiseled-amd64": {}
               }
             },
             {
@@ -6323,8 +6319,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.0|product-version)-ubuntu-chiseled-arm64v8": {},
-                "8.0-ubuntu-chiseled-arm64v8": {},
-                "8-ubuntu-chiseled-arm64v8": {}
+                "8.0-ubuntu-chiseled-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6337,9 +6332,6 @@
               "docType": "Undocumented"
             },
             "8.0-cbl-mariner-distroless": {
-              "docType": "Undocumented"
-            },
-            "8-cbl-mariner-distroless": {
               "docType": "Undocumented"
             }
           },
@@ -6358,9 +6350,6 @@
                 },
                 "8.0-cbl-mariner-distroless-amd64": {
                   "docType": "Undocumented"
-                },
-                "8-cbl-mariner-distroless-amd64": {
-                  "docType": "Undocumented"
                 }
               }
             },
@@ -6378,6 +6367,105 @@
                   "docType": "Undocumented"
                 },
                 "8.0-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|8.1|product-version)",
+          "sharedTags": {
+            "$(monitor|8.1|product-version)-ubuntu-chiseled": {},
+            "8.1-ubuntu-chiseled": {},
+            "8-ubuntu-chiseled": {},
+            "$(monitor|8.1|product-version)": {},
+            "8.1": {},
+            "8": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.1/ubuntu-chiseled/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.1|product-version)-ubuntu-chiseled-amd64": {},
+                "8.1-ubuntu-chiseled-amd64": {},
+                "8-ubuntu-chiseled-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.1/ubuntu-chiseled/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.1|product-version)-ubuntu-chiseled-arm64v8": {},
+                "8.1-ubuntu-chiseled-arm64v8": {},
+                "8-ubuntu-chiseled-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|8.1|product-version)",
+          "sharedTags": {
+            "$(monitor|8.1|product-version)-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8.1-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.1/cbl-mariner-distroless/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.1|product-version)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8.1-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                }
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/monitor-base/8.1/cbl-mariner-distroless/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.1|product-version)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "8.1-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 },
                 "8-cbl-mariner-distroless-arm64v8": {
@@ -6808,11 +6896,8 @@
           "sharedTags": {
             "$(monitor|8.0|product-version)-ubuntu-chiseled": {},
             "8.0-ubuntu-chiseled": {},
-            "8-ubuntu-chiseled": {},
             "$(monitor|8.0|product-version)": {},
-            "8.0": {},
-            "8": {},
-            "latest": {}
+            "8.0": {}
           },
           "platforms": [
             {
@@ -6825,8 +6910,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.0|product-version)-ubuntu-chiseled-amd64": {},
-                "8.0-ubuntu-chiseled-amd64": {},
-                "8-ubuntu-chiseled-amd64": {}
+                "8.0-ubuntu-chiseled-amd64": {}
               }
             },
             {
@@ -6840,8 +6924,7 @@
               "osVersion": "jammy-chiseled",
               "tags": {
                 "$(monitor|8.0|product-version)-ubuntu-chiseled-arm64v8": {},
-                "8.0-ubuntu-chiseled-arm64v8": {},
-                "8-ubuntu-chiseled-arm64v8": {}
+                "8.0-ubuntu-chiseled-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6854,9 +6937,6 @@
               "docType": "Undocumented"
             },
             "8.0-cbl-mariner-distroless": {
-              "docType": "Undocumented"
-            },
-            "8-cbl-mariner-distroless": {
               "docType": "Undocumented"
             }
           },
@@ -6875,9 +6955,6 @@
                 },
                 "8.0-cbl-mariner-distroless-amd64": {
                   "docType": "Undocumented"
-                },
-                "8-cbl-mariner-distroless-amd64": {
-                  "docType": "Undocumented"
                 }
               }
             },
@@ -6895,6 +6972,105 @@
                   "docType": "Undocumented"
                 },
                 "8.0-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                }
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|8.1|product-version)",
+          "sharedTags": {
+            "$(monitor|8.1|product-version)-ubuntu-chiseled": {},
+            "8.1-ubuntu-chiseled": {},
+            "8-ubuntu-chiseled": {},
+            "$(monitor|8.1|product-version)": {},
+            "8.1": {},
+            "8": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:monitor-base)"
+              },
+              "dockerfile": "src/monitor/8.1/ubuntu-chiseled/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.1|product-version)-ubuntu-chiseled-amd64": {},
+                "8.1-ubuntu-chiseled-amd64": {},
+                "8-ubuntu-chiseled-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:monitor-base)"
+              },
+              "dockerfile": "src/monitor/8.1/ubuntu-chiseled/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
+              "os": "linux",
+              "osVersion": "jammy-chiseled",
+              "tags": {
+                "$(monitor|8.1|product-version)-ubuntu-chiseled-arm64v8": {},
+                "8.1-ubuntu-chiseled-arm64v8": {},
+                "8-ubuntu-chiseled-arm64v8": {}
+              },
+              "variant": "v8"
+            }
+          ]
+        },
+        {
+          "productVersion": "$(monitor|8.1|product-version)",
+          "sharedTags": {
+            "$(monitor|8.1|product-version)-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8.1-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            },
+            "8-cbl-mariner-distroless": {
+              "docType": "Undocumented"
+            }
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:monitor-base)"
+              },
+              "dockerfile": "src/monitor/8.1/cbl-mariner-distroless/amd64",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.1|product-version)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8.1-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "8-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                }
+              }
+            },
+            {
+              "architecture": "arm64",
+              "buildArgs": {
+                "REPO": "$(Repo:monitor-base)"
+              },
+              "dockerfile": "src/monitor/8.1/cbl-mariner-distroless/arm64v8",
+              "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0-distroless",
+              "tags": {
+                "$(monitor|8.1|product-version)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "8.1-cbl-mariner-distroless-arm64v8": {
                   "docType": "Undocumented"
                 },
                 "8-cbl-mariner-distroless-arm64v8": {

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -58,6 +58,8 @@
     "base-url|7.3-monitor|nightly": "$(base-url|public|maintenance|nightly)",
     "base-url|8.0-monitor|main": "$(base-url|public|main)",
     "base-url|8.0-monitor|nightly": "$(base-url|public|maintenance|nightly)",
+    "base-url|8.1-monitor|main": "$(base-url|public|main)",
+    "base-url|8.1-monitor|nightly": "$(base-url|public|nightly)",
 
     "chisel|6.0|url": "github.com/canonical/chisel",
     "chisel|8.0|url": "$(chisel|6.0|url)",
@@ -111,6 +113,18 @@
 
     "monitor-ext-s3storage|8.0|linux|x64|sha": "b3c08e47675756c85de6631f3d0fe9ee764f9d6fd2d7c7804ee9b54dace4e937dbdda4a50e1e1f14291ce1eebff2f71f48b5e75d0699061a940c77c77ad9b607",
     "monitor-ext-s3storage|8.0|linux|arm64|sha": "4d17f8b01c7606db04d247dc82588b650b107bf90b78bb31715984cfa1ae863dda5a2b5df1e1c50af1cfcafe464dae9b0ee79c0826425b7589b8a130a13ab285",
+
+    "monitor|8.1|build-version": "8.1.0-alpha.1.23564.5",
+    "monitor|8.1|product-version": "8.1.0-alpha.1",
+
+    "monitor-base|8.1|linux|x64|sha": "3f9f1c19aec606c723b6a6fc95d21adae09a33bb8eb6e0c84af3603f3ac1bad89b77670aff98fcbca5b7223b932e7b1bac18bc6540dd54ad30ca32ef8c969fae",
+    "monitor-base|8.1|linux|arm64|sha": "c79f1a9641d07dfc79791ad9612737146b3d52ef95703984da242a6fac9a51535058b19cd6b97b9210891e7dfd2cffb2450b32789470ffc7da5f0b18360ca702",
+
+    "monitor-ext-azureblobstorage|8.1|linux|x64|sha": "23373dc539b6d424ab0e1f68728884904b97800a43c044a551790dc1c73c57b52896fda3db01e30d4bbe3e13e6dec2a64fc1f5b1426913a929f7669ef4a1fd1c",
+    "monitor-ext-azureblobstorage|8.1|linux|arm64|sha": "d8c5242f181ad81686e58feb484821014a85e0ab98dedccbcc671e0d20cdcc29d0429be6fc7e7b30dfd80ee6de5866129d001bb8d924b992dd11727176732bdd",
+
+    "monitor-ext-s3storage|8.1|linux|x64|sha": "07b1b93d40b3a2194429e4704c83db4426d759686d0b4cee31d29c335dbc4e24bdd2c732c116e46518f0145ac35770ddf4386a2fd8e6b5d74939308cab3cf11b",
+    "monitor-ext-s3storage|8.1|linux|arm64|sha": "e274777ec393dadc0b116ebb1cb8e9368dd9f6c5d86ffa73ced1302ca131096bd52e430be94db4f19f933a48ce4f7495f0a53a1f1a69635390fcdac3c7cee5e8",
 
     "netstandard-targeting-pack-2.1.0|linux-rpm|x64|sha": "fab41a86b9182b276992795247868c093890c6b3d5739376374a302430229624944998e054de0ff99bddd9459fc9543636df1ebd5392db069ae953ac17ea2880",
 

--- a/src/monitor-base/8.1/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor-base/8.1/cbl-mariner-distroless/amd64/Dockerfile
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz \
+    && dotnet_monitor_base_sha512='3f9f1c19aec606c723b6a6fc95d21adae09a33bb8eb6e0c84af3603f3ac1bad89b77670aff98fcbca5b7223b932e7b1bac18bc6540dd54ad30ca32ef8c969fae' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-cbl-mariner2.0-distroless-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor-base/8.1/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor-base/8.1/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz \
+    && dotnet_monitor_base_sha512='c79f1a9641d07dfc79791ad9612737146b3d52ef95703984da242a6fac9a51535058b19cd6b97b9210891e7dfd2cffb2450b32789470ffc7da5f0b18360ca702' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-cbl-mariner2.0-distroless-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz \
+    && dotnet_monitor_base_sha512='3f9f1c19aec606c723b6a6fc95d21adae09a33bb8eb6e0c84af3603f3ac1bad89b77670aff98fcbca5b7223b932e7b1bac18bc6540dd54ad30ca32ef8c969fae' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-jammy-chiseled-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz \
+    && dotnet_monitor_base_sha512='c79f1a9641d07dfc79791ad9612737146b3d52ef95703984da242a6fac9a51535058b19cd6b97b9210891e7dfd2cffb2450b32789470ffc7da5f0b18360ca702' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:8.0.0-jammy-chiseled-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/src/monitor/8.1/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/monitor/8.1/cbl-mariner-distroless/amd64/Dockerfile
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='23373dc539b6d424ab0e1f68728884904b97800a43c044a551790dc1c73c57b52896fda3db01e30d4bbe3e13e6dec2a64fc1f5b1426913a929f7669ef4a1fd1c' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='07b1b93d40b3a2194429e4704c83db4426d759686d0b4cee31d29c335dbc4e24bdd2c732c116e46518f0145ac35770ddf4386a2fd8e6b5d74939308cab3cf11b' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:8.1.0-alpha.1-cbl-mariner-distroless-amd64
+
+COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.1/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/monitor/8.1/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='d8c5242f181ad81686e58feb484821014a85e0ab98dedccbcc671e0d20cdcc29d0429be6fc7e7b30dfd80ee6de5866129d001bb8d924b992dd11727176732bdd' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='e274777ec393dadc0b116ebb1cb8e9368dd9f6c5d86ffa73ced1302ca131096bd52e430be94db4f19f933a48ce4f7495f0a53a1f1a69635390fcdac3c7cee5e8' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:8.1.0-alpha.1-cbl-mariner-distroless-arm64v8
+
+COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile
+++ b/src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile
@@ -1,0 +1,26 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='23373dc539b6d424ab0e1f68728884904b97800a43c044a551790dc1c73c57b52896fda3db01e30d4bbe3e13e6dec2a64fc1f5b1426913a929f7669ef4a1fd1c' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
+    && dotnet_monitor_extension_sha512='07b1b93d40b3a2194429e4704c83db4426d759686d0b4cee31d29c335dbc4e24bdd2c732c116e46518f0145ac35770ddf4386a2fd8e6b5d74939308cab3cf11b' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:8.1.0-alpha.1-ubuntu-chiseled-amd64
+
+COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile
+++ b/src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile
@@ -1,0 +1,26 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=8.1.0-alpha.1.23564.5 \
+    && curl -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='d8c5242f181ad81686e58feb484821014a85e0ab98dedccbcc671e0d20cdcc29d0429be6fc7e7b30dfd80ee6de5866129d001bb8d924b992dd11727176732bdd' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -fSL --output dotnet-monitor-egress-s3storage.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
+    && dotnet_monitor_extension_sha512='e274777ec393dadc0b116ebb1cb8e9368dd9f6c5d86ffa73ced1302ca131096bd52e430be94db4f19f933a48ce4f7495f0a53a1f1a69635390fcdac3c7cee5e8' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:8.1.0-alpha.1-ubuntu-chiseled-arm64v8
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static readonly ImageVersion V7_0 = new(new Version(7, 0), isPreview: false);
         public static readonly ImageVersion V7_3 = new(new Version(7, 3), isPreview: false);
         public static readonly ImageVersion V8_0 = new(new Version(8, 0), isPreview: false);
+        public static readonly ImageVersion V8_1 = new(new Version(8, 1), isPreview: true);
 
         public ImageVersion(Version version, bool isPreview)
         {

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -205,7 +205,11 @@ namespace Microsoft.DotNet.Docker.Tests
             new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Amd64,  SupportedImageRepos = DotNetImageRepo.Monitor },
             new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Arm64,  SupportedImageRepos = DotNetImageRepo.Monitor },
             new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Amd64,  SupportedImageRepos = DotNetImageRepo.Monitor },
-            new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64,  SupportedImageRepos = DotNetImageRepo.Monitor }
+            new ProductImageData { Version = V8_0, VersionFamily = V8_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64,  SupportedImageRepos = DotNetImageRepo.Monitor },
+            new ProductImageData { Version = V8_1, VersionFamily = V8_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Amd64,  SupportedImageRepos = DotNetImageRepo.Monitor },
+            new ProductImageData { Version = V8_1, VersionFamily = V8_0, OS = OS.JammyChiseled,       OSTag = OS.UbuntuChiseled,    Arch = Arch.Arm64,  SupportedImageRepos = DotNetImageRepo.Monitor },
+            new ProductImageData { Version = V8_1, VersionFamily = V8_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Amd64,  SupportedImageRepos = DotNetImageRepo.Monitor },
+            new ProductImageData { Version = V8_1, VersionFamily = V8_0, OS = OS.Mariner20Distroless, OSTag = OS.MarinerDistroless, Arch = Arch.Arm64,  SupportedImageRepos = DotNetImageRepo.Monitor }
         };
 
         private static readonly ProductImageData[] s_windowsMonitorTestData =

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -255,12 +255,20 @@
     "src/monitor/8.0/ubuntu-chiseled/amd64": 127821834,
     "src/monitor/8.0/ubuntu-chiseled/arm64v8": 134958622,
     "src/monitor/8.0/cbl-mariner-distroless/amd64": 141200979,
-    "src/monitor/8.0/cbl-mariner-distroless/arm64v8": 148117492
+    "src/monitor/8.0/cbl-mariner-distroless/arm64v8": 148117492,
+    "src/monitor/8.1/ubuntu-chiseled/amd64": 127821834,
+    "src/monitor/8.1/ubuntu-chiseled/arm64v8": 134958622,
+    "src/monitor/8.1/cbl-mariner-distroless/amd64": 141200979,
+    "src/monitor/8.1/cbl-mariner-distroless/arm64v8": 148117492
   },
   "dotnet/nightly/monitor/base": {
     "src/monitor-base/8.0/ubuntu-chiseled/amd64": 119965752,
     "src/monitor-base/8.0/ubuntu-chiseled/arm64v8": 127102540,
     "src/monitor-base/8.0/cbl-mariner-distroless/amd64": 133344897,
-    "src/monitor-base/8.0/cbl-mariner-distroless/arm64v8": 140261410
+    "src/monitor-base/8.0/cbl-mariner-distroless/arm64v8": 140261410,
+    "src/monitor-base/8.1/ubuntu-chiseled/amd64": 119965752,
+    "src/monitor-base/8.1/ubuntu-chiseled/arm64v8": 127102540,
+    "src/monitor-base/8.1/cbl-mariner-distroless/amd64": 133344897,
+    "src/monitor-base/8.1/cbl-mariner-distroless/arm64v8": 140261410
   }
 }


### PR DESCRIPTION
- Add preliminary .NET Monitor 8.1 nightly images
- Move the `8-*`, `8`, and `latest` tags to target the 8.1 images
- Fix extensions template to use .NET Monitor version for base image