### PR TITLE
Factor test cache ACR argument out of common pipeline infrastructure

### DIFF
--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -17,7 +17,7 @@ steps:
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
-    optionalTestArgs=" -CacheRegistry $(public-mirror.server)"
+    optionalTestArgs="$OPTIONALTESTARGS"
     if [ "${{ parameters.preBuildValidation }}" == "true" ]; then
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -17,18 +17,15 @@ steps:
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
-    optionalTestArgs="$OPTIONALTESTARGS"
+    additionalTestArgs="$ADDITIONALTESTARGS"
     if [ "${{ parameters.preBuildValidation }}" == "true" ]; then
-      optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
+      additionalTestArgs="$additionalTestArgs -TestCategories pre-build"
     else
       if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
-        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr-staging.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
-      fi
-      if [ "$REPOTESTARGS" != "" ]; then
-        optionalTestArgs="$optionalTestArgs $REPOTESTARGS"
+        additionalTestArgs="$additionalTestArgs -PullImages -Registry $(acr-staging.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
       fi
     fi
-    echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
+    echo "##vso[task.setvariable variable=additionalTestArgs]$additionalTestArgs"
   displayName: Set Test Variables
   condition: and(succeeded(), ${{ parameters.condition }})
 - script: >
@@ -69,7 +66,7 @@ steps:
     -Paths $(imageBuilderPathsArrayInitStr)
     -OSVersions $(osVersionsArrayInitStr)
     -Architecture '$(architecture)'
-    $(optionalTestArgs)"
+    $(additionalTestArgs)"
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -23,6 +23,9 @@ steps:
     else
       if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
         additionalTestArgs="$additionalTestArgs -PullImages -Registry $(acr-staging.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
+        if [ "$TESTCATEGORIESOVERRIDE" != "" ]; then
+          additionalTestArgs="$additionalTestArgs -TestCategories $TESTCATEGORIESOVERRIDE"
+        fi
       fi
     fi
     echo "##vso[task.setvariable variable=additionalTestArgs]$additionalTestArgs"

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -23,12 +23,9 @@ steps:
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry ${env:ACR-STAGING_SERVER} -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
+      $additionalTestArgs="$env:ADDITIONALTESTARGS -PullImages -Registry ${env:ACR-STAGING_SERVER} -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     }
-    if ($env:REPOTESTARGS) {
-      $optionalTestArgs += " $env:REPOTESTARGS"
-    }
-    echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
+    echo "##vso[task.setvariable variable=additionalTestArgs]$additionalTestArgs"
   displayName: Set Test Variables
   condition: and(succeeded(), ${{ parameters.condition }})
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
@@ -46,7 +43,7 @@ steps:
     $(testScriptPath)
     -Paths $(imageBuilderPathsArrayInitStr)
     -OSVersions $(osVersionsArrayInitStr)
-    $(optionalTestArgs)
+    $(additionalTestArgs)
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -11,8 +11,6 @@ variables:
   value: ./tests/run-tests.ps1
 - name: testResultsDirectory
   value: tests/Microsoft.DotNet.Docker.Tests/TestResults/
-- name: optionalTestArgs
-  value: -CacheRegistry $(public-mirror.server)
 - name: officialRepoPrefixes
   value: public/,internal/private/
 

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -11,6 +11,8 @@ variables:
   value: ./tests/run-tests.ps1
 - name: testResultsDirectory
   value: tests/Microsoft.DotNet.Docker.Tests/TestResults/
+- name: optionalTestArgs
+  value: -CacheRegistry $(public-mirror.server)
 - name: officialRepoPrefixes
   value: public/,internal/private/
 

--- a/eng/pipelines/steps/set-custom-test-variables.yml
+++ b/eng/pipelines/steps/set-custom-test-variables.yml
@@ -1,5 +1,8 @@
 steps:
 - powershell: |
+    # Use public cache registry for pulling external images during tests
+    $additionalTestArgs = "$env:ADDITIONALTESTARGS -CacheRegistry $(public-mirror.server)"
+
     # Forward team project name for consumption by test script
     $testRunnerOptions="-e SYSTEM_TEAMPROJECT='$env:SYSTEM_TEAMPROJECT'"
     $testInit=""
@@ -19,6 +22,7 @@ steps:
       }
     }
     
+    echo "##vso[task.setvariable variable=additionalTestArgs]$additionalTestArgs"
     echo "##vso[task.setvariable variable=testRunner.options]$testRunnerOptions"
     echo "##vso[task.setvariable variable=test.init]$testInit"
   displayName: Set Custom Test Variables

--- a/eng/pipelines/variables/samples.yml
+++ b/eng/pipelines/variables/samples.yml
@@ -2,7 +2,7 @@ variables:
 - template: ../../common/templates/variables/dotnet/build-test-publish.yml
 - name: manifest
   value: manifest.samples.json
-- name: repoTestArgs
+- name: additionalTestArgs
   value: -TestCategories sample
 - name: imageInfoVariant
   value: "-samples"

--- a/eng/pipelines/variables/samples.yml
+++ b/eng/pipelines/variables/samples.yml
@@ -2,7 +2,7 @@ variables:
 - template: ../../common/templates/variables/dotnet/build-test-publish.yml
 - name: manifest
   value: manifest.samples.json
-- name: additionalTestArgs
-  value: -TestCategories sample
+- name: testCategoriesOverride
+  value: sample
 - name: imageInfoVariant
   value: "-samples"


### PR DESCRIPTION
This argument was unnecessarily placed in the shared templates under eng/common. It would be overwritten by https://github.com/dotnet/dotnet-docker/pull/5736. Instead, we should change the common template to allow additional arguments to be set beforehand by consuming repos, in case some pipelines may not have the variable set. Then, in this repo, we'll set the argument in the `build-test-publish` variables.