### PR TITLE
Fix SDK installation in 9.0 Noble arm32 Dockerfile

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
@@ -124,5 +124,5 @@ if isFullAzureLinux:    dotnet_version={{VARIABLES[cat("runtime|", dotnetVersion
         "skip-install": !installEnabled,
         "install-dir": installDir,
         "create-install-dir": !isFullAzureLinux
-    ], "    ")}}{{if !ARGS["is-internal"] || (ARGS["is-rpm-install"] && installEnabled): \
+    ], "    ")}}{{if !ARGS["disable-first-run-experience"] && (!ARGS["is-internal"] || (ARGS["is-rpm-install"] && installEnabled)): \
     {{InsertTemplate("Dockerfile.linux.first-run", ["append-cmd": "true"], "    ")}}}}

--- a/src/sdk/9.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/9.0/noble/arm32v7/Dockerfile
@@ -8,9 +8,7 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
-    && rm dotnet.tar.gz \
-    # Trigger first run experience by running arbitrary cmd
-    && dotnet help
+    && rm dotnet.tar.gz
 
 
 # .NET SDK image


### PR DESCRIPTION
This was the result of a bad merge from nightly to main, which prevented this image from being able to build.