### PR TITLE
Add latest tag back to 8.0 SDK

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -63,7 +63,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.203-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.203-bookworm-slim, 8.0-bookworm-slim, 8.0.203, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
+8.0.203-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.203-bookworm-slim, 8.0-bookworm-slim, 8.0.203, 8.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
 8.0.203-alpine3.18-amd64, 8.0-alpine3.18-amd64, 8.0-alpine-amd64, 8.0.203-alpine3.18, 8.0-alpine3.18 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/alpine3.18/amd64/Dockerfile) | Alpine 3.18
 8.0.203-alpine3.19-amd64, 8.0-alpine3.19-amd64, 8.0.203-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/alpine3.19/amd64/Dockerfile) | Alpine 3.19
 8.0.203-jammy-amd64, 8.0-jammy-amd64, 8.0.203-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
@@ -93,7 +93,7 @@ Tags | Dockerfile | OS Version
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.203-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.203-bookworm-slim, 8.0-bookworm-slim, 8.0.203, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
+8.0.203-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.203-bookworm-slim, 8.0-bookworm-slim, 8.0.203, 8.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
 8.0.203-alpine3.18-arm64v8, 8.0-alpine3.18-arm64v8, 8.0-alpine-arm64v8, 8.0.203-alpine3.18, 8.0-alpine3.18 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/alpine3.18/arm64v8/Dockerfile) | Alpine 3.18
 8.0.203-alpine3.19-arm64v8, 8.0-alpine3.19-arm64v8, 8.0.203-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/alpine3.19/arm64v8/Dockerfile) | Alpine 3.19
 8.0.203-jammy-arm64v8, 8.0-jammy-arm64v8, 8.0.203-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
@@ -123,7 +123,7 @@ Tags | Dockerfile | OS Version
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.203-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.203-bookworm-slim, 8.0-bookworm-slim, 8.0.203, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
+8.0.203-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.203-bookworm-slim, 8.0-bookworm-slim, 8.0.203, 8.0, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
 8.0.203-alpine3.18-arm32v7, 8.0-alpine3.18-arm32v7, 8.0-alpine-arm32v7, 8.0.203-alpine3.18, 8.0-alpine3.18 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/alpine3.18/arm32v7/Dockerfile) | Alpine 3.18
 8.0.203-alpine3.19-arm32v7, 8.0-alpine3.19-arm32v7, 8.0.203-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/alpine3.19/arm32v7/Dockerfile) | Alpine 3.19
 8.0.203-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.203-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/manifest.json
+++ b/manifest.json
@@ -8325,8 +8325,11 @@
         {
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
+            "$(sdk|8.0|product-version)-bookworm-slim": {},
+            "8.0-bookworm-slim": {},
             "$(sdk|8.0|product-version)": {},
-            "8.0": {}
+            "8.0": {},
+            "latest": {}
           },
           "platforms": [
             {
@@ -8370,50 +8373,6 @@
                 "$(sdk|8.0|product-version)-bookworm-slim-arm64v8": {},
                 "8.0-bookworm-slim-arm64v8": {}
               },
-              "variant": "v8"
-            }
-          ]
-        },
-        {
-          "id": "bookworm-slim",
-          "productVersion": "$(sdk|8.0|product-version)",
-          "sharedTags": {
-            "$(sdk|8.0|product-version)-bookworm-slim": {},
-            "8.0-bookworm-slim": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "dockerfile": "src/sdk/8.0/bookworm-slim/amd64",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/Dockerfile.linux",
-              "os": "linux",
-              "osVersion": "bookworm-slim",
-              "tags": {}
-            },
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "architecture": "arm",
-              "dockerfile": "src/sdk/8.0/bookworm-slim/arm32v7",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/Dockerfile.linux",
-              "os": "linux",
-              "osVersion": "bookworm-slim",
-              "tags": {},
-              "variant": "v7"
-            },
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "architecture": "arm64",
-              "dockerfile": "src/sdk/8.0/bookworm-slim/arm64v8",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/Dockerfile.linux",
-              "os": "linux",
-              "osVersion": "bookworm-slim",
-              "tags": {},
               "variant": "v8"
             }
           ]


### PR DESCRIPTION
Fixes #5311 

The cause was a bad merge in https://github.com/dotnet/dotnet-docker/pull/5185 where 9.0 Dockerfiles were added to main. They have the latest tag in nightly, only half the merge got done correctly (i.e. we ended up with no latest tag across 8.0/9.0).