### PR TITLE
Update port to 8080

### DIFF
--- a/samples/build-in-sdk-container.md
+++ b/samples/build-in-sdk-container.md
@@ -15,13 +15,13 @@ This scenario relies on [volume mounting](https://docs.docker.com/engine/admin/v
 It is recommended to pull the SDK image before running the appropriate command. This ensures that you get the latest patch version of the SDK. Use the following command:
 
 ```console
-docker pull mcr.microsoft.com/dotnet/sdk:7.0
+docker pull mcr.microsoft.com/dotnet/sdk:8.0
 ```
 
 ## Linux
 
 ```console
-docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out
+docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet publish -c Release -o out
 ```
 
 You can see the built binaries with the following command:
@@ -34,7 +34,7 @@ dotnetapp  dotnetapp.deps.json  dotnetapp.dll  dotnetapp.pdb  dotnetapp.runtimec
 ## macOS
 
 ```console
-docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out -r osx-x64 --self-contained false
+docker run --rm -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet publish -c Release -o out -r osx-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:
@@ -51,7 +51,7 @@ dotnetapp.dll
 The following example uses PowerShell.
 
 ```console
-docker run --rm -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out -r win-x64 --self-contained false
+docker run --rm -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet publish -c Release -o out -r win-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:
@@ -76,8 +76,12 @@ Mode                 LastWriteTime         Length Name
 The following example uses PowerShell.
 
 ```console
-docker run --rm -v ${pwd}:c:\app -w c:\app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out
+docker run --rm -v ${pwd}:c:\app -w c:\app mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022 dotnet publish -c Release -o out
 ```
+
+> [!WARNING]
+> From .NET 8 onwards, [.NET multi-platform images are Linux-only](https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/multi-platform-tags).
+> This means Windows containers must all be referenced by a full tag name including the specific Windows version.
 
 You can see the built binaries with the following command:
 
@@ -103,7 +107,7 @@ You may want the build output to be written to a separate location than the sour
 The following example demonstrates doing that on macOS:
 
 ```console
-docker run --rm -v ~/dotnetapp:/out -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o /out -r osx-x64 --self-contained false
+docker run --rm -v ~/dotnetapp:/out -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet publish -c Release -o /out -r osx-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:
@@ -119,7 +123,7 @@ The following PowerShell example demonstrates doing that on Windows (using Linux
 
 ```console
 mkdir C:\dotnetapp
-docker run --rm -v C:\dotnetapp:c:\app\out -v ${pwd}:c:\app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet publish -c Release -o out -r win-x64 --self-contained false
+docker run --rm -v C:\dotnetapp:c:\app\out -v ${pwd}:c:\app -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet publish -c Release -o out -r win-x64 --self-contained false
 ```
 
 You can see the built binaries with the following command:

--- a/samples/host-aspnetcore-https.md
+++ b/samples/host-aspnetcore-https.md
@@ -28,21 +28,26 @@ You need the [.NET 6 SDK or newer](https://dotnet.microsoft.com/download) for so
 
 Generate cert and configure local machine:
 
+> [!NOTE]
+> If you are using PowerShell instead of CMD, substitute `%USERPROFILE%` with `$env:USERPROFILE`.
+
 ```console
 dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p crypticpassword
 dotnet dev-certs https --trust
 ```
 
-> Note: `crypticpassword` is used as a stand-in for a password of your own choosing.
+> [!NOTE]
+> `crypticpassword` is used as a stand-in for a password of your own choosing.
 
 Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
 docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v %USERPROFILE%\.aspnet\https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
+docker run --rm -it -p 8000:8080 -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v %USERPROFILE%\.aspnet\https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
 ```
 
-> Note: The password must match the password used for the certificate.
+> [!NOTE]
+> The password must match the password used for the certificate.
 
 ### macOS or Linux
 
@@ -53,18 +58,21 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p crypticpasswor
 dotnet dev-certs https --trust
 ```
 
-> Note: `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distro. It is likely that you need to trust the certificate in your browser.
+> [!NOTE]
+> `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distro. It is likely that you need to trust the certificate in your browser.
 
-> Note: `crypticpassword` is used as a stand-in for a password of your own choosing.
+> [!NOTE]
+> `crypticpassword` is used as a stand-in for a password of your own choosing.
 
 Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
 docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v ${HOME}/.aspnet/https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
+docker run --rm -it -p 8000:8080 -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v ${HOME}/.aspnet/https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
 ```
 
-> Note: The password must match the password used for the certificate.
+> [!NOTE]
+> The password must match the password used for the certificate.
 
 ### Windows using Windows containers
 
@@ -75,13 +83,15 @@ dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p crypticp
 dotnet dev-certs https --trust
 ```
 
-> Note: `crypticpassword` is used as a stand-in for a password of your own choosing.
+> [!NOTE]
+> `crypticpassword` is used as a stand-in for a password of your own choosing.
 
 Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
 docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=\https\aspnetapp.pfx -v %USERPROFILE%\.aspnet\https:C:\https\ --user ContainerAdministrator mcr.microsoft.com/dotnet/samples:aspnetapp
+docker run --rm -it -p 8000:8080 -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=\https\aspnetapp.pfx -v %USERPROFILE%\.aspnet\https:C:\https\ --user ContainerAdministrator mcr.microsoft.com/dotnet/samples:aspnetapp
 ```
 
-> Note: The password must match the password used for the certificate. Running as ContainerAdministrator is not recommended in production scenarios. The `--user ContainerAdministrator` flag has been added in this example since there is a potential and intermittent race condition that throws a `WindowsCryptographicException` at the container/app startup when using self-signed certificates. This is a known bug and it has been [reported here](https://github.com/dotnet/runtime/issues/70386).
+> [!NOTE]
+> The password must match the password used for the certificate. Running as ContainerAdministrator is not recommended in production scenarios. The `--user ContainerAdministrator` flag has been added in this example since there is a potential and intermittent race condition that throws a `WindowsCryptographicException` at the container/app startup when using self-signed certificates. This is a known bug and it has been [reported here](https://github.com/dotnet/runtime/issues/70386).

--- a/samples/host-aspnetcore-https.md
+++ b/samples/host-aspnetcore-https.md
@@ -29,10 +29,10 @@ You need the [.NET 6 SDK or newer](https://dotnet.microsoft.com/download) for so
 Generate cert and configure local machine:
 
 > [!NOTE]
-> If you are using PowerShell instead of CMD, substitute `%USERPROFILE%` with `$env:USERPROFILE`.
+> If you are using CMD instead of PowerShell, substitute `$env:USERPROFILE` with `%USERPROFILE%`.
 
 ```console
-dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p crypticpassword
+dotnet dev-certs https -ep $env:USERPROFILE\.aspnet\https\aspnetapp.pfx -p crypticpassword
 dotnet dev-certs https --trust
 ```
 
@@ -43,7 +43,7 @@ Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
 docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
-docker run --rm -it -p 8000:8080 -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v %USERPROFILE%\.aspnet\https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
+docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v $env:USERPROFILE\.aspnet\https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
 ```
 
 > [!NOTE]
@@ -68,7 +68,7 @@ Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
 docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
-docker run --rm -it -p 8000:8080 -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v ${HOME}/.aspnet/https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
+docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v ${HOME}/.aspnet/https:/https/ mcr.microsoft.com/dotnet/samples:aspnetapp
 ```
 
 > [!NOTE]
@@ -79,7 +79,7 @@ docker run --rm -it -p 8000:8080 -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e 
 Generate cert and configure local machine:
 
 ```console
-dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p crypticpassword
+dotnet dev-certs https -ep $env:USERPROFILE\.aspnet\https\aspnetapp.pfx -p crypticpassword
 dotnet dev-certs https --trust
 ```
 
@@ -90,7 +90,7 @@ Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
 docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
-docker run --rm -it -p 8000:8080 -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=\https\aspnetapp.pfx -v %USERPROFILE%\.aspnet\https:C:\https\ --user ContainerAdministrator mcr.microsoft.com/dotnet/samples:aspnetapp
+docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Kestrel__Certificates__Default__Password="crypticpassword" -e ASPNETCORE_Kestrel__Certificates__Default__Path=\https\aspnetapp.pfx -v $env:USERPROFILE\.aspnet\https:C:\https\ --user ContainerAdministrator mcr.microsoft.com/dotnet/samples:aspnetapp
 ```
 
 > [!NOTE]

--- a/samples/kubernetes/dotnet-monitor/dotnet-monitor.yaml
+++ b/samples/kubernetes/dotnet-monitor/dotnet-monitor.yaml
@@ -16,13 +16,13 @@ spec:
       - name: aspnetapp
         image: mcr.microsoft.com/dotnet/samples:aspnetapp
         ports:
-        - containerPort: 80     
+        - containerPort: 8080
         env:
         - name: DOTNET_DiagnosticPorts
           value: /diag/dotnet-monitor.sock
         volumeMounts:
         - mountPath: /diag
-          name: diagvol        
+          name: diagvol
         resources:
           requests:
             memory: "60Mi"
@@ -62,7 +62,7 @@ spec:
             memory: 256Mi
       volumes:
       - name: diagvol
-        emptyDir: {}            
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/samples/kubernetes/manual-deployment/README.md
+++ b/samples/kubernetes/manual-deployment/README.md
@@ -6,7 +6,7 @@ You can do that with a few quick commands
 
 ```bash
 kubectl create deployment dotnet-app --image mcr.microsoft.com/dotnet/samples:aspnetapp
-kubectl expose deployment dotnet-app --type=ClusterIP --port=80
+kubectl expose deployment dotnet-app --type=ClusterIP --port=8080
 ```
 
 View the resources that have been deployed.
@@ -22,7 +22,7 @@ If the container takes a while to download and launch, you can add `-w` to `get 
 Create a proxy to the service.
 
 ```bash
-kubectl port-forward service/dotnet-app 8080:80
+kubectl port-forward service/dotnet-app 8080:8080
 ```
 
 View the sample app at http://localhost:8080/ or call `curl http://localhost:8080/Environment`.

--- a/samples/push-image-to-acr.md
+++ b/samples/push-image-to-acr.md
@@ -71,8 +71,8 @@ Alternatively, you can persist your password across logins with the following te
 Login on Windows:
 
 ```console
-az acr credential show -n richlander --query passwords[0].value --output tsv > %USERPROFILE%\password-acr.txt
-type %USERPROFILE%\password-acr.txt | docker login richlander.azurecr.io -u richlander --password-stdin
+az acr credential show -n richlander --query passwords[0].value --output tsv > $env:USERPROFILE\password-acr.txt
+type $env:USERPROFILE\password-acr.txt | docker login richlander.azurecr.io -u richlander --password-stdin
 ```
 
 Login on macOS or Linux:

--- a/samples/run-aspnetcore-https-development.md
+++ b/samples/run-aspnetcore-https-development.md
@@ -88,10 +88,10 @@ docker build --pull -t aspnetapp .
 Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_ENVIRONMENT=Development -v $env:APPDATA\microsoft\UserSecrets\:/root/.microsoft/usersecrets -v $env:USERPROFILE\.aspnet\https:/root/.aspnet/https/ aspnetapp
+docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -v $env:APPDATA\microsoft\UserSecrets\:/root/.microsoft/usersecrets -v $env:USERPROFILE\.aspnet\https:/root/.aspnet/https/ aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8000` in your web browser.
+After the application starts, navigate to `http://localhost:8001` in your web browser.
 
 ### macOS
 
@@ -127,10 +127,10 @@ docker build --pull -t aspnetapp .
 Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_ENVIRONMENT=Development -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
+docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8000` in your web browser.
+After the application starts, navigate to `http://localhost:8001` in your web browser.
 
 ### Linux
 
@@ -165,10 +165,10 @@ docker build --pull -t aspnetapp .
 Run the container image with ASP.NET Core configured for HTTPS:
 
 ```console
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_ENVIRONMENT=Development -e ASPNETCORE_Kestrel__Certificates__Development__Password="<CREDENTIAL_PLACEHOLDER>" -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
+docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -e ASPNETCORE_Kestrel__Certificates__Development__Password="<CREDENTIAL_PLACEHOLDER>" -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8000` in your web browser.
+After the application starts, navigate to `http://localhost:8001` in your web browser.
 
 ### Windows using Windows containers
 
@@ -210,10 +210,10 @@ docker build --pull -t aspnetapp .
 Run the container image with ASP.NET Core configured for HTTPS.
 
 ```console
-docker run --rm -it -p 8000:80 -p 8001:443 -e ASPNETCORE_URLS="https://+;http://+" -e ASPNETCORE_HTTPS_PORT=8001 -e ASPNETCORE_ENVIRONMENT=Development -v $env:APPDATA\microsoft\UserSecrets\:C:\Users\ContainerUser\AppData\Roaming\microsoft\UserSecrets -v $env:USERPROFILE\.aspnet\https:C:\Users\ContainerUser\AppData\Roaming\ASP.NET\Https aspnetapp
+docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -v $env:APPDATA\microsoft\UserSecrets\:C:\Users\ContainerUser\AppData\Roaming\microsoft\UserSecrets -v $env:USERPROFILE\.aspnet\https:C:\Users\ContainerUser\AppData\Roaming\ASP.NET\Https aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8000` in your web browser.
+After the application starts, navigate to `http://localhost:8001` in your web browser.
 
 > In the case of using https, be sure to check the certificate you're using is trusted on the host. You can start with navigating to https://localhost:8001 in the browser. If you're looking to test https with a domain name (e.g. https://contoso.com:8001), the certificate would also need the appropiate Subject Alternative Name included, and the DNS settings on the host would need to be updated. In the case of using the generated dev certificate, the trusted certificate will be issued from localhost and will not have the SAN added.
 

--- a/samples/run-aspnetcore-https-development.md
+++ b/samples/run-aspnetcore-https-development.md
@@ -6,7 +6,7 @@ This document demonstrates how to develop ASP.NET Core applications with HTTPS i
 
 See [Hosting ASP.NET Core Images with Docker over HTTPS](host-aspnetcore-https.md) for production scenarios.
 
-The samples are written for `cmd.exe`. PowerShell users will need to special case the environment variables that are used in the instructions.
+The Windows examples below are written for PowerShell. CMD users will need to change the format of the environment variables in the instructions from `$env:USERPROFILE` to `%USERPROFILE%`.
 
 This sample requires [Docker 17.06](https://docs.docker.com/release-notes/docker-ce) or later of the [Docker client](https://www.docker.com/products/docker).
 
@@ -74,6 +74,7 @@ dotnet dev-certs https --trust
 Configure application secrets, for the certificate:
 
 ```console
+dotnet user-secrets init -p aspnetapp\aspnetapp.csproj
 dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "<CREDENTIAL_PLACEHOLDER>"
 ```
 
@@ -91,7 +92,7 @@ Run the container image with ASP.NET Core configured for HTTPS:
 docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -v $env:APPDATA\microsoft\UserSecrets\:/root/.microsoft/usersecrets -v $env:USERPROFILE\.aspnet\https:/root/.aspnet/https/ aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8001` in your web browser.
+After the application starts, navigate to `https://localhost:8001` in your web browser.
 
 ### macOS
 
@@ -113,6 +114,7 @@ dotnet dev-certs https --trust
 Configure application secrets, for the certificate:
 
 ```console
+dotnet user-secrets init -p aspnetapp/aspnetapp.csproj
 dotnet user-secrets -p aspnetapp/aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "<CREDENTIAL_PLACEHOLDER>"
 ```
 
@@ -130,7 +132,7 @@ Run the container image with ASP.NET Core configured for HTTPS:
 docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8001` in your web browser.
+After the application starts, navigate to `https://localhost:8001` in your web browser.
 
 ### Linux
 
@@ -153,6 +155,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p <CREDENTIAL_PL
 Configure application secrets, for the certificate:
 
 ```console
+dotnet user-secrets init -p aspnetapp/aspnetapp.csproj
 dotnet user-secrets -p aspnetapp/aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "<CREDENTIAL_PLACEHOLDER>"
 ```
 
@@ -168,7 +171,7 @@ Run the container image with ASP.NET Core configured for HTTPS:
 docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -e ASPNETCORE_Kestrel__Certificates__Development__Password="<CREDENTIAL_PLACEHOLDER>" -v ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets -v ${HOME}/.aspnet/https:/root/.aspnet/https/ aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8001` in your web browser.
+After the application starts, navigate to `https://localhost:8001` in your web browser.
 
 ### Windows using Windows containers
 
@@ -196,6 +199,7 @@ dotnet dev-certs https --trust
 Configure application secrets, for the certificate:
 
 ```console
+dotnet user-secrets init -p aspnetapp/aspnetapp.csproj
 dotnet user-secrets -p aspnetapp\aspnetapp.csproj set "Kestrel:Certificates:Development:Password" "<CREDENTIAL_PLACEHOLDER>"
 ```
 
@@ -213,7 +217,7 @@ Run the container image with ASP.NET Core configured for HTTPS.
 docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_ENVIRONMENT=Development -v $env:APPDATA\microsoft\UserSecrets\:C:\Users\ContainerUser\AppData\Roaming\microsoft\UserSecrets -v $env:USERPROFILE\.aspnet\https:C:\Users\ContainerUser\AppData\Roaming\ASP.NET\Https aspnetapp
 ```
 
-After the application starts, navigate to `http://localhost:8001` in your web browser.
+After the application starts, navigate to `https://localhost:8001` in your web browser.
 
 > In the case of using https, be sure to check the certificate you're using is trusted on the host. You can start with navigating to https://localhost:8001 in the browser. If you're looking to test https with a domain name (e.g. https://contoso.com:8001), the certificate would also need the appropiate Subject Alternative Name included, and the DNS settings on the host would need to be updated. In the case of using the generated dev certificate, the trusted certificate will be issued from localhost and will not have the SAN added.
 

--- a/samples/run-in-sdk-container.md
+++ b/samples/run-in-sdk-container.md
@@ -27,22 +27,25 @@ The following example demonstrates using `dotnet run` with a console app in a .N
 The instructions assume you are in the `samples/dotnetapp` directory (due to the [volume mounting](https://docs.docker.com/engine/admin/volumes/volumes/) `-v` syntax).
 
 ```console
-% docker run --rm -it -v $(pwd):/app/ -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run
+% docker run --rm -it -v $(pwd):/app/ -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet run
          42
          42              ,d                             ,d
          42              42                             42
  ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM
 a8"    `Y42 a8"     "8a  42    42P'   `"8a a8P_____42   42
-8b       42 8b       d8  42    42       42 8PP"""""""   42
+8b       42 8b       d8  42    42       42 8PP!!!!!!!   42
 "8a,   ,d42 "8a,   ,a8"  42,   42       42 "8b,   ,aa   42,
  `"8bbdP"Y8  `"YbbdP"'   "Y428 42       42  `"Ybbd8"'   "Y428
 
-.NET 7.0.0
-Debian GNU/Linux 11 (bullseye)
+OSArchitecture: X64
+OSDescription: Debian GNU/Linux 12 (bookworm)
+FrameworkDescription: .NET 8.0.0
 
-OSArchitecture: Arm64
-ProcessorCount: 4
-TotalAvailableMemoryBytes: 3.83 GiB
+UserName: root
+HostName : 0dea5548ae88
+
+ProcessorCount: 16
+TotalAvailableMemoryBytes: 33632350208 (31.32 GiB)
 ```
 
 You can test this working by simply editing [Program.cs](dotnetapp/Program.cs). If you make an observable change, you will see it. If you make a syntax error, you will see compiler errors.
@@ -52,7 +55,7 @@ The following instructions demonstrate this scenario in various environments.
 ## Linux or macOS
 
 ```console
-docker run --rm -it -v $(pwd):/app/ -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run
+docker run --rm -it -v $(pwd):/app/ -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet run
 ```
 
 ## Windows using Linux containers
@@ -60,7 +63,7 @@ docker run --rm -it -v $(pwd):/app/ -w /app mcr.microsoft.com/dotnet/sdk:7.0 dot
 This example uses PowerShell.
 
 ```console
-docker run --rm -it -v ${pwd}:/app/ -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run
+docker run --rm -it -v ${pwd}:/app/ -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet run
 ```
 
 ## Windows using Windows containers
@@ -68,7 +71,7 @@ docker run --rm -it -v ${pwd}:/app/ -w /app mcr.microsoft.com/dotnet/sdk:7.0 dot
 This example uses PowerShell.
 
 ```console
-docker run --rm -it -v ${pwd}:c:\app\ -w \app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run
+docker run --rm -it -v ${pwd}:c:\app\ -w \app mcr.microsoft.com/dotnet/sdk:8.0 dotnet run
 ```
 
 ## ASP.NET Core App
@@ -78,7 +81,7 @@ The following example demonstrates using `dotnet run` with an ASP.NET Core app i
 The instructions assume you are in the `samples/aspnetapp/aspnetapp` directory (due to the [volume mounting](https://docs.docker.com/engine/admin/volumes/volumes/) `-v` syntax used).
 
 ```console
-% docker run --rm -it -p 8000:8080 -v $(pwd):/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+% docker run --rm -it -p 8000:8080 -v $(pwd):/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:8.0 dotnet run --no-launch-profile
 
 info: Microsoft.Hosting.Lifetime[0]
       Now listening on: http://[::]:8080
@@ -99,7 +102,7 @@ The following instructions demonstrate this scenario in various environments:
 ### Linux or macOS
 
 ```console
-docker run --rm -it -p 8000:8080 -v $(pwd):/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+docker run --rm -it -p 8000:8080 -v $(pwd):/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:8.0 dotnet run --no-launch-profile
 ```
 
 ### Windows using Linux containers
@@ -107,7 +110,7 @@ docker run --rm -it -p 8000:8080 -v $(pwd):/app/ -w /app -e ASPNETCORE_HTTP_URLS
 This example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:8080 -v ${pwd}:/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+docker run --rm -it -p 8000:8080 -v ${pwd}:/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:8.0 dotnet run --no-launch-profile
 ```
 
 ### Windows using Windows containers
@@ -115,7 +118,7 @@ docker run --rm -it -p 8000:8080 -v ${pwd}:/app/ -w /app -e ASPNETCORE_HTTP_URLS
 This example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:8080 -v ${pwd}:C:\app\ -w \app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+docker run --rm -it -p 8000:8080 -v ${pwd}:C:\app\ -w \app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:8.0 dotnet run --no-launch-profile
 ```
 
 ### Using a launch profile to configure ASP.NET Core
@@ -140,7 +143,7 @@ The following instructions demonstrate this scenario in various environments:
 ### Linux or macOS
 
 ```console
-docker run --rm -it -p 8000:8080 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
+docker run --rm -it -p 8000:8080 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet run --launch-profile publicdev
 ```
 
 ### Windows using Linux containers
@@ -148,7 +151,7 @@ docker run --rm -it -p 8000:8080 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet
 The following example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:8080 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
+docker run --rm -it -p 8000:8080 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:8.0 dotnet run --launch-profile publicdev
 ```
 
 ### Windows using Windows containers
@@ -156,8 +159,7 @@ docker run --rm -it -p 8000:8080 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet
 The following example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:8080 -v ${pwd}:C:\app -w C:\app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
-
+docker run --rm -it -p 8000:8080 -v ${pwd}:C:\app -w C:\app mcr.microsoft.com/dotnet/sdk:8.0 dotnet run --launch-profile publicdev
 ```
 
 ## More Samples

--- a/samples/run-in-sdk-container.md
+++ b/samples/run-in-sdk-container.md
@@ -78,10 +78,10 @@ The following example demonstrates using `dotnet run` with an ASP.NET Core app i
 The instructions assume you are in the `samples/aspnetapp/aspnetapp` directory (due to the [volume mounting](https://docs.docker.com/engine/admin/volumes/volumes/) `-v` syntax used).
 
 ```console
-% docker run --rm -it -p 8000:80 -v $(pwd):/app/ -w /app -e ASPNETCORE_URLS=http://+:80 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+% docker run --rm -it -p 8000:8080 -v $(pwd):/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
 
 info: Microsoft.Hosting.Lifetime[0]
-      Now listening on: http://[::]:80
+      Now listening on: http://[::]:8080
 info: Microsoft.Hosting.Lifetime[0]
       Application started. Press Ctrl+C to shut down.
 info: Microsoft.Hosting.Lifetime[0]
@@ -99,7 +99,7 @@ The following instructions demonstrate this scenario in various environments:
 ### Linux or macOS
 
 ```console
-docker run --rm -it -p 8000:80 -v $(pwd):/app/ -w /app -e ASPNETCORE_URLS=http://+:80 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+docker run --rm -it -p 8000:8080 -v $(pwd):/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
 ```
 
 ### Windows using Linux containers
@@ -107,7 +107,7 @@ docker run --rm -it -p 8000:80 -v $(pwd):/app/ -w /app -e ASPNETCORE_URLS=http:/
 This example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:80 -v ${pwd}:/app/ -w /app -e ASPNETCORE_URLS=http://+:80 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+docker run --rm -it -p 8000:8080 -v ${pwd}:/app/ -w /app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
 ```
 
 ### Windows using Windows containers
@@ -115,7 +115,7 @@ docker run --rm -it -p 8000:80 -v ${pwd}:/app/ -w /app -e ASPNETCORE_URLS=http:/
 This example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:80 -v ${pwd}:C:\app\ -w \app -e ASPNETCORE_URLS=http://+:80 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
+docker run --rm -it -p 8000:8080 -v ${pwd}:C:\app\ -w \app -e ASPNETCORE_HTTP_URLS=8080 -e ASPNETCORE_ENVIRONMENT=Development mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --no-launch-profile
 ```
 
 ### Using a launch profile to configure ASP.NET Core
@@ -128,7 +128,7 @@ The following JSON segment shows the `container` profile that was added to enabl
 "publicdev": {
   "commandName": "Project",
   "launchBrowser": true,
-  "applicationUrl": "http://+:80",
+  "applicationUrl": "http://+:8080",
   "environmentVariables": {
     "ASPNETCORE_ENVIRONMENT": "Development"
   }
@@ -140,7 +140,7 @@ The following instructions demonstrate this scenario in various environments:
 ### Linux or macOS
 
 ```console
-docker run --rm -it -p 8000:80 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
+docker run --rm -it -p 8000:8080 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
 ```
 
 ### Windows using Linux containers
@@ -148,7 +148,7 @@ docker run --rm -it -p 8000:80 -v $(pwd):/app -w /app mcr.microsoft.com/dotnet/s
 The following example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:80 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
+docker run --rm -it -p 8000:8080 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
 ```
 
 ### Windows using Windows containers
@@ -156,7 +156,8 @@ docker run --rm -it -p 8000:80 -v ${pwd}:/app -w /app mcr.microsoft.com/dotnet/s
 The following example uses PowerShell.
 
 ```console
-docker run --rm -it -p 8000:80 -v ${pwd}:C:\app -w C:\app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
+docker run --rm -it -p 8000:8080 -v ${pwd}:C:\app -w C:\app mcr.microsoft.com/dotnet/sdk:7.0 dotnet run --launch-profile publicdev
+
 ```
 
 ## More Samples

--- a/samples/run-tests-in-sdk-container.md
+++ b/samples/run-tests-in-sdk-container.md
@@ -29,22 +29,23 @@ curl -o Directory.Build.props https://raw.githubusercontent.com/dotnet/dotnet-do
 You can run `dotnet test` within a .NET SDK container using the following pattern, with `docker run` and volume mounting. This initial example is demonstrated on Windows with PowerShell (in Linux container mode). Instructions for all OSes follow.
 
 ```console
-> docker run --rm -v ${pwd}:/app -w /app/tests mcr.microsoft.com/dotnet/sdk:7.0 dotnet test
+> docker run --rm -v ${pwd}:/app -w /app/tests mcr.microsoft.com/dotnet/sdk:8.0 dotnet test
   Determining projects to restore...
-  Restored /app/libbar/libbar.csproj (in 3.95 sec).
-  Restored /app/libfoo/libfoo.csproj (in 3.95 sec).
-  Restored /app/tests/tests.csproj (in 8.25 sec).
-  libfoo -> /app/libfoo/bin/Debug/netstandard2.0/libfoo.dll
-  libbar -> /app/libbar/bin/Debug/netstandard2.0/libbar.dll
-  tests -> /app/tests/bin/Debug/net7.0/tests.dll
-Test run for /app/tests/bin/Debug/net7.0/tests.dll (.NETCoreApp,Version=v7.0)
-Microsoft (R) Test Execution Command Line Tool Version 16.8.0
+  Restored /app/libbar/libbar.csproj (in 251 ms).
+  Restored /app/libfoo/libfoo.csproj (in 250 ms).
+  Restored /app/tests/tests.csproj (in 4.58 sec).
+  libbar -> /app/libbar/bin/Debug/net8.0/libbar.dll
+  libfoo -> /app/libfoo/bin/Debug/net8.0/libfoo.dll
+  tests -> /app/tests/bin/Debug/net8.0/tests.dll
+Test run for /app/tests/bin/Debug/net8.0/tests.dll (.NETCoreApp,Version=v8.0)
+Microsoft (R) Test Execution Command Line Tool Version 17.8.0 (x64)
 Copyright (c) Microsoft Corporation.  All rights reserved.
+
 Starting test execution, please wait...
 A total of 1 test files matched the specified pattern.
 
-Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 2 ms - /app/tests/bin/Debug/net7.0/tests.dll (net7.0)
- ```
+Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 3 ms - tests.dll (net8.0)
+```
 
 In this example, the tests (and any other required code) are [volume mounted](https://docs.docker.com/engine/admin/volumes/volumes/) into the container, and `dotnet test` is run from the `tests` directory (`-w` sets the working directory). Test results can be read from the console or from logs, which can be written to disk with the `--logger:trx` flag.
 
@@ -57,7 +58,7 @@ The following instructions demonstrate this scenario in various configurations w
 ### Linux or macOS
 
 ```console
-docker run --rm -v $(pwd):/app -w /app/tests mcr.microsoft.com/dotnet/sdk:7.0 dotnet test --logger:trx
+docker run --rm -v $(pwd):/app -w /app/tests mcr.microsoft.com/dotnet/sdk:8.0 dotnet test --logger:trx
 ```
 
 ### Windows using Linux containers
@@ -65,7 +66,7 @@ docker run --rm -v $(pwd):/app -w /app/tests mcr.microsoft.com/dotnet/sdk:7.0 do
 This example uses PowerShell.
 
 ```console
-docker run --rm -v ${pwd}:/app -w /app/tests mcr.microsoft.com/dotnet/sdk:7.0 dotnet test --logger:trx
+docker run --rm -v ${pwd}:/app -w /app/tests mcr.microsoft.com/dotnet/sdk:8.0 dotnet test --logger:trx
 ```
 
 ### Windows using Windows containers
@@ -73,7 +74,7 @@ docker run --rm -v ${pwd}:/app -w /app/tests mcr.microsoft.com/dotnet/sdk:7.0 do
 This example uses PowerShell.
 
 ```console
-docker run --rm -v ${pwd}:C:\app -w C:\app\tests mcr.microsoft.com/dotnet/sdk:7.0 dotnet test --logger:trx
+docker run --rm -v ${pwd}:C:\app -w C:\app\tests mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022 dotnet test --logger:trx
 ```
 
 ## More Samples


### PR DESCRIPTION
update to `8080` since the default port changed to `8080`

https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port


it not working with current `80` port

![image](https://github.com/dotnet/dotnet-docker/assets/7604648/7e471665-f781-4642-a913-6bf9b8d456d0)

works when updated to `8080`

![image](https://github.com/dotnet/dotnet-docker/assets/7604648/68ec7af1-0e8d-4644-95f2-c09a9750c69b)

![image](https://github.com/dotnet/dotnet-docker/assets/7604648/3a3ab107-5f79-4e6d-b495-8cd3f3bd2526)
