### PR TITLE
Add openssl to Noble Chiseled expected packages list

### DIFF
--- a/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile.chiseled-ubuntu
@@ -53,7 +53,7 @@
     set username to "app" ^
     set uid to 1654 ^
     set gid to uid
-}}FROM {{ARCH_VERSIONED}}/golang:{{golangVersion}} as chisel
+}}FROM {{ARCH_VERSIONED}}/golang:{{golangVersion}} AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/6.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-aot/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-aot/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-aot/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-aot/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-aot/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-aot/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-aot/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-aot/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-aot/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-aot/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21 as chisel
+FROM amd64/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
+++ b/src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.21 as chisel
+FROM arm64v8/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/9.0/noble-chiseled-aot/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled-aot/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
+++ b/src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/golang:1.21 as chisel
+FROM arm32v7/golang:1.21 AS chisel
 
 RUN apt-get update \
     && apt-get install -y \

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -427,11 +427,11 @@ namespace Microsoft.DotNet.Docker.Tests
                 { OS: string os } when os.Contains(OS.Noble) => new[]
                     {
                         "ca-certificates",
-                        "openssl",
+                        "gcc-14-base",
                         "libc6",
                         "libgcc-s1",
-                        "gcc-14-base",
                         "libssl3t64",
+                        "openssl",
                         "zlib1g"
                     },
                 { OS: OS.Focal } => new[]

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -427,6 +427,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 { OS: string os } when os.Contains(OS.Noble) => new[]
                     {
                         "ca-certificates",
+                        "openssl",
                         "libc6",
                         "libgcc-s1",
                         "gcc-14-base",

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.linux
@@ -3,7 +3,7 @@ ARG runtime_image
 ARG runtime_deps_image
 
 
-FROM $sdk_image as build
+FROM $sdk_image AS build
 
 ARG rid
 ARG NuGetFeedPassword
@@ -21,7 +21,7 @@ COPY app/ .
 RUN dotnet build --no-restore
 
 
-FROM $sdk_image as blazorwasm_build
+FROM $sdk_image AS blazorwasm_build
 
 ARG rid
 ARG NuGetFeedPassword
@@ -51,7 +51,7 @@ COPY app/ .
 RUN dotnet build --no-restore
 
 
-FROM blazorwasm_build as blazorwasm_publish
+FROM blazorwasm_build AS blazorwasm_publish
 
 ARG rid
 RUN dotnet publish -r $rid -c Release --self-contained true -o out
@@ -71,7 +71,7 @@ COPY tests/ .
 ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 
-FROM build as publish_fx_dependent
+FROM build AS publish_fx_dependent
 RUN dotnet publish --no-restore -c Release -o out
 
 
@@ -85,7 +85,7 @@ COPY --from=publish_fx_dependent /source/app/out ./
 ENTRYPOINT ["dotnet", "app.dll"]
 
 
-FROM build as publish_self_contained
+FROM build AS publish_self_contained
 ARG rid
 RUN dotnet publish -r $rid -c Release --self-contained true -o out
 
@@ -100,7 +100,7 @@ COPY --from=publish_self_contained /source/app/out ./
 ENTRYPOINT ["./app"]
 
 
-FROM build as publish_aot
+FROM build AS publish_aot
 
 RUN dotnet publish -r $rid --no-restore -o /app
 

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG sdk_image
 ARG runtime_image
 
-FROM $sdk_image as build
+FROM $sdk_image AS build
 
 ENV NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY="3,1000"
 
@@ -35,7 +35,7 @@ COPY tests/ .
 ENTRYPOINT ["dotnet", "test", "--logger:trx", "--no-restore"]
 
 
-FROM build as publish_fx_dependent
+FROM build AS publish_fx_dependent
 RUN dotnet publish --no-restore -c Release -o out
 
 


### PR DESCRIPTION
Our tests are failing because the Noble ca-certificates slice added a dependency on a file from the openssl slice. See https://github.com/canonical/chisel-releases/pull/266 for more context.