### PR TITLE
Allow update-dependencies to update product base URL

### DIFF
--- a/eng/DependencyManagement.psm1
+++ b/eng/DependencyManagement.psm1
@@ -27,5 +27,9 @@ function Resolve-DotnetProductUrl([string] $akaMsUrl) {
 }
 
 function Get-ProductReleaseState() {
-    return $(Get-Branch) -ieq 'main' ? 'Release' : 'Prerelease'
+    if ($(Get-Branch) -ieq 'main') {
+        return 'Release'
+    } else {
+        return 'Prerelease'
+    }
 }

--- a/eng/DependencyManagement.psm1
+++ b/eng/DependencyManagement.psm1
@@ -25,3 +25,7 @@ function Resolve-DotnetProductUrl([string] $akaMsUrl) {
     Write-Host "Resolved URL: $resolvedUrl"
     return $resolvedUrl
 }
+
+function Get-ProductReleaseState() {
+    return $(Get-Branch) -ieq 'main' ? 'Release' : 'Prerelease'
+}

--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -58,7 +58,12 @@ param(
 
     # File containing checksums for each product asset; used to override the behavior of locating the checksums from blob storage accounts.
     [string]
-    $ChecksumsFile
+    $ChecksumsFile,
+
+    # The release state of the product assets
+    [ValidateSet("Prerelease", "Release")]
+    [string]
+    $ReleaseState
 )
 
 Import-Module -force $PSScriptRoot/DependencyManagement.psm1
@@ -111,6 +116,10 @@ if ($ChecksumsFile) {
 
 if ($UseStableBranding) {
     $updateDepsArgs += "--stable-branding"
+}
+
+if ($ReleaseState) {
+    $updateDepsArgs += "--release-state=$ReleaseState"
 }
 
 $versionSourceName = switch ($PSCmdlet.ParameterSetName) {

--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -43,6 +43,8 @@ steps:
       if ("${{ parameters.useInternalBuild }}" -eq "true") {
         $args["ChecksumSasQueryString"] = '"$(dotnetchecksumsstage-account-sas-read-token)"'
         $args["BinarySasQueryString"] = '"$(dotnetstage-account-sas-read-token)"'
+      } else {
+        $args["ReleaseState"] = $(Get-ProductReleaseState)
       }
 
       Write-Host "Executing Set-DotnetVersions.ps1 for $($versionInfo.DockerfileVersion)"

--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -26,6 +26,8 @@ steps:
     $(engPath)/Get-DropVersions.ps1 @args
   displayName: Get Versions
 - powershell: |
+    Import-Module -force $(engPath)/DependencyManagement.psm1
+
     $versionInfos = '$(versionInfos)' | ConvertFrom-Json
 
     $index=0

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -30,6 +30,8 @@ stages:
     - pwsh: $(engPath)/Get-MonitorDropVersions.ps1 -BuildVersionFilePath "$(Pipeline.Workspace)/dotnet-monitor/Build_Info/dotnet-monitor.nupkg.buildversion"
       displayName: Get Versions
     - powershell: |
+        Import-Module -force $(engPath)/DependencyManagement.psm1
+
         $scriptArgs = @{
           ProductVersion = "$(monitorMajorMinorVersion)"
           MonitorVersion = "$(monitorVer)"

--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -35,6 +35,7 @@ stages:
           MonitorVersion = "$(monitorVer)"
           AzdoVariableName = 'updateDepsArgs'
           UseStableBranding = [bool]::Parse("$(stableBranding)")
+          ReleaseState = $(Get-ProductReleaseState)
         }
 
         $(engPath)/Set-DotnetVersions.ps1 @scriptArgs

--- a/eng/update-dependencies/BaseUrlUpdater.cs
+++ b/eng/update-dependencies/BaseUrlUpdater.cs
@@ -51,6 +51,10 @@ internal class BaseUrlUpdater : FileRegexUpdater
 
             unresolvedBaseUrl = $"https://dotnetstage.blob.core.windows.net/{sdkVersion}-internal";
         }
+        else if (_options.ReleaseState.HasValue)
+        {
+            unresolvedBaseUrl = $"$({ManifestHelper.GetBaseUrlVariableName(_options.ReleaseState.Value, _options.TargetBranch)})";
+        }
         else
         {
             // Modifying the URL from internal to public is not suppported because it's not possible to know

--- a/eng/update-dependencies/ManifestHelper.cs
+++ b/eng/update-dependencies/ManifestHelper.cs
@@ -27,7 +27,7 @@ public static partial class ManifestHelper
         ResolveVariableValue(GetBaseUrlVariableName(options.DockerfileVersion, options.SourceBranch, options.VersionSourceName), manifestVariables);
 
     /// <summary>
-    /// Constructs the name of the base URL variable.
+    /// Constructs the name of the product version base URL variable.
     /// </summary>
     /// <param name="dockerfileVersion">Dockerfile version.</param>
     /// <param name="branch">Name of the branch.</param>
@@ -41,6 +41,23 @@ public static partial class ManifestHelper
         };
 
         return $"{product}|{dockerfileVersion}|base-url|{branch}";
+    }
+
+    /// <summary>
+    /// Constructs the name of the shared base URL variable.
+    /// </summary>
+    /// <param name="releaseState">Release state of the product assets.</param>
+    /// <param name="branch">Name of the branch.</param>
+    public static string GetBaseUrlVariableName(ReleaseState releaseState, string branch)
+    {
+        string qualityString = releaseState switch
+        {
+            ReleaseState.Prerelease => "preview",
+            ReleaseState.Release => "maintenance",
+            _ => throw new NotSupportedException()
+        };
+
+        return $"base-url|public|{qualityString}|{branch}";
     }
 
     public static string GetVersionVariableName(VersionType versionType, string productName, string dockerfileVersion) =>

--- a/eng/update-dependencies/Options.cs
+++ b/eng/update-dependencies/Options.cs
@@ -31,9 +31,11 @@ namespace Dotnet.Docker
         public bool UpdateOnly => Email == null || Password == null || User == null || TargetBranch == null;
         public bool IsInternal => !string.IsNullOrEmpty(BinarySasQueryString) || !string.IsNullOrEmpty(ChecksumSasQueryString);
         public string ChecksumsFile { get; }
+        public ReleaseState? ReleaseState { get; }
 
         public Options(string dockerfileVersion, string[] productVersion, string versionSourceName, string email, string password, string user,
-            bool computeShas, bool stableBranding, string binarySas, string checksumSas, string sourceBranch, string targetBranch, string org, string project, string repo, string checksumsFile)
+            bool computeShas, bool stableBranding, string binarySas, string checksumSas, string sourceBranch, string targetBranch, string org,
+            string project, string repo, string checksumsFile, ReleaseState? releaseState)
         {
             DockerfileVersion = dockerfileVersion;
             ProductVersions = productVersion
@@ -66,6 +68,8 @@ namespace Dotnet.Docker
             {
                 ProductVersions["dotnet"] = ProductVersions["aspnet"];
             }
+
+            ReleaseState = releaseState;
         }
 
         public static IEnumerable<Symbol> GetCliSymbols() =>
@@ -86,8 +90,15 @@ namespace Dotnet.Docker
                 new Option<string>("--org", "Name of the AzDO organization"),
                 new Option<string>("--project", "Name of the AzDO project"),
                 new Option<string>("--repo", "Name of the AzDO repo"),
-                new Option<string>("--checksums-file", "File containing a list of checksums for each product asset")
+                new Option<string>("--checksums-file", "File containing a list of checksums for each product asset"),
+                new Option<ReleaseState?>("--release-state", "The release state of the product assets")
             };
+    }
+
+    public enum ReleaseState
+    {
+        Prerelease,
+        Release
     }
 }
 #nullable disable


### PR DESCRIPTION
The intent of this change is to allow the update-dependencies tool to set the product base URL as it is updating the product version. This allows automation to automatically fix up the product base URL to correspond with where the product version assets are staged at the time of updating.

An example situation where this would be useful is when a security release is inserted directly into the main branch (which means its only the dotnetcli storage account at time of publishing) but the assets were never available on the dotnetbuilds storage account. When those changes are merged back to the nightly branch, automated updates for prerelease versions are stuck until the base URL is manually updated (along with a new product version) in the nightly branch.

With the proposed changes, the update-dependencies tool that is invoked by the update pipelines will set the base URL that corresponds with the product version. The pipelines assume that if targeting the nightly branch, then the product assets are in a prerelease mode, whereas if targeting the main branch, then the product assets are already released.

If need be, the `Set-DotnetVersions.ps1` script can be manually invoked with the `-ReleaseState` parameter to indicate whether the product assets have been released or not, which then informs the update-dependency tool which common base URL should be used for the product version. This parameter is not required; if not specified, the base URL for the product version is not updated.

closes #4939