### PR TITLE
Fix CG Code build

### DIFF
--- a/eng/pipelines/cg-code.yml
+++ b/eng/pipelines/cg-code.yml
@@ -8,14 +8,17 @@ trigger:
 pr: none
 
 variables:
+- template: /eng/common/templates/variables/common.yml@self
 - name: skipComponentGovernanceDetection
   value: false
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:


### PR DESCRIPTION
Fixes #5289. The common variables were not included which caused the cgGrepArgs variable to be interpreted literally by grep when looking for projects to build.