### PR TITLE
Condition out internal authentication for VerifyDotnetFolderContents test

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -318,16 +318,21 @@ namespace Microsoft.DotNet.Docker.Tests
         private async Task<IEnumerable<SdkContentFileInfo>> GetExpectedSdkContentsAsync(ProductImageData imageData)
         {
             string sdkUrl = GetSdkUrl(imageData);
+            OutputHelper.WriteLine("Downloading SDK archive: " + sdkUrl);
 
             if (!s_sdkContentsCache.TryGetValue(sdkUrl, out IEnumerable<SdkContentFileInfo> files))
             {
                 string sdkFile = Path.GetTempFileName();
 
                 using HttpClient httpClient = new();
-                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
-                    "Basic",
-                    Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "",
-                        Config.InternalAccessToken))));
+
+                if (Config.IsInternal)
+                {
+                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                        "Basic",
+                        Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "",
+                            Config.InternalAccessToken))));
+                }
 
                 await httpClient.DownloadFileAsync(new Uri(sdkUrl), sdkFile);
 


### PR DESCRIPTION
Fixes #6007 

Internal test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2568476&view=logs&j=1cd3c31d-f87a-5340-7f4c-1efc1ae5d874&t=e94617f8-c028-5efe-9cc4-f7765cc028e5

This was a regression from https://github.com/dotnet/dotnet-docker/pull/5928