### PR TITLE
Re-write related repos readme template

### DIFF
--- a/.portal-docs/docker-hub/README.aspire-dashboard.md
+++ b/.portal-docs/docker-hub/README.aspire-dashboard.md
@@ -97,12 +97,12 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.aspire-dashboard.md
+++ b/.portal-docs/docker-hub/README.aspire-dashboard.md
@@ -96,6 +96,7 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 .NET:
 
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -60,6 +60,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 .NET:
 
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -61,12 +61,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -40,13 +40,13 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -39,6 +39,7 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 
 .NET:
 
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -40,6 +40,7 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 
 .NET:
 
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -41,13 +41,13 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor/base](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor-base/): .NET Monitor Base (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -41,6 +41,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 .NET:
 
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -42,12 +42,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -49,6 +49,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 .NET:
 
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -50,12 +50,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.samples.md
+++ b/.portal-docs/docker-hub/README.samples.md
@@ -59,12 +59,13 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 .NET:
 
-* [dotnet/sdk](https://hub.docker.com/r/microsoft/dotnet-sdk/): .NET SDK
-* [dotnet/aspnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime](https://hub.docker.com/r/microsoft/dotnet-runtime/): .NET Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/monitor](https://hub.docker.com/r/microsoft/dotnet-monitor/): .NET Monitor Tool
-* [dotnet/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/): .NET Aspire Dashboard
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
+* [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+* [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.samples.md
+++ b/.portal-docs/docker-hub/README.samples.md
@@ -60,12 +60,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
-* [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/sdk](https://hub.docker.com/r/microsoft/dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/r/microsoft/dotnet-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/): .NET Runtime Dependencies
+* [dotnet/monitor](https://hub.docker.com/r/microsoft/dotnet-monitor/): .NET Monitor Tool
+* [dotnet/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/): .NET Aspire Dashboard
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -52,12 +52,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -51,6 +51,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 .NET:
 
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)

--- a/.portal-docs/mar/README.aspire-dashboard.portal.md
+++ b/.portal-docs/mar/README.aspire-dashboard.portal.md
@@ -19,6 +19,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/mar/README.aspire-dashboard.portal.md
+++ b/.portal-docs/mar/README.aspire-dashboard.portal.md
@@ -20,12 +20,12 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -35,6 +35,7 @@ For more information, see the [composite images section in the Image Variants do
 
 .NET:
 
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -36,12 +36,12 @@ For more information, see the [composite images section in the Image Variants do
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -29,13 +29,13 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -28,6 +28,7 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 .NET:
 
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -30,6 +30,7 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 .NET:
 
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -31,13 +31,13 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor/base](https://mcr.microsoft.com/product/dotnet/nightly/monitor/base/about): .NET Monitor Base (Preview)
 * [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -30,6 +30,7 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 .NET:
 
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -31,12 +31,12 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 * [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -30,6 +30,7 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 .NET:
 
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -31,12 +31,12 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.samples.portal.md
+++ b/.portal-docs/mar/README.samples.portal.md
@@ -24,12 +24,13 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 .NET:
 
-* [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
-* [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
-* [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
-* [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
-* [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about): .NET Monitor Tool
-* [dotnet/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/aspire-dashboard/about): .NET Aspire Dashboard
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
+* [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
+* [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.samples.portal.md
+++ b/.portal-docs/mar/README.samples.portal.md
@@ -25,12 +25,12 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/nightly/sdk](https://mcr.microsoft.com/product/dotnet/nightly/sdk/about): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
-* [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
+* [dotnet/sdk](https://mcr.microsoft.com/product/dotnet/sdk/about): .NET SDK
+* [dotnet/aspnet](https://mcr.microsoft.com/product/dotnet/aspnet/about): ASP.NET Core Runtime
+* [dotnet/runtime](https://mcr.microsoft.com/product/dotnet/runtime/about): .NET Runtime
+* [dotnet/runtime-deps](https://mcr.microsoft.com/product/dotnet/runtime-deps/about): .NET Runtime Dependencies
+* [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about): .NET Monitor Tool
+* [dotnet/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/aspire-dashboard/about): .NET Aspire Dashboard
 
 .NET Framework:
 

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -29,6 +29,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 .NET:
 
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -30,12 +30,12 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet): .NET
-* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 * [dotnet/nightly/aspnet](https://mcr.microsoft.com/product/dotnet/nightly/aspnet/about): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://mcr.microsoft.com/product/dotnet/nightly/runtime/about): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://mcr.microsoft.com/product/dotnet/nightly/runtime-deps/about): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://mcr.microsoft.com/product/dotnet/nightly/monitor/about): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://mcr.microsoft.com/product/dotnet/nightly/aspire-dashboard/about): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about): .NET Samples
 
 .NET Framework:
 

--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -97,12 +97,12 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -61,12 +61,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 # About
 
@@ -79,13 +80,13 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/sdk](https://hub.docker.com/r/microsoft/dotnet-sdk/): .NET SDK
 * [dotnet/aspnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/): ASP.NET Core Runtime
 * [dotnet/runtime](https://hub.docker.com/r/microsoft/dotnet-runtime/): .NET Runtime
 * [dotnet/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/): .NET Runtime Dependencies
 * [dotnet/monitor](https://hub.docker.com/r/microsoft/dotnet-monitor/): .NET Monitor Tool
 * [dotnet/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/): .NET Aspire Dashboard
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 .NET:
 
-* [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
-* [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
+* [dotnet/sdk](https://hub.docker.com/r/microsoft/dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/r/microsoft/dotnet-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/): .NET Runtime Dependencies
+* [dotnet/monitor](https://hub.docker.com/r/microsoft/dotnet-monitor/): .NET Monitor Tool
+* [dotnet/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/): .NET Aspire Dashboard
 
 .NET Framework:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 # About
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 .NET:
 
-* [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
+* [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+* [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
 
 .NET Framework:
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -40,13 +40,13 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -41,13 +41,13 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor/base](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor-base/): .NET Monitor Base (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -42,12 +42,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -50,12 +50,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -60,12 +60,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
-* [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
-* [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/sdk](https://hub.docker.com/r/microsoft/dotnet-sdk/): .NET SDK
+* [dotnet/aspnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/): ASP.NET Core Runtime
+* [dotnet/runtime](https://hub.docker.com/r/microsoft/dotnet-runtime/): .NET Runtime
+* [dotnet/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/): .NET Runtime Dependencies
+* [dotnet/monitor](https://hub.docker.com/r/microsoft/dotnet-monitor/): .NET Monitor Tool
+* [dotnet/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/): .NET Aspire Dashboard
 
 .NET Framework:
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -60,12 +60,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/sdk](https://hub.docker.com/r/microsoft/dotnet-sdk/): .NET SDK
-* [dotnet/aspnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/): ASP.NET Core Runtime
-* [dotnet/runtime](https://hub.docker.com/r/microsoft/dotnet-runtime/): .NET Runtime
-* [dotnet/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/): .NET Runtime Dependencies
-* [dotnet/monitor](https://hub.docker.com/r/microsoft/dotnet-monitor/): .NET Monitor Tool
-* [dotnet/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/): .NET Aspire Dashboard
+* [dotnet/nightly/sdk](https://hub.docker.com/r/microsoft/dotnet-nightly-sdk/): .NET SDK (Preview)
+* [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
+* [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
+* [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
+* [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
+* [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
 
 .NET Framework:
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -52,12 +52,12 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 * [dotnet/nightly/aspnet](https://hub.docker.com/r/microsoft/dotnet-nightly-aspnet/): ASP.NET Core Runtime (Preview)
 * [dotnet/nightly/runtime](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime/): .NET Runtime (Preview)
 * [dotnet/nightly/runtime-deps](https://hub.docker.com/r/microsoft/dotnet-nightly-runtime-deps/): .NET Runtime Dependencies (Preview)
 * [dotnet/nightly/monitor](https://hub.docker.com/r/microsoft/dotnet-nightly-monitor/): .NET Monitor Tool (Preview)
 * [dotnet/nightly/aspire-dashboard](https://hub.docker.com/r/microsoft/dotnet-nightly-aspire-dashboard/): .NET Aspire Dashboard (Preview)
+* [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 .NET Framework:
 

--- a/eng/readme-templates/DefaultLayout.md
+++ b/eng/readme-templates/DefaultLayout.md
@@ -1,31 +1,21 @@
 {{
-  set commonArgs to [
-    "top-header": "#"
-    "readme-host": ARGS["readme-host"]
-  ] ^
-  set isNightlyRepo to match(split(REPO, "/")[1], "nightly") ^
-  set isMonitor to find(split(REPO, "/"), "monitor") >= 0 ^
-  set isAspireDashboard to find(split(REPO, "/"), "aspire-dashboard") >= 0
+    set commonArgs to [
+        "top-header": "#"
+        "readme-host": ARGS["readme-host"]
+    ] ^
+
+    set insertReposListTemplate(template) to:{{
+        return InsertTemplate("ReposProvider.md", union([ "template": template ], commonArgs))
+    }} ^
+
+    set isNightlyRepo to match(split(REPO, "/")[1], "nightly") ^
+    set isMonitor to find(split(REPO, "/"), "monitor") >= 0 ^
+    set isAspireDashboard to find(split(REPO, "/"), "aspire-dashboard") >= 0
+
 }}{{InsertTemplate("Announcement.md", union(commonArgs, [ "trailing-line-break": "true" ]))}}{{
 if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
-}}{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":# Featured Repos
-
-* [dotnet/sdk]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/sdk" ])}}): .NET SDK
-* [dotnet/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/aspnet" ])}}): ASP.NET Core Runtime
-* [dotnet/runtime]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/runtime" ])}}): .NET Runtime
-* [dotnet/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/runtime-deps" ])}}): .NET Runtime Dependencies
-* [dotnet/monitor]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/monitor" ])}}): .NET Monitor Tool
-* [dotnet/aspire-dashboard]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/aspire-dashboard" ])}}): .NET Aspire Dashboard
-* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/samples" ])}}): .NET Samples
-^elif IS_PRODUCT_FAMILY && VARIABLES["branch"] = "nightly"
-:# Featured Repos
-
-* [dotnet/nightly/sdk]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/sdk" ])}}): .NET SDK (Preview)
-* [dotnet/nightly/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/aspnet" ])}}): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/runtime" ])}}): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/runtime-deps" ])}}): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/monitor" ])}}): .NET Monitor Tool (Preview)
-* [dotnet/nightly/aspire-dashboard]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/aspire-dashboard" ])}}): .NET Aspire Dashboard (Preview)
+}}{{if IS_PRODUCT_FAMILY:{{
+    insertReposListTemplate("FeaturedRepos.md")}}
 }}
 {{InsertTemplate("About.md", commonArgs)}}
 
@@ -33,7 +23,7 @@ if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 
 {{InsertTemplate("About.variants.md", commonArgs)}}}}
 
-{{InsertTemplate("RelatedRepos.md", commonArgs)}}
+{{insertReposListTemplate("RelatedRepos.md")}}
 {{if !IS_PRODUCT_FAMILY:
 # Full Tag Listing
 {{if ARGS["readme-host"] = "github":<!--End of generated tags-->

--- a/eng/readme-templates/FeaturedRepos.md
+++ b/eng/readme-templates/FeaturedRepos.md
@@ -30,7 +30,7 @@
 
     set repos to filter(ARGS["product-repos"], filterMonitorRepo) ^
     set repos to when(isNightlyRepo, map(repos, insertNightly), repos) ^
-    set repos to cat(repos, ARGS["samples-repos"])
+    set repos to when(!IS_PRODUCT_FAMILY, cat(repos, ARGS["samples-repos"]), repos)
 
 }}{{ARGS["top-header"]}} Featured Repos
 {{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": repos ])}}

--- a/eng/readme-templates/FeaturedRepos.md
+++ b/eng/readme-templates/FeaturedRepos.md
@@ -2,19 +2,10 @@
     _ ARGS:
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readmes
-      repos: List of normal .NET product repos
-      common-repos: List of other non-product repos (e.g. samples)
+      product-repos: List of .NET product repos
+      product-family-repos: List of .NET product family repos
+      samples-repos: List of .NET samples repos
       framework-repos: List of .NET Framework repos ^
-
-    set isCurrentRepo(repo) to:{{
-        set repoNameParts to split(repo[0], "/") ^
-        set shortRepo to repoNameParts[len(repoNameParts) - 1] ^
-        return shortRepo = SHORT_REPO
-    }} ^
-
-    set isNotCurrentRepo(repo) to:{{
-        return not(isCurrentRepo(repo))
-    }} ^
 
     set isNightlyRepo to VARIABLES["branch"] = "nightly" ^
 
@@ -37,10 +28,9 @@
         return when(SHORT_REPO != "monitor", find(repo[0], "base") < 0, 1)
     }} ^
 
-    set repos to cat(ARGS["repos"], ARGS["common-repos"]) ^
-    set repos to filter(repos, isNotCurrentRepo) ^
-    set repos to filter(repos, filterMonitorRepo) ^
-    set repos to when(isNightlyRepo, map(repos, insertNightly), repos)
+    set repos to filter(ARGS["product-repos"], filterMonitorRepo) ^
+    set repos to when(isNightlyRepo, map(repos, insertNightly), repos) ^
+    set repos to cat(repos, ARGS["samples-repos"])
 
 }}{{ARGS["top-header"]}} Featured Repos
 {{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": repos ])}}

--- a/eng/readme-templates/FeaturedRepos.md
+++ b/eng/readme-templates/FeaturedRepos.md
@@ -6,6 +6,16 @@
       common-repos: List of other non-product repos (e.g. samples)
       framework-repos: List of .NET Framework repos ^
 
+    set isCurrentRepo(repo) to:{{
+        set repoNameParts to split(repo[0], "/") ^
+        set shortRepo to repoNameParts[len(repoNameParts) - 1] ^
+        return shortRepo = SHORT_REPO
+    }} ^
+
+    set isNotCurrentRepo(repo) to:{{
+        return not(isCurrentRepo(repo))
+    }} ^
+
     set isNightlyRepo to VARIABLES["branch"] = "nightly" ^
 
     set insertNightlyRepoName(repoName) to:{{
@@ -27,7 +37,8 @@
         return when(SHORT_REPO != "monitor", find(repo[0], "base") < 0, 1)
     }} ^
 
-    set repos to ARGS["repos"] ^
+    set repos to cat(ARGS["repos"], ARGS["common-repos"]) ^
+    set repos to filter(repos, isNotCurrentRepo) ^
     set repos to filter(repos, filterMonitorRepo) ^
     set repos to when(isNightlyRepo, map(repos, insertNightly), repos)
 

--- a/eng/readme-templates/FeaturedRepos.md
+++ b/eng/readme-templates/FeaturedRepos.md
@@ -1,18 +1,35 @@
-{{if IS_PRODUCT_FAMILY && VARIABLES["branch"] = "main":# Featured Repos
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readmes
+      repos: List of normal .NET product repos
+      common-repos: List of other non-product repos (e.g. samples)
+      framework-repos: List of .NET Framework repos ^
 
-* [dotnet/sdk]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/sdk" ])}}): .NET SDK
-* [dotnet/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/aspnet" ])}}): ASP.NET Core Runtime
-* [dotnet/runtime]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/runtime" ])}}): .NET Runtime
-* [dotnet/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/runtime-deps" ])}}): .NET Runtime Dependencies
-* [dotnet/monitor]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/monitor" ])}}): .NET Monitor Tool
-* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/samples" ])}}): .NET Samples
-^elif IS_PRODUCT_FAMILY && VARIABLES["branch"] = "nightly"
-:# Featured Repos
+    set isNightlyRepo to VARIABLES["branch"] = "nightly" ^
 
-* [dotnet/nightly/sdk]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/sdk" ])}}): .NET SDK (Preview)
-* [dotnet/nightly/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/aspnet" ])}}): ASP.NET Core Runtime (Preview)
-* [dotnet/nightly/runtime]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/runtime" ])}}): .NET Runtime (Preview)
-* [dotnet/nightly/runtime-deps]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/runtime-deps" ])}}): .NET Runtime Dependencies (Preview)
-* [dotnet/nightly/monitor]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/monitor" ])}}): .NET Monitor Tool (Preview)
-* [dotnet/nightly/aspire-dashboard]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/nightly/aspire-dashboard" ])}}): .NET Aspire Dashboard (Preview)
-}}
+    set insertNightlyRepoName(repoName) to:{{
+        return token(repoName, "/", 0, "dotnet/nightly")
+    }} ^
+
+    set insertNightlyRepoDisplayName(displayName) to:{{
+        return join([displayName, "(Preview)"], " ")
+    }} ^
+
+    set insertNightly(repo) to:{{
+        return [
+            insertNightlyRepoName(repo[0]),
+            insertNightlyRepoDisplayName(repo[1])
+        ]
+    }} ^
+
+    set filterMonitorRepo(repo) to:{{
+        return when(SHORT_REPO != "monitor", find(repo[0], "base") < 0, 1)
+    }} ^
+
+    set repos to ARGS["repos"] ^
+    set repos to filter(repos, filterMonitorRepo) ^
+    set repos to when(isNightlyRepo, map(repos, insertNightly), repos)
+
+}}{{ARGS["top-header"]}} Featured Repos
+{{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": repos ])}}

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -4,7 +4,7 @@
 
 {{InsertTemplate("FeaturedTags.md", commonArgs)}}
 
-{{InsertTemplate("RelatedRepos.md", commonArgs)}}
+{{InsertTemplate("ReposProvider.md", union([ "template": "RelatedRepos.md" ], commonArgs))}}
 
 {{InsertTemplate("Use.md", commonArgs)}}{{if (find(REPO, "monitor") < 0 && find(REPO, "aspire") < 0):
 

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -65,7 +65,7 @@
         ["dotnet/framework/samples", ".NET Framework, ASP.NET and WCF Samples"]
     ] ^
 
-    _ Create final set of repos to display
+    _ Create final set of repos to display ^
 
     set currentRepo to cat(filter(repos, isCurrentRepo)) ^
     set commonRepos to filter(commonRepos, isNotCurrentRepo) ^
@@ -96,5 +96,5 @@
 {{getRepoBulletPoint(r)}}}}
 
 .NET Framework:
-{{for i, r in frameworkRepos:
+{{for r in frameworkRepos:
 {{getRepoBulletPoint(r)}}}}

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -58,7 +58,7 @@
                 cat(productFamilyRepos, repos, samplesRepos),
                 cat(productFamilyRepos, map(repos, insertNightly), samplesRepos)),
             when(IS_PRODUCT_FAMILY,
-                cat(map(repos, insertNightly), samplesRepos),
+                cat(map(repos, insertNightly)),
                 cat(productFamilyRepos, repos, samplesRepos))) ^
 
     _ Exclude this repo from its own readme ^

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -15,7 +15,7 @@
         return not(isCurrentRepo(repo))
     }} ^
 
-    set isNightlyRepo to match(split(REPO, "/")[1], "nightly") ^
+    set isNightlyRepo to VARIABLES["branch"] = "nightly" ^
 
     set insertNightlyRepoName(repoName) to:{{
         return token(repoName, "/", 0, "dotnet/nightly")
@@ -44,10 +44,6 @@
         return when(SHORT_REPO != "monitor", find(repo[0], "base") < 0, 1)
     }} ^
 
-    set monitorRepo to when(SHORT_REPO = "monitor",
-            ["dotnet/monitor/base", ".NET Monitor Base"],
-            ["dotnet/monitor", ".NET Monitor Tool"]) ^
-
     _ Lists of repos to render
       Format: [repoName, displayName, isProductFamilyRepo] ^
 
@@ -69,6 +65,8 @@
         ["dotnet/framework/samples", ".NET Framework, ASP.NET and WCF Samples"]
     ] ^
 
+    _ Create final set of repos to display
+
     set currentRepo to cat(filter(repos, isCurrentRepo)) ^
     set commonRepos to filter(commonRepos, isNotCurrentRepo) ^
 
@@ -77,16 +75,19 @@
     _ Exclude this repo from its own readme ^
     set repos to filter(repos, isNotCurrentRepo) ^
 
-    set repos to when(
-        (IS_PRODUCT_FAMILY && !isNightlyRepo) || !IS_PRODUCT_FAMILY,
-        map(repos, insertNightly), repos) ^
+    set repos to
+        when(isNightlyRepo,
+            when(IS_PRODUCT_FAMILY,
+                cat(commonRepos, repos),
+                cat(commonRepos, map(repos, insertNightly))),
+            when(IS_PRODUCT_FAMILY,
+                map(repos, insertNightly),
+                cat(commonRepos, repos))) ^
 
-    _ For non-nightly product repos, show the nightly version
+    _ For non-nightly product repos, show the nightly version ^
     set repos to when(!isNightlyRepo && !IS_PRODUCT_FAMILY,
         cat(repos, map(currentRepo, insertNightly)),
-        repos) ^
-
-    set repos to when(not(IS_PRODUCT_FAMILY), cat(commonRepos, repos), repos)
+        repos)
 
 }}{{ARGS["top-header"]}} Related Repositories
 

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -2,12 +2,14 @@
     _ ARGS:
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readmes
-      repos: List of normal .NET product repos
-      common-repos: List of other non-product repos (e.g. samples)
+      product-repos: List of .NET product repos
+      product-family-repos: List of .NET product family repos
+      samples-repos: List of .NET samples repos
       framework-repos: List of .NET Framework repos ^
 
-    set repos to ARGS["repos"] ^
-    set commonRepos to ARGS["common-repos"] ^
+    set repos to ARGS["product-repos"] ^
+    set productFamilyRepos to ARGS["product-family-repos"] ^
+    set samplesRepos to ARGS["samples-repos"] ^
     set frameworkRepos to ARGS["framework-repos"] ^
 
     _ Common functions to help with repo rendering ^
@@ -46,21 +48,21 @@
     _ Create final set of repos to display ^
 
     set currentRepo to cat(filter(repos, isCurrentRepo)) ^
-    set commonRepos to filter(commonRepos, isNotCurrentRepo) ^
 
     _ Exclude monitor/base from repos besides monitor ^
     set repos to filter(repos, filterMonitorRepo) ^
-    _ Exclude this repo from its own readme ^
-    set repos to filter(repos, isNotCurrentRepo) ^
 
     set repos to
         when(isNightlyRepo,
             when(IS_PRODUCT_FAMILY,
-                cat(commonRepos, repos),
-                cat(commonRepos, map(repos, insertNightly))),
+                cat(productFamilyRepos, repos, samplesRepos),
+                cat(productFamilyRepos, map(repos, insertNightly), samplesRepos)),
             when(IS_PRODUCT_FAMILY,
-                map(repos, insertNightly),
-                cat(commonRepos, repos))) ^
+                cat(map(repos, insertNightly), samplesRepos),
+                cat(productFamilyRepos, repos, samplesRepos))) ^
+
+    _ Exclude this repo from its own readme ^
+    set repos to filter(repos, isNotCurrentRepo) ^
 
     _ For non-nightly product repos, show the nightly version ^
     set repos to when(!isNightlyRepo && !IS_PRODUCT_FAMILY,

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -1,7 +1,14 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
-      readme-host: Moniker of the site that will host the readme ^
+      readme-host: Moniker of the site that will host the readmes
+      repos: List of normal .NET product repos
+      common-repos: List of other non-product repos (e.g. samples)
+      framework-repos: List of .NET Framework repos ^
+
+    set repos to ARGS["repos"] ^
+    set commonRepos to ARGS["common-repos"] ^
+    set frameworkRepos to ARGS["framework-repos"] ^
 
     _ Common functions to help with repo rendering ^
 
@@ -32,38 +39,9 @@
         ]
     }} ^
 
-    set getRepoBulletPoint(repo) to:{{
-        set repoName to repo[0] ^
-        set displayName to repo[1] ^
-        set isProductFamilyRepo to repo[2] ^
-        set url to InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": repoName, "is-product-family": isProductFamilyRepo ]) ^
-        return join(["* [", repoName, "](", url, "): ", displayName])
-    }} ^
-
     set filterMonitorRepo(repo) to:{{
         return when(SHORT_REPO != "monitor", find(repo[0], "base") < 0, 1)
     }} ^
-
-    _ Lists of repos to render
-      Format: [repoName, displayName, isProductFamilyRepo] ^
-
-    set repos to [
-        ["dotnet/sdk", ".NET SDK"],
-        ["dotnet/aspnet", "ASP.NET Core Runtime"],
-        ["dotnet/runtime", ".NET Runtime"],
-        ["dotnet/runtime-deps", ".NET Runtime Dependencies"],
-        ["dotnet/monitor", ".NET Monitor Tool"],
-        ["dotnet/monitor/base", ".NET Monitor Base"],
-        ["dotnet/aspire-dashboard", ".NET Aspire Dashboard"]
-    ] ^
-    set commonRepos to [
-        ["dotnet", ".NET", 1],
-        ["dotnet/samples", ".NET Samples"]
-    ] ^
-    set frameworkRepos to [
-        ["dotnet/framework", ".NET Framework, ASP.NET and WCF", 1],
-        ["dotnet/framework/samples", ".NET Framework, ASP.NET and WCF Samples"]
-    ] ^
 
     _ Create final set of repos to display ^
 
@@ -92,9 +70,7 @@
 }}{{ARGS["top-header"]}} Related Repositories
 
 .NET:
-{{for r in repos:
-{{getRepoBulletPoint(r)}}}}
+{{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": repos ])}}
 
 .NET Framework:
-{{for r in frameworkRepos:
-{{getRepoBulletPoint(r)}}}}
+{{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": frameworkRepos ])}}

--- a/eng/readme-templates/RepoList.md
+++ b/eng/readme-templates/RepoList.md
@@ -1,0 +1,15 @@
+{{
+    _ ARGS:
+      readme-host: Moniker of the site that will host the readme
+      repos: List of repos to render, in the format [repoName, displayName, isProductFamilyRepo] ^
+
+    set getRepoBulletPoint(repo) to:{{
+        set repoName to repo[0] ^
+        set displayName to repo[1] ^
+        set isProductFamilyRepo to repo[2] ^
+        set url to InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": repoName, "is-product-family": isProductFamilyRepo ]) ^
+        return join(["* [", repoName, "](", url, "): ", displayName])
+    }}
+
+}}{{ARGS["top-header"]}}{{for r in ARGS["repos"]:
+{{getRepoBulletPoint(r)}}}}

--- a/eng/readme-templates/ReposProvider.md
+++ b/eng/readme-templates/ReposProvider.md
@@ -6,7 +6,7 @@
       readme-host: Moniker of the site that will host the readme
       template: Template to pass the repo lists to ^
 
-    set repos to [
+    set productRepos to [
         ["dotnet/sdk", ".NET SDK"],
         ["dotnet/aspnet", "ASP.NET Core Runtime"],
         ["dotnet/runtime", ".NET Runtime"],
@@ -15,8 +15,10 @@
         ["dotnet/monitor/base", ".NET Monitor Base"],
         ["dotnet/aspire-dashboard", ".NET Aspire Dashboard"]
     ] ^
-    set commonRepos to [
+    set productFamilyRepos to [
         ["dotnet", ".NET", 1],
+    ] ^
+    set samplesRepos to [
         ["dotnet/samples", ".NET Samples"]
     ] ^
     set frameworkRepos to [
@@ -27,7 +29,8 @@
 }}{{InsertTemplate(ARGS["template"], [
     "top-header": ARGS["top-header"],
     "readme-host": ARGS["readme-host"],
-    "repos": repos,
-    "common-repos": commonRepos,
+    "product-repos": productRepos,
+    "product-family-repos": productFamilyRepos,
+    "samples-repos": samplesRepos,
     "framework-repos": frameworkRepos
 ])}}

--- a/eng/readme-templates/ReposProvider.md
+++ b/eng/readme-templates/ReposProvider.md
@@ -1,0 +1,33 @@
+{{
+    _ Wrapper template for providing the list of repos to other templates.
+
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
+      template: Template to pass the repo lists to ^
+
+    set repos to [
+        ["dotnet/sdk", ".NET SDK"],
+        ["dotnet/aspnet", "ASP.NET Core Runtime"],
+        ["dotnet/runtime", ".NET Runtime"],
+        ["dotnet/runtime-deps", ".NET Runtime Dependencies"],
+        ["dotnet/monitor", ".NET Monitor Tool"],
+        ["dotnet/monitor/base", ".NET Monitor Base"],
+        ["dotnet/aspire-dashboard", ".NET Aspire Dashboard"]
+    ] ^
+    set commonRepos to [
+        ["dotnet", ".NET", 1],
+        ["dotnet/samples", ".NET Samples"]
+    ] ^
+    set frameworkRepos to [
+        ["dotnet/framework", ".NET Framework, ASP.NET and WCF", 1],
+        ["dotnet/framework/samples", ".NET Framework, ASP.NET and WCF Samples"]
+    ]
+
+}}{{InsertTemplate(ARGS["template"], [
+    "top-header": ARGS["top-header"],
+    "readme-host": ARGS["readme-host"],
+    "repos": repos,
+    "common-repos": commonRepos,
+    "framework-repos": frameworkRepos
+])}}


### PR DESCRIPTION
I'm trying to remove lots of the hardcoded nonsense in this template. This should address #5596 as well when it's completed. I'm making sure at the same time that this template still has a sensible output for the main branch too.

TODO:

- [x] Make samples READMEs not reference nightly repos
- [x] Make README.md RelatedRepos reference non-nightly repos instead of nightly ones
- [x] Try to share implementation with Featured Repos