### PR TITLE
Explicitly install libgcc-atomic for Azure Linux

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -1,7 +1,8 @@
 {{
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
-    set isAzureLinux to find(OS_VERSION, "cbl-mariner") >= 0 || find(OS_VERSION, "azurelinux") >= 0 ^
+    set isMariner to find(OS_VERSION, "cbl-mariner") >= 0 ^
+    set isAzureLinux to isMariner || find(OS_VERSION, "azurelinux") >= 0 ^
     set isFullAzureLinux to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
     set baseUrl to VARIABLES[cat("base-url|", dotnetVersion, "|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "msrc") >= 0 || find(baseUrl, "internal") >= 0 ^
@@ -43,17 +44,23 @@
                     "tzdata",
                 ])),
         when(isAzureLinux,
-            when (dotnetVersion = "6.0",
+            when (isMariner,
+                when (dotnetVersion = "6.0",
+                    [
+                        "git",
+                        "tar",
+                    ],
+                    [
+                        "git",
+                        "libatomic_ops",
+                        "tar",
+                    ]
+                ),
                 [
                     "git",
+                    "libgcc-atomic",
                     "tar",
-                ],
-                [
-                    "git",
-                    "libatomic_ops",
-                    "tar",
-                ]
-            ),
+                ]),
             when (dotnetVersion = "6.0",
                 [
                     "curl",

--- a/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
@@ -17,7 +17,7 @@ ENV \
 
 RUN tdnf install -y \
         git \
-        libatomic_ops \
+        libgcc-atomic \
         tar \
     && tdnf clean all
 

--- a/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -17,7 +17,7 @@ ENV \
 
 RUN tdnf install -y \
         git \
-        libatomic_ops \
+        libgcc-atomic \
         tar \
     && tdnf clean all
 

--- a/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
@@ -17,7 +17,7 @@ ENV \
 
 RUN tdnf install -y \
         git \
-        libatomic_ops \
+        libgcc-atomic \
         tar \
     && tdnf clean all
 

--- a/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
@@ -17,7 +17,7 @@ ENV \
 
 RUN tdnf install -y \
         git \
-        libatomic_ops \
+        libgcc-atomic \
         tar \
     && tdnf clean all
 


### PR DESCRIPTION
The SDK relies on `libatomic.so.1` for wasm scenarios (see https://github.com/dotnet/dotnet-docker/issues/5033). In Azure Linux, this file is provided by `libgcc-atomic` which is aliased by `libatomic`. A recent change in Azure Linux packages has caused `libgcc-atomic` to no longer be a dependency of `git`. This has caused a test failure when attempting to load `libatomic.so.1`: https://github.com/dotnet/dotnet-docker/issues/5598.

The SDK Dockerfiles _do_ install `libatomic_ops` but this doesn't actually provide the files we need. In reality, this package isn't needed at all and it was really `git` that was providing the necessary files up to this point.

To fix this, I've updated the Dockerfiles to explicitly install `libgcc-atomic` and no longer install `libatomic_ops`.

Fixes https://github.com/dotnet/dotnet-docker/issues/5598