### PR TITLE
Update scripts to compensate for installer->sdk migration

### DIFF
--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -12,17 +12,17 @@ param(
     $ProductVersion,
 
     # Build version of the SDK
-    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetInstaller')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetSdk')]
     [string]
     $SdkVersion,
 
     # Build version of ASP.NET Core
-    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetInstaller')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetSdk')]
     [string]
     $AspnetVersion,
 
     # Build version of the .NET runtime
-    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetInstaller')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'DotnetSdk')]
     [string]
     $RuntimeVersion,
 
@@ -114,7 +114,7 @@ if ($UseStableBranding) {
 }
 
 $versionSourceName = switch ($PSCmdlet.ParameterSetName) {
-    "DotnetInstaller" { "dotnet/installer" }
+    "DotnetSdk" { "dotnet/sdk" }
     "DotnetMonitor" { "dotnet/dotnet-monitor/$ProductVersion" }
     "DotnetAspireDashboard" { "dotnet/aspire-dashboard/$ProductVersion" }
     default { Write-Error -Message "Unknown version source" -ErrorAction Stop }

--- a/eng/pipelines/update-dependencies-internal.yml
+++ b/eng/pipelines/update-dependencies-internal.yml
@@ -9,7 +9,7 @@ stages:
 - stage: DotNet
   jobs:
   - job: UpdateDependencies
-    displayName: Update Dependencies (dotnet/installer)
+    displayName: Update Dependencies (dotnet/sdk)
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -13,7 +13,7 @@ stages:
 - stage: DotNet
   jobs:
   - job: UpdateDependencies
-    displayName: Update Dependencies (dotnet/installer)
+    displayName: Update Dependencies (dotnet/sdk)
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:


### PR DESCRIPTION
Builds of 9.0 SDK now come from dotnet/sdk instead of dotnet/installer. This updates the scripts to compensate for this.