### PR TITLE
Re-enable Dockerfile and Readme updaters in update-dependencies tool

### DIFF
--- a/eng/update-dependencies/UpdateDependencies.cs
+++ b/eng/update-dependencies/UpdateDependencies.cs
@@ -441,8 +441,8 @@ namespace Dotnet.Docker
             updaters =
             [
                 ..updaters,
-                // ScriptRunnerUpdater.GetDockerfileUpdater(RepoRoot),
-                // ScriptRunnerUpdater.GetReadMeUpdater(RepoRoot)
+                ScriptRunnerUpdater.GetDockerfileUpdater(RepoRoot),
+                ScriptRunnerUpdater.GetReadMeUpdater(RepoRoot)
             ];
 
             return updaters;


### PR DESCRIPTION
These were accidentally uncommented for debugging purposes in https://github.com/dotnet/dotnet-docker/commit/deca2174e601b501e322bc6ccdc5f6b4063eb848. This PR re-enables Dockerfile and Readme generation in the update-dependencies tool.