### PR TITLE
Remove `-1` tag suffix for sdk

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -69,26 +69,26 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 ## Linux amd64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.302-1-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.302-1-bookworm-slim, 8.0-bookworm-slim, 8.0.302, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.302-1-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0.302-alpine3.20, 8.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+8.0.302-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.302-bookworm-slim, 8.0-bookworm-slim, 8.0.302, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
+8.0.302-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0.302-alpine3.20, 8.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
 8.0.302-alpine3.20-aot-amd64, 8.0-alpine3.20-aot-amd64, 8.0.302-alpine3.20-aot, 8.0-alpine3.20-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
-8.0.302-1-alpine3.19-amd64, 8.0-alpine3.19-amd64, 8.0-alpine-amd64, 8.0.302-1-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19/amd64/Dockerfile) | Alpine 3.19
+8.0.302-alpine3.19-amd64, 8.0-alpine3.19-amd64, 8.0-alpine-amd64, 8.0.302-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19/amd64/Dockerfile) | Alpine 3.19
 8.0.302-alpine3.19-aot-amd64, 8.0-alpine3.19-aot-amd64, 8.0-alpine-aot-amd64, 8.0.302-alpine3.19-aot, 8.0-alpine3.19-aot, 8.0-alpine-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19-aot/amd64/Dockerfile) | Alpine 3.19
-8.0.302-1-noble-amd64, 8.0-noble-amd64, 8.0.302-noble, 8.0-noble | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
+8.0.302-noble-amd64, 8.0-noble-amd64, 8.0.302-noble, 8.0-noble | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.302-noble-aot-amd64, 8.0-noble-aot-amd64, 8.0.302-noble-aot, 8.0-noble-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/noble-aot/amd64/Dockerfile) | Ubuntu 24.04
-8.0.302-1-jammy-amd64, 8.0-jammy-amd64, 8.0.302-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
+8.0.302-jammy-amd64, 8.0-jammy-amd64, 8.0.302-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
 8.0.302-jammy-aot-amd64, 8.0-jammy-aot-amd64, 8.0.302-jammy-aot, 8.0-jammy-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy-aot/amd64/Dockerfile) | Ubuntu 22.04
 8.0.302-azurelinux3.0-amd64, 8.0-azurelinux3.0-amd64, 8.0.302-azurelinux3.0, 8.0-azurelinux3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile) | Azure Linux 3.0
 8.0.302-azurelinux3.0-aot-amd64, 8.0-azurelinux3.0-aot-amd64, 8.0.302-azurelinux3.0-aot, 8.0-azurelinux3.0-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/azurelinux3.0-aot/amd64/Dockerfile) | Azure Linux 3.0
-8.0.302-1-cbl-mariner2.0-amd64, 8.0-cbl-mariner2.0-amd64, 8.0.302-cbl-mariner2.0, 8.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile) | CBL-Mariner 2.0
+8.0.302-cbl-mariner2.0-amd64, 8.0-cbl-mariner2.0-amd64, 8.0.302-cbl-mariner2.0, 8.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile) | CBL-Mariner 2.0
 8.0.302-cbl-mariner2.0-aot-amd64, 8.0-cbl-mariner2.0-aot-amd64, 8.0.302-cbl-mariner2.0-aot, 8.0-cbl-mariner2.0-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/cbl-mariner2.0-aot/amd64/Dockerfile) | CBL-Mariner 2.0
-6.0.423-1-bookworm-slim-amd64, 6.0-bookworm-slim-amd64, 6.0.423-1-bookworm-slim, 6.0-bookworm-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-6.0.423-1-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.423-1-bullseye-slim, 6.0-bullseye-slim, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
-6.0.423-1-alpine3.20-amd64, 6.0-alpine3.20-amd64, 6.0.423-1-alpine3.20, 6.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
-6.0.423-1-alpine3.19-amd64, 6.0-alpine3.19-amd64, 6.0-alpine-amd64, 6.0.423-1-alpine3.19, 6.0-alpine3.19, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.19/amd64/Dockerfile) | Alpine 3.19
-6.0.423-1-jammy-amd64, 6.0-jammy-amd64, 6.0.423-1-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
-6.0.423-1-cbl-mariner2.0-amd64, 6.0-cbl-mariner2.0-amd64, 6.0.423-1-cbl-mariner2.0, 6.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile) | CBL-Mariner 2.0
-6.0.423-1-focal-amd64, 6.0-focal-amd64, 6.0.423-1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/amd64/Dockerfile) | Ubuntu 20.04
+6.0.423-bookworm-slim-amd64, 6.0-bookworm-slim-amd64, 6.0.423-bookworm-slim, 6.0-bookworm-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bookworm-slim/amd64/Dockerfile) | Debian 12
+6.0.423-bullseye-slim-amd64, 6.0-bullseye-slim-amd64, 6.0.423-bullseye-slim, 6.0-bullseye-slim, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/amd64/Dockerfile) | Debian 11
+6.0.423-alpine3.20-amd64, 6.0-alpine3.20-amd64, 6.0.423-alpine3.20, 6.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+6.0.423-alpine3.19-amd64, 6.0-alpine3.19-amd64, 6.0-alpine-amd64, 6.0.423-alpine3.19, 6.0-alpine3.19, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.19/amd64/Dockerfile) | Alpine 3.19
+6.0.423-jammy-amd64, 6.0-jammy-amd64, 6.0.423-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
+6.0.423-cbl-mariner2.0-amd64, 6.0-cbl-mariner2.0-amd64, 6.0.423-cbl-mariner2.0, 6.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/cbl-mariner2.0/amd64/Dockerfile) | CBL-Mariner 2.0
+6.0.423-focal-amd64, 6.0-focal-amd64, 6.0.423-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/amd64/Dockerfile) | Ubuntu 20.04
 
 ##### .NET 9 Preview Tags
 Tags | Dockerfile | OS Version
@@ -104,26 +104,26 @@ Tags | Dockerfile | OS Version
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.302-1-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.302-1-bookworm-slim, 8.0-bookworm-slim, 8.0.302, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.302-1-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0.302-alpine3.20, 8.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+8.0.302-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.302-bookworm-slim, 8.0-bookworm-slim, 8.0.302, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
+8.0.302-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0.302-alpine3.20, 8.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
 8.0.302-alpine3.20-aot-arm64v8, 8.0-alpine3.20-aot-arm64v8, 8.0.302-alpine3.20-aot, 8.0-alpine3.20-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
-8.0.302-1-alpine3.19-arm64v8, 8.0-alpine3.19-arm64v8, 8.0-alpine-arm64v8, 8.0.302-1-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19/arm64v8/Dockerfile) | Alpine 3.19
+8.0.302-alpine3.19-arm64v8, 8.0-alpine3.19-arm64v8, 8.0-alpine-arm64v8, 8.0.302-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19/arm64v8/Dockerfile) | Alpine 3.19
 8.0.302-alpine3.19-aot-arm64v8, 8.0-alpine3.19-aot-arm64v8, 8.0-alpine-aot-arm64v8, 8.0.302-alpine3.19-aot, 8.0-alpine3.19-aot, 8.0-alpine-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19-aot/arm64v8/Dockerfile) | Alpine 3.19
-8.0.302-1-noble-arm64v8, 8.0-noble-arm64v8, 8.0.302-noble, 8.0-noble | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
+8.0.302-noble-arm64v8, 8.0-noble-arm64v8, 8.0.302-noble, 8.0-noble | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.302-noble-aot-arm64v8, 8.0-noble-aot-arm64v8, 8.0.302-noble-aot, 8.0-noble-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/noble-aot/arm64v8/Dockerfile) | Ubuntu 24.04
-8.0.302-1-jammy-arm64v8, 8.0-jammy-arm64v8, 8.0.302-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
+8.0.302-jammy-arm64v8, 8.0-jammy-arm64v8, 8.0.302-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
 8.0.302-jammy-aot-arm64v8, 8.0-jammy-aot-arm64v8, 8.0.302-jammy-aot, 8.0-jammy-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy-aot/arm64v8/Dockerfile) | Ubuntu 22.04
 8.0.302-azurelinux3.0-arm64v8, 8.0-azurelinux3.0-arm64v8, 8.0.302-azurelinux3.0, 8.0-azurelinux3.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.302-azurelinux3.0-aot-arm64v8, 8.0-azurelinux3.0-aot-arm64v8, 8.0.302-azurelinux3.0-aot, 8.0-azurelinux3.0-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/azurelinux3.0-aot/arm64v8/Dockerfile) | Azure Linux 3.0
-8.0.302-1-cbl-mariner2.0-arm64v8, 8.0-cbl-mariner2.0-arm64v8, 8.0.302-cbl-mariner2.0, 8.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile) | CBL-Mariner 2.0
+8.0.302-cbl-mariner2.0-arm64v8, 8.0-cbl-mariner2.0-arm64v8, 8.0.302-cbl-mariner2.0, 8.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile) | CBL-Mariner 2.0
 8.0.302-cbl-mariner2.0-aot-arm64v8, 8.0-cbl-mariner2.0-aot-arm64v8, 8.0.302-cbl-mariner2.0-aot, 8.0-cbl-mariner2.0-aot | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/cbl-mariner2.0-aot/arm64v8/Dockerfile) | CBL-Mariner 2.0
-6.0.423-1-bookworm-slim-arm64v8, 6.0-bookworm-slim-arm64v8, 6.0.423-1-bookworm-slim, 6.0-bookworm-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-6.0.423-1-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.423-1-bullseye-slim, 6.0-bullseye-slim, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
-6.0.423-1-alpine3.20-arm64v8, 6.0-alpine3.20-arm64v8, 6.0.423-1-alpine3.20, 6.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
-6.0.423-1-alpine3.19-arm64v8, 6.0-alpine3.19-arm64v8, 6.0-alpine-arm64v8, 6.0.423-1-alpine3.19, 6.0-alpine3.19, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.19/arm64v8/Dockerfile) | Alpine 3.19
-6.0.423-1-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.423-1-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
-6.0.423-1-cbl-mariner2.0-arm64v8, 6.0-cbl-mariner2.0-arm64v8, 6.0.423-1-cbl-mariner2.0, 6.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile) | CBL-Mariner 2.0
-6.0.423-1-focal-arm64v8, 6.0-focal-arm64v8, 6.0.423-1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
+6.0.423-bookworm-slim-arm64v8, 6.0-bookworm-slim-arm64v8, 6.0.423-bookworm-slim, 6.0-bookworm-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
+6.0.423-bullseye-slim-arm64v8, 6.0-bullseye-slim-arm64v8, 6.0.423-bullseye-slim, 6.0-bullseye-slim, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm64v8/Dockerfile) | Debian 11
+6.0.423-alpine3.20-arm64v8, 6.0-alpine3.20-arm64v8, 6.0.423-alpine3.20, 6.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+6.0.423-alpine3.19-arm64v8, 6.0-alpine3.19-arm64v8, 6.0-alpine-arm64v8, 6.0.423-alpine3.19, 6.0-alpine3.19, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.19/arm64v8/Dockerfile) | Alpine 3.19
+6.0.423-jammy-arm64v8, 6.0-jammy-arm64v8, 6.0.423-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
+6.0.423-cbl-mariner2.0-arm64v8, 6.0-cbl-mariner2.0-arm64v8, 6.0.423-cbl-mariner2.0, 6.0-cbl-mariner2.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/cbl-mariner2.0/arm64v8/Dockerfile) | CBL-Mariner 2.0
+6.0.423-focal-arm64v8, 6.0-focal-arm64v8, 6.0.423-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm64v8/Dockerfile) | Ubuntu 20.04
 
 ##### .NET 9 Preview Tags
 Tags | Dockerfile | OS Version
@@ -139,16 +139,16 @@ Tags | Dockerfile | OS Version
 ## Linux arm32 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.0.302-1-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.302-1-bookworm-slim, 8.0-bookworm-slim, 8.0.302, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.302-1-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0.302-alpine3.20, 8.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
-8.0.302-1-alpine3.19-arm32v7, 8.0-alpine3.19-arm32v7, 8.0-alpine-arm32v7, 8.0.302-1-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19/arm32v7/Dockerfile) | Alpine 3.19
-8.0.302-1-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.302-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
-6.0.423-1-bookworm-slim-arm32v7, 6.0-bookworm-slim-arm32v7, 6.0.423-1-bookworm-slim, 6.0-bookworm-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-6.0.423-1-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.423-1-bullseye-slim, 6.0-bullseye-slim, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
-6.0.423-1-alpine3.20-arm32v7, 6.0-alpine3.20-arm32v7, 6.0.423-1-alpine3.20, 6.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
-6.0.423-1-alpine3.19-arm32v7, 6.0-alpine3.19-arm32v7, 6.0-alpine-arm32v7, 6.0.423-1-alpine3.19, 6.0-alpine3.19, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.19/arm32v7/Dockerfile) | Alpine 3.19
-6.0.423-1-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.423-1-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
-6.0.423-1-focal-arm32v7, 6.0-focal-arm32v7, 6.0.423-1-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
+8.0.302-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.302-bookworm-slim, 8.0-bookworm-slim, 8.0.302, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
+8.0.302-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0.302-alpine3.20, 8.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+8.0.302-alpine3.19-arm32v7, 8.0-alpine3.19-arm32v7, 8.0-alpine-arm32v7, 8.0.302-alpine3.19, 8.0-alpine3.19, 8.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/alpine3.19/arm32v7/Dockerfile) | Alpine 3.19
+8.0.302-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.302-jammy, 8.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
+6.0.423-bookworm-slim-arm32v7, 6.0-bookworm-slim-arm32v7, 6.0.423-bookworm-slim, 6.0-bookworm-slim | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
+6.0.423-bullseye-slim-arm32v7, 6.0-bullseye-slim-arm32v7, 6.0.423-bullseye-slim, 6.0-bullseye-slim, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/bullseye-slim/arm32v7/Dockerfile) | Debian 11
+6.0.423-alpine3.20-arm32v7, 6.0-alpine3.20-arm32v7, 6.0.423-alpine3.20, 6.0-alpine3.20 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+6.0.423-alpine3.19-arm32v7, 6.0-alpine3.19-arm32v7, 6.0-alpine-arm32v7, 6.0.423-alpine3.19, 6.0-alpine3.19, 6.0-alpine | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/alpine3.19/arm32v7/Dockerfile) | Alpine 3.19
+6.0.423-jammy-arm32v7, 6.0-jammy-arm32v7, 6.0.423-jammy, 6.0-jammy | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
+6.0.423-focal-arm32v7, 6.0-focal-arm32v7, 6.0.423-focal, 6.0-focal | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/focal/arm32v7/Dockerfile) | Ubuntu 20.04
 
 ##### .NET 9 Preview Tags
 Tags | Dockerfile | OS Version
@@ -160,8 +160,8 @@ Tags | Dockerfile | OS Version
 ## Nano Server 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-8.0.302-1-nanoserver-ltsc2022, 8.0-nanoserver-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile)
-6.0.423-1-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile)
+8.0.302-nanoserver-ltsc2022, 8.0-nanoserver-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile)
+6.0.423-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-ltsc2022/amd64/Dockerfile)
 
 ##### .NET 9 Preview Tags
 Tag | Dockerfile
@@ -171,8 +171,8 @@ Tag | Dockerfile
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-8.0.302-1-windowsservercore-ltsc2022, 8.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile)
-6.0.423-1-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
+8.0.302-windowsservercore-ltsc2022, 8.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile)
+6.0.423-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2022/amd64/Dockerfile)
 
 ##### .NET 9 Preview Tags
 Tag | Dockerfile
@@ -182,8 +182,8 @@ Tag | Dockerfile
 ## Nano Server, version 1809 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-8.0.302-1-nanoserver-1809, 8.0-nanoserver-1809 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile)
-6.0.423-1-nanoserver-1809, 6.0-nanoserver-1809, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile)
+8.0.302-nanoserver-1809, 8.0-nanoserver-1809 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile)
+6.0.423-nanoserver-1809, 6.0-nanoserver-1809, 6.0.423-1, 6.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/nanoserver-1809/amd64/Dockerfile)
 
 ##### .NET 9 Preview Tags
 Tag | Dockerfile
@@ -193,8 +193,8 @@ Tag | Dockerfile
 ## Windows Server Core 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-8.0.302-1-windowsservercore-ltsc2019, 8.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile)
-6.0.423-1-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+8.0.302-windowsservercore-ltsc2019, 8.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile)
+6.0.423-windowsservercore-ltsc2019, 6.0-windowsservercore-ltsc2019 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/sdk/6.0/windowsservercore-ltsc2019/amd64/Dockerfile)
 
 ##### .NET 9 Preview Tags
 Tag | Dockerfile

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.aot
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.aot
@@ -1,6 +1,6 @@
 {{
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
-    set baseImageTag to cat("$REPO:", VARIABLES[cat("sdk|", dotnetVersion, "|product-version")], when(dotnetVersion = "8.0" && find(OS_VERSION, "azurelinux") < 0, "-1", ""), "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
+    set baseImageTag to cat("$REPO:", VARIABLES[cat("sdk|", dotnetVersion, "|product-version")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
 
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isAzureLinux to find(OS_VERSION, "cbl-mariner") >= 0 || find(OS_VERSION, "azurelinux") >= 0 ^

--- a/manifest.json
+++ b/manifest.json
@@ -7911,7 +7911,7 @@
               "os": "linux",
               "osVersion": "bullseye-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-1-bullseye-slim-amd64": {},
+                "$(sdk|6.0|product-version)-bullseye-slim-amd64": {},
                 "6.0-bullseye-slim-amd64": {}
               }
             },
@@ -7925,7 +7925,7 @@
               "os": "linux",
               "osVersion": "bullseye-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-1-bullseye-slim-arm32v7": {},
+                "$(sdk|6.0|product-version)-bullseye-slim-arm32v7": {},
                 "6.0-bullseye-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -7940,7 +7940,7 @@
               "os": "linux",
               "osVersion": "bullseye-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-1-bullseye-slim-arm64v8": {},
+                "$(sdk|6.0|product-version)-bullseye-slim-arm64v8": {},
                 "6.0-bullseye-slim-arm64v8": {}
               },
               "variant": "v8"
@@ -7954,7 +7954,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(sdk|6.0|product-version)-1-nanoserver-1809": {},
+                "$(sdk|6.0|product-version)-nanoserver-1809": {},
                 "6.0-nanoserver-1809": {}
               }
             },
@@ -7967,7 +7967,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "$(sdk|6.0|product-version)-1-nanoserver-ltsc2022": {},
+                "$(sdk|6.0|product-version)-nanoserver-ltsc2022": {},
                 "6.0-nanoserver-ltsc2022": {}
               }
             }
@@ -7977,7 +7977,7 @@
           "id": "bullseye-slim",
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-bullseye-slim": {},
+            "$(sdk|6.0|product-version)-bullseye-slim": {},
             "6.0-bullseye-slim": {}
           },
           "platforms": [
@@ -8020,7 +8020,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-bookworm-slim": {},
+            "$(sdk|6.0|product-version)-bookworm-slim": {},
             "6.0-bookworm-slim": {}
           },
           "platforms": [
@@ -8033,7 +8033,7 @@
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-1-bookworm-slim-amd64": {},
+                "$(sdk|6.0|product-version)-bookworm-slim-amd64": {},
                 "6.0-bookworm-slim-amd64": {}
               }
             },
@@ -8047,7 +8047,7 @@
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-1-bookworm-slim-arm32v7": {},
+                "$(sdk|6.0|product-version)-bookworm-slim-arm32v7": {},
                 "6.0-bookworm-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -8062,7 +8062,7 @@
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
-                "$(sdk|6.0|product-version)-1-bookworm-slim-arm64v8": {},
+                "$(sdk|6.0|product-version)-bookworm-slim-arm64v8": {},
                 "6.0-bookworm-slim-arm64v8": {}
               },
               "variant": "v8"
@@ -8072,7 +8072,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-alpine3.19": {},
+            "$(sdk|6.0|product-version)-alpine3.19": {},
             "6.0-alpine3.19": {},
             "6.0-alpine": {}
           },
@@ -8086,7 +8086,7 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.19-amd64": {},
+                "$(sdk|6.0|product-version)-alpine3.19-amd64": {},
                 "6.0-alpine3.19-amd64": {},
                 "6.0-alpine-amd64": {}
               }
@@ -8101,7 +8101,7 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.19-arm32v7": {},
+                "$(sdk|6.0|product-version)-alpine3.19-arm32v7": {},
                 "6.0-alpine3.19-arm32v7": {},
                 "6.0-alpine-arm32v7": {}
               },
@@ -8117,7 +8117,7 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.19-arm64v8": {},
+                "$(sdk|6.0|product-version)-alpine3.19-arm64v8": {},
                 "6.0-alpine3.19-arm64v8": {},
                 "6.0-alpine-arm64v8": {}
               },
@@ -8128,7 +8128,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-alpine3.20": {},
+            "$(sdk|6.0|product-version)-alpine3.20": {},
             "6.0-alpine3.20": {}
           },
           "platforms": [
@@ -8141,7 +8141,7 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.20-amd64": {},
+                "$(sdk|6.0|product-version)-alpine3.20-amd64": {},
                 "6.0-alpine3.20-amd64": {}
               }
             },
@@ -8155,7 +8155,7 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.20-arm32v7": {},
+                "$(sdk|6.0|product-version)-alpine3.20-arm32v7": {},
                 "6.0-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
@@ -8170,7 +8170,7 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "$(sdk|6.0|product-version)-1-alpine3.20-arm64v8": {},
+                "$(sdk|6.0|product-version)-alpine3.20-arm64v8": {},
                 "6.0-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
@@ -8180,7 +8180,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-focal": {},
+            "$(sdk|6.0|product-version)-focal": {},
             "6.0-focal": {}
           },
           "platforms": [
@@ -8193,7 +8193,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(sdk|6.0|product-version)-1-focal-amd64": {},
+                "$(sdk|6.0|product-version)-focal-amd64": {},
                 "6.0-focal-amd64": {}
               }
             },
@@ -8207,7 +8207,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(sdk|6.0|product-version)-1-focal-arm32v7": {},
+                "$(sdk|6.0|product-version)-focal-arm32v7": {},
                 "6.0-focal-arm32v7": {}
               },
               "variant": "v7"
@@ -8222,7 +8222,7 @@
               "os": "linux",
               "osVersion": "focal",
               "tags": {
-                "$(sdk|6.0|product-version)-1-focal-arm64v8": {},
+                "$(sdk|6.0|product-version)-focal-arm64v8": {},
                 "6.0-focal-arm64v8": {}
               },
               "variant": "v8"
@@ -8232,7 +8232,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-jammy": {},
+            "$(sdk|6.0|product-version)-jammy": {},
             "6.0-jammy": {}
           },
           "platforms": [
@@ -8245,7 +8245,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|6.0|product-version)-1-jammy-amd64": {},
+                "$(sdk|6.0|product-version)-jammy-amd64": {},
                 "6.0-jammy-amd64": {}
               }
             },
@@ -8259,7 +8259,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|6.0|product-version)-1-jammy-arm32v7": {},
+                "$(sdk|6.0|product-version)-jammy-arm32v7": {},
                 "6.0-jammy-arm32v7": {}
               },
               "variant": "v7"
@@ -8274,7 +8274,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|6.0|product-version)-1-jammy-arm64v8": {},
+                "$(sdk|6.0|product-version)-jammy-arm64v8": {},
                 "6.0-jammy-arm64v8": {}
               },
               "variant": "v8"
@@ -8284,7 +8284,7 @@
         {
           "productVersion": "$(sdk|6.0|product-version)",
           "sharedTags": {
-            "$(sdk|6.0|product-version)-1-cbl-mariner2.0": {},
+            "$(sdk|6.0|product-version)-cbl-mariner2.0": {},
             "6.0-cbl-mariner2.0": {},
             "6.0-cbl-mariner": {
               "docType": "Undocumented"
@@ -8300,7 +8300,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "$(sdk|6.0|product-version)-1-cbl-mariner2.0-amd64": {},
+                "$(sdk|6.0|product-version)-cbl-mariner2.0-amd64": {},
                 "6.0-cbl-mariner2.0-amd64": {},
                 "6.0-cbl-mariner-amd64": {
                   "docType": "Undocumented"
@@ -8317,7 +8317,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "$(sdk|6.0|product-version)-1-cbl-mariner2.0-arm64v8": {},
+                "$(sdk|6.0|product-version)-cbl-mariner2.0-arm64v8": {},
                 "6.0-cbl-mariner2.0-arm64v8": {},
                 "6.0-cbl-mariner-arm64v8": {
                   "docType": "Undocumented"
@@ -8339,7 +8339,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(sdk|6.0|product-version)-1-windowsservercore-ltsc2019": {},
+                "$(sdk|6.0|product-version)-windowsservercore-ltsc2019": {},
                 "6.0-windowsservercore-ltsc2019": {}
               }
             }
@@ -8357,7 +8357,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "$(sdk|6.0|product-version)-1-windowsservercore-ltsc2022": {},
+                "$(sdk|6.0|product-version)-windowsservercore-ltsc2022": {},
                 "6.0-windowsservercore-ltsc2022": {}
               }
             }
@@ -8366,7 +8366,7 @@
         {
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
-            "$(sdk|8.0|product-version)-1-bookworm-slim": {},
+            "$(sdk|8.0|product-version)-bookworm-slim": {},
             "8.0-bookworm-slim": {},
             "$(sdk|8.0|product-version)": {},
             "8.0": {}
@@ -8381,7 +8381,7 @@
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
-                "$(sdk|8.0|product-version)-1-bookworm-slim-amd64": {},
+                "$(sdk|8.0|product-version)-bookworm-slim-amd64": {},
                 "8.0-bookworm-slim-amd64": {}
               }
             },
@@ -8395,7 +8395,7 @@
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
-                "$(sdk|8.0|product-version)-1-bookworm-slim-arm32v7": {},
+                "$(sdk|8.0|product-version)-bookworm-slim-arm32v7": {},
                 "8.0-bookworm-slim-arm32v7": {}
               },
               "variant": "v7"
@@ -8410,7 +8410,7 @@
               "os": "linux",
               "osVersion": "bookworm-slim",
               "tags": {
-                "$(sdk|8.0|product-version)-1-bookworm-slim-arm64v8": {},
+                "$(sdk|8.0|product-version)-bookworm-slim-arm64v8": {},
                 "8.0-bookworm-slim-arm64v8": {}
               },
               "variant": "v8"
@@ -8420,7 +8420,7 @@
         {
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
-            "$(sdk|8.0|product-version)-1-alpine3.19": {},
+            "$(sdk|8.0|product-version)-alpine3.19": {},
             "8.0-alpine3.19": {},
             "8.0-alpine": {}
           },
@@ -8434,7 +8434,7 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "$(sdk|8.0|product-version)-1-alpine3.19-amd64": {},
+                "$(sdk|8.0|product-version)-alpine3.19-amd64": {},
                 "8.0-alpine3.19-amd64": {},
                 "8.0-alpine-amd64": {}
               }
@@ -8449,7 +8449,7 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "$(sdk|8.0|product-version)-1-alpine3.19-arm32v7": {},
+                "$(sdk|8.0|product-version)-alpine3.19-arm32v7": {},
                 "8.0-alpine3.19-arm32v7": {},
                 "8.0-alpine-arm32v7": {}
               },
@@ -8465,7 +8465,7 @@
               "os": "linux",
               "osVersion": "alpine3.19",
               "tags": {
-                "$(sdk|8.0|product-version)-1-alpine3.19-arm64v8": {},
+                "$(sdk|8.0|product-version)-alpine3.19-arm64v8": {},
                 "8.0-alpine3.19-arm64v8": {},
                 "8.0-alpine-arm64v8": {}
               },
@@ -8547,7 +8547,7 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "$(sdk|8.0|product-version)-1-alpine3.20-amd64": {},
+                "$(sdk|8.0|product-version)-alpine3.20-amd64": {},
                 "8.0-alpine3.20-amd64": {}
               }
             },
@@ -8561,7 +8561,7 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "$(sdk|8.0|product-version)-1-alpine3.20-arm32v7": {},
+                "$(sdk|8.0|product-version)-alpine3.20-arm32v7": {},
                 "8.0-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
@@ -8576,7 +8576,7 @@
               "os": "linux",
               "osVersion": "alpine3.20",
               "tags": {
-                "$(sdk|8.0|product-version)-1-alpine3.20-arm64v8": {},
+                "$(sdk|8.0|product-version)-alpine3.20-arm64v8": {},
                 "8.0-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
@@ -8654,7 +8654,7 @@
               "os": "linux",
               "osVersion": "noble",
               "tags": {
-                "$(sdk|8.0|product-version)-1-noble-amd64": {},
+                "$(sdk|8.0|product-version)-noble-amd64": {},
                 "8.0-noble-amd64": {}
               }
             },
@@ -8668,7 +8668,7 @@
               "os": "linux",
               "osVersion": "noble",
               "tags": {
-                "$(sdk|8.0|product-version)-1-noble-arm64v8": {},
+                "$(sdk|8.0|product-version)-noble-arm64v8": {},
                 "8.0-noble-arm64v8": {}
               },
               "variant": "v8"
@@ -8728,7 +8728,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|8.0|product-version)-1-jammy-amd64": {},
+                "$(sdk|8.0|product-version)-jammy-amd64": {},
                 "8.0-jammy-amd64": {}
               }
             },
@@ -8742,7 +8742,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|8.0|product-version)-1-jammy-arm32v7": {},
+                "$(sdk|8.0|product-version)-jammy-arm32v7": {},
                 "8.0-jammy-arm32v7": {}
               },
               "variant": "v7"
@@ -8757,7 +8757,7 @@
               "os": "linux",
               "osVersion": "jammy",
               "tags": {
-                "$(sdk|8.0|product-version)-1-jammy-arm64v8": {},
+                "$(sdk|8.0|product-version)-jammy-arm64v8": {},
                 "8.0-jammy-arm64v8": {}
               },
               "variant": "v8"
@@ -8820,7 +8820,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "$(sdk|8.0|product-version)-1-cbl-mariner2.0-amd64": {},
+                "$(sdk|8.0|product-version)-cbl-mariner2.0-amd64": {},
                 "8.0-cbl-mariner2.0-amd64": {},
                 "8.0-cbl-mariner-amd64": {
                   "docType": "Undocumented"
@@ -8837,7 +8837,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "$(sdk|8.0|product-version)-1-cbl-mariner2.0-arm64v8": {},
+                "$(sdk|8.0|product-version)-cbl-mariner2.0-arm64v8": {},
                 "8.0-cbl-mariner2.0-arm64v8": {},
                 "8.0-cbl-mariner-arm64v8": {
                   "docType": "Undocumented"
@@ -8979,7 +8979,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "$(sdk|8.0|product-version)-1-nanoserver-1809": {},
+                "$(sdk|8.0|product-version)-nanoserver-1809": {},
                 "8.0-nanoserver-1809": {}
               }
             }
@@ -8997,7 +8997,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "$(sdk|8.0|product-version)-1-nanoserver-ltsc2022": {},
+                "$(sdk|8.0|product-version)-nanoserver-ltsc2022": {},
                 "8.0-nanoserver-ltsc2022": {}
               }
             }
@@ -9015,7 +9015,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "$(sdk|8.0|product-version)-1-windowsservercore-ltsc2019": {},
+                "$(sdk|8.0|product-version)-windowsservercore-ltsc2019": {},
                 "8.0-windowsservercore-ltsc2019": {}
               }
             }
@@ -9033,7 +9033,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "$(sdk|8.0|product-version)-1-windowsservercore-ltsc2022": {},
+                "$(sdk|8.0|product-version)-windowsservercore-ltsc2022": {},
                 "8.0-windowsservercore-ltsc2022": {}
               }
             }

--- a/src/sdk/8.0/alpine3.19-aot/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.19-aot/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-alpine3.19-amd64
+FROM $REPO:8.0.302-alpine3.19-amd64
 
 RUN apk add --upgrade --no-cache \
         build-base \

--- a/src/sdk/8.0/alpine3.19-aot/arm64v8/Dockerfile
+++ b/src/sdk/8.0/alpine3.19-aot/arm64v8/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-alpine3.19-arm64v8
+FROM $REPO:8.0.302-alpine3.19-arm64v8
 
 RUN apk add --upgrade --no-cache \
         build-base \

--- a/src/sdk/8.0/alpine3.20-aot/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.20-aot/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-alpine3.20-amd64
+FROM $REPO:8.0.302-alpine3.20-amd64
 
 RUN apk add --upgrade --no-cache \
         build-base \

--- a/src/sdk/8.0/alpine3.20-aot/arm64v8/Dockerfile
+++ b/src/sdk/8.0/alpine3.20-aot/arm64v8/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-alpine3.20-arm64v8
+FROM $REPO:8.0.302-alpine3.20-arm64v8
 
 RUN apk add --upgrade --no-cache \
         build-base \

--- a/src/sdk/8.0/cbl-mariner2.0-aot/amd64/Dockerfile
+++ b/src/sdk/8.0/cbl-mariner2.0-aot/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-cbl-mariner2.0-amd64
+FROM $REPO:8.0.302-cbl-mariner2.0-amd64
 
 RUN tdnf install -y \
         build-essential \

--- a/src/sdk/8.0/cbl-mariner2.0-aot/arm64v8/Dockerfile
+++ b/src/sdk/8.0/cbl-mariner2.0-aot/arm64v8/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-cbl-mariner2.0-arm64v8
+FROM $REPO:8.0.302-cbl-mariner2.0-arm64v8
 
 RUN tdnf install -y \
         build-essential \

--- a/src/sdk/8.0/jammy-aot/amd64/Dockerfile
+++ b/src/sdk/8.0/jammy-aot/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-jammy-amd64
+FROM $REPO:8.0.302-jammy-amd64
 
 RUN echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted" > /etc/apt/sources.list.d/arm64.list \
     && echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted" >> /etc/apt/sources.list.d/arm64.list \

--- a/src/sdk/8.0/jammy-aot/arm64v8/Dockerfile
+++ b/src/sdk/8.0/jammy-aot/arm64v8/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-jammy-arm64v8
+FROM $REPO:8.0.302-jammy-arm64v8
 
 RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted" > /etc/apt/sources.list.d/amd64.list \
     && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted" >> /etc/apt/sources.list.d/amd64.list \

--- a/src/sdk/8.0/noble-aot/amd64/Dockerfile
+++ b/src/sdk/8.0/noble-aot/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-noble-amd64
+FROM $REPO:8.0.302-noble-amd64
 
 COPY <<EOF /etc/apt/sources.list.d/arm64.sources
 Types: deb

--- a/src/sdk/8.0/noble-aot/arm64v8/Dockerfile
+++ b/src/sdk/8.0/noble-aot/arm64v8/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG REPO=mcr.microsoft.com/dotnet/sdk
-FROM $REPO:8.0.302-1-noble-arm64v8
+FROM $REPO:8.0.302-noble-arm64v8
 
 COPY <<EOF /etc/apt/sources.list.d/amd64.sources
 Types: deb


### PR DESCRIPTION
This removes the special `-1` tag suffix that was added in https://github.com/dotnet/dotnet-docker/pull/5579. This ensures that we don't accidentally leave it in for the next release.