### PR TITLE
Force new issues to have untriaged label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐞 Bug report
 about: Create a report about something that is not working
-labels: 'bug'
+labels: 'bug,untriaged'
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: 💡 Feature request
 about: Suggest an idea for this project
-labels: 'enhancement'
+labels: 'enhancement,untriaged'
 ---
 
 ### Describe the Problem


### PR DESCRIPTION
New issues that are created with the templates do not automatically get assigned the `untriaged` label by https://github.com/apps/dotnet-issue-labeler. This works around that by explicitly defining the templates to set `untriaged`.