### PR TITLE
Update `Microsoft.TeamFoundationServer.Client` package in update-dependencies tool

### DIFF
--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>


### PR DESCRIPTION
Fixes CG issue due to vulnerable version of `System.Data.SqlClient` referenced by the previous version of this library. I ran a test with this new package version and it was able to create a AzDo PR with no issues. ([Test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2425684&view=results) [internal link])