### PR TITLE
Workaround symcrypt openssl issue in Azure Linux 3.0 base image

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -10,6 +10,7 @@
     set isDebian to find(OS_ARCH_HYPHENATED, "Debian") >= 0 ^
     set isUbuntu to find(OS_ARCH_HYPHENATED, "Ubuntu") >= 0 ^
     set isAzureLinux to find(OS_VERSION, "cbl-mariner") >= 0 || find(OS_VERSION, "azurelinux") >= 0 ^
+    set isAzureLinux3 to isAzureLinux && find(OS_VERSION, "3.0") >= 0 ^
     set isDistrolessAzureLinux to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) || defined(match(OS_VERSION, "^azurelinux\d+\.\d+-distroless$")) ^
     set isFullAzureLinux to isAzureLinux && !isDistrolessAzureLinux ^
     set useLegacyPackageLayout to dotnetVersion = "6.0" ^
@@ -128,12 +129,17 @@
         "") ^
     set pkgMgrOpts to when(isDistrolessAzureLinux,
         cat(" --releasever=", OS_VERSION_NUMBER, pkgMgrOpts),
-        pkgMgrOpts)
+        pkgMgrOpts) ^
+
+    _ Workaround for https://github.com/dotnet/dotnet-docker/issues/5479. Remove when completed ^
+    set useSymCryptOpenSslWorkaround to isAzureLinux3 ^
+    set removePkgs to when(useSymCryptOpenSslWorkaround, ["symcrypt-openssl"])
 
 }}{{InsertTemplate("Dockerfile.linux.install-pkgs",
     [
         "pkgs": pkgs,
         "noninteractive": (OS_VERSION = "focal"),
         "pkg-mgr": when(isDistrolessAzureLinux, "tdnf", ""),
-        "pkg-mgr-opts": pkgMgrOpts
+        "pkg-mgr-opts": pkgMgrOpts,
+        "remove-pkgs": removePkgs
     ])}}

--- a/eng/dockerfile-templates/Dockerfile.linux.install-pkgs
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-pkgs
@@ -4,8 +4,9 @@
         pkg-mgr (optional): package manager to use
         pkg-mgr-opts (optional): additional options to pass to the package manager
         noninteractive (optional): whether to use noninteractive mode
-        no-clean (optional): skip package manager cleanup after install ^
-    
+        no-clean (optional): skip package manager cleanup after install
+        remove-pkgs (optional): optional packages to remove after install, before cleanup ^
+
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isAzureLinux to find(OS_VERSION, "cbl-mariner") >= 0 || find(OS_VERSION, "azurelinux") >= 0 ^
     set isDnf to ARGS["pkg-mgr"] = "dnf" ^
@@ -23,7 +24,11 @@ elif isTdnf:tdnf install -y{{ARGS["pkg-mgr-opts"]}} \^
 else:apt-get update \
     &&{{if ARGS["noninteractive"]: DEBIAN_FRONTEND=noninteractive}} apt-get install -y --no-install-recommends{{ARGS["pkg-mgr-opts"]}} \}}{{
     for index, pkg in ARGS["pkgs"]:
-        {{pkg}}{{if appendPkgSuffix(pkg, index):{{if pkg != "": }}\}}}}{{if !ARGS["no-clean"]:{{
+        {{pkg}}{{if appendPkgSuffix(pkg, index):{{if pkg != "": }}\}}}}{{
+if ARGS["remove-pkgs"]:
+    && tdnf remove -y{{ARGS["pkg-mgr-opts"]}} \{{
+    for index, pkg in ARGS["remove-pkgs"]:
+        {{pkg}} \}}}}{{if !ARGS["no-clean"]:{{
 if isTdnf:
     && tdnf clean all{{ARGS["pkg-mgr-opts"]}}^
 elif isDnf:

--- a/src/runtime-deps/8.0/azurelinux3.0-distroless-aot/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0-distroless-aot/amd64/Dockerfile
@@ -16,6 +16,8 @@ RUN mkdir /staging \
         libgcc \
         openssl-libs \
         zlib \
+    && tdnf remove -y --releasever=3.0 --installroot /staging \
+        symcrypt-openssl \
     && tdnf clean all --releasever=3.0 --installroot /staging
 
 # Generate RPM manifest file by appending to the original manifest file from base distroless image

--- a/src/runtime-deps/8.0/azurelinux3.0-distroless-aot/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0-distroless-aot/arm64v8/Dockerfile
@@ -16,6 +16,8 @@ RUN mkdir /staging \
         libgcc \
         openssl-libs \
         zlib \
+    && tdnf remove -y --releasever=3.0 --installroot /staging \
+        symcrypt-openssl \
     && tdnf clean all --releasever=3.0 --installroot /staging
 
 # Generate RPM manifest file by appending to the original manifest file from base distroless image

--- a/src/runtime-deps/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile
@@ -19,6 +19,8 @@ RUN mkdir /staging \
         openssl-libs \
         tzdata \
         zlib \
+    && tdnf remove -y --releasever=3.0 --installroot /staging \
+        symcrypt-openssl \
     && tdnf clean all --releasever=3.0 --installroot /staging
 
 # Generate RPM manifest file by appending to the original manifest file from base distroless image

--- a/src/runtime-deps/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile
@@ -19,6 +19,8 @@ RUN mkdir /staging \
         openssl-libs \
         tzdata \
         zlib \
+    && tdnf remove -y --releasever=3.0 --installroot /staging \
+        symcrypt-openssl \
     && tdnf clean all --releasever=3.0 --installroot /staging
 
 # Generate RPM manifest file by appending to the original manifest file from base distroless image

--- a/src/runtime-deps/8.0/azurelinux3.0-distroless/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0-distroless/amd64/Dockerfile
@@ -17,6 +17,8 @@ RUN mkdir /staging \
         libstdc++ \
         openssl-libs \
         zlib \
+    && tdnf remove -y --releasever=3.0 --installroot /staging \
+        symcrypt-openssl \
     && tdnf clean all --releasever=3.0 --installroot /staging
 
 # Generate RPM manifest file by appending to the original manifest file from base distroless image

--- a/src/runtime-deps/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile
@@ -17,6 +17,8 @@ RUN mkdir /staging \
         libstdc++ \
         openssl-libs \
         zlib \
+    && tdnf remove -y --releasever=3.0 --installroot /staging \
+        symcrypt-openssl \
     && tdnf clean all --releasever=3.0 --installroot /staging
 
 # Generate RPM manifest file by appending to the original manifest file from base distroless image

--- a/src/runtime-deps/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0/amd64/Dockerfile
@@ -19,6 +19,8 @@ RUN tdnf install -y \
         openssl-libs \
         tzdata \
         zlib \
+    && tdnf remove -y \
+        symcrypt-openssl \
     && tdnf clean all
 
 

--- a/src/runtime-deps/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -19,6 +19,8 @@ RUN tdnf install -y \
         openssl-libs \
         tzdata \
         zlib \
+    && tdnf remove -y \
+        symcrypt-openssl \
     && tdnf clean all
 
 


### PR DESCRIPTION
Workaround https://github.com/dotnet/dotnet-docker/issues/5479 by removing the symcrypt package with the bug. I tested by running the following:

Before:
```pwsh
PS> docker run --rm azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0 /bin/sh -c "curl https://bing.com"

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0[ERROR] error:41080106:SCOSSL::passed invalid argument:set_iv_fixed only works with TLS IV length at /usr/src/azl/BUILD/SymCrypt-OpenSSL-1.4.2/ScosslCommon/src/scossl_aes_aead.c, line 305
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (35) OpenSSL/3.3.0: error:41080106:SCOSSL::passed invalid argument
```

After:
```pwsh
PS> docker run --rm azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0 /bin/sh -c "tdnf remove -y symcrypt-openssl && curl https://bing.com"

Loaded plugin: tdnfrepogpgcheck
<snip>

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0<html><head><title>Object moved</title></head><body>
<h2>Object moved to <a href="https://www.bing.com:443/?toWww=1&amp;redig=2B67BF9265244C288D9C018DF26669DC">here</a>.</h2>
</body></html>
100   193  100   193    0     0   3076      0 --:--:-- --:--:-- --:--:--  3112
```
