### PR TITLE
Downgrade chisel to v0.9.1

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -49,7 +49,7 @@
     set username to "app" ^
     set uid to 1654 ^
     set gid to uid
-}}FROM {{ARCH_VERSIONED}}/golang:1.21 as chisel
+}}FROM {{ARCH_VERSIONED}}/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -80,9 +80,9 @@
     "chisel|8.0|url": "$(chisel|6.0|url)",
     "chisel|9.0|url": "$(chisel|6.0|url)",
 
-    "chisel|9.0|ref": "v0.10.0",
-    "chisel|8.0|ref": "v0.10.0",
-    "chisel|6.0|ref": "v0.10.0",
+    "chisel|9.0|ref": "v0.9.1",
+    "chisel|8.0|ref": "v0.9.1",
+    "chisel|6.0|ref": "v0.9.1",
 
     "dotnet|6.0|product-version": "6.0.32",
     "dotnet|6.0|fixed-tag": "$(dotnet|6.0|product-version)",

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 

--- a/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.20 as chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
         ca-certificates \
         file
 
-RUN go install github.com/canonical/chisel/cmd/chisel@v0.10.0 \
+RUN go install github.com/canonical/chisel/cmd/chisel@v0.9.1 \
     && wget -O /usr/bin/chisel-wrapper https://raw.githubusercontent.com/canonical/rocks-toolbox/v1.1.2/chisel-wrapper \
     && chmod 755 /usr/bin/chisel-wrapper
 


### PR DESCRIPTION
Seeing as Chisel v0.10.0 is untested in the nightly branch, the safest thing to do for the release is downgrade to the last known-good version until next month's servicing.