### PR TITLE
Add dotnet-public to test NuGet.Config

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config
@@ -1,2 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<configuration></configuration>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Some wasm-tools workload installations were failing due to this NuGet config being incorrectly configured.