### PR TITLE
Update .NET Monitor readmes

### DIFF
--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -7,9 +7,9 @@
 
 # About
 
-This image contains the .NET Monitor Base installation.
+This image contains the base installation of .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts.
 
-Use this image as a base image for building a .NET Monitor image with extensions.
+This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [dotnet/monitor](https://hub.docker.com/r/microsoft/dotnet-monitor/) image.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
@@ -23,8 +23,6 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 # Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
-
-## Building a Custom .NET Monitor Image
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -9,9 +9,7 @@
 
 # About
 
-This image contains the .NET Monitor tool.
-
-Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
+This image contains .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts. This image also contains .NET Monitor extensions for egressing artifacts to Azure Blob Storage and Amazon S3.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
@@ -26,11 +24,11 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-## Container sample: Run the tool
+You can run this image as a sidecar container to collect diagnostic information and artifacts from other containers running .NET Core 3.1 or .NET 5 and later.
 
-You can run a container with a pre-built [.NET Docker Image](https://hub.docker.com/r/microsoft/dotnet-monitor/), based on the dotnet-monitor global tool.
+See [Running in Kubernetes](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/kubernetes.md) or [Running in Docker Compose](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/docker-compose.md) for examples of how to run this image in orchestration environments.
 
-See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
+See [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image and documentation for the web API.
 
 # Related Repositories
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -1,8 +1,8 @@
 ## About
 
-This image contains the .NET Monitor Base installation.
+This image contains the base installation of .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts.
 
-Use this image as a base image for building a .NET Monitor image with extensions.
+This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [dotnet/monitor](https://mcr.microsoft.com/product/dotnet/monitor/about) image.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
@@ -42,8 +42,6 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 ## Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
-
-### Building a Custom .NET Monitor Image
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -1,8 +1,6 @@
 ## About
 
-This image contains the .NET Monitor tool.
-
-Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
+This image contains .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts. This image also contains .NET Monitor extensions for egressing artifacts to Azure Blob Storage and Amazon S3.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
@@ -45,11 +43,11 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-### Container sample: Run the tool
+You can run this image as a sidecar container to collect diagnostic information and artifacts from other containers running .NET Core 3.1 or .NET 5 and later.
 
-You can run a container with a pre-built [.NET Docker Image](https://mcr.microsoft.com/product/dotnet/monitor/about), based on the dotnet-monitor global tool.
+See [Running in Kubernetes](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/kubernetes.md) or [Running in Docker Compose](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/docker-compose.md) for examples of how to run this image in orchestration environments.
 
-See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
+See [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image and documentation for the web API.
 
 ## Support
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -11,7 +11,7 @@
 
 This image contains the base installation of .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts.
 
-This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [dotnet/monitor](https://github.com/dotnet/dotnet-docker/blob/main/README.monitor.md) image.
+This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [dotnet/monitor](./README.monitor.md) image.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -9,9 +9,9 @@
 
 ## About
 
-This image contains the .NET Monitor Base installation.
+This image contains the base installation of .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts.
 
-Use this image as a base image for building a .NET Monitor image with extensions.
+This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [dotnet/monitor](https://github.com/dotnet/dotnet-docker/blob/main/README.monitor.md) image.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
@@ -25,8 +25,6 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 ## Usage
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
-
-### Building a Custom .NET Monitor Image
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -11,9 +11,7 @@
 
 ## About
 
-This image contains the .NET Monitor tool.
-
-Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
+This image contains .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts. This image also contains .NET Monitor extensions for egressing artifacts to Azure Blob Storage and Amazon S3.
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
@@ -28,11 +26,11 @@ Please see the [Ubuntu Chiseled + .NET](https://github.com/dotnet/dotnet-docker/
 
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
 
-### Container sample: Run the tool
+You can run this image as a sidecar container to collect diagnostic information and artifacts from other containers running .NET Core 3.1 or .NET 5 and later.
 
-You can run a container with a pre-built [.NET Docker Image](https://github.com/dotnet/dotnet-docker/blob/main/README.monitor.md), based on the dotnet-monitor global tool.
+See [Running in Kubernetes](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/kubernetes.md) or [Running in Docker Compose](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/docker-compose.md) for examples of how to run this image in orchestration environments.
 
-See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
+See [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image and documentation for the web API.
 
 ## Related Repositories
 

--- a/eng/readme-templates/About.md
+++ b/eng/readme-templates/About.md
@@ -11,7 +11,7 @@
     "leading-line-break": "true",
     "readme-host": ARGS["readme-host"]
   ])}}}}
-{{InsertTemplate(join(["About", templateQualifier, "md"], "."), [ "top-header": ARGS["top-header"] ])}}
+{{InsertTemplate(join(["About", templateQualifier, "md"], "."), [ "top-header": ARGS["top-header"], "readme-host": ARGS["readme-host"] ])}}
 
 Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) for Docker-related .NET announcements.{{if templateQualifier != "sdk" && templateQualifier != "aspire-dashboard":
 

--- a/eng/readme-templates/About.monitor-base.md
+++ b/eng/readme-templates/About.monitor-base.md
@@ -1,7 +1,8 @@
 {{
     _ ARGS:
       readme-host: Moniker of the site that will host the readme ^
-    set monitorRepo to when(VARIABLES["branch"] = "nightly", "dotnet/nightly/monitor", "dotnet/monitor")
+    set monitorRepo to when(VARIABLES["branch"] = "nightly", "dotnet/nightly/monitor", "dotnet/monitor") ^
+    set useRelativeLink to ARGS["readme-host"] = "github"
 }}This image contains the base installation of .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts.
 
-This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [{{monitorRepo}}]({{InsertTemplate("Url.md", [ "repo": monitorRepo "readme-host": ARGS["readme-host"] ])}}) image.
+This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [{{monitorRepo}}]({{InsertTemplate("Url.md", [ "repo": monitorRepo "readme-host": ARGS["readme-host"] "use-relative-link": useRelativeLink ])}}) image.

--- a/eng/readme-templates/About.monitor-base.md
+++ b/eng/readme-templates/About.monitor-base.md
@@ -1,3 +1,7 @@
-This image contains the .NET Monitor Base installation.
+{{
+    _ ARGS:
+      readme-host: Moniker of the site that will host the readme ^
+    set monitorRepo to when(VARIABLES["branch"] = "nightly", "dotnet/nightly/monitor", "dotnet/monitor")
+}}This image contains the base installation of .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts.
 
-Use this image as a base image for building a .NET Monitor image with extensions.
+This image only provides the base functionality of the .NET Monitor tool; it is only meant to be used as a base image upon which .NET Monitor extensions are installed. If you are looking for the full feature set that is provided by the .NET Monitor global tool (including the egress capabilities), see the [{{monitorRepo}}]({{InsertTemplate("Url.md", [ "repo": monitorRepo "readme-host": ARGS["readme-host"] ])}}) image.

--- a/eng/readme-templates/About.monitor.md
+++ b/eng/readme-templates/About.monitor.md
@@ -1,3 +1,1 @@
-This image contains the .NET Monitor tool.
-
-Use this image as a sidecar container to collect diagnostic information from other containers running .NET Core 3.1 or later processes.
+This image contains .NET Monitor, a diagnostic tool for capturing diagnostic artifacts (such as dumps and traces) in an operator-driven or automated manner. This tool is an ASP.NET application that hosts a web API for inspecting .NET processes and collecting diagnostic artifacts. This image also contains .NET Monitor extensions for egressing artifacts to Azure Blob Storage and Amazon S3.

--- a/eng/readme-templates/Url.md
+++ b/eng/readme-templates/Url.md
@@ -3,14 +3,20 @@
     ARGS:
       readme-host: Moniker of the site that will host the readme
       repo: Repo path of the URL to be generated
-      is-product-family: Indicates whether the URL refers to a product family page ^
+      is-product-family: Indicates whether the URL refers to a product family page
+      use-relative-link: Indicates whether the URL should be relative or absolute ^
 
     set isProductFamily to ARGS["is-product-family"] ^
+    set useRelativeLink to ARGS["use-relative-link"] ^
     set readmeHost to ARGS["readme-host"] ^
     set repo to ARGS["repo"] ^
     set repoParts to split(repo, "/") ^
     set isNightlyRepo to match(repoParts[1], "nightly") ^
-    set isFrameworkRepo to match(repoParts[1], "framework")
+    set isFrameworkRepo to match(repoParts[1], "framework") ^
+    set readmeFileName to cat(
+        "README.",
+        when(isProductFamily, "", cat(join(slice(repoParts, when(isNightlyRepo || isFrameworkRepo, 2, 1)), "-"), ".")),
+        "md")
 
 }}{{
 when(readmeHost = "mar",
@@ -18,15 +24,16 @@ when(readmeHost = "mar",
         cat("https://mcr.microsoft.com/catalog?search=", repo),
         cat("https://mcr.microsoft.com/product/", repo, "/about")),
     when(readmeHost = "github",
-        cat("https://github.com/",
-            when(isFrameworkRepo, "microsoft", "dotnet"),
-            "/dotnet",
-            when(isFrameworkRepo, "-framework", ""),
-            "-docker/blob/",
-            when(isNightlyRepo, "nightly", "main"),
-            "/README.",
-            when(isProductFamily, "", cat(join(slice(repoParts, when(isNightlyRepo || isFrameworkRepo, 2, 1)), "-"), ".")),
-            "md"),
+        when(useRelativeLink,
+            cat("./", readmeFileName),
+            cat("https://github.com/",
+                when(isFrameworkRepo, "microsoft", "dotnet"),
+                "/dotnet",
+                when(isFrameworkRepo, "-framework", ""),
+                "-docker/blob/",
+                when(isNightlyRepo, "nightly", "main"),
+                "/",
+                readmeFileName)),
         when(readmeHost = "dockerhub",
             cat("https://hub.docker.com/r/microsoft/", join(repoParts, "-"), "/"),
             cat("UNKNOWN HOST: ", readmeHost))))}}

--- a/eng/readme-templates/Use.monitor-base.md
+++ b/eng/readme-templates/Use.monitor-base.md
@@ -2,9 +2,7 @@
     _ ARGS:
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme
-}}{{ARGS["top-header"]}}# Building a Custom .NET Monitor Image
-
-The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
+}}The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 
 * [Ubuntu Chiseled - amd64](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile)
 * [Ubuntu Chiseled - arm64v8](https://github.com/dotnet/dotnet-docker/blob/main/src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile)

--- a/eng/readme-templates/Use.monitor.md
+++ b/eng/readme-templates/Use.monitor.md
@@ -2,8 +2,8 @@
     _ ARGS:
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme
-}}{{ARGS["top-header"]}}# Container sample: Run the tool
+}}You can run this image as a sidecar container to collect diagnostic information and artifacts from other containers running .NET Core 3.1 or .NET 5 and later.
 
-You can run a container with a pre-built [.NET Docker Image]({{InsertTemplate("Url.md", [ "repo": "dotnet/monitor" "readme-host": ARGS["readme-host"] ])}}), based on the dotnet-monitor global tool.
+See [Running in Kubernetes](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/kubernetes.md) or [Running in Docker Compose](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/docker-compose.md) for examples of how to run this image in orchestration environments.
 
-See the [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image to be run in a Docker or Kubernetes environment, including how to configure authentication and certificates for https bindings.
+See [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to configure the image and documentation for the web API.


### PR DESCRIPTION
These changes to the .NET Monitor readmes are intended to better describe the intended usage of base and derived .NET Monitor images and link to more examples of how the derived image is intended to be used. The `dotnet/monitor/base` readme attempts to steer customers to the `dotnet/monitor` readme for those who are intending to use the full functionality of .NET Monitor rather than building a customized .NET Monitor image.

closes #5933