### PR TITLE
Adjustments to markdown link checker's configuration

### DIFF
--- a/.github/linters/.check-markdown-links.json
+++ b/.github/linters/.check-markdown-links.json
@@ -1,7 +1,11 @@
 {
+    "aliveStatusCodes": [200, 406],
     "ignorePatterns": [
         {
             "pattern": "^https://dev.azure.com/dnceng/internal/_build\\?definitionId=359"
+        },
+        {
+            "pattern": "^https://github.com/dotnet/dotnet-docker/blob/\\{\\{if"
         },
         {
             "pattern": "^https://github.com/dotnet/release/blob/main/.github/ISSUE_TEMPLATE/dotnet-docker-servicing-release.md"
@@ -10,11 +14,15 @@
             "pattern": "^https://mcr.microsoft.com/v2/\\{\\{REPO\\}\\}/tags/list"
         },
         {
-            "pattern": "^https://github.com/dotnet/dotnet-docker/blob/\\{\\{if"
+            "pattern": "^https://support.microsoft.com/contactus/"
         },
         {
             "pattern": "^l-is-the-package-in-the-linux-distro-base-image"
         }
     ],
-    "aliveStatusCodes": [200, 406]
+    "retry":
+    {
+        "count": 3,
+        "interval": "3000"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-test
-
 # .NET
 
 ## Featured Repos

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+test
+
 # .NET
 
 ## Featured Repos


### PR DESCRIPTION
Contributes to #5872 

1. Added config to skip https://support.microsoft.com/contactus/ which has been causing issues
2. Enabled retries
3. Alphabetized the config file