### PR TITLE
Add `DOTNET_RUNTIME_ID` environment variable to .NET 6 Alpine 3.19 images

### DIFF
--- a/eng/dockerfile-templates/runtime/Dockerfile.envs
+++ b/eng/dockerfile-templates/runtime/Dockerfile.envs
@@ -1,4 +1,11 @@
 {{
-    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".")
-}}# .NET Runtime version
-{{if INDENT ="":ENV }}DOTNET_VERSION={{VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]}}
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
+    set alpineVersion to split(OS_VERSION, ".")[1] ^
+    set usePortableRid to isAlpine && alpineVersion != "18" && dotnetVersion = "6.0" ^
+    set runtimeComment to "# .NET Runtime version"
+}}{{if !usePortableRid:{{runtimeComment}}
+}}{{if INDENT ="":ENV }}{{if usePortableRid:\
+    {{runtimeComment}}
+    }}DOTNET_VERSION={{VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]}}{{if usePortableRid: \
+    DOTNET_RUNTIME_ID=linux-musl-{{ARCH_SHORT}}}}

--- a/src/runtime/6.0/alpine3.19/amd64/Dockerfile
+++ b/src/runtime/6.0/alpine3.19/amd64/Dockerfile
@@ -4,8 +4,10 @@ FROM $REPO:6.0.27-alpine3.19-amd64
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# .NET Runtime version
-ENV DOTNET_VERSION=6.0.27
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.27 \
+    DOTNET_RUNTIME_ID=linux-musl-x64
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-x64.tar.gz \

--- a/src/runtime/6.0/alpine3.19/arm32v7/Dockerfile
+++ b/src/runtime/6.0/alpine3.19/arm32v7/Dockerfile
@@ -4,8 +4,10 @@ FROM $REPO:6.0.27-alpine3.19-arm32v7
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# .NET Runtime version
-ENV DOTNET_VERSION=6.0.27
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.27 \
+    DOTNET_RUNTIME_ID=linux-musl-arm
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm.tar.gz \

--- a/src/runtime/6.0/alpine3.19/arm64v8/Dockerfile
+++ b/src/runtime/6.0/alpine3.19/arm64v8/Dockerfile
@@ -4,8 +4,10 @@ FROM $REPO:6.0.27-alpine3.19-arm64v8
 # .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
 # by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
 
-# .NET Runtime version
-ENV DOTNET_VERSION=6.0.27
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=6.0.27 \
+    DOTNET_RUNTIME_ID=linux-musl-arm64
 
 # Install .NET Runtime
 RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-musl-arm64.tar.gz \


### PR DESCRIPTION
Context: https://github.com/dotnet/dotnet-docker/issues/5243#issuecomment-1986096650

This is a draft PR so that we can review and talk about this change. It is up in the air whether or not we will take this change yet, depending on if we decide to address the issue in the .NET 6 Runtime.

I also have a work-in-progress test for this issue, but it's not complete yet.

Related: https://github.com/dotnet/runtime/issues/96155