### PR TITLE
Don't remove containers twice during sample image tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -73,7 +73,8 @@ namespace Microsoft.DotNet.Docker.Tests
                         image: image,
                         name: containerName,
                         detach: true,
-                        optionalRunArgs: $"-p {port}");
+                        optionalRunArgs: $"-p {port}",
+                        skipAutoCleanup: true);
 
                     if (!Config.IsHttpVerificationDisabled)
                     {

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/WebScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/WebScenario.cs
@@ -124,7 +124,13 @@ public class WebScenario(ProductImageData imageData, DockerHelper dockerHelper, 
         throw new TimeoutException($"Timed out attempting to access the endpoint {url} on container {containerName}");
     }
 
-    public static async Task VerifyHttpResponseFromContainerAsync(string containerName, DockerHelper dockerHelper, ITestOutputHelper outputHelper, int containerPort, string? pathAndQuery = null, Action<HttpResponseMessage>? validateCallback = null)
+    public static async Task VerifyHttpResponseFromContainerAsync(
+        string containerName,
+        DockerHelper dockerHelper,
+        ITestOutputHelper outputHelper,
+        int containerPort,
+        string? pathAndQuery = null,
+        Action<HttpResponseMessage>? validateCallback = null)
     {
         (await GetHttpResponseFromContainerAsync(
             containerName,


### PR DESCRIPTION
This PR resolves some unreliability in the sample image tests that was introduced by https://github.com/dotnet/dotnet-docker/pull/5143.