### PR TITLE
Compare VerifyDotnetFolderContents using Git Diff

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -277,13 +277,19 @@ namespace Microsoft.DotNet.Docker.Tests
             bool detach = false,
             string runAsUser = null,
             bool skipAutoCleanup = false,
-            bool useMountedDockerSocket = false)
+            bool useMountedDockerSocket = false,
+            bool silenceOutput = false)
         {
             string cleanupArg = skipAutoCleanup ? string.Empty : " --rm";
             string detachArg = detach ? " -d -t" : string.Empty;
             string userArg = runAsUser != null ? $" -u {runAsUser}" : string.Empty;
             string workdirArg = workdir == null ? string.Empty : $" -w {workdir}";
             string mountedDockerSocketArg = useMountedDockerSocket ? " -v /var/run/docker.sock:/var/run/docker.sock" : string.Empty;
+            if (silenceOutput)
+            {
+                return Execute(
+                    $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg}{mountedDockerSocketArg} {optionalRunArgs} {image} {command}");
+            }
             return ExecuteWithLogging(
                 $"run --name {name}{cleanupArg}{workdirArg}{userArg}{detachArg}{mountedDockerSocketArg} {optionalRunArgs} {image} {command}");
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/FileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/FileHelper.cs
@@ -40,8 +40,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (!string.IsNullOrEmpty(diffOutput))
             {
-                outputHelper.WriteLine($"Files differ:");
-                outputHelper.WriteLine(diffOutput);
                 return false;
             }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/FileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/FileHelper.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Diagnostics;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
 {
@@ -16,32 +16,47 @@ namespace Microsoft.DotNet.Docker.Tests
             return new TempFolderContext();
         }
 
-        /// <summary>
-        /// Returns a value indicating whether the two lists are equivalent (order does not matter).
-        /// </summary>
-        public static bool CompareLists(IList<string> expectedItems, IList<string> items)
+        public static TempFileContext UseTempFile()
         {
-            if (items.Count != expectedItems.Count)
+            return new TempFileContext();
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the two files are equal.
+        /// </summary>
+        public static bool CompareFiles(string expectedFilePath, string actualFilePath, ITestOutputHelper outputHelper)
+        {
+            if (!File.Exists(expectedFilePath))
             {
+                throw new FileNotFoundException($"Expected file not found: {expectedFilePath}");
+            }
+
+            if (!File.Exists(actualFilePath))
+            {
+                throw new FileNotFoundException($"Actual file not found: {actualFilePath}");
+            }
+
+            string diffOutput = DiffFiles(expectedFilePath, actualFilePath, outputHelper);
+
+            if (!string.IsNullOrEmpty(diffOutput))
+            {
+                outputHelper.WriteLine($"Files differ:");
+                outputHelper.WriteLine(diffOutput);
                 return false;
             }
 
-            items = items
-                .OrderBy(p => p)
-                .ToList();
-            expectedItems = expectedItems
-                .OrderBy(p => p)
-                .ToList();
-
-            for (int i = 0; i < items.Count; i++)
-            {
-                if (items[i] != expectedItems[i])
-                {
-                    return false;
-                }
-            }
-
             return true;
+        }
+
+        /// <summary>
+        /// Runs a git diff of two files and returns the output.
+        /// </summary>
+        public static string DiffFiles(string file1Path, string file2Path, ITestOutputHelper outputHelper)
+        {
+            (Process Process, string StdOut, string StdErr) diffResult =
+                ExecuteHelper.ExecuteProcess("git", $"diff --no-index {file1Path} {file2Path}", outputHelper);
+
+            return diffResult.StdOut;
         }
     }
 
@@ -65,6 +80,29 @@ namespace Microsoft.DotNet.Docker.Tests
         public void Dispose()
         {
             Directory.Delete(Path, true);
+        }
+    }
+
+    public class TempFileContext : IDisposable
+    {
+        public TempFileContext()
+        {
+            do
+            {
+                Path = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(),
+                    Guid.NewGuid().ToString());
+            }
+            while (File.Exists(Path));
+
+            File.Create(Path).Dispose();
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            File.Delete(Path);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -178,41 +177,15 @@ namespace Microsoft.DotNet.Docker.Tests
             IEnumerable<SdkContentFileInfo> actualDotnetFiles = GetActualSdkContents(imageData);
             IEnumerable<SdkContentFileInfo> expectedDotnetFiles = await GetExpectedSdkContentsAsync(imageData);
 
-            bool hasCountDifference = expectedDotnetFiles.Count() != actualDotnetFiles.Count();
+            using TempFileContext actualFiles = FileHelper.UseTempFile();
+            using TempFileContext expectedFiles = FileHelper.UseTempFile();
 
-            bool hasFileContentDifference = false;
+            File.WriteAllLines(actualFiles.Path, actualDotnetFiles.Select(file => $"{file.Path} {file.Sha512}"));
+            File.WriteAllLines(expectedFiles.Path, expectedDotnetFiles.Select(file => $"{file.Path} {file.Sha512}"));
 
-            int fileCount = expectedDotnetFiles.Count();
-            for (int i = 0; i < fileCount; i++)
-            {
-                if (expectedDotnetFiles.ElementAt(i).CompareTo(actualDotnetFiles.ElementAt(i)) != 0)
-                {
-                    hasFileContentDifference = true;
-                    break;
-                }
-            }
+            bool filesMatch = FileHelper.CompareFiles(expectedFiles.Path, actualFiles.Path, OutputHelper);
 
-            if (hasCountDifference || hasFileContentDifference)
-            {
-                OutputHelper.WriteLine(string.Empty);
-                OutputHelper.WriteLine("EXPECTED FILES:");
-                foreach (SdkContentFileInfo file in expectedDotnetFiles)
-                {
-                    OutputHelper.WriteLine($"Path: {file.Path}");
-                    OutputHelper.WriteLine($"Checksum: {file.Sha512}");
-                }
-
-                OutputHelper.WriteLine(string.Empty);
-                OutputHelper.WriteLine("ACTUAL FILES:");
-                foreach (SdkContentFileInfo file in actualDotnetFiles)
-                {
-                    OutputHelper.WriteLine($"Path: {file.Path}");
-                    OutputHelper.WriteLine($"Checksum: {file.Sha512}");
-                }
-            }
-
-            Assert.Equal(expectedDotnetFiles.Count(), actualDotnetFiles.Count());
-            Assert.False(hasFileContentDifference, "There are file content differences. Check the log output.");
+            Assert.True(filesMatch, "Differences found in the dotnet folder contents.");
         }
 
         [DotNetTheory]

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -177,13 +177,13 @@ namespace Microsoft.DotNet.Docker.Tests
             IEnumerable<SdkContentFileInfo> actualDotnetFiles = GetActualSdkContents(imageData);
             IEnumerable<SdkContentFileInfo> expectedDotnetFiles = await GetExpectedSdkContentsAsync(imageData);
 
-            using TempFileContext actualFiles = FileHelper.UseTempFile();
-            using TempFileContext expectedFiles = FileHelper.UseTempFile();
+            using TempFileContext actualFilesContext = FileHelper.UseTempFile();
+            using TempFileContext expectedFilesContext = FileHelper.UseTempFile();
 
-            File.WriteAllLines(actualFiles.Path, actualDotnetFiles.Select(file => $"{file.Path} {file.Sha512}"));
-            File.WriteAllLines(expectedFiles.Path, expectedDotnetFiles.Select(file => $"{file.Path} {file.Sha512}"));
+            File.WriteAllLines(actualFilesContext.Path, actualDotnetFiles.Select(file => $"{file.Path} {file.Sha512}"));
+            File.WriteAllLines(expectedFilesContext.Path, expectedDotnetFiles.Select(file => $"{file.Path} {file.Sha512}"));
 
-            bool filesMatch = FileHelper.CompareFiles(expectedFiles.Path, actualFiles.Path, OutputHelper);
+            bool filesMatch = FileHelper.CompareFiles(expectedFilesContext.Path, actualFilesContext.Path, OutputHelper);
 
             Assert.True(filesMatch, "Differences found in the dotnet folder contents.");
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -277,7 +277,8 @@ namespace Microsoft.DotNet.Docker.Tests
             string containerFileList = DockerHelper.Run(
                 image: imageData.GetImage(ImageRepo, DockerHelper),
                 command: command,
-                name: imageData.GetIdentifier("DotnetFolder"));
+                name: imageData.GetIdentifier("DotnetFolder"),
+                silenceOutput: true);
 
             IEnumerable<SdkContentFileInfo> actualDotnetFiles = containerFileList
                 .Replace("\r\n", "\n")


### PR DESCRIPTION
Closes https://github.com/dotnet/dotnet-docker/issues/4843

This PR primarily focuses on changing the `VerifyDotnetFolderContents` test to compare the folder contents using `git diff`. These changes involve the introduction of new helper methods for file comparison, the creation of temporary files, and the simplification of the test assertions.

- FileHelper.cs:
  * Removed unused imports and added new ones for `System.Diagnostics` and `Xunit.Abstractions`.
  * Replaced the `CompareLists` method with a new `CompareFiles` method that compares two files using `git diff` via the `DiffFiles` method. Also, added a new `UseTempFile` method that creates a temporary file.
  * Introduced a new `TempFileContext` class that creates a temporary file in its constructor and deletes it in its `Dispose` method.

- SdkImageTest.cs
  * Removed an unused import for `System.Data.Common`.
  * Simplified the `VerifyDotnetFolderContents` test method by using the new `FileHelper` methods. The test now writes the expected and actual contents to temporary files and compares them using `FileHelper.CompareFiles`. The assertion has been simplified to check whether the files contained any differences.

[Example run of the tests](https://dev.azure.com/dnceng/internal/_build/results?buildId=2483215&view=results) (internal Microsoft link)

Note - I'd like to do a test run that produces failing test results, but I'm unsure of how to do this. If anyone has information on how to do this, please let me know.