### PR TITLE
Update Microsoft.DotNet.VersionTools

### DIFF
--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.23513.3" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />


### PR DESCRIPTION
This will hopefully fix https://github.com/dotnet/dotnet-docker/issues/5227. It's not clear if this latest build contains my changes from https://github.com/dotnet/arcade/pull/14537, but it was published a couple hours after that PR was merged. We can always update again if necessary.