### PR TITLE
Move dotnet-docker main pipeline to 1ES PT

### DIFF
--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -3,19 +3,31 @@ pr: none
 
 resources:
   repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
   - repository: InternalVersionsRepo
     type: github
     endpoint: dotnet
     name: dotnet/versions
 
 variables:
-- template: variables/core.yml
+- template: /eng/pipelines/variables/core.yml@self
 
-stages:
-- template: stages/build-test-publish-repo.yml
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    internalProjectName: ${{ variables.internalProjectName }}
-    publicProjectName: ${{ variables.publicProjectName }}
-    linuxAmd64Pool:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022
+      os: windows
+    sdl:
+      sourceRepositoriesToScan:
+        include:
+        - repository: InternalVersionsRepo
+    stages:
+    - template: /eng/pipelines/stages/build-test-publish-repo.yml@self
+      parameters:
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}


### PR DESCRIPTION
I tested this, based on the main branch (not nightly) with the other 1ES PT commits here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2407515&view=results

We should merge all pipelines into nightly and then make one merge from nightly to main when we are confident the changes are working well in nightly.

Part of https://github.com/dotnet/dotnet-docker-internal/issues/4475