### PR TITLE
Update golang to 1.21

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -49,7 +49,7 @@
     set username to "app" ^
     set uid to 1654 ^
     set gid to uid
-}}FROM {{ARCH_VERSIONED}}/golang:1.20 as chisel
+}}FROM {{ARCH_VERSIONED}}/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.20 as chisel
+FROM amd64/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.20 as chisel
+FROM arm32v7/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.20 as chisel
+FROM arm64v8/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.20 as chisel
+FROM amd64/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.20 as chisel
+FROM arm32v7/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.20 as chisel
+FROM arm64v8/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.20 as chisel
+FROM amd64/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.20 as chisel
+FROM arm32v7/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.20 as chisel
+FROM arm64v8/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.20 as chisel
+FROM amd64/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.20 as chisel
+FROM arm32v7/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.20 as chisel
+FROM arm64v8/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.20 as chisel
+FROM amd64/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.20 as chisel
+FROM arm64v8/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.20 as chisel
+FROM amd64/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.20 as chisel
+FROM arm64v8/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.20 as chisel
+FROM arm32v7/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.20 as chisel
+FROM arm32v7/golang:1.21 as chisel
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
Fixes a build issue with the Ubuntu Chiseled images:

```
------
 > [chisel 3/5] RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper     && chmod 755 /usr/bin/chisel-wrapper:
1.371 go: downloading github.com/canonical/chisel v0.10.0
2.325 go: downloading github.com/jessevdk/go-flags v1.5.0
2.327 go: downloading golang.org/x/term v0.18.0
2.344 go: downloading github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
2.349 go: downloading github.com/klauspost/compress v1.15.4
2.351 go: downloading github.com/ulikunitz/xz v0.5.10
2.372 go: downloading golang.org/x/crypto v0.21.0
2.399 go: downloading github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
2.408 go: downloading gopkg.in/yaml.v3 v3.0.0-20220512140231-539c8e751b99
2.534 go: downloading go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd
2.554 go: downloading golang.org/x/sys v0.18.0
3.741 pkg/mod/github.com/canonical/chisel@v0.10.0/internal/setup/setup.go:10:2: package slices is not in GOROOT (/usr/local/go/src/slices)
3.741 note: imported by a module that requires go 1.21
------
```