### PR TITLE
Fix update-dependencies Docker build based on new Alpine version

### DIFF
--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -24,8 +24,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine
 
 # install Docker
 RUN apk add --no-cache \
-        docker \
-        openssl1.1-compat
+        docker
 
 # copy update-dependencies
 WORKDIR /update-dependencies

--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -2,7 +2,7 @@
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
 ARG TARGETARCH
 # The rid must be version-specific to workaround a libgit2sharp issue (see https://github.com/dotnet/dotnet-docker/pull/2111)
-ARG RID=alpine.3.19-$TARGETARCH
+ARG RID=linux-musl-$TARGETARCH
 WORKDIR /update-dependencies
 
 # copy csproj and restore as distinct layers

--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -2,7 +2,7 @@
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build-env
 ARG TARGETARCH
 # The rid must be version-specific to workaround a libgit2sharp issue (see https://github.com/dotnet/dotnet-docker/pull/2111)
-ARG RID=alpine.3.18-$TARGETARCH
+ARG RID=alpine.3.19-$TARGETARCH
 WORKDIR /update-dependencies
 
 # copy csproj and restore as distinct layers

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="6.0.0-beta.22351.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.23513.3" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>


### PR DESCRIPTION
Alpine 3.19 doesn't have OpenSSL 1 compat libraries. This requires an update to libgit2sharp. I updated a couple other package versions at the same time. I also took another look at updating S.CL but it was not trivial.