### PR TITLE
Disable PowerShell tests for .NET 9 on Arm32

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -39,6 +39,12 @@ namespace Microsoft.DotNet.Docker.Tests
                 return false;
             }
 
+            if (imageData.Arch == Arch.Arm && imageData.Version.Major == 9)
+            {
+                reason = "https://github.com/dotnet/dotnet-docker/issues/5592";
+                return false;
+            }
+
             reason = "";
             return true;
         }


### PR DESCRIPTION
Disabling these tests due to https://github.com/dotnet/dotnet-docker/issues/5592. This will allow builds to get through more easily while the issue is investigated.