### PR TITLE
Update Image Update Policy to include monthly rebuild clause

### DIFF
--- a/.portal-docs/docker-hub/README.aspire-dashboard.md
+++ b/.portal-docs/docker-hub/README.aspire-dashboard.md
@@ -121,7 +121,7 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/docker-hub/README.aspire-dashboard.md
+++ b/.portal-docs/docker-hub/README.aspire-dashboard.md
@@ -119,9 +119,10 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.aspire-dashboard.md
+++ b/.portal-docs/docker-hub/README.aspire-dashboard.md
@@ -119,10 +119,11 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -80,9 +80,10 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -82,7 +82,7 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -80,10 +80,11 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -62,10 +62,11 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -64,7 +64,7 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -62,9 +62,10 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -63,10 +63,11 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -65,7 +65,7 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -63,9 +63,10 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -61,10 +61,11 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -63,7 +63,7 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -61,9 +61,10 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -69,9 +69,10 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -71,7 +71,7 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -69,10 +69,11 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.samples.md
+++ b/.portal-docs/docker-hub/README.samples.md
@@ -88,9 +88,10 @@ These sample images are not intended for production use and may be subject to br
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.samples.md
+++ b/.portal-docs/docker-hub/README.samples.md
@@ -90,7 +90,7 @@ These sample images are not intended for production use and may be subject to br
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/docker-hub/README.samples.md
+++ b/.portal-docs/docker-hub/README.samples.md
@@ -88,10 +88,11 @@ These sample images are not intended for production use and may be subject to br
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -71,9 +71,10 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -71,10 +71,11 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 ## Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 ### CVE Update Policy
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -73,7 +73,7 @@ View the current tags at the [Microsoft Artifact Registry portal](https://mcr.mi
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.aspire-dashboard.portal.md
+++ b/.portal-docs/mar/README.aspire-dashboard.portal.md
@@ -117,7 +117,7 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.aspire-dashboard.portal.md
+++ b/.portal-docs/mar/README.aspire-dashboard.portal.md
@@ -115,10 +115,11 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.aspire-dashboard.portal.md
+++ b/.portal-docs/mar/README.aspire-dashboard.portal.md
@@ -115,9 +115,10 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -76,9 +76,10 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -78,7 +78,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -76,10 +76,11 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -60,7 +60,7 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -58,9 +58,10 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -58,10 +58,11 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -61,7 +61,7 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -59,10 +59,11 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -59,9 +59,10 @@ See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -57,10 +57,11 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -59,7 +59,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -57,9 +57,10 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -65,9 +65,10 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -67,7 +67,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -65,10 +65,11 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.samples.portal.md
+++ b/.portal-docs/mar/README.samples.portal.md
@@ -84,9 +84,10 @@ These sample images are not intended for production use and may be subject to br
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.samples.portal.md
+++ b/.portal-docs/mar/README.samples.portal.md
@@ -86,7 +86,7 @@ These sample images are not intended for production use and may be subject to br
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/.portal-docs/mar/README.samples.portal.md
+++ b/.portal-docs/mar/README.samples.portal.md
@@ -84,10 +84,11 @@ These sample images are not intended for production use and may be subject to br
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -67,10 +67,11 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -67,9 +67,10 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -69,7 +69,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -134,10 +134,11 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -134,9 +134,10 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -136,7 +136,7 @@ Tags | Dockerfile | OS Version
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -289,7 +289,7 @@ Tag | Dockerfile
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -287,10 +287,11 @@ Tag | Dockerfile
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -287,9 +287,10 @@ Tag | Dockerfile
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -93,7 +93,7 @@ Tags | Dockerfile | OS Version
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -91,9 +91,10 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -91,10 +91,11 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -102,7 +102,7 @@ Tags | Dockerfile | OS Version
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -100,9 +100,10 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -100,10 +100,11 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -190,7 +190,7 @@ Tags | Dockerfile | OS Version
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -188,10 +188,11 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -188,9 +188,10 @@ Tags | Dockerfile | OS Version
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -239,10 +239,11 @@ Tag | Dockerfile
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -241,7 +241,7 @@ Tag | Dockerfile
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -239,9 +239,10 @@ Tag | Dockerfile
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -132,10 +132,11 @@ These sample images are not intended for production use and may be subject to br
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -132,9 +132,10 @@ These sample images are not intended for production use and may be subject to br
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -134,7 +134,7 @@ These sample images are not intended for production use and may be subject to br
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -207,7 +207,7 @@ Tag | Dockerfile
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -205,10 +205,11 @@ Tag | Dockerfile
 
 ### Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -205,9 +205,10 @@ Tag | Dockerfile
 
 ### Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 #### CVE Update Policy
 

--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -156,7 +156,7 @@ Examples:
 > - These tags are considered _fixed tags_ since they reference a specific .NET patch version.
 > - They are updated in response to base image updates (like a Debian base image) for the supported life of the image (typically one month).
 > - The .NET components within the image will not be updated.
-> - In the rare event that .NET components are updated before the next regular .NET service release, then a new image with a `-1` tag will be created. The same practice will repeat itself if necessary (with `-2` and then `-3` tags).
+> - At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with a `-1` suffix appended to the fixed tag so that you can roll back to the previous fixed tag if necessary. The same practice will repeat itself if necessary (with `-2` and then `-3` tags).
 
 ### Floating version tags
 

--- a/eng/readme-templates/Support.md
+++ b/eng/readme-templates/Support.md
@@ -19,10 +19,11 @@
 
 {{ARGS["top-header"]}}# Image Update Policy
 
-* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
-* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
+* **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 {{ARGS["top-header"]}}## CVE Update Policy
 

--- a/eng/readme-templates/Support.md
+++ b/eng/readme-templates/Support.md
@@ -19,9 +19,10 @@
 
 {{ARGS["top-header"]}}# Image Update Policy
 
-* We update supported .NET images within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
-* We re-build all .NET images as part of releasing new versions of .NET including new major/minor versions and servicing.
-* Distroless images such as Ubuntu Chiseled have no base image, and as such will only be updated with .NET releases and CVE fixes as described below.
+* Supported .NET images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
+* All .NET images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
+* All images are re-built at least once per month, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
+* At times, components of .NET images like PowerShell or MinGit may require updates out of band with .NET releases in order to fix critical bugs or vulnerabilities. If this happens, new images will be created with suffix as described in the [Fixed Tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 
 {{ARGS["top-header"]}}## CVE Update Policy
 

--- a/eng/readme-templates/Support.md
+++ b/eng/readme-templates/Support.md
@@ -21,7 +21,7 @@
 
 * **Base Image Updates:** Images are re-built within 12 hours of any updates to their base images (e.g. debian:bookworm-slim, windows/nanoserver:ltsc2022, etc.).
 * **.NET Releases:** Images are re-built as part of releasing new .NET versions. This includes new major versions, minor versions, and servicing releases.
-* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the [CVE Update Policy](#cve-update-policy) below.
+* **Critical CVEs:** Images are re-built to pick up critical CVE fixes as described by the CVE Update Policy below.
 * **Monthly Re-builds:** Images are re-built monthly, typically on the second Tuesday of the month, in order to pick up lower-severity CVE fixes.
 * **Out-Of-Band Updates:** Images can sometimes be re-built when out-of-band updates are necessary to address critical issues. If this happens, new fixed version tags will be updated according to the [Fixed version tags documentation](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md#fixed-version-tags).
 


### PR DESCRIPTION
Our current Image Update policy specifies that we only force re-build for base image updates and CRITICAL severity CVEs. Ubuntu Chiseled images are made from `scratch`, so that never happens. In the case where .NET servicing skips a month, that leaves Chiseled users with no updates for two whole months. Since Ubuntu Chiseled has limited support for extending or updating images (https://github.com/dotnet/dotnet-docker/issues/4811, https://github.com/canonical/chisel/issues/118), that leaves users without any action to take to resolve any HIGH or lower severity CVEs that have been disclosed since the last re-build.

In practice, this hasn't been a huge issue because Chiseled images inherently have a much smaller attack surface than other images we publish. However, it's still a scenario which can and does happen, so we should account for it.

Rebuilding all images every month regardless of whether there's a .NET release is a reasonable compromise for this scenario. This should be a temporary measure until #4811 is better supported.

/cc @richlander 