### PR TITLE
Re-enable .NET 9 Windows ASP.NET scenario tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -26,14 +26,6 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyAppScenario(ProductImageData imageData)
         {
-            string[] unsupportedWindowsVersions = [ OS.ServerCoreLtsc2019, OS.NanoServer1809 ];
-            if (imageData.Version.Major == 9 && unsupportedWindowsVersions.Contains(imageData.OS))
-            {
-                OutputHelper.WriteLine(
-                    "Skipping test due to https://github.com/dotnet/msbuild/issues/9662. Re-enable when fixed.");
-                return;
-            }
-
             using ProjectTemplateTestScenario scenario = imageData.ImageVariant.HasFlag(DotNetImageVariant.Composite)
                 ? new WebScenarioComposite(imageData, DockerHelper, OutputHelper)
                 : new WebScenario(imageData, DockerHelper, OutputHelper);


### PR DESCRIPTION
This should fix #5683 if CI passes.