### PR TITLE
Synchronize Dockerfile templates with nightly branch

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -1,5 +1,6 @@
 {{
     _ ARGS:
+        is-aot (optional): Whether to use the smallest set of packages that is necessary to run native AOT apps
         is-extra (optional): Whether to include extra packages that are not needed for every app,
             for example globalization support
         staging-dir (optional): Location of the staging directory for distroless installation ^
@@ -102,9 +103,11 @@
 
     set pkgs to when(useLegacyPackageLayout,
         legacyPkgs,
-        when(ARGS["is-extra"] || isDebian || isUbuntu || isFullAzureLinux,
-            extraPkgs,
-            standardPkgs)) ^
+        when(ARGS["is-aot"],
+            basePkgs,
+            when(ARGS["is-extra"] || isDebian || isUbuntu || isFullAzureLinux,
+                extraPkgs,
+                standardPkgs))) ^
 
     set certsPkgName to when(isDistrolessAzureLinux,
         "prebuilt-ca-certificates",

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -1,5 +1,6 @@
 {{
     _ ARGS:
+        is-aot (optional): Whether to use the smallest set of packages that is necessary to run native AOT apps
         is-extra (optional): Whether to include extra packages that are not needed for every app,
             for example globalization support ^
 
@@ -64,6 +65,7 @@ FROM {{baseImageRepo}}:{{baseImageTag}}}}
 
 RUN {{InsertTemplate("../Dockerfile.linux.install-deps",
     [
+        "is-aot": ARGS["is-aot"],
         "is-extra": ARGS["is-extra"]
     ]
 )}}{{if isRpmInstall:{{if isMultiStage:

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.aot
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.aot
@@ -1,0 +1,1 @@
+{{InsertTemplate("Dockerfile", [ "is-aot": "true" ])}}

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -1,5 +1,6 @@
 {{
     _ ARGS:
+        is-aot (optional): Whether to use the smallest set of packages that is necessary to run native AOT apps
         is-extra (optional): Whether to include extra packages that are not needed for every app,
             for example globalization support ^
 
@@ -42,9 +43,11 @@
     set icuPkgs to [ cat("libicu", VARIABLES[cat("libicu|", osVersionBase)], "_libs") ] ^
     set extraPkgs to cat(sort(cat(standardPkgs, tzdataPkgs, icuPkgs))) ^
 
-    set pkgs to when(ARGS["is-extra"],
-            extraPkgs,
-            standardPkgs) ^
+    set pkgs to when(ARGS["is-aot"],
+            basePkgs,
+            when(ARGS["is-extra"],
+                extraPkgs,
+                standardPkgs)) ^
 
     set username to "app" ^
     set uid to 1654 ^

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu.aot
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu.aot
@@ -1,0 +1,1 @@
+{{InsertTemplate("Dockerfile.chiseled-ubuntu", [ "is-aot": "true" ])}}

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner
@@ -1,5 +1,6 @@
 {{
     _ ARGS:
+        is-aot (optional): Whether to use the smallest set of packages that is necessary to run native AOT apps
         is-extra (optional): Whether to include extra packages that are not needed for every app,
             for example globalization support ^
 
@@ -23,6 +24,7 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 RUN mkdir {{distrolessStagingDir}} \
     && {{InsertTemplate("../Dockerfile.linux.install-deps",
             [
+                "is-aot": ARGS["is-aot"],
                 "is-extra": ARGS["is-extra"],
                 "staging-dir": distrolessStagingDir
             ]

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner.aot
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.distroless-mariner.aot
@@ -1,0 +1,1 @@
+{{InsertTemplate("Dockerfile.distroless-mariner", [ "is-aot": "true" ])}}


### PR DESCRIPTION
This PR resets the templates in the main branch to the state that they're currently in in the nightly branch.

The Dockerfile templates are carefully architected to prevent the addition of new features from affecting existing Dockerfiles. As such, including new templates (like AOT) in the main branch does not affect the Dockerfiles in the main branch. To simplify merges from nightly to main and vice versa, the templates should stay the same between the two branches.

I'm submitting this PR now so that we can sync up the templates before there are any additional changes added to nightly for the August release.