### PR TITLE
Add more images to globalization doc

### DIFF
--- a/samples/enable-globalization.md
+++ b/samples/enable-globalization.md
@@ -15,8 +15,7 @@ In many scenarios, globalization support with ICU is required, for example, to c
 - Alpine `sdk` images
 - Debian images
 - Ubuntu images
-- Ubuntu chiseled `extra` variant images
-- Mariner 2.0 `extra` variant images
+- All [`extra` variant](../documentation/image-variants.md) images
 
 .NET container images that do not include ICU:
 

--- a/samples/enable-globalization.md
+++ b/samples/enable-globalization.md
@@ -15,6 +15,8 @@ In many scenarios, globalization support with ICU is required, for example, to c
 - Alpine `sdk` images
 - Debian images
 - Ubuntu images
+- Ubuntu chiseled `extra` variant images
+- Mariner 2.0 `extra` variant images
 
 .NET container images that do not include ICU:
 


### PR DESCRIPTION
Ubuntu chiseled `extra` variant and Mariner 2.0 `extra` variant images were not listed in the list of images containing `ICU`.