### PR TITLE
Remove distro from aspire-dashboard tags

### DIFF
--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -49,13 +49,13 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 ##### .NET Aspire Dashboard Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-preview.3-cbl-mariner-distroless-amd64, 8.0-preview-cbl-mariner-distroless-amd64, 8.0.0-preview.3-cbl-mariner-distroless, 8.0-preview-cbl-mariner-distroless, 8.0.0-preview.3, 8.0-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0-distroless
+8.0.0-preview.3-amd64, 8.0-preview-amd64, 8.0.0-preview.3, 8.0-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0-distroless
 
 ## Linux arm64 Tags
 ##### .NET Aspire Dashboard Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.0-preview.3-cbl-mariner-distroless-arm64v8, 8.0-preview-cbl-mariner-distroless-arm64v8, 8.0.0-preview.3-cbl-mariner-distroless, 8.0-preview-cbl-mariner-distroless, 8.0.0-preview.3, 8.0-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspire-dashboard/8.0/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0-distroless
+8.0.0-preview.3-arm64v8, 8.0-preview-arm64v8, 8.0.0-preview.3, 8.0-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/aspire-dashboard/8.0/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0-distroless
 
 You can retrieve a list of all available tags for dotnet/nightly/aspire-dashboard at https://mcr.microsoft.com/v2/dotnet/nightly/aspire-dashboard/tags/list.
 <!--End of generated tags-->

--- a/eng/mcr-tags-metadata-templates/aspire-dashboard-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspire-dashboard-tags.yml
@@ -1,5 +1,5 @@
 $(McrTagsYmlRepo:aspire-dashboard)
-$(McrTagsYmlTagGroup:8.0-preview-cbl-mariner-distroless-amd64)
+$(McrTagsYmlTagGroup:8.0-preview-amd64)
     customSubTableTitle: .NET Aspire Dashboard Preview Tags
-$(McrTagsYmlTagGroup:8.0-preview-cbl-mariner-distroless-arm64v8)
+$(McrTagsYmlTagGroup:8.0-preview-arm64v8)
     customSubTableTitle: .NET Aspire Dashboard Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -10779,8 +10779,6 @@
         {
           "productVersion": "$(aspire-dashboard|8.0|product-version)",
           "sharedTags": {
-            "$(aspire-dashboard|8.0|fixed-tag)-cbl-mariner-distroless": {},
-            "$(aspire-dashboard|8.0|floating-tag)-cbl-mariner-distroless": {},
             "$(aspire-dashboard|8.0|fixed-tag)": {},
             "$(aspire-dashboard|8.0|floating-tag)": {},
             "latest": {}
@@ -10795,8 +10793,8 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
-                "$(aspire-dashboard|8.0|fixed-tag)-cbl-mariner-distroless-amd64": {},
-                "$(aspire-dashboard|8.0|floating-tag)-cbl-mariner-distroless-amd64": {}
+                "$(aspire-dashboard|8.0|fixed-tag)-amd64": {},
+                "$(aspire-dashboard|8.0|floating-tag)-amd64": {}
               }
             },
             {
@@ -10809,8 +10807,8 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
-                "$(aspire-dashboard|8.0|fixed-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(aspire-dashboard|8.0|floating-tag)-cbl-mariner-distroless-arm64v8": {}
+                "$(aspire-dashboard|8.0|fixed-tag)-arm64v8": {},
+                "$(aspire-dashboard|8.0|floating-tag)-arm64v8": {}
               },
               "variant": "v8"
             }


### PR DESCRIPTION
There are currently no plans to ship other distros for `aspire-dashboard`. Since there is no choice to be made between distros for these images, this PR removes the distro from the tags.