### PR TITLE
Remove the link to the obsolete dotnet/core full tag listing

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -251,8 +251,6 @@ Tag | Dockerfile
 You can retrieve a list of all available tags for dotnet/aspnet at https://mcr.microsoft.com/v2/dotnet/aspnet/tags/list.
 <!--End of generated tags-->
 
-For tags contained in the old dotnet/core/aspnet repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/aspnet/tags/list.
-
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -164,8 +164,6 @@ Tags | Dockerfile | OS Version
 You can retrieve a list of all available tags for dotnet/runtime-deps at https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list.
 <!--End of generated tags-->
 
-For tags contained in the old dotnet/core/runtime-deps repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/runtime-deps/tags/list.
-
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -207,8 +207,6 @@ Tag | Dockerfile
 You can retrieve a list of all available tags for dotnet/runtime at https://mcr.microsoft.com/v2/dotnet/runtime/tags/list.
 <!--End of generated tags-->
 
-For tags contained in the old dotnet/core/runtime repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/runtime/tags/list.
-
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support

--- a/README.samples.md
+++ b/README.samples.md
@@ -113,8 +113,6 @@ aspnetapp-8.0-nanoserver-1809, aspnetapp-nanoserver-1809, aspnetapp-8.0, aspneta
 You can retrieve a list of all available tags for dotnet/samples at https://mcr.microsoft.com/v2/dotnet/samples/tags/list.
 <!--End of generated tags-->
 
-For tags contained in the old dotnet/core/samples repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/samples/tags/list.
-
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -177,8 +177,6 @@ Tag | Dockerfile
 You can retrieve a list of all available tags for dotnet/sdk at https://mcr.microsoft.com/v2/dotnet/sdk/tags/list.
 <!--End of generated tags-->
 
-For tags contained in the old dotnet/core/sdk repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core/sdk/tags/list.
-
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 
 # Support

--- a/eng/readme-templates/DefaultLayout.md
+++ b/eng/readme-templates/DefaultLayout.md
@@ -27,9 +27,7 @@ if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 {{if !IS_PRODUCT_FAMILY:
 # Full Tag Listing
 {{if ARGS["readme-host"] = "github":<!--End of generated tags-->
-{{if !(isMonitor || isAspireDashboard):For tags contained in the old dotnet/core{{if isNightlyRepo:-nightly}}/{{SHORT_REPO}} repository, you can retrieve a list of those tags at https://mcr.microsoft.com/v2/dotnet/core{{if isNightlyRepo:-nightly}}/{{SHORT_REPO}}/tags/list.
-
-}}*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md)*
 ^elif ARGS["readme-host"] = "dockerhub":
 View the current tags at the [Microsoft Artifact Registry portal](https://mcr.microsoft.com/product/{{REPO}}/tags) or on [GitHub](https://github.com/dotnet/dotnet-docker/blob/{{if isNightlyRepo:nightly^else:main}}/README.{{SHORT_REPO}}.md#full-tag-listing).
 }}}}


### PR DESCRIPTION
These changes remove the obsolete dotnet/core full tag listing from the GitHub readme tag listing section.  The dotnet/core repos were used back when the product was referred to as .NET Core.  Core was dropped from the name when 5.0 was released.  The only images that we stop listing are 1.0 and 1.1.  All other images are available in the current dotnet repos.