### PR TITLE
Revert "Enable diagnostic output"

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
@@ -32,7 +32,7 @@ COPY tests/*.csproj .
 RUN dotnet restore -r $rid
 
 COPY tests/ .
-ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore", "-v", "diag"]
+ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 
 FROM build as publish_fx_dependent


### PR DESCRIPTION
This reverts commit f6c932bc75d2764868ad880e65ad2ef96a0e98ed. It was accidentally committed directly to `nightly` when it was meant to be in #5083.