### PR TITLE
Trigger dependency update for .NET Monitor 9.0 nightly builds

### DIFF
--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -6,6 +6,7 @@ resources:
       branches:
         include:
         - main
+        - feature/9.x
         - release/*
         - internal/release/*
       tags:


### PR DESCRIPTION
.NET Monitor produces nightly builds of its 9.0 version out of the `feature/9.x` branch; update the trigger on the dependency update pipeline to trigger on this branch.