### PR TITLE
Updating PowerShell DotNet SDK

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -194,12 +194,12 @@
     "powershell|8.0|Linux|x64|sha": "3dcdb54cdd40540211668825e2fddb09f49af3f372a3cc0b6f0fa60a7cd2e4a84310c9361fc3d92ffc194e87a00ae2ce6efded5ac714ff019f0850e6b82108b4",
     "powershell|8.0|Windows|x64|sha": "c072de6451beb3046af331387acad9f981366bb6c0b23f26c643e5f2d8e00adafb4d0520c98b1021f5a0cf498fc1cb9ad86af6cecaa260a286f34fed3f435892",
 
-    "powershell|9.0|build-version": "7.5.0-preview.3",
-    "powershell|9.0|Linux.Alpine|sha": "abfaf9e8f8d012b83710bc6bb5ce31e69986071afd8f9aeb678612176d77787e7446f06f9a3cbeb2c0e17d23bf827798b7b20a4dec60b060f258c6c043059353",
-    "powershell|9.0|Linux|arm32|sha": "1f06a9b716709fdcfb107ae796612e0e22f8d26e80f4e9d89d989b5cca40534bb2c618903b92d52c95ae73fa10863bf0ebe422e923faf0c88e46006a3b617e8b",
-    "powershell|9.0|Linux|arm64|sha": "3746519084ccba4e77cee8c21e0a36b8ef84a2153d102c04286717db0454beaf16ce7af70bf3b9eaf924e19580a97cc18d54089f9b88fde863e9bda839b2e776",
-    "powershell|9.0|Linux|x64|sha": "81d35c63cf0a67d558bed839aed26a2197771ef9d2ed14df0c2ee99c4aa4b7b3da02a3dd7bd12191b6c3822e4cfdd34346c890606374fe76a93f6751be4b2169",
-    "powershell|9.0|Windows|x64|sha": "03a7379a0f7814b7ba6de7ea725fd1acb0e8e44bbe6ee33d621b2705d8242bd3b41047d08667eb04db15dd4ee3ebebf421cd1ca3a43b4b41d9d18071b00d7a8c",
+    "powershell|9.0|build-version": "7.5.0-preview.5",
+    "powershell|9.0|Linux.Alpine|sha": "32cdececd819ee5db94f45c00a092d6f36e42aff7074470c84dc2eef9713a1faeac9302166dfc83936a4d4c6e98a8941e4232efd5f7577e43acdd0d62d3e8ad0",
+    "powershell|9.0|Linux|arm32|sha": "667203585a5244d4f4197aa737c30f854d727001cbea5330afad6a414b8a8623fa6a65c573e810117f71faf33de04c973007abc2ddade5f5e4df29d062841aba",
+    "powershell|9.0|Linux|arm64|sha": "719655ae2a636f6ab93bdef9141b26e8f7056b8ae508894a4487e353b37b6ee39d897f42d540c353a44799846134196fafd8baa8a4ff427c430bc604bd293074",
+    "powershell|9.0|Linux|x64|sha": "149934997170960f00f9df9720d000fc901fe40bc83399751dfeefbe514b5e2b4d1f76c8dfdbfaafbb7b5a2bdfc14e235055a9529d80d57312856ee5c8d54ea9",
+    "powershell|9.0|Windows|x64|sha": "c4a6d8bdc7ebedaf74b867da52103eb614d7a2c708e8a8e831c59d54562e2e9648bf5af8a89744cbe2728a29e0ce452609ea25d191a3216b617a7c4673a6dd24",
 
     "rocks-toolbox|latest|url": "https://raw.githubusercontent.com/canonical/rocks-toolbox",
     "rocks-toolbox|6.0|url": "$(rocks-toolbox|latest|url)",

--- a/src/sdk/9.0/alpine3.20/amd64/Dockerfile
+++ b/src/sdk/9.0/alpine3.20/amd64/Dockerfile
@@ -36,9 +36,9 @@ RUN wget -O dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/Sdk/$DOTNET_
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && wget -O PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='abfaf9e8f8d012b83710bc6bb5ce31e69986071afd8f9aeb678612176d77787e7446f06f9a3cbeb2c0e17d23bf827798b7b20a4dec60b060f258c6c043059353' \
+    && powershell_sha512='32cdececd819ee5db94f45c00a092d6f36e42aff7074470c84dc2eef9713a1faeac9302166dfc83936a4d4c6e98a8941e4232efd5f7577e43acdd0d62d3e8ad0' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \

--- a/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
@@ -31,9 +31,9 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='81d35c63cf0a67d558bed839aed26a2197771ef9d2ed14df0c2ee99c4aa4b7b3da02a3dd7bd12191b6c3822e4cfdd34346c890606374fe76a93f6751be4b2169' \
+    && powershell_sha512='149934997170960f00f9df9720d000fc901fe40bc83399751dfeefbe514b5e2b4d1f76c8dfdbfaafbb7b5a2bdfc14e235055a9529d80d57312856ee5c8d54ea9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
@@ -31,9 +31,9 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3746519084ccba4e77cee8c21e0a36b8ef84a2153d102c04286717db0454beaf16ce7af70bf3b9eaf924e19580a97cc18d54089f9b88fde863e9bda839b2e776' \
+    && powershell_sha512='719655ae2a636f6ab93bdef9141b26e8f7056b8ae508894a4487e353b37b6ee39d897f42d540c353a44799846134196fafd8baa8a4ff427c430bc604bd293074' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
@@ -34,9 +34,9 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='81d35c63cf0a67d558bed839aed26a2197771ef9d2ed14df0c2ee99c4aa4b7b3da02a3dd7bd12191b6c3822e4cfdd34346c890606374fe76a93f6751be4b2169' \
+    && powershell_sha512='149934997170960f00f9df9720d000fc901fe40bc83399751dfeefbe514b5e2b4d1f76c8dfdbfaafbb7b5a2bdfc14e235055a9529d80d57312856ee5c8d54ea9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
@@ -34,9 +34,9 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='1f06a9b716709fdcfb107ae796612e0e22f8d26e80f4e9d89d989b5cca40534bb2c618903b92d52c95ae73fa10863bf0ebe422e923faf0c88e46006a3b617e8b' \
+    && powershell_sha512='667203585a5244d4f4197aa737c30f854d727001cbea5330afad6a414b8a8623fa6a65c573e810117f71faf33de04c973007abc2ddade5f5e4df29d062841aba' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
@@ -34,9 +34,9 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3746519084ccba4e77cee8c21e0a36b8ef84a2153d102c04286717db0454beaf16ce7af70bf3b9eaf924e19580a97cc18d54089f9b88fde863e9bda839b2e776' \
+    && powershell_sha512='719655ae2a636f6ab93bdef9141b26e8f7056b8ae508894a4487e353b37b6ee39d897f42d540c353a44799846134196fafd8baa8a4ff427c430bc604bd293074' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/9.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-1809/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.0-preview.3'; `
+        $powershell_version = '7.5.0-preview.5'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '03a7379a0f7814b7ba6de7ea725fd1acb0e8e44bbe6ee33d621b2705d8242bd3b41047d08667eb04db15dd4ee3ebebf421cd1ca3a43b4b41d9d18071b00d7a8c'; `
+        $powershell_sha512 = 'c4a6d8bdc7ebedaf74b867da52103eb614d7a2c708e8a8e831c59d54562e2e9648bf5af8a89744cbe2728a29e0ce452609ea25d191a3216b617a7c4673a6dd24'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.0-preview.3'; `
+        $powershell_version = '7.5.0-preview.5'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '03a7379a0f7814b7ba6de7ea725fd1acb0e8e44bbe6ee33d621b2705d8242bd3b41047d08667eb04db15dd4ee3ebebf421cd1ca3a43b4b41d9d18071b00d7a8c'; `
+        $powershell_sha512 = 'c4a6d8bdc7ebedaf74b867da52103eb614d7a2c708e8a8e831c59d54562e2e9648bf5af8a89744cbe2728a29e0ce452609ea25d191a3216b617a7c4673a6dd24'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/noble/amd64/Dockerfile
+++ b/src/sdk/9.0/noble/amd64/Dockerfile
@@ -34,9 +34,9 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='81d35c63cf0a67d558bed839aed26a2197771ef9d2ed14df0c2ee99c4aa4b7b3da02a3dd7bd12191b6c3822e4cfdd34346c890606374fe76a93f6751be4b2169' \
+    && powershell_sha512='149934997170960f00f9df9720d000fc901fe40bc83399751dfeefbe514b5e2b4d1f76c8dfdbfaafbb7b5a2bdfc14e235055a9529d80d57312856ee5c8d54ea9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/9.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/9.0/noble/arm32v7/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='1f06a9b716709fdcfb107ae796612e0e22f8d26e80f4e9d89d989b5cca40534bb2c618903b92d52c95ae73fa10863bf0ebe422e923faf0c88e46006a3b617e8b' \
+    && powershell_sha512='667203585a5244d4f4197aa737c30f854d727001cbea5330afad6a414b8a8623fa6a65c573e810117f71faf33de04c973007abc2ddade5f5e4df29d062841aba' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/9.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/9.0/noble/arm64v8/Dockerfile
@@ -34,9 +34,9 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetbuilds.azureedge.net/public/S
     && dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.0-preview.3 \
+RUN powershell_version=7.5.0-preview.5 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3746519084ccba4e77cee8c21e0a36b8ef84a2153d102c04286717db0454beaf16ce7af70bf3b9eaf924e19580a97cc18d54089f9b88fde863e9bda839b2e776' \
+    && powershell_sha512='719655ae2a636f6ab93bdef9141b26e8f7056b8ae508894a4487e353b37b6ee39d897f42d540c353a44799846134196fafd8baa8a4ff427c430bc604bd293074' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -47,9 +47,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.0-preview.3'; `
+        $powershell_version = '7.5.0-preview.5'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '03a7379a0f7814b7ba6de7ea725fd1acb0e8e44bbe6ee33d621b2705d8242bd3b41047d08667eb04db15dd4ee3ebebf421cd1ca3a43b4b41d9d18071b00d7a8c'; `
+        $powershell_sha512 = 'c4a6d8bdc7ebedaf74b867da52103eb614d7a2c708e8a8e831c59d54562e2e9648bf5af8a89744cbe2728a29e0ce452609ea25d191a3216b617a7c4673a6dd24'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -47,9 +47,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.0-preview.3'; `
+        $powershell_version = '7.5.0-preview.5'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '03a7379a0f7814b7ba6de7ea725fd1acb0e8e44bbe6ee33d621b2705d8242bd3b41047d08667eb04db15dd4ee3ebebf421cd1ca3a43b4b41d9d18071b00d7a8c'; `
+        $powershell_sha512 = 'c4a6d8bdc7ebedaf74b867da52103eb614d7a2c708e8a8e831c59d54562e2e9648bf5af8a89744cbe2728a29e0ce452609ea25d191a3216b617a7c4673a6dd24'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `


### PR DESCRIPTION
This pull request updates the PowerShell version used in various Dockerfiles and the `manifest.versions.json` file to `7.5.0-preview.5`. The changes ensure that the latest preview version of PowerShell is used across different platforms and architectures.

### Version Updates:
* [`manifest.versions.json`](diffhunk://#diff-f657b02176508554b475067f99d956c3c0fb1c08be55990212cb9179813b4acaL197-R202): Updated PowerShell `9.0` build version to `7.5.0-preview.5` and corresponding SHA values for various platforms and architectures.

### Dockerfile Changes:
* [`src/sdk/9.0/alpine3.20/amd64/Dockerfile`](diffhunk://#diff-7a7770082e05da6ac8f88009de501496e56f4a8c11804b15087cb7b0357e8223L39-R41): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/azurelinux3.0/amd64/Dockerfile`](diffhunk://#diff-e9cbabde899510d1af7a7cf1e76612b928ade0da5d600f89247feebc274e6e02L34-R36): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile`](diffhunk://#diff-d03ef4efb8d13a823aa748125616fdc97856ebc5bac4b14a265844e8de989a6fL34-R36): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/bookworm-slim/amd64/Dockerfile`](diffhunk://#diff-ee2b5755ad619b6a333605a297cc4296e3cfc3b74262148b78386d0f7c8ccd8aL37-R39): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile`](diffhunk://#diff-3248198d4c1797eb1c00a3a38e49899cd635c8a0afe8c9d7cc82888281da2ae4L37-R39): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile`](diffhunk://#diff-b38784ec621b1ab7f1045548c58ba77772a89dec2524f99faf815330d2f29b34L37-R39): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/nanoserver-1809/amd64/Dockerfile`](diffhunk://#diff-9bcafbf524ccd35fd4c8a327dca4bf778eddefe2d3e6eb757d7b420a998ab556L40-R42): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile`](diffhunk://#diff-766bbbd3007b5ab540f3a0003795cda8cae0d0f98049ef4ec54944080feeaee0L40-R42): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/noble/amd64/Dockerfile`](diffhunk://#diff-b249fc03590bf82c06038ffe8ef82953be7f6eeed8eae40ecba2bdb32e07cc7cL37-R39): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/noble/arm32v7/Dockerfile`](diffhunk://#diff-9f4ce0ee04bfb6f01b0ba93e25a9b6a5eaef983ab2b50d7791dc1c7dafa29a85L45-R47): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/noble/arm64v8/Dockerfile`](diffhunk://#diff-5265ec999e4ba496cb072680bdfc832145297c9dc1c00b4b8a3f397625f38a5fL37-R39): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile`](diffhunk://#diff-0f04a4a0c114b4f22a49ef3cb2462b5573b13fe1147597b10e84d23198f372b4L50-R52): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.
* [`src/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile`](diffhunk://#diff-793430467ee389eeef8cb9d727acb1f70587b78781b0475c5d5842039d49f09cL50-R52): Updated PowerShell version to `7.5.0-preview.5` and corresponding SHA value.