### PR TITLE
Package upgrade for update-dependencies

### DIFF
--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -16,5 +16,8 @@
 
     <!-- Workaround for CVE-2024-0056 introduced as a transient dependency of Microsoft.TeamFoundationServer.Client -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+
+    <!-- CVE-2024-38095: Upgrade version of System.Formats.Asn1 implicitly referenced by Microsoft.DotNet.VersionTools -->
+    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
 
     <!-- CVE-2024-38095: Upgrade version of System.Formats.Asn1 implicitly referenced by Microsoft.DotNet.VersionTools -->
+    <!-- Tracking issue for Arcade: https://github.com/dotnet/dnceng/issues/3336 -->
     <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Addresses CVE-2024-38095 caused by transitive dependency from Microsoft.DotNet.VersionTools.