### PR TITLE
Drop caveats about dev cert trust on Linux

### DIFF
--- a/samples/host-aspnetcore-https.md
+++ b/samples/host-aspnetcore-https.md
@@ -59,9 +59,6 @@ dotnet dev-certs https --trust
 ```
 
 > [!NOTE]
-> `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distro. It is likely that you need to trust the certificate in your browser.
-
-> [!NOTE]
 > `<CREDENTIAL_PLACEHOLDER>` is used as a stand-in for a password of your own choosing.
 
 Run the container image with ASP.NET Core configured for HTTPS:

--- a/samples/host-aspnetcore-https.md
+++ b/samples/host-aspnetcore-https.md
@@ -51,6 +51,12 @@ docker run --rm -it -p 8001:8001 -e ASPNETCORE_HTTPS_PORTS=8001 -e ASPNETCORE_Ke
 
 ### macOS or Linux
 
+Create a certificate directory with appropriate permissions:
+
+```console
+mkdir -p -m 700 ${HOME}/.aspnet/https
+```
+
 Generate cert and configure local machine:
 
 ```console

--- a/samples/run-aspnetcore-https-development.md
+++ b/samples/run-aspnetcore-https-development.md
@@ -146,8 +146,6 @@ Generate cert and configure local machine:
 dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p <CREDENTIAL_PLACEHOLDER>
 ```
 
-> Note: `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distro. It is likely that you need to trust the certificate in your browser.
-
 > Note: The certificate name, in this case *aspnetapp*.pfx must match the project assembly name.
 
 > Note: `<CREDENTIAL_PLACEHOLDER>` is used as a stand-in for a password of your own choosing.

--- a/samples/run-aspnetcore-https-development.md
+++ b/samples/run-aspnetcore-https-development.md
@@ -97,7 +97,13 @@ After the application starts, navigate to `https://localhost:8001` in your web b
 ### macOS
 
 ```console
-cd samples\aspnetapp
+cd samples/aspnetapp
+```
+
+Create a certificate directory with appropriate permissions:
+
+```console
+mkdir -p -m 700 ${HOME}/.aspnet/https
 ```
 
 Generate cert and configure local machine:
@@ -137,7 +143,13 @@ After the application starts, navigate to `https://localhost:8001` in your web b
 ### Linux
 
 ```console
-cd samples\aspnetapp
+cd samples/aspnetapp
+```
+
+Create a certificate directory with appropriate permissions:
+
+```console
+mkdir -p -m 700 ${HOME}/.aspnet/https
 ```
 
 Generate cert and configure local machine:


### PR DESCRIPTION
As of 9.0 RC1 and 8.0.9, `--trust` should work on Linux as well (though it is only officially supported on Ubuntu and Fedora).