### PR TITLE
Add more Azure Linux commands to vulnerability reporting documentation

### DIFF
--- a/documentation/vulnerability-reporting.md
+++ b/documentation/vulnerability-reporting.md
@@ -383,6 +383,13 @@ RUN apk update \
     && apk upgrade <package-name>
 ```
 
+#### Azure Linux
+
+```dockerfile
+RUN tdnf install -y <package-name> \
+    && tdnf clean all
+```
+
 ### N. Is the package installed by .NET?
 
 Run the script below to determine whether the package is installed by one of the .NET image layers.
@@ -479,7 +486,7 @@ The first `FROM` line of the Dockerfile will have the name of the Linux distro b
 ### How can I determine the OS version of a Linux image?
 
 Use the appropriate command below to determine the OS version of your image.
-If you get an error like the following: `unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown`, then you're using a security-hardened image which requires a different command.
+If you get an error like the following: `unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown`, then you're likely using a distroless image which requires a different command.
 
 ```shell
 docker run --rm <image-digest> cat /etc/os-release
@@ -488,9 +495,9 @@ docker run --rm <image-digest> cat /etc/os-release
 The output will include a `NAME` field indicating the name of the distro (`Debian`, `Ubuntu`, `Alpine`, `Microsoft Azure Linux`, or `Common Base Linux Mariner`).
 In the case of Debian and Ubuntu, the output will also include a `VERSION_CODENAME` field. Make note of this codename because the vulnerability pages on the distro's website refers to that codename instead of a version number.
 
-#### Linux Hardened Images
+#### Distroless Images
 
-Since Linux hardened images have no shell with which to run the commands above, you can use the following command to determine the OS version:
+Since distroless images have no shell with which to run the commands above, you can use [Syft](https://github.com/anchore/syft) to determine the the OS version using the following command:
 
 ##### macOS/Linux
 
@@ -507,7 +514,7 @@ docker run --rm anchore/syft packages --output json -q <image-digest> | jq -r .d
 ### How can I determine what Linux package version is installed?
 
 Use the appropriate command below to determine the package version installed in your image.
-If you get an error like the following: `unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown`, then you're using a security-hardened image which requires a different command.
+If you get an error like the following: `unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown`, then you're likely using a distroless image which requires a different command.
 
 #### Debian/Ubuntu Images
 
@@ -521,9 +528,15 @@ docker run --rm --entrypoint /bin/sh <my-image-digest> apt list <package-name>
 docker run --rm --entrypoint /bin/sh <my-image-digest> apk list <package-name>
 ```
 
-#### Hardened Images
+#### Azure Linux Images
 
-Since hardened images have no shell with which to run the commands above, you can use the following command to determine the package version:
+```shell
+docker run --rm --entrypoint /bin/sh <my-image-digest> tdnf list installed <package-name>
+```
+
+#### Distroless Images
+
+Since distroless images have no shell with which to run the commands above, you can use [Syft](https://github.com/anchore/syft) to determine the package version using the following command:
 
 ##### macOS/Linux
 
@@ -556,6 +569,8 @@ The following are links to the security sites for the Linux distros that we supp
   * `https://ubuntu.com/security/CVE-<NUMBER>`
 * Alpine: <https://security.alpinelinux.org>
   * `https://security.alpinelinux.org/vuln/CVE-<NUMBER>`
+* Azure Linux: https://github.com/microsoft/AzureLinuxVulnerabilityData
+  * Azure Linux provides vulnerability data in the [OVAL](https://oval.mitre.org/language/about/overview.html) format.
 
 Within those pages the distro will indicate in which release the vulnerability was fixed or not fixed. Use the distro version/codename to determine which release is relevant.
 

--- a/documentation/vulnerability-reporting.md
+++ b/documentation/vulnerability-reporting.md
@@ -569,7 +569,7 @@ The following are links to the security sites for the Linux distros that we supp
   * `https://ubuntu.com/security/CVE-<NUMBER>`
 * Alpine: <https://security.alpinelinux.org>
   * `https://security.alpinelinux.org/vuln/CVE-<NUMBER>`
-* Azure Linux: https://github.com/microsoft/AzureLinuxVulnerabilityData
+* Azure Linux: <https://github.com/microsoft/AzureLinuxVulnerabilityData>
   * Azure Linux provides vulnerability data in the [OVAL](https://oval.mitre.org/language/about/overview.html) format.
 
 Within those pages the distro will indicate in which release the vulnerability was fixed or not fixed. Use the distro version/codename to determine which release is relevant.


### PR DESCRIPTION
Fixes #5060. There were already some Azure Linux commands in the document but this PR adds the remaining ones.

I also replaced "linux-hardened" terminology with "distroless" since we don't use that terminology anywhere else, and added links to the Syft project rather than referring to it in magic commands.