### PR TITLE
Simplify Azure Linux 3.0 Runtime deps build

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.remove-pkgs
+++ b/eng/dockerfile-templates/Dockerfile.linux.remove-pkgs
@@ -8,22 +8,38 @@
 
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isAzureLinux to find(OS_VERSION, "cbl-mariner") >= 0 || find(OS_VERSION, "azurelinux") >= 0 ^
+
     set isDnf to ARGS["pkg-mgr"] = "dnf" ^
     set isTdnf to ARGS["pkg-mgr"] = "tdnf" || (!isDnf && isAzureLinux) ^
-    set isApk to ARGS["pkg-mgr"] = "apk" || isAlpine
+    set isTdnf3_4 to isTdnf && find(OS_VERSION, "3.0") >= 0 ^
+    set isApk to ARGS["pkg-mgr"] = "apk" || isAlpine ^
+    set isApt to ARGS["pkg-mgr"] = "apt-get" || (!isDnf && !isTdnf && !isApk) ^
+
+    set removeCmd to
+        when(isApk,
+            "apk del",
+        when(isDnf,
+            "dnf remove -y",
+        when(isTdnf3_4,
+            "tdnf autoremove -y",
+        when(isTdnf,
+            "tdnf remove -y",
+        when (ARGS["noninteractive"],
+            "DEBIAN_FRONTEND=noninteractive apt-get remove -y",
+            "apt-get remove -y"
+        ))))) ^
+
+    set cleanCmd to
+        when(isApk,
+            "apk del",
+        when(isTdnf,
+            "tdnf clean all",
+            "apt-get autoremove \
+&& rm -rf /var/lib/apt/lists/*"))
+
 }}{{
-if isDnf:dnf remove -y{{ARGS["pkg-mgr-opts"]}} \^
-elif isApk:apk del{{ARGS["pkg-mgr-opts"]}} \^
-elif isTdnf:tdnf remove -y{{ARGS["pkg-mgr-opts"]}} \^
-else:apt-get remove \
-&&{{if ARGS["noninteractive"]: DEBIAN_FRONTEND=noninteractive}} apt-get remove -y {{ARGS["pkg-mgr-opts"]}} \}}{{
+removeCmd}}{{ARGS["pkg-mgr-opts"]}} \{{
 for index, pkg in ARGS["pkgs"]:
-    {{pkg}} \}}{{if !no-clean:{{
-if isTdnf:
-&& tdnf clean all{{ARGS["pkg-mgr-opts"]}}^
-elif isDnf:
-&& dnf autoremove{{ARGS["pkg-mgr-opts"]}} \
-&& dnf clean all{{ARGS["pkg-mgr-opts"]}}^
-elif !isApk:
-&& apt-get autoremove \
-&& rm -rf /var/lib/apt/lists/*}}}}
+    {{pkg}} \}}{{
+if !no-clean:
+&& {{cleanCmd}}}}

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.azlinux
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.azlinux
@@ -9,7 +9,6 @@
     set isDebian to find(OS_ARCH_HYPHENATED, "Debian") >= 0 ^
     set isUbuntu to find(OS_ARCH_HYPHENATED, "Ubuntu") >= 0 ^
     set isAzureLinux to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) || defined(match(OS_VERSION, "^azurelinux\d+\.\d+$")) ^
-    set isCblMariner2 to isAzureLinux && find(OS_VERSION_NUMBER, "2.0") >= 0 ^
 
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
@@ -27,7 +26,7 @@
     set baseImageTag to when(isAlpine || isAzureLinux, OS_VERSION_NUMBER, OS_VERSION) ^
     set isRpmInstall to isAzureLinux && dotnetVersion = "6.0" ^
     set nonRootUserSupported to dotnetVersion != "6.0" ^
-    set isMultiStage to (isRpmInstall && isInternal) || (isCblMariner2 && nonRootUserSupported) ^
+    set isMultiStage to (isRpmInstall && isInternal) || (isAzureLinux && nonRootUserSupported) ^
     set firstStageName to when(isRpmInstall, "installer", "base") ^
     set secondStageName to when(isMultiStage && nonRootUserSupported, "installer") ^
     set stagingDir to "/staging" ^

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.non-root-user
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.linux.non-root-user
@@ -11,13 +11,19 @@
     set isDebian to find(OS_ARCH_HYPHENATED, "Debian") >= 0 ^
     set isUbuntu to find(OS_ARCH_HYPHENATED, "Ubuntu") >= 0 ^
     set isAzureLinux to find(OS_VERSION, "cbl-mariner") >= 0 || find(OS_VERSION, "azurelinux") >= 0 ^
+    set isAzureLinux3 to isAzureLinux && find(OS_VERSION_NUMBER, "3.0") >= 0 ^
     set isDistrolessAzureLinux to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+-distroless$")) || defined(match(OS_VERSION, "^azurelinux\d+\.\d+-distroless$")) ^
     set isChiseledUbuntu to find(OS_VERSION, "chiseled") >= 0 ^
     set addUserCommand to when(isDebian || isUbuntu || isAzureLinux, "useradd -l", "adduser") ^
     set isSystemUser to isDistrolessAzureLinux && (dotnetVersion = "6.0") ^
     set uid to when(len(ARGS["uid"]) > 0, ARGS["uid"], "$APP_UID") ^
-    set gid to when(len(ARGS["gid"]) > 0, ARGS["gid"], "$APP_UID")
-}}{{if isAlpine:addgroup^else:groupadd}} \{{if isSystemUser:
+    set gid to when(len(ARGS["gid"]) > 0, ARGS["gid"], "$APP_UID") ^
+    set utilPkgs to when(isAzureLinux3 && !isDistrolessAzureLinux && dotnetVersion != "6.0", ["shadow-utils"], [])
+}}{{if len(utilPkgs) > 0:{{InsertTemplate("../Dockerfile.linux.install-pkgs", [
+        "pkgs": utilPkgs,
+        "no-clean": "true"
+    ])}}
+    && }}{{if isAlpine:addgroup^else:groupadd}} \{{if isSystemUser:
         --system \}}
         --gid={{gid}} \
         {{ARGS["name"]}} \
@@ -29,4 +35,7 @@
         --create-home \}}{{if isSystemUser:
         --system \}}{{if isAlpine:
         --disabled-password \}}
-        {{ARGS["name"]}}
+        {{ARGS["name"]}}{{if len(utilPkgs) > 0: \
+    && {{InsertTemplate("../Dockerfile.linux.remove-pkgs", [
+        "pkgs": utilPkgs
+        ], "    ")}}}}

--- a/src/runtime-deps/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0 AS base
+FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
 
 ENV \
     # UID of the non-root user 'app'
@@ -21,31 +21,17 @@ RUN tdnf install -y \
         zlib \
     && tdnf clean all
 
-
-FROM base AS installer
-
+# Create a non-root user and group
 RUN tdnf install -y \
         shadow-utils \
-    && tdnf clean all
-
-# Create a non-root user and group
-RUN groupadd \
+    && groupadd \
         --gid=$APP_UID \
         app \
     && useradd -l \
         --uid=$APP_UID \
         --gid=$APP_UID \
-        --no-create-home \
+        --create-home \
         app \
-    && mkdir -p "/staging/etc" \
-    # Copy user/group info to staging
-    && cp /etc/passwd /staging/etc/passwd \
-    && cp /etc/group /staging/etc/group
-
-
-# Final image
-FROM base
-
-COPY --from=installer /staging/ /
-
-RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"
+    && tdnf autoremove -y \
+        shadow-utils \
+    && tdnf clean all

--- a/src/runtime-deps/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0 AS base
+FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core:3.0
 
 ENV \
     # UID of the non-root user 'app'
@@ -21,31 +21,17 @@ RUN tdnf install -y \
         zlib \
     && tdnf clean all
 
-
-FROM base AS installer
-
+# Create a non-root user and group
 RUN tdnf install -y \
         shadow-utils \
-    && tdnf clean all
-
-# Create a non-root user and group
-RUN groupadd \
+    && groupadd \
         --gid=$APP_UID \
         app \
     && useradd -l \
         --uid=$APP_UID \
         --gid=$APP_UID \
-        --no-create-home \
+        --create-home \
         app \
-    && mkdir -p "/staging/etc" \
-    # Copy user/group info to staging
-    && cp /etc/passwd /staging/etc/passwd \
-    && cp /etc/group /staging/etc/group
-
-
-# Final image
-FROM base
-
-COPY --from=installer /staging/ /
-
-RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"
+    && tdnf autoremove -y \
+        shadow-utils \
+    && tdnf clean all


### PR DESCRIPTION
Fixes #5484 

These changes make the build single-stage since tndf is version > 3.4.0 in AzureLinux 3.0. This means we have access to tdnf autoremove, which can remove packages along with dangling dependencies.

This change actually adds about 2.3-2.4 MB to the image (uncompressed). Some additional files are left behind after user creation, unrelated to the package manager. The biggest change is a ~400kb increase in `/var/lib/rpm/rpmdb.sqlite`.

Some of the files, like `/home/app/.*` (dotfiles) are the same but just moved locations.

Here is a screenshot from `dive` showing the diff of the final image layer:

![image](https://github.com/dotnet/dotnet-docker/assets/36081148/8b3f499a-05f3-4e14-a638-8b35038ebaa3)
