### PR TITLE
Undocument .NET Aspire Dashboard arch-specific tags

### DIFF
--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -116,13 +116,13 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.2.1-amd64, 8.2-amd64, 8-amd64, 8.2.1, 8.2, 8, latest | [Dockerfile](src/aspire-dashboard/8.2/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+8.2.1, 8.2, 8, latest | [Dockerfile](src/aspire-dashboard/8.2/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
 
 ### Linux arm64 Tags
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-8.2.1-arm64v8, 8.2-arm64v8, 8-arm64v8, 8.2.1, 8.2, 8, latest | [Dockerfile](src/aspire-dashboard/8.2/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+8.2.1, 8.2, 8, latest | [Dockerfile](src/aspire-dashboard/8.2/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md). See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/nightly/aspire-dashboard/tags/list) for all supported and unsupported tags.*

--- a/eng/mcr-tags-metadata-templates/aspire-dashboard-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspire-dashboard-tags.yml
@@ -1,3 +1,3 @@
 $(McrTagsYmlRepo:aspire-dashboard)
-$(McrTagsYmlTagGroup:8-amd64)
-$(McrTagsYmlTagGroup:8-arm64v8)
+$(McrTagsYmlTagGroup:8.2)
+$(McrTagsYmlTagGroup:8)

--- a/manifest.json
+++ b/manifest.json
@@ -9479,9 +9479,15 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
-                "$(aspire-dashboard|8.2|fixed-tag)-amd64": {},
-                "$(aspire-dashboard|8.2|minor-tag)-amd64": {},
-                "$(aspire-dashboard|8|major-tag)-amd64": {}
+                "$(aspire-dashboard|8.2|fixed-tag)-amd64": {
+                  "docType": "Undocumented"
+                },
+                "$(aspire-dashboard|8.2|minor-tag)-amd64": {
+                  "docType": "Undocumented"
+                },
+                "$(aspire-dashboard|8|major-tag)-amd64": {
+                  "docType": "Undocumented"
+                }
               }
             },
             {
@@ -9494,9 +9500,15 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
-                "$(aspire-dashboard|8.2|fixed-tag)-arm64v8": {},
-                "$(aspire-dashboard|8.2|minor-tag)-arm64v8": {},
-                "$(aspire-dashboard|8|major-tag)-arm64v8": {}
+                "$(aspire-dashboard|8.2|fixed-tag)-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "$(aspire-dashboard|8.2|minor-tag)-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "$(aspire-dashboard|8|major-tag)-arm64v8": {
+                  "docType": "Undocumented"
+                }
               },
               "variant": "v8"
             }


### PR DESCRIPTION
As described in https://github.com/dotnet/dotnet-docker/issues/5946, the arch-specific tags for .NET Aspire Dashboard should be undocumented.