### PR TITLE
Enable localization in Aspire Dashboard image

### DIFF
--- a/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux
@@ -3,7 +3,7 @@
     set dotnetMajorMinor to cat(dotnetMajor, ".0") ^
     set isMariner to find(OS_VERSION, "mariner") >= 0 ^
     set aspnetBaseTag to
-        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
+        cat("$REPO:", VARIABLES[cat("dotnet|", dotnetMajorMinor, "|product-version")], "-", OS_VERSION, "-extra", ARCH_TAG_SUFFIX) ^
     set osVersionBase to match(OS_VERSION, ".+(?=.*-)")[0] ^
     set installerImageTag to when(isMariner,
         cat("mcr.microsoft.com/cbl-mariner/base/core:", OS_VERSION_NUMBER),

--- a/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/aspire-dashboard/8.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -19,7 +19,7 @@ RUN dotnet_aspire_version=8.0.0-preview.5.24157.3 \
 
 
 # Aspire Dashboard image
-FROM $REPO:8.0.3-cbl-mariner2.0-distroless-amd64
+FROM $REPO:8.0.3-cbl-mariner2.0-distroless-extra-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/aspire-dashboard/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/aspire-dashboard/8.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -19,7 +19,7 @@ RUN dotnet_aspire_version=8.0.0-preview.5.24157.3 \
 
 
 # Aspire Dashboard image
-FROM $REPO:8.0.3-cbl-mariner2.0-distroless-arm64v8
+FROM $REPO:8.0.3-cbl-mariner2.0-distroless-extra-arm64v8
 
 WORKDIR /app
 COPY --from=installer /app .


### PR DESCRIPTION
Fixes #5258

I tested this locally and was able to start the container and access the dashboard.

`pwsh .\build-and-test.ps1 -paths "*8.0*mariner*" -mode "Build"`
`docker run -p 18888:18888 -p 18889:18889 --rm mcr.microsoft.com/dotnet/nightly/aspire-dashboard:8.0.0-preview.5-amd64`