### PR TITLE
Adding Readme contents for the Aspire container image.

### DIFF
--- a/.mar/portal/README.aspire-dashboard.portal.md
+++ b/.mar/portal/README.aspire-dashboard.portal.md
@@ -35,12 +35,80 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
+The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
 
+The dashboard shows:
 
-## Image Variants
+- Resources that make up your app, such as .NET projects, executables and containers.
+- Live console logs of resources.
+- Live telemetry, such as structured logs, traces and metrics.
 
-.NET container images have several variants that offer different combinations of flexibility and deployment size.
-The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-variants.md) contains a summary of the image variants and their use-cases.
+### Configuration
+
+The dashboard must be configured when it is started. The configuration is done via environment variables. The following environment variables are supported:
+
+- `ASPNETCORE_URLS` specifies one or more HTTP endpoints through which the dashboard frontend is served. The frontend endpoint is used to view the dashboard in a browser. Defaults to http://localhost:18888.
+- `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` specifies the OTLP endpoint. OTLP endpoint hosts an OTLP service and recevies telemetry. Defaults to http://localhost:18889.
+- `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` specifies the dashboard doesn't use authentication and accepts anonymous access. This setting is a shortcut to configuring `Dashboard:Frontend:AuthMode` and `Dashboard:Otlp:AuthMode` to `Unsecured`.
+- `DOTNET_DASHBOARD_CONFIG_FILE_PATH` specifies the path for an optional JSON configuration file.
+
+#### Frontend authentication
+
+The dashboard's frontend supports OpenID Connect (OIDC). Set `Dashboard__Frontend__AuthMode` to `OpenIdConnect`, then add the following configuration:
+
+- `Authentication__Schemes__OpenIdConnect__Authority` &mdash; URL to the identity provider (IdP)
+- `Authentication__Schemes__OpenIdConnect__ClientId` &mdash; Identity of the relying party (RP)
+- `Authentication__Schemes__OpenIdConnect__ClientSecret`&mdash; A secret that only the real RP would know
+- Other properties of [`OpenIdConnectOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions) specified in configuration container `Authentication__Schemes__OpenIdConnect__*`
+
+It may also be run unsecured. Set `Dashboard__Frontend__AuthMode` to `Unsecured`. The frontend endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+### OTLP authentication
+
+The OTLP endpoint can be secured with [client certificate](https://learn.microsoft.com/aspnet/core/security/authentication/certauth) or API key authentication.
+
+For client certification authentication, set `Dashboard__Otlp__AuthMode` to `Certificate`.
+
+For API key authentication, set `Dashboard__Otlp__AuthMode` to `ApiKey`, then add the following configuration:
+
+- `Dashboard__Otlp__PrimaryApiKey` specifies the primary API key. (required, string)
+- `Dashboard__Otlp__SecondaryApiKey` specifies the secondary API key. (optional, string)
+
+It may also be run unsecured. Set `Dashboard__Otlp__AuthMode` to `Unsecured`. The OTLP endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+### Resources
+
+- `Dashboard__ResourceServiceClient__Url` specifies the gRPC endpoint to which the dashboard connects for its data. There's no default. If this variable is unspecified, the dashboard shows OTEL data but no resource list or console logs.
+
+The resource service client supports certificates. Set `Dashboard__ResourceServiceClient__AuthMode` to `Certificate`, then add the following configuration:
+
+- `Dashboard__ResourceServiceClient__ClientCertificate__Source` (required) one of:
+  - `File` to load the cert from a file path, configured with:
+    - `Dashboard__ResourceServiceClient__ClientCertificate__FilePath` (required, string)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Password` (optional, string)
+  - `KeyStore` to load the cert from a key store, configured with:
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Subject` (required, string)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Store` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
+
+To opt-out of authentication, set `Dashboard__ResourceServiceClient__AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+#### Telemetry Limits
+
+Telemetry is stored in-memory. To avoid excessive memory usage, the dashboard has limits on the count and size of stored telemetry. When a count limit is reached, new telemetry is added, and the oldest telemetry is removed. When a size limit is reached, data is truncated to the limit.
+
+- `Dashboard__TelemetryLimits__MaxLogCount` specifies the maximum number of log entries. Defaults to 10,000.
+- `Dashboard__TelemetryLimits__MaxTraceCount` specifies the maximum number of traces. Defaults to 10,000.
+- `Dashboard__TelemetryLimits__MaxMetricsCount` specifies the maximum number of metric data points. Defaults to 50,000.
+- `Dashboard__TelemetryLimits__MaxAttributeCount` specifies the maximum number of attributes on telemetry. Defaults to 128.
+- `Dashboard__TelemetryLimits__MaxAttributeLength` specifies the maximum length of attributes. Defaults to unlimited.
+- `Dashboard__TelemetryLimits__MaxSpanEventCount` specifies the maximum number of events on span attributes. Defaults to unlimited.
+
+Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures the dashboard to store up to 10,000 log entries per-resource.
+
+### Other
+
+- `Dashboard__ApplicationName` specifies the application name to be displayed in the UI. This applies only when no resource service URL is specified. When a resource service exists, the service specifies the application name.
 
 ## Support
 

--- a/.mar/portal/README.aspire-dashboard.portal.md
+++ b/.mar/portal/README.aspire-dashboard.portal.md
@@ -33,8 +33,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
-
 The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
 
 The dashboard shows:

--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -17,8 +17,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
-
 The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
 
 The dashboard shows:

--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -19,12 +19,80 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
+The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
 
+The dashboard shows:
 
-# Image Variants
+- Resources that make up your app, such as .NET projects, executables and containers.
+- Live console logs of resources.
+- Live telemetry, such as structured logs, traces and metrics.
 
-.NET container images have several variants that offer different combinations of flexibility and deployment size.
-The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-variants.md) contains a summary of the image variants and their use-cases.
+## Configuration
+
+The dashboard must be configured when it is started. The configuration is done via environment variables. The following environment variables are supported:
+
+- `ASPNETCORE_URLS` specifies one or more HTTP endpoints through which the dashboard frontend is served. The frontend endpoint is used to view the dashboard in a browser. Defaults to http://localhost:18888.
+- `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` specifies the OTLP endpoint. OTLP endpoint hosts an OTLP service and recevies telemetry. Defaults to http://localhost:18889.
+- `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` specifies the dashboard doesn't use authentication and accepts anonymous access. This setting is a shortcut to configuring `Dashboard:Frontend:AuthMode` and `Dashboard:Otlp:AuthMode` to `Unsecured`.
+- `DOTNET_DASHBOARD_CONFIG_FILE_PATH` specifies the path for an optional JSON configuration file.
+
+### Frontend authentication
+
+The dashboard's frontend supports OpenID Connect (OIDC). Set `Dashboard__Frontend__AuthMode` to `OpenIdConnect`, then add the following configuration:
+
+- `Authentication__Schemes__OpenIdConnect__Authority` &mdash; URL to the identity provider (IdP)
+- `Authentication__Schemes__OpenIdConnect__ClientId` &mdash; Identity of the relying party (RP)
+- `Authentication__Schemes__OpenIdConnect__ClientSecret`&mdash; A secret that only the real RP would know
+- Other properties of [`OpenIdConnectOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions) specified in configuration container `Authentication__Schemes__OpenIdConnect__*`
+
+It may also be run unsecured. Set `Dashboard__Frontend__AuthMode` to `Unsecured`. The frontend endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+## OTLP authentication
+
+The OTLP endpoint can be secured with [client certificate](https://learn.microsoft.com/aspnet/core/security/authentication/certauth) or API key authentication.
+
+For client certification authentication, set `Dashboard__Otlp__AuthMode` to `Certificate`.
+
+For API key authentication, set `Dashboard__Otlp__AuthMode` to `ApiKey`, then add the following configuration:
+
+- `Dashboard__Otlp__PrimaryApiKey` specifies the primary API key. (required, string)
+- `Dashboard__Otlp__SecondaryApiKey` specifies the secondary API key. (optional, string)
+
+It may also be run unsecured. Set `Dashboard__Otlp__AuthMode` to `Unsecured`. The OTLP endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+## Resources
+
+- `Dashboard__ResourceServiceClient__Url` specifies the gRPC endpoint to which the dashboard connects for its data. There's no default. If this variable is unspecified, the dashboard shows OTEL data but no resource list or console logs.
+
+The resource service client supports certificates. Set `Dashboard__ResourceServiceClient__AuthMode` to `Certificate`, then add the following configuration:
+
+- `Dashboard__ResourceServiceClient__ClientCertificate__Source` (required) one of:
+  - `File` to load the cert from a file path, configured with:
+    - `Dashboard__ResourceServiceClient__ClientCertificate__FilePath` (required, string)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Password` (optional, string)
+  - `KeyStore` to load the cert from a key store, configured with:
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Subject` (required, string)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Store` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
+
+To opt-out of authentication, set `Dashboard__ResourceServiceClient__AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+### Telemetry Limits
+
+Telemetry is stored in-memory. To avoid excessive memory usage, the dashboard has limits on the count and size of stored telemetry. When a count limit is reached, new telemetry is added, and the oldest telemetry is removed. When a size limit is reached, data is truncated to the limit.
+
+- `Dashboard__TelemetryLimits__MaxLogCount` specifies the maximum number of log entries. Defaults to 10,000.
+- `Dashboard__TelemetryLimits__MaxTraceCount` specifies the maximum number of traces. Defaults to 10,000.
+- `Dashboard__TelemetryLimits__MaxMetricsCount` specifies the maximum number of metric data points. Defaults to 50,000.
+- `Dashboard__TelemetryLimits__MaxAttributeCount` specifies the maximum number of attributes on telemetry. Defaults to 128.
+- `Dashboard__TelemetryLimits__MaxAttributeLength` specifies the maximum length of attributes. Defaults to unlimited.
+- `Dashboard__TelemetryLimits__MaxSpanEventCount` specifies the maximum number of events on span attributes. Defaults to unlimited.
+
+Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures the dashboard to store up to 10,000 log entries per-resource.
+
+## Other
+
+- `Dashboard__ApplicationName` specifies the application name to be displayed in the UI. This applies only when no resource service URL is specified. When a resource service exists, the service specifies the application name.
 
 # Related Repositories
 

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -6,7 +6,7 @@
 
 {{InsertTemplate("RelatedRepos.md", commonArgs)}}
 
-{{InsertTemplate("Use.md", commonArgs)}}{{if find(REPO, "monitor") < 0:
+{{InsertTemplate("Use.md", commonArgs)}}{{if (find(REPO, "monitor") < 0 && find(REPO, "aspire") < 0):
 
 {{InsertTemplate("About.variants.md", commonArgs)}}}}
 

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -28,7 +28,7 @@ if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 }}
 {{InsertTemplate("About.md", commonArgs)}}
 
-{{InsertTemplate("Use.md", commonArgs)}}{{if find(REPO, "monitor") < 0:
+{{InsertTemplate("Use.md", commonArgs)}}{{if (find(REPO, "monitor") < 0 && find(REPO, "aspire") < 0):
 
 {{InsertTemplate("About.variants.md", commonArgs)}}}}
 

--- a/eng/readme-templates/Use.aspire-dashboard.md
+++ b/eng/readme-templates/Use.aspire-dashboard.md
@@ -2,6 +2,79 @@
     _ ARGS:
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme ^
-
-    _ This should be filled out according to https://github.com/dotnet/dotnet-docker/issues/5153
 }}
+
+The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
+
+The dashboard shows:
+
+- Resources that make up your app, such as .NET projects, executables and containers.
+- Live console logs of resources.
+- Live telemetry, such as structured logs, traces and metrics.
+
+### Configuration
+
+The dashboard must be configured when it is started. The configuration is done via environment variables. The following environment variables are supported:
+
+- `ASPNETCORE_URLS` specifies one or more HTTP endpoints through which the dashboard frontend is served. The frontend endpoint is used to view the dashboard in a browser. Defaults to http://localhost:18888.
+- `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` specifies the OTLP endpoint. OTLP endpoint hosts an OTLP service and recevies telemetry. Defaults to http://localhost:18889.
+- `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` specifies the dashboard doesn't use authentication and accepts anonymous access. This setting is a shortcut to configuring `Dashboard:Frontend:AuthMode` and `Dashboard:Otlp:AuthMode` to `Unsecured`.
+- `DOTNET_DASHBOARD_CONFIG_FILE_PATH` specifies the path for an optional JSON configuration file.
+
+#### Frontend authentication
+
+The dashboard's frontend supports OpenID Connect (OIDC). Set `Dashboard__Frontend__AuthMode` to `OpenIdConnect`, then add the following configuration:
+
+- `Authentication__Schemes__OpenIdConnect__Authority` &mdash; URL to the identity provider (IdP)
+- `Authentication__Schemes__OpenIdConnect__ClientId` &mdash; Identity of the relying party (RP)
+- `Authentication__Schemes__OpenIdConnect__ClientSecret`&mdash; A secret that only the real RP would know
+- Other properties of [`OpenIdConnectOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions) specified in configuration container `Authentication__Schemes__OpenIdConnect__*`
+
+It may also be run unsecured. Set `Dashboard__Frontend__AuthMode` to `Unsecured`. The frontend endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+### OTLP authentication
+
+The OTLP endpoint can be secured with [client certificate](https://learn.microsoft.com/aspnet/core/security/authentication/certauth) or API key authentication.
+
+For client certification authentication, set `Dashboard__Otlp__AuthMode` to `Certificate`.
+
+For API key authentication, set `Dashboard__Otlp__AuthMode` to `ApiKey`, then add the following configuration:
+
+- `Dashboard__Otlp__PrimaryApiKey` specifies the primary API key. (required, string)
+- `Dashboard__Otlp__SecondaryApiKey` specifies the secondary API key. (optional, string)
+
+It may also be run unsecured. Set `Dashboard__Otlp__AuthMode` to `Unsecured`. The OTLP endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+### Resources
+
+- `Dashboard__ResourceServiceClient__Url` specifies the gRPC endpoint to which the dashboard connects for its data. There's no default. If this variable is unspecified, the dashboard shows OTEL data but no resource list or console logs.
+
+The resource service client supports certificates. Set `Dashboard__ResourceServiceClient__AuthMode` to `Certificate`, then add the following configuration:
+
+- `Dashboard__ResourceServiceClient__ClientCertificate__Source` (required) one of:
+  - `File` to load the cert from a file path, configured with:
+    - `Dashboard__ResourceServiceClient__ClientCertificate__FilePath` (required, string)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Password` (optional, string)
+  - `KeyStore` to load the cert from a key store, configured with:
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Subject` (required, string)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Store` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
+    - `Dashboard__ResourceServiceClient__ClientCertificate__Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
+
+To opt-out of authentication, set `Dashboard__ResourceServiceClient__AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+#### Telemetry Limits
+
+Telemetry is stored in-memory. To avoid excessive memory usage, the dashboard has limits on the count and size of stored telemetry. When a count limit is reached, new telemetry is added, and the oldest telemetry is removed. When a size limit is reached, data is truncated to the limit.
+
+- `Dashboard__TelemetryLimits__MaxLogCount` specifies the maximum number of log entries. Defaults to 10,000.
+- `Dashboard__TelemetryLimits__MaxTraceCount` specifies the maximum number of traces. Defaults to 10,000.
+- `Dashboard__TelemetryLimits__MaxMetricsCount` specifies the maximum number of metric data points. Defaults to 50,000.
+- `Dashboard__TelemetryLimits__MaxAttributeCount` specifies the maximum number of attributes on telemetry. Defaults to 128.
+- `Dashboard__TelemetryLimits__MaxAttributeLength` specifies the maximum length of attributes. Defaults to unlimited.
+- `Dashboard__TelemetryLimits__MaxSpanEventCount` specifies the maximum number of events on span attributes. Defaults to unlimited.
+
+Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures the dashboard to store up to 10,000 log entries per-resource.
+
+### Other
+
+- `Dashboard__ApplicationName` specifies the application name to be displayed in the UI. This applies only when no resource service URL is specified. When a resource service exists, the service specifies the application name.

--- a/eng/readme-templates/Use.aspire-dashboard.md
+++ b/eng/readme-templates/Use.aspire-dashboard.md
@@ -1,10 +1,8 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
-      readme-host: Moniker of the site that will host the readme ^
-}}
-
-The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
+      readme-host: Moniker of the site that will host the readme
+}}The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
 
 The dashboard shows:
 
@@ -12,7 +10,7 @@ The dashboard shows:
 - Live console logs of resources.
 - Live telemetry, such as structured logs, traces and metrics.
 
-### Configuration
+{{ARGS["top-header"]}}# Configuration
 
 The dashboard must be configured when it is started. The configuration is done via environment variables. The following environment variables are supported:
 
@@ -21,7 +19,7 @@ The dashboard must be configured when it is started. The configuration is done v
 - `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` specifies the dashboard doesn't use authentication and accepts anonymous access. This setting is a shortcut to configuring `Dashboard:Frontend:AuthMode` and `Dashboard:Otlp:AuthMode` to `Unsecured`.
 - `DOTNET_DASHBOARD_CONFIG_FILE_PATH` specifies the path for an optional JSON configuration file.
 
-#### Frontend authentication
+{{ARGS["top-header"]}}## Frontend authentication
 
 The dashboard's frontend supports OpenID Connect (OIDC). Set `Dashboard__Frontend__AuthMode` to `OpenIdConnect`, then add the following configuration:
 
@@ -32,7 +30,7 @@ The dashboard's frontend supports OpenID Connect (OIDC). Set `Dashboard__Fronten
 
 It may also be run unsecured. Set `Dashboard__Frontend__AuthMode` to `Unsecured`. The frontend endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
 
-### OTLP authentication
+{{ARGS["top-header"]}}# OTLP authentication
 
 The OTLP endpoint can be secured with [client certificate](https://learn.microsoft.com/aspnet/core/security/authentication/certauth) or API key authentication.
 
@@ -45,7 +43,7 @@ For API key authentication, set `Dashboard__Otlp__AuthMode` to `ApiKey`, then ad
 
 It may also be run unsecured. Set `Dashboard__Otlp__AuthMode` to `Unsecured`. The OTLP endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
 
-### Resources
+{{ARGS["top-header"]}}# Resources
 
 - `Dashboard__ResourceServiceClient__Url` specifies the gRPC endpoint to which the dashboard connects for its data. There's no default. If this variable is unspecified, the dashboard shows OTEL data but no resource list or console logs.
 
@@ -62,7 +60,7 @@ The resource service client supports certificates. Set `Dashboard__ResourceServi
 
 To opt-out of authentication, set `Dashboard__ResourceServiceClient__AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
 
-#### Telemetry Limits
+{{ARGS["top-header"]}}## Telemetry Limits
 
 Telemetry is stored in-memory. To avoid excessive memory usage, the dashboard has limits on the count and size of stored telemetry. When a count limit is reached, new telemetry is added, and the oldest telemetry is removed. When a size limit is reached, data is truncated to the limit.
 
@@ -75,6 +73,6 @@ Telemetry is stored in-memory. To avoid excessive memory usage, the dashboard ha
 
 Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures the dashboard to store up to 10,000 log entries per-resource.
 
-### Other
+{{ARGS["top-header"]}}# Other
 
 - `Dashboard__ApplicationName` specifies the application name to be displayed in the UI. This applies only when no resource service URL is specified. When a resource service exists, the service specifies the application name.

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -6,8 +6,9 @@
         "samples",
         when(PARENT_REPO = "monitor", cat("monitor-", SHORT_REPO), SHORT_REPO))
 }}{{ARGS["top-header"]}} Usage
-
+{{ _ Special case while aspire-dashboard image doesn't have any samples. Remove when https://github.com/dotnet/dotnet-docker/issues/5335 is resolved. ^
+if templateQualifier != "aspire-dashboard":
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
-
+}}
 {{InsertTemplate(join(["Use", templateQualifier, "md"], "."),
   [ "top-header": ARGS["top-header"], "readme-host": ARGS["readme-host"]])}}


### PR DESCRIPTION
Fixes #5153 

@drewnoakes @kvenkatrajan @JamesNK @davidfowl Grabbed most of the content from https://github.com/dotnet/aspire/blob/main/src/Aspire.Dashboard/README.md and just adapted variable names by swapping `:` for `__`. Please let me know if there is anything that should be changed here, or if there is any other feedback around the documentation structure.

@lbussell I tried several times but wasn't able to run the generate script to evaluate all the templates and generate the actual READMEs. Happy to follow any additional instructions on how to do this.