### PR TITLE
Use better format for nightly repo warnings

### DIFF
--- a/.portal-docs/docker-hub/README.aspire-dashboard.md
+++ b/.portal-docs/docker-hub/README.aspire-dashboard.md
@@ -1,8 +1,6 @@
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 # Featured Tags
 

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -1,8 +1,6 @@
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 # Featured Tags
 

--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -1,8 +1,6 @@
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor-base/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor-base/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 # Featured Tags
 

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -1,8 +1,6 @@
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 # Featured Tags
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -1,8 +1,6 @@
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 # Featured Tags
 

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -1,8 +1,6 @@
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 # Featured Tags
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -1,8 +1,6 @@
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-sdk/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-sdk/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 # Featured Tags
 

--- a/.portal-docs/mar/README.aspire-dashboard.portal.md
+++ b/.portal-docs/mar/README.aspire-dashboard.portal.md
@@ -1,10 +1,8 @@
 ## About
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/aspire-dashboard/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://mcr.microsoft.com/product/dotnet/aspire-dashboard/about) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET Aspire Dashboard.
 

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -1,10 +1,8 @@
 ## About
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/aspnet/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://mcr.microsoft.com/product/dotnet/aspnet/about) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the ASP.NET Core and .NET runtimes and libraries and is optimized for running ASP.NET Core apps in production.
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -1,10 +1,8 @@
 ## About
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/monitor/base/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://mcr.microsoft.com/product/dotnet/monitor/base/about) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET Monitor Base installation.
 

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -1,10 +1,8 @@
 ## About
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/monitor/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://mcr.microsoft.com/product/dotnet/monitor/about) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET Monitor tool.
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -1,10 +1,8 @@
 ## About
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/runtime-deps/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://mcr.microsoft.com/product/dotnet/runtime-deps/about) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the native dependencies needed by .NET. It does not include .NET. It is for [self-contained](https://docs.microsoft.com/dotnet/articles/core/deploying/index) applications.
 

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -1,10 +1,8 @@
 ## About
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/runtime/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://mcr.microsoft.com/product/dotnet/runtime/about) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET runtimes and libraries and is optimized for running .NET apps in production.
 

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -1,10 +1,8 @@
 ## About
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://mcr.microsoft.com/product/dotnet/sdk/about) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://mcr.microsoft.com/product/dotnet/sdk/about) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 This image contains the .NET SDK which is comprised of three parts:
 

--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -1,10 +1,8 @@
 # .NET Aspire Dashboard
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspire-dashboard/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Tags
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,10 +1,8 @@
 # ASP.NET Core Runtime
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-aspnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Tags
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # .NET
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Repos
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -1,10 +1,8 @@
 # .NET Monitor Base
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor-base/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor-base/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Tags
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -1,10 +1,8 @@
 # .NET Monitor Tool
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-monitor/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Tags
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -1,10 +1,8 @@
 # .NET Runtime Dependencies
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime-deps/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Tags
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,10 +1,8 @@
 # .NET Runtime
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-runtime/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Tags
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,10 +1,8 @@
 # .NET SDK
 
-**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet](https://hub.docker.com/r/microsoft/dotnet-sdk/) for images with official releases of [.NET](https://github.com/dotnet/core).**
+> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet](https://hub.docker.com/r/microsoft/dotnet-sdk/) for images with official releases of [.NET](https://github.com/dotnet/core).
 
 ## Featured Tags
 

--- a/eng/readme-templates/Announcement.md
+++ b/eng/readme-templates/Announcement.md
@@ -7,10 +7,8 @@
     set isNightlyRepo to match(split(REPO, "/")[1], "nightly")
 }}{{if isNightlyRepo || VARIABLES["branch"] = "nightly"
 :{{if ARGS["leading-line-break"]:
-}}**IMPORTANT**
-
-**The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).**
-
-**See [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": nonNightlyRepo ])}}) for images with official releases of [.NET](https://github.com/dotnet/core).**
+}}> **Important**: The images from the dotnet/nightly repositories include last-known-good (LKG) builds for the next release of [.NET](https://github.com/dotnet/core).
+>
+> See [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": nonNightlyRepo ])}}) for images with official releases of [.NET](https://github.com/dotnet/core).
 {{if ARGS["trailing-line-break"]:
 }}}}


### PR DESCRIPTION
Resolves markdown linting error: `README.md:3 MD036/no-emphasis-as-heading Emphasis used instead of a heading [Context: "IMPORTANT"]`
