### PR TITLE
[main] Re-enable aspnet app scenario test due to fixed runtime issue

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -26,13 +26,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
-            if (imageData.IsArm && imageData.OS == OS.Jammy)
-            {
-                OutputHelper.WriteLine(
-                    "Skipping test due to https://github.com/dotnet/runtime/issues/66310. Re-enable when fixed.");
-                return;
-            }
-
             string[] unsupportedWindowsVersions = [ OS.ServerCoreLtsc2019, OS.NanoServer1809 ];
             if (imageData.Version.Major == 9 && unsupportedWindowsVersions.Contains(imageData.OS))
             {


### PR DESCRIPTION
This is the second half of https://github.com/dotnet/dotnet-docker/issues/5657. The linked runtime issue is fixed so this test should be re-enabled.