### PR TITLE
Add additional test-dependencies in manifest for 8.0 Mariner distroless

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1522,6 +1522,13 @@
                   "dependencies": [
                     "$(Repo:sdk):8.0-cbl-mariner2.0-amd64"
                   ]
+                },
+                {
+                  "name": "test-dependencies",
+                  "type": "Integral",
+                  "dependencies": [
+                    "$(Repo:sdk):8.0-cbl-mariner2.0-amd64"
+                  ]
                 }
               ]
             },
@@ -1543,6 +1550,13 @@
                 {
                   "name": "pr-build",
                   "type": "Supplemental",
+                  "dependencies": [
+                    "$(Repo:sdk):8.0-cbl-mariner2.0-arm64v8"
+                  ]
+                },
+                {
+                  "name": "test-dependencies",
+                  "type": "Integral",
                   "dependencies": [
                     "$(Repo:sdk):8.0-cbl-mariner2.0-arm64v8"
                   ]


### PR DESCRIPTION
Fixes test build matrix generation in internal due to https://github.com/dotnet/dotnet-docker/pull/5338.