### PR TITLE
Fix issues with Get-DropVersions.ps1 using Build ID

### DIFF
--- a/eng/Get-DropVersions.ps1
+++ b/eng/Get-DropVersions.ps1
@@ -161,7 +161,7 @@ function GetVersionInfoFromBuildId([string]$buildId) {
 
         return [PSCustomObject]@{
             DockerfileVersion = $config.Channel
-            SdkVersion = ($config.Sdks | Sort-Object -Descending)[0]
+            SdkVersion = @($config.Sdks | Sort-Object -Descending)[0]
             RuntimeVersion = $config.Runtime
             AspnetVersion = $config.Asp
             StableBranding = $isStableVersion
@@ -269,7 +269,7 @@ if ($UpdateDependencies)
             -AspnetVersion $versionInfo.AspnetVersion `
             -SdkVersion $versionInfo.SdkVersion `
 
-        Write-Host "`r`nDone: Updates for .NET ${versionInfo.RuntimeVersion}/${versionInfo.SdkVersion}`r`n"
+        Write-Host "`r`nDone: Updates for .NET $($versionInfo.RuntimeVersion)/$($versionInfo.SdkVersion)`r`n"
     }
 } else {
     Write-Output "##vso[task.setvariable variable=versionInfos]$($versionInfos | ConvertTo-Json -Compress -AsArray)"


### PR DESCRIPTION
There were a couple of minor issues with the Get-DropVersions.ps1 script that I discovered when creating #5772.

1. Fix situation where Sdks can be an array with a single value. PowerShell treats arrays with single values as the value itself. So we need to force it to be an array or else we'll get an empty value for SdkVersion.
2. Fix PSObject reference in string.