### PR TITLE
Simplify appliance product base URL calculation

### DIFF
--- a/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux.install-aspire-dashboard
+++ b/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux.install-aspire-dashboard
@@ -3,11 +3,8 @@
     set buildVersion to VARIABLES[cat("aspire-dashboard|", aspireMajorMinor, "|build-version")] ^
     set aspireVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
     set aspireVersion to VARIABLES[cat("aspire-dashboard|", aspireMajorMinor, "|", aspireVersionVariable)] ^
-    _ When build and product versions are the same and they are stable versions, use account from main branch e.g. dotnetcli
-      Otherwise, use the account that is associated with the current branch. ^
-    set urlBranch to when(find(aspireVersion, "-") >= 0 || buildVersion != aspireVersion, VARIABLES["branch"], "main") ^
     set versionFolder to when(buildVersion != aspireVersion, buildVersion, '$dotnet_aspire_version') ^
-    set aspireBaseUrl to cat(VARIABLES[cat("aspire-dashboard|", aspireMajorMinor, "|base-url|", urlBranch)], "/aspire/", versionFolder, "/") ^
+    set aspireBaseUrl to cat(VARIABLES[cat("aspire-dashboard|", aspireMajorMinor, "|base-url|", VARIABLES["branch"])], "/aspire/", versionFolder, "/") ^
     set files to [
         [
             "filename": "aspire_dashboard.zip",

--- a/eng/dockerfile-templates/monitor-base/Dockerfile.linux.install-monitor-base
+++ b/eng/dockerfile-templates/monitor-base/Dockerfile.linux.install-monitor-base
@@ -3,11 +3,8 @@
     set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
     set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
     set monitorVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|", monitorVersionVariable)] ^
-    _ When build and product versions are the same and they are stable versions, use account from main branch e.g. dotnetcli
-      Otherwise, use the account that is associated with the current branch. ^
-    set urlBranch to when(find(monitorVersion, "-") >= 0 || buildVersion != monitorVersion, VARIABLES["branch"], "main") ^
     set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$dotnet_monitor_version') ^
-    set monitorBaseUrl to cat(VARIABLES[cat("monitor|", monitorMajorMinor, "|base-url|", urlBranch)], "/diagnostics/monitor/", versionFolder, "/") ^
+    set monitorBaseUrl to cat(VARIABLES[cat("monitor|", monitorMajorMinor, "|base-url|", VARIABLES["branch"])], "/diagnostics/monitor/", versionFolder, "/") ^
     set files to [
         [
             "filename": "dotnet-monitor-base.tar.gz",

--- a/eng/dockerfile-templates/monitor/Dockerfile.linux.install-extensions
+++ b/eng/dockerfile-templates/monitor/Dockerfile.linux.install-extensions
@@ -3,11 +3,8 @@
     set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
     set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
     set monitorVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|", monitorVersionVariable)] ^
-    _ When build and product versions are the same and they are stable versions, use account from main branch e.g. dotnetcli
-      Otherwise, use the account that is associated with the current branch. ^
-    set urlBranch to when(find(monitorVersion, "-") >= 0 || buildVersion != monitorVersion, VARIABLES["branch"], "main") ^
     set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$dotnet_monitor_extension_version') ^
-    set monitorBaseUrl to cat(VARIABLES[cat("monitor|", monitorMajorMinor, "|base-url|", urlBranch)], "/diagnostics/monitor/", versionFolder, "/") ^
+    set monitorBaseUrl to cat(VARIABLES[cat("monitor|", monitorMajorMinor, "|base-url|", VARIABLES["branch"])], "/diagnostics/monitor/", versionFolder, "/") ^
     set files to [
         [
             "filename": "dotnet-monitor-egress-azureblobstorage.tar.gz",

--- a/eng/dockerfile-templates/monitor/Dockerfile.linux.install-monitor
+++ b/eng/dockerfile-templates/monitor/Dockerfile.linux.install-monitor
@@ -3,13 +3,10 @@
     set buildVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|build-version")] ^
     set monitorVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
     set monitorVersion to VARIABLES[cat("monitor|", monitorMajorMinor, "|", monitorVersionVariable)] ^
-    _ When build and product versions are the same and they are stable versions, use account from main branch e.g. dotnetcli
-      Otherwise, use the account that is associated with the current branch. ^
-    set urlBranch to when(find(monitorVersion, "-") >= 0 || buildVersion != monitorVersion, VARIABLES["branch"], "main") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set varPlatform to when(isAlpine, "linux-musl", "linux") ^
     set versionFolder to when(buildVersion != monitorVersion, buildVersion, '$dotnet_monitor_version') ^
-    set monitorBaseUrl to cat(VARIABLES[cat("monitor|", monitorMajorMinor, "|base-url|", urlBranch)], "/diagnostics/monitor/", versionFolder, "/") ^
+    set monitorBaseUrl to cat(VARIABLES[cat("monitor|", monitorMajorMinor, "|base-url|", VARIABLES["branch"])], "/diagnostics/monitor/", versionFolder, "/") ^
     set files to [
         [
             "filename": "dotnet-monitor.tar.gz",


### PR DESCRIPTION
The appliance-style image templates use a non-trivial base URL lookup based on version patterns and equality of product and build version. This was born out of necessity when there were only one set of base URLs for a given version and branch in the [manifest.versions.json](https://github.com/dotnet/dotnet-docker/blob/d5943b12928c24b8d16da6c0a2d805823c3f436a/manifest.versions.json) file that dictated the base URL for all products. [Subsequent changes](https://github.com/dotnet/dotnet-docker/commit/6a957822418dfdfd78a4816154dfdd3926b51e29#diff-f657b02176508554b475067f99d956c3c0fb1c08be55990212cb9179813b4aca) further split the URLs by product, thus each product can independently declare its base URLs for each version and branch combination.

The complicated logic for calculating the base URL for the appliance-style images is no longer necessary due to this split. While the proposed change in this PR largely has no effect on the existing dockerfiles nor an effect on how versions are updated, the removal of the unnecessary logic simplifies the templates a small amount and can prevent confusion to those who attempt to reason about why this logic exists.