### PR TITLE
Run VerifyDotnetFolderContents test on all images

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -68,9 +68,9 @@ namespace Microsoft.DotNet.Docker.Tests
         /// this helper image stores the entire root of the distroless filesystem at the specified destination path within
         /// the built container image.
         /// </remarks>
-        public string BuildDistrolessHelper(DotNetImageRepo imageRepo, ProductImageData imageData, string rootDestination)
+        public string BuildDistrolessHelper(DotNetImageRepo imageRepo, ProductImageData imageData, string copyDestination, string copyOrigin = "/")
         {
-            string dockerfile = Path.Combine(TestArtifactsDir, "Dockerfile.distroless");
+            string dockerfile = Path.Combine(TestArtifactsDir, "Dockerfile.copy");
             string distrolessImageTag = imageData.GetImage(imageRepo, this);
 
             // Use the runtime-deps image as the target of the filesyste copy.
@@ -100,9 +100,10 @@ namespace Microsoft.DotNet.Docker.Tests
                 platform: imageData.Platform,
                 buildArgs:
                 [
-                    $"distroless_image={distrolessImageTag}",
+                    $"copy_image={distrolessImageTag}",
                     $"base_image={baseImageTag}",
-                    $"root_destination={rootDestination}"
+                    $"copy_origin={copyOrigin}",
+                    $"copy_destination={copyDestination}"
                 ]);
 
             return tag;

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -162,20 +162,9 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public async Task VerifyDotnetFolderContents(ProductImageData imageData)
         {
-            if (!IsPowerShellSupported(imageData, out string powerShellReason))
-            {
-                OutputHelper.WriteLine(powerShellReason);
-                return;
-            }
-
             // Skip test on CBL-Mariner. Since installation is done via RPM package, we just need to verify the package installation
             // was done (handled by VerifyPackageInstallation test). There's no need to check the actual contents of the package.
             if (imageData.OS.StartsWith(OS.Mariner) || imageData.OS.StartsWith(OS.AzureLinux))
-            {
-                return;
-            }
-
-            if (!imageData.SdkOS.StartsWith(OS.Alpine) && DockerHelper.IsLinuxContainerModeEnabled)
             {
                 return;
             }
@@ -263,40 +252,57 @@ namespace Microsoft.DotNet.Docker.Tests
         private IEnumerable<SdkContentFileInfo> GetActualSdkContents(ProductImageData imageData)
         {
             string dotnetPath;
+            string destinationPath;
+            string command;
 
             if (DockerHelper.IsLinuxContainerModeEnabled)
             {
                 dotnetPath = "/usr/share/dotnet";
+                destinationPath = "/sdk";
+                command = $"find {destinationPath} -type f -exec sha512sum {{}} +";
             }
             else
             {
-                dotnetPath = "Program Files\\dotnet";
+                dotnetPath = "\"Program Files\\dotnet\"";
+                destinationPath = "C:\\sdk";
+                string powerShellCommand =
+                    $"Get-ChildItem -File -Force -Recurse '{destinationPath}' " +
+                    "| Get-FileHash -Algorithm SHA512 " +
+                    "| select @{name='Value'; expression={$_.Hash + '  ' +$_.Path}} " +
+                    "| select -ExpandProperty Value";
+                command = $"pwsh -Command \"{powerShellCommand}\"";
             }
 
-            string powerShellCommand =
-                $"Get-ChildItem -File -Force -Recurse '{dotnetPath}' " +
-                "| Get-FileHash -Algorithm SHA512 " +
-                "| select @{name='Value'; expression={$_.Hash + '  ' +$_.Path}} " +
-                "| select -ExpandProperty Value";
-            string command = $"pwsh -Command \"{powerShellCommand}\"";
+            string baseImage = imageData.GetImage(ImageRepo, DockerHelper);
+            string tag = imageData.GetIdentifier("SdkContents").ToLower();
+
+            DockerHelper.Build(
+                tag: tag,
+                dockerfile: Path.Combine(DockerHelper.TestArtifactsDir, "Dockerfile.copy"),
+                contextDir: DockerHelper.TestArtifactsDir,
+                platform: imageData.Platform,
+                buildArgs:
+                [
+                    $"copy_image={baseImage}",
+                    $"base_image={baseImage}",
+                    $"copy_origin={dotnetPath}",
+                    $"copy_destination={destinationPath}"
+                ]);
 
             string containerFileList = DockerHelper.Run(
-                image: imageData.GetImage(ImageRepo, DockerHelper),
+                image: tag,
+                name: tag,
                 command: command,
-                name: imageData.GetIdentifier("DotnetFolder"),
                 silenceOutput: true);
 
-            IEnumerable<SdkContentFileInfo> actualDotnetFiles = containerFileList
-                .Replace("\r\n", "\n")
+            return containerFileList
                 .Split("\n")
-                .Select(output =>
+                .Select(line =>
                 {
-                    string[] outputParts = output.Split("  ");
-                    return new SdkContentFileInfo(outputParts[1], outputParts[0]);
+                    string[] parts = line.Split("  ").Select(part => part.Trim()).ToArray();
+                    return new SdkContentFileInfo(Path.GetRelativePath(destinationPath, parts[1]), parts[0]);
                 })
-                .OrderBy(fileInfo => fileInfo.Path)
-                .ToArray();
-            return actualDotnetFiles;
+                .OrderBy(fileInfo => fileInfo.Path);
         }
 
         private static IEnumerable<SdkContentFileInfo> EnumerateArchiveContents(string path)

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.copy
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.copy
@@ -1,0 +1,10 @@
+ARG base_image
+ARG copy_image
+
+FROM $copy_image AS copy_image
+
+FROM $base_image
+
+ARG copy_origin
+ARG copy_destination
+COPY --from=copy_image $copy_origin $copy_destination

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.distroless
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/Dockerfile.distroless
@@ -1,9 +1,0 @@
-ARG base_image
-ARG distroless_image
-
-FROM $distroless_image AS distroless
-
-FROM $base_image
-
-ARG root_destination
-COPY --from=distroless / $root_destination


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-docker/issues/4845

These changes implement the use of a multi-stage Dockerfile to copy the SDK contents of the image being tested into a local directory. The test builds the image using this Dockerfile and then runs `find {sdkCopyPath} -type f -exec sha512sum {{}} +` to output the hashes.