### PR TITLE
Set publicSourceBranch var for matrix generation

### DIFF
--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -6,6 +6,7 @@ parameters:
   isTestStage: false
   internalProjectName: null
   noCache: false
+  customInitSteps: []
   commonInitStepsForMatrixAndBuild: []
 
 jobs:
@@ -15,6 +16,7 @@ jobs:
   - ${{ parameters.commonInitStepsForMatrixAndBuild }}
   - template: /eng/common/templates/steps/retain-build.yml@self
   - template: /eng/common/templates/steps/init-docker-linux.yml@self
+  - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -4,6 +4,7 @@ parameters:
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
   customCopyBaseImagesInitSteps: []
+  customGenerateMatrixInitSteps: []
   customBuildInitSteps: []
   customTestInitSteps: []
   customPublishInitSteps: []
@@ -83,6 +84,7 @@ stages:
       customBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
       internalProjectName: ${{ parameters.internalProjectName }}
       noCache: ${{ parameters.noCache }}
+      customInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
       commonInitStepsForMatrixAndBuild:
       - template: /eng/common/templates/steps/common-init-for-matrix-and-build.yml@self
         parameters:
@@ -257,6 +259,7 @@ stages:
         isTestStage: true
         internalProjectName: ${{ parameters.internalProjectName }}
         publicProjectName: ${{ parameters.publicProjectName }}
+        customInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
         commonInitStepsForMatrixAndBuild:
         - template: /eng/common/templates/steps/common-init-for-matrix-and-build.yml@self
           parameters:

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -8,6 +8,7 @@ parameters:
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
   customCopyBaseImagesInitSteps: []
+  customGenerateMatrixInitSteps: []
   customBuildInitSteps: []
   customTestInitSteps: []
   customPublishInitSteps: []
@@ -27,6 +28,7 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
     isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
+    customGenerateMatrixInitSteps: ${{ parameters.customGenerateMatrixInitSteps }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
     testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
     customCopyBaseImagesInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -23,7 +23,8 @@ stages:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
     testMatrixCustomBuildLegGroupArgs: --custom-build-leg-group test-dependencies
 
-    # Template paths must be relative to the YAML job that executes them
+    customGenerateMatrixInitSteps:
+    - template: /eng/pipelines/steps/set-public-source-branch-var.yml@self
     customBuildInitSteps:
     - template: /eng/pipelines/steps/set-public-source-branch-var.yml@self
     - powershell: |


### PR DESCRIPTION
The changes from https://github.com/dotnet/dotnet-docker/pull/5942 caused a regression in `GenerateBuildMatrix` job for this repo. It failed in the `Set Image Info Path Vars` step with this error:

```
   5 |  $publicSourceBranch = "$(publicSourceBranch)"
     |                           ~~~~~~~~~~~~~~~~~~
     | The term 'publicSourceBranch' is not recognized as a name of a cmdlet,
     | function, script file, or executable program. Check the spelling of the
     | name, or if a path was included, verify that the path is correct and try
     | again.
```

[Example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2557404) (internal link)

This occurs because this repo has special logic for setting the `publicSourceBranch` variable that wasn't being executed for the `GenerateBuildMatrix` job. It is set in a step template that needs to be passed in as custom init steps to the job, just as it is done for build and other jobs.

These changes include changes to eng/common that I'll backport to docker-tools.