### PR TITLE
Add expose instruction to ASP.NET Core samples

### DIFF
--- a/samples/aspnetapp/Dockerfile
+++ b/samples/aspnetapp/Dockerfile
@@ -15,6 +15,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 USER $APP_UID

--- a/samples/aspnetapp/Dockerfile.alpine
+++ b/samples/aspnetapp/Dockerfile.alpine
@@ -17,6 +17,7 @@ RUN dotnet publish --no-restore -a $TARGETARCH -o /app
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.alpine-composite
+++ b/samples/aspnetapp/Dockerfile.alpine-composite
@@ -17,6 +17,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
 # final stage/image
 FROM mcr.microsoft.com/dotnet/nightly/aspnet:8.0-alpine-composite
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 USER $APP_UID

--- a/samples/aspnetapp/Dockerfile.alpine-icu
+++ b/samples/aspnetapp/Dockerfile.alpine-icu
@@ -17,6 +17,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+EXPOSE 8080
 
 ENV \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \

--- a/samples/aspnetapp/Dockerfile.chiseled
+++ b/samples/aspnetapp/Dockerfile.chiseled
@@ -15,6 +15,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.chiseled-composite
+++ b/samples/aspnetapp/Dockerfile.chiseled-composite
@@ -15,6 +15,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/nightly/aspnet:8.0-jammy-chiseled-composite
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["./aspnetapp"]

--- a/samples/aspnetapp/Dockerfile.debian
+++ b/samples/aspnetapp/Dockerfile.debian
@@ -6,7 +6,7 @@ WORKDIR /source
 
 # copy csproj and restore as distinct layers
 COPY aspnetapp/*.csproj .
-RUN dotnet restore -a $TARGETARCH  
+RUN dotnet restore -a $TARGETARCH
 
 # copy everything else and build app
 COPY aspnetapp/. .
@@ -15,6 +15,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 USER $APP_UID

--- a/samples/aspnetapp/Dockerfile.nanoserver
+++ b/samples/aspnetapp/Dockerfile.nanoserver
@@ -16,6 +16,7 @@ RUN dotnet publish --ucr --no-restore -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-$TAG
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 HEALTHCHECK CMD curl -sf --show-error http://localhost:80/healthz || exit 1

--- a/samples/aspnetapp/Dockerfile.ubuntu
+++ b/samples/aspnetapp/Dockerfile.ubuntu
@@ -15,6 +15,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 USER $APP_UID

--- a/samples/aspnetapp/Dockerfile.windowsservercore
+++ b/samples/aspnetapp/Dockerfile.windowsservercore
@@ -13,6 +13,7 @@ RUN dotnet publish --ucr --no-restore -o /app
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-windowsservercore-ltsc2022
+EXPOSE 8080
 WORKDIR /app
 COPY --from=build /app .
 USER ContainerUser


### PR DESCRIPTION
Context: https://github.com/dotnet/dotnet-docker/issues/3968#issuecomment-1852480821

I am open to the idea of using `EXPOSE $ASPNETCORE_HTTP_PORTS` as well - however this would only work because we specify one port (8080). [Official ASP.NET Core documentation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-8.0#specify-ports-only) shows defining multiple ports this way. It would be a bad user experience to set multiple ports as documented there and have that break the `EXPOSE` instruction.