### PR TITLE
Add EnableSdkContainerSupport property

### DIFF
--- a/samples/complexapp/complexapp/complexapp.csproj
+++ b/samples/complexapp/complexapp/complexapp.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <PublishRelease>true</PublishRelease>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dotnetapp/dotnetapp.csproj
+++ b/samples/dotnetapp/dotnetapp.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
 </Project>

--- a/samples/globalapp/globalapp.csproj
+++ b/samples/globalapp/globalapp.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
 </Project>

--- a/samples/releasesapp/releasesapp.csproj
+++ b/samples/releasesapp/releasesapp.csproj
@@ -9,6 +9,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSelfContained>true</PublishSelfContained>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET SDK 8.0.200 required `EnableSdkContainerSupport` to be set for `Microsoft.NET.Sdk` projects for container publishing.

We can add that to make it easy to use these projects to test out the cointainer publishing feature.

The property is set of by default for `.Web` projects.