### PR TITLE
Remove workaround for Mariner ARM container images not setting architecture variant metadata

### DIFF
--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -25,7 +25,7 @@ stages:
     customBuildInitSteps:
     - template: /eng/pipelines/steps/set-public-source-branch-var.yml@self
     - powershell: |
-        $imageBuilderBuildArgs = "$(imageBuilderBuildArgs)"
+        $imageBuilderBuildArgs = "$IMAGEBUILDERBUILDARGS"
         if ("$(publishRepoPrefix)".Contains("internal/")) {
           $sasQueryString = "$(dotnetstage-account-sas-read-token)"
           $imageBuilderBuildArgs += " --build-arg SAS_QUERY_STRING='$sasQueryString'"

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -23,7 +23,6 @@ stages:
 
     # Template paths must be relative to the YAML job that executes them
     customBuildInitSteps:
-    - template: /eng/pipelines/steps/set-imagebuilder-build-args-var.yml@self
     - template: /eng/pipelines/steps/set-public-source-branch-var.yml@self
     - powershell: |
         $imageBuilderBuildArgs = "$(imageBuilderBuildArgs)"

--- a/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
+++ b/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
@@ -1,10 +1,5 @@
 steps:
 - powershell: |
     $imageBuilderBuildArgs = $env:IMAGEBUILDERBUILDARGS
-    # Disable platform checks for CBL-Mariner on ARM64 due to https://github.com/dotnet/dotnet-docker/issues/3520
-    if ("$(osVersions)".Contains("cbl-mariner") -and "$(architecture)" -eq "arm64") {
-      $imageBuilderBuildArgs += " --skip-platform-check"
-    }
-
     echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
   displayName: Set Custom ImageBuilder Build Args

--- a/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
+++ b/eng/pipelines/steps/set-imagebuilder-build-args-var.yml
@@ -1,5 +1,0 @@
-steps:
-- powershell: |
-    $imageBuilderBuildArgs = $env:IMAGEBUILDERBUILDARGS
-    echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
-  displayName: Set Custom ImageBuilder Build Args


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-docker/issues/3520