### PR TITLE
Update Monitor 8.0 and 8.1 to Azure Linux 3.0

### DIFF
--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -59,27 +59,27 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 8.0.4-ubuntu-chiseled-amd64, 8.0-ubuntu-chiseled-amd64, 8.0.4-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.4, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-8.0.4-cbl-mariner-distroless-amd64, 8.0-cbl-mariner-distroless-amd64, 8.0.4-cbl-mariner-distroless, 8.0-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+8.0.4-azurelinux-distroless-amd64, 8.0-azurelinux-distroless-amd64, 8.0.4-azurelinux-distroless, 8.0-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.0-preview.7-amd64, 9.0-preview-amd64, 9.0.0-preview.7, 9.0-preview, 9-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/9.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-preview-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-8.1.0-alpha.1-cbl-mariner-distroless-amd64, 8.1-preview-cbl-mariner-distroless-amd64, 8-cbl-mariner-distroless-amd64, 8.1.0-alpha.1-cbl-mariner-distroless, 8.1-preview-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+8.1.0-alpha.1-azurelinux-distroless-amd64, 8.1-preview-azurelinux-distroless-amd64, 8-azurelinux-distroless-amd64, 8.1.0-alpha.1-azurelinux-distroless, 8.1-preview-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 8.0.4-ubuntu-chiseled-arm64v8, 8.0-ubuntu-chiseled-arm64v8, 8.0.4-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.4, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-8.0.4-cbl-mariner-distroless-arm64v8, 8.0-cbl-mariner-distroless-arm64v8, 8.0.4-cbl-mariner-distroless, 8.0-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+8.0.4-azurelinux-distroless-arm64v8, 8.0-azurelinux-distroless-arm64v8, 8.0.4-azurelinux-distroless, 8.0-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 
 ##### .NET Monitor Preview Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.0-preview.7-arm64v8, 9.0-preview-arm64v8, 9.0.0-preview.7, 9.0-preview, 9-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/9.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-preview-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-8.1.0-alpha.1-cbl-mariner-distroless-arm64v8, 8.1-preview-cbl-mariner-distroless-arm64v8, 8-cbl-mariner-distroless-arm64v8, 8.1.0-alpha.1-cbl-mariner-distroless, 8.1-preview-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+8.1.0-alpha.1-azurelinux-distroless-arm64v8, 8.1-preview-azurelinux-distroless-arm64v8, 8-azurelinux-distroless-arm64v8, 8.1.0-alpha.1-azurelinux-distroless, 8.1-preview-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor-base/8.1/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor/base at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/base/tags/list.
 <!--End of generated tags-->

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -60,7 +60,7 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 8.0.4-ubuntu-chiseled-amd64, 8.0-ubuntu-chiseled-amd64, 8.0.4-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.4, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-8.0.4-cbl-mariner-distroless-amd64, 8.0-cbl-mariner-distroless-amd64, 8.0.4-cbl-mariner-distroless, 8.0-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+8.0.4-azurelinux-distroless-amd64, 8.0-azurelinux-distroless-amd64, 8.0.4-azurelinux-distroless, 8.0-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 6.3.8-alpine-amd64, 6.3-alpine-amd64, 6-alpine-amd64, 6.3.8-alpine, 6.3-alpine, 6-alpine, 6.3.8, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/amd64/Dockerfile) | Alpine 3.20
 6.3.8-ubuntu-chiseled-amd64, 6.3-ubuntu-chiseled-amd64, 6-ubuntu-chiseled-amd64, 6.3.8-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 6.3.8-cbl-mariner-amd64, 6.3-cbl-mariner-amd64, 6-cbl-mariner-amd64, 6.3.8-cbl-mariner, 6.3-cbl-mariner, 6-cbl-mariner | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/cbl-mariner/amd64/Dockerfile) | CBL-Mariner 2.0
@@ -71,13 +71,13 @@ Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.0-preview.7-amd64, 9.0-preview-amd64, 9.0.0-preview.7, 9.0-preview, 9-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/9.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 8.1.0-alpha.1-ubuntu-chiseled-amd64, 8.1-preview-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-8.1.0-alpha.1-cbl-mariner-distroless-amd64, 8.1-preview-cbl-mariner-distroless-amd64, 8-cbl-mariner-distroless-amd64, 8.1.0-alpha.1-cbl-mariner-distroless, 8.1-preview-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+8.1.0-alpha.1-azurelinux-distroless-amd64, 8.1-preview-azurelinux-distroless-amd64, 8-azurelinux-distroless-amd64, 8.1.0-alpha.1-azurelinux-distroless, 8.1-preview-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 
 ## Linux arm64 Tags
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 8.0.4-ubuntu-chiseled-arm64v8, 8.0-ubuntu-chiseled-arm64v8, 8.0.4-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.4, 8.0 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-8.0.4-cbl-mariner-distroless-arm64v8, 8.0-cbl-mariner-distroless-arm64v8, 8.0.4-cbl-mariner-distroless, 8.0-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+8.0.4-azurelinux-distroless-arm64v8, 8.0-azurelinux-distroless-arm64v8, 8.0.4-azurelinux-distroless, 8.0-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 6.3.8-alpine-arm64v8, 6.3-alpine-arm64v8, 6-alpine-arm64v8, 6.3.8-alpine, 6.3-alpine, 6-alpine, 6.3.8, 6.3, 6 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/alpine/arm64v8/Dockerfile) | Alpine 3.20
 6.3.8-ubuntu-chiseled-arm64v8, 6.3-ubuntu-chiseled-arm64v8, 6-ubuntu-chiseled-arm64v8, 6.3.8-ubuntu-chiseled, 6.3-ubuntu-chiseled, 6-ubuntu-chiseled | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 6.3.8-cbl-mariner-arm64v8, 6.3-cbl-mariner-arm64v8, 6-cbl-mariner-arm64v8, 6.3.8-cbl-mariner, 6.3-cbl-mariner, 6-cbl-mariner | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/6.3/cbl-mariner/arm64v8/Dockerfile) | CBL-Mariner 2.0
@@ -88,7 +88,7 @@ Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.0-preview.7-arm64v8, 9.0-preview-arm64v8, 9.0.0-preview.7, 9.0-preview, 9-preview, latest | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/9.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 8.1.0-alpha.1-ubuntu-chiseled-arm64v8, 8.1-preview-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-alpha.1-ubuntu-chiseled, 8.1-preview-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0-alpha.1, 8.1-preview, 8 | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-8.1.0-alpha.1-cbl-mariner-distroless-arm64v8, 8.1-preview-cbl-mariner-distroless-arm64v8, 8-cbl-mariner-distroless-arm64v8, 8.1.0-alpha.1-cbl-mariner-distroless, 8.1-preview-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+8.1.0-alpha.1-azurelinux-distroless-arm64v8, 8.1-preview-azurelinux-distroless-arm64v8, 8-azurelinux-distroless-arm64v8, 8.1.0-alpha.1-azurelinux-distroless, 8.1-preview-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/nightly/src/monitor/8.1/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 
 You can retrieve a list of all available tags for dotnet/nightly/monitor at https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list.
 <!--End of generated tags-->

--- a/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-base-tags.yml
@@ -7,11 +7,11 @@ $(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-arm64v8)
     customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:8.1-preview-cbl-mariner-distroless-amd64)
+$(McrTagsYmlTagGroup:8.1-preview-azurelinux-distroless-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:8.1-preview-cbl-mariner-distroless-arm64v8)
+$(McrTagsYmlTagGroup:8.1-preview-azurelinux-distroless-arm64v8)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-amd64)
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-arm64v8)
-$(McrTagsYmlTagGroup:8.0-cbl-mariner-distroless-amd64)
-$(McrTagsYmlTagGroup:8.0-cbl-mariner-distroless-arm64v8)
+$(McrTagsYmlTagGroup:8.0-azurelinux-distroless-amd64)
+$(McrTagsYmlTagGroup:8.0-azurelinux-distroless-arm64v8)

--- a/eng/mcr-tags-metadata-templates/monitor-tags.yml
+++ b/eng/mcr-tags-metadata-templates/monitor-tags.yml
@@ -7,14 +7,14 @@ $(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.1-preview-ubuntu-chiseled-arm64v8)
     customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:8.1-preview-cbl-mariner-distroless-amd64)
+$(McrTagsYmlTagGroup:8.1-preview-azurelinux-distroless-amd64)
     customSubTableTitle: .NET Monitor Preview Tags
-$(McrTagsYmlTagGroup:8.1-preview-cbl-mariner-distroless-arm64v8)
+$(McrTagsYmlTagGroup:8.1-preview-azurelinux-distroless-arm64v8)
     customSubTableTitle: .NET Monitor Preview Tags
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-amd64)
 $(McrTagsYmlTagGroup:8.0-ubuntu-chiseled-arm64v8)
-$(McrTagsYmlTagGroup:8.0-cbl-mariner-distroless-amd64)
-$(McrTagsYmlTagGroup:8.0-cbl-mariner-distroless-arm64v8)
+$(McrTagsYmlTagGroup:8.0-azurelinux-distroless-amd64)
+$(McrTagsYmlTagGroup:8.0-azurelinux-distroless-arm64v8)
 $(McrTagsYmlTagGroup:6.3-alpine-amd64)
 $(McrTagsYmlTagGroup:6.3-alpine-arm64v8)
 $(McrTagsYmlTagGroup:6.3-ubuntu-chiseled-amd64)

--- a/manifest.json
+++ b/manifest.json
@@ -9548,21 +9548,25 @@
         {
           "productVersion": "$(monitor|8.0|product-version)",
           "sharedTags": {
-            "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless": {},
-            "$(monitor|8.0|minor-tag)-cbl-mariner-distroless": {}
+            "$(monitor|8.0|fixed-tag)-azurelinux-distroless": {},
+            "$(monitor|8.0|minor-tag)-azurelinux-distroless": {},
+            "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless": { "docType": "Undocumented" },
+            "$(monitor|8.0|minor-tag)-cbl-mariner-distroless": { "docType": "Undocumented" }
           },
           "platforms": [
             {
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
               },
-              "dockerfile": "src/monitor-base/8.0/cbl-mariner-distroless/amd64",
+              "dockerfile": "src/monitor-base/8.0/azurelinux-distroless/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-amd64": {}
+                "$(monitor|8.0|fixed-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8.0|minor-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" },
+                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" }
               }
             },
             {
@@ -9570,13 +9574,15 @@
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
               },
-              "dockerfile": "src/monitor-base/8.0/cbl-mariner-distroless/arm64v8",
+              "dockerfile": "src/monitor-base/8.0/azurelinux-distroless/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-arm64v8": {}
+                "$(monitor|8.0|fixed-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8.0|minor-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" },
+                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" }
               },
               "variant": "v8"
             }
@@ -9628,23 +9634,29 @@
         {
           "productVersion": "$(monitor|8.1|product-version)",
           "sharedTags": {
-            "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless": {},
-            "$(monitor|8.1|minor-tag)-cbl-mariner-distroless": {},
-            "$(monitor|8|major-tag)-cbl-mariner-distroless": {}
+            "$(monitor|8.1|fixed-tag)-azurelinux-distroless": {},
+            "$(monitor|8.1|minor-tag)-azurelinux-distroless": {},
+            "$(monitor|8|major-tag)-azurelinux-distroless": {},
+            "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless": { "docType": "Undocumented" },
+            "$(monitor|8.1|minor-tag)-cbl-mariner-distroless": { "docType": "Undocumented" },
+            "$(monitor|8|major-tag)-cbl-mariner-distroless": { "docType": "Undocumented" }
           },
           "platforms": [
             {
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
               },
-              "dockerfile": "src/monitor-base/8.1/cbl-mariner-distroless/amd64",
+              "dockerfile": "src/monitor-base/8.1/azurelinux-distroless/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8|major-tag)-cbl-mariner-distroless-amd64": {}
+                "$(monitor|8.1|fixed-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8.1|minor-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8|major-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" },
+                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" },
+                "$(monitor|8|major-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" }
               }
             },
             {
@@ -9652,14 +9664,17 @@
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
               },
-              "dockerfile": "src/monitor-base/8.1/cbl-mariner-distroless/arm64v8",
+              "dockerfile": "src/monitor-base/8.1/azurelinux-distroless/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor-base/Dockerfile.linux",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8|major-tag)-cbl-mariner-distroless-arm64v8": {}
+                "$(monitor|8.1|fixed-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8.1|minor-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8|major-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" },
+                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" },
+                "$(monitor|8|major-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" }
               },
               "variant": "v8"
             }
@@ -9930,21 +9945,25 @@
         {
           "productVersion": "$(monitor|8.0|product-version)",
           "sharedTags": {
-            "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless": {},
-            "$(monitor|8.0|minor-tag)-cbl-mariner-distroless": {}
+            "$(monitor|8.0|fixed-tag)-azurelinux-distroless": {},
+            "$(monitor|8.0|minor-tag)-azurelinux-distroless": {},
+            "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless": { "docType": "Undocumented" },
+            "$(monitor|8.0|minor-tag)-cbl-mariner-distroless": { "docType": "Undocumented" }
           },
           "platforms": [
             {
               "buildArgs": {
                 "REPO": "$(Repo:monitor-base)"
               },
-              "dockerfile": "src/monitor/8.0/cbl-mariner-distroless/amd64",
+              "dockerfile": "src/monitor/8.0/azurelinux-distroless/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-amd64": {}
+                "$(monitor|8.0|fixed-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8.0|minor-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" },
+                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" }
               }
             },
             {
@@ -9952,13 +9971,15 @@
               "buildArgs": {
                 "REPO": "$(Repo:monitor-base)"
               },
-              "dockerfile": "src/monitor/8.0/cbl-mariner-distroless/arm64v8",
+              "dockerfile": "src/monitor/8.0/azurelinux-distroless/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-arm64v8": {}
+                "$(monitor|8.0|fixed-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8.0|minor-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8.0|fixed-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" },
+                "$(monitor|8.0|minor-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" }
               },
               "variant": "v8"
             }
@@ -10010,23 +10031,25 @@
         {
           "productVersion": "$(monitor|8.1|product-version)",
           "sharedTags": {
-            "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless": {},
-            "$(monitor|8.1|minor-tag)-cbl-mariner-distroless": {},
-            "$(monitor|8|major-tag)-cbl-mariner-distroless": {}
+            "$(monitor|8.1|fixed-tag)-azurelinux-distroless": {},
+            "$(monitor|8.1|minor-tag)-azurelinux-distroless": {},
+            "$(monitor|8|major-tag)-azurelinux-distroless": {},
+            "$(monitor|8|major-tag)-cbl-mariner-distroless": { "docType": "Undocumented" }
           },
           "platforms": [
             {
               "buildArgs": {
                 "REPO": "$(Repo:monitor-base)"
               },
-              "dockerfile": "src/monitor/8.1/cbl-mariner-distroless/amd64",
+              "dockerfile": "src/monitor/8.1/azurelinux-distroless/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8|major-tag)-cbl-mariner-distroless-amd64": {}
+                "$(monitor|8.1|fixed-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8.1|minor-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8|major-tag)-azurelinux-distroless-amd64": {},
+                "$(monitor|8|major-tag)-cbl-mariner-distroless-amd64": { "docType": "Undocumented" }
               }
             },
             {
@@ -10034,14 +10057,15 @@
               "buildArgs": {
                 "REPO": "$(Repo:monitor-base)"
               },
-              "dockerfile": "src/monitor/8.1/cbl-mariner-distroless/arm64v8",
+              "dockerfile": "src/monitor/8.1/azurelinux-distroless/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/monitor/Dockerfile.linux.extensions",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8|major-tag)-cbl-mariner-distroless-arm64v8": {}
+                "$(monitor|8.1|fixed-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8.1|minor-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8|major-tag)-azurelinux-distroless-arm64v8": {},
+                "$(monitor|8|major-tag)-cbl-mariner-distroless-arm64v8": { "docType": "Undocumented" }
               },
               "variant": "v8"
             }

--- a/src/monitor-base/8.0/azurelinux-distroless/amd64/Dockerfile
+++ b/src/monitor-base/8.0/azurelinux-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -10,9 +10,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=8.1.0-alpha.1.24401.5 \
-    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz \
-    && dotnet_monitor_base_sha512='7b8fecf5334d3a4b13f36f65bfb7742164f97d2d659b2bddcdd98adac92576cea0afc2b9109ccb568c1c677b3dcfdcf465e520e58f778d68da23ee70754f7ab8' \
+RUN dotnet_monitor_version=8.0.4 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/8.0.4-servicing.24406.4/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz \
+    && dotnet_monitor_base_sha512='3bbc2f8864fd7dad2eb19349362e9337cca2407b6b81411bac18cbe0bcc453a1e3137f01006e89165c8be5e15ff31a2e189c9d6ee3e61cffb0a7ffaeed4028a0' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \
     && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
@@ -20,7 +20,7 @@ RUN dotnet_monitor_version=8.1.0-alpha.1.24401.5 \
 
 
 # .NET Monitor Base image
-FROM $REPO:8.0.7-cbl-mariner2.0-distroless-arm64v8
+FROM $REPO:8.0.7-azurelinux3.0-distroless-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor-base/8.0/azurelinux-distroless/arm64v8/Dockerfile
+++ b/src/monitor-base/8.0/azurelinux-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -20,7 +20,7 @@ RUN dotnet_monitor_version=8.0.4 \
 
 
 # .NET Monitor Base image
-FROM $REPO:8.0.7-cbl-mariner2.0-distroless-arm64v8
+FROM $REPO:8.0.7-azurelinux3.0-distroless-arm64v8
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor-base/8.1/azurelinux-distroless/amd64/Dockerfile
+++ b/src/monitor-base/8.1/azurelinux-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -20,7 +20,7 @@ RUN dotnet_monitor_version=8.1.0-alpha.1.24401.5 \
 
 
 # .NET Monitor Base image
-FROM $REPO:8.0.7-cbl-mariner2.0-distroless-amd64
+FROM $REPO:8.0.7-azurelinux3.0-distroless-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor-base/8.1/azurelinux-distroless/arm64v8/Dockerfile
+++ b/src/monitor-base/8.1/azurelinux-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -10,9 +10,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=8.0.4 \
-    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/8.0.4-servicing.24406.4/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz \
-    && dotnet_monitor_base_sha512='3bbc2f8864fd7dad2eb19349362e9337cca2407b6b81411bac18cbe0bcc453a1e3137f01006e89165c8be5e15ff31a2e189c9d6ee3e61cffb0a7ffaeed4028a0' \
+RUN dotnet_monitor_version=8.1.0-alpha.1.24401.5 \
+    && curl -fSL --output dotnet-monitor-base.tar.gz https://dotnetbuilds.azureedge.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz \
+    && dotnet_monitor_base_sha512='7b8fecf5334d3a4b13f36f65bfb7742164f97d2d659b2bddcdd98adac92576cea0afc2b9109ccb568c1c677b3dcfdcf465e520e58f778d68da23ee70754f7ab8' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \
     && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
@@ -20,7 +20,7 @@ RUN dotnet_monitor_version=8.0.4 \
 
 
 # .NET Monitor Base image
-FROM $REPO:8.0.7-cbl-mariner2.0-distroless-amd64
+FROM $REPO:8.0.7-azurelinux3.0-distroless-arm64v8
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/monitor/8.0/azurelinux-distroless/amd64/Dockerfile
+++ b/src/monitor/8.0/azurelinux-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -27,6 +27,6 @@ RUN dotnet_monitor_extension_version=8.0.4 \
 
 
 # .NET Monitor image
-FROM $REPO:8.0.4-cbl-mariner-distroless-amd64
+FROM $REPO:8.0.4-azurelinux-distroless-amd64
 
 COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.0/azurelinux-distroless/arm64v8/Dockerfile
+++ b/src/monitor/8.0/azurelinux-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -27,6 +27,6 @@ RUN dotnet_monitor_extension_version=8.0.4 \
 
 
 # .NET Monitor image
-FROM $REPO:8.0.4-cbl-mariner-distroless-arm64v8
+FROM $REPO:8.0.4-azurelinux-distroless-arm64v8
 
 COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.1/azurelinux-distroless/amd64/Dockerfile
+++ b/src/monitor/8.1/azurelinux-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -27,6 +27,6 @@ RUN dotnet_monitor_extension_version=8.1.0-alpha.1.24401.5 \
 
 
 # .NET Monitor image
-FROM $REPO:8.1.0-alpha.1-cbl-mariner-distroless-amd64
+FROM $REPO:8.1.0-alpha.1-azurelinux-distroless-amd64
 
 COPY --from=installer ["/app", "/app"]

--- a/src/monitor/8.1/azurelinux-distroless/arm64v8/Dockerfile
+++ b/src/monitor/8.1/azurelinux-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -27,6 +27,6 @@ RUN dotnet_monitor_extension_version=8.1.0-alpha.1.24401.5 \
 
 
 # .NET Monitor image
-FROM $REPO:8.1.0-alpha.1-cbl-mariner-distroless-arm64v8
+FROM $REPO:8.1.0-alpha.1-azurelinux-distroless-arm64v8
 
 COPY --from=installer ["/app", "/app"]


### PR DESCRIPTION
2/2 of #5375

According to the recommendation in that issue, this adds new tags for Azure Linux and makes the existing `cbl-mariner*` tags undocumented. This way, users referencing the existing floating tags will still get updates, but new users will only see the Azure Linux tags.

I chose to remove tags with the format `8.1*-cbl-mariner-distroless*` since .NET Monitor 8.1 is still in preview, and thus those tags were never published as supported. The `8-cbl-mariner-distroless` tag will need to stick around, however, since that tag is currently supported in the main branch.