### PR TITLE
Use 0.0.0.0 URIs for Aspire Dashboard environment variables

### DIFF
--- a/eng/dockerfile-templates/aspire-dashboard/Dockerfile.envs
+++ b/eng/dockerfile-templates/aspire-dashboard/Dockerfile.envs
@@ -2,7 +2,7 @@ ENV \
     # Unset ASPNETCORE_HTTP_PORTS from base image
     ASPNETCORE_HTTP_PORTS= \
     # Aspire Dashboard environment variables
-    ASPNETCORE_URLS=http://*:18888 \
-    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://*:18889  \
+    ASPNETCORE_URLS=http://0.0.0.0:18888 \
+    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://0.0.0.0:18889  \
     # Server GC mode
     DOTNET_gcServer=1

--- a/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/nightly/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
@@ -26,8 +26,8 @@ ENV \
     # Unset ASPNETCORE_HTTP_PORTS from base image
     ASPNETCORE_HTTP_PORTS= \
     # Aspire Dashboard environment variables
-    ASPNETCORE_URLS=http://*:18888 \
-    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://*:18889  \
+    ASPNETCORE_URLS=http://0.0.0.0:18888 \
+    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://0.0.0.0:18889 \
     # Server GC mode
     DOTNET_gcServer=1
 

--- a/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPO=mcr.microsoft.com/dotnet/nightly/aspnet
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
@@ -27,7 +27,7 @@ ENV \
     ASPNETCORE_HTTP_PORTS= \
     # Aspire Dashboard environment variables
     ASPNETCORE_URLS=http://0.0.0.0:18888 \
-    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://0.0.0.0:18889 \
+    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://0.0.0.0:18889  \
     # Server GC mode
     DOTNET_gcServer=1
 

--- a/src/aspire-dashboard/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/aspire-dashboard/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -26,8 +26,8 @@ ENV \
     # Unset ASPNETCORE_HTTP_PORTS from base image
     ASPNETCORE_HTTP_PORTS= \
     # Aspire Dashboard environment variables
-    ASPNETCORE_URLS=http://*:18888 \
-    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://*:18889  \
+    ASPNETCORE_URLS=http://0.0.0.0:18888 \
+    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://0.0.0.0:18889  \
     # Server GC mode
     DOTNET_gcServer=1
 


### PR DESCRIPTION
This is a workaround for https://github.com/dotnet/dotnet-docker/issues/5164 until the issue is fixed in Aspire.