### PR TITLE
Update Aspire to latest version from release/9.0 branch

### DIFF
--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -118,14 +118,14 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 8.2.1, 8.2, 8 | [Dockerfile](src/aspire-dashboard/8.2/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
-9.0.0-preview.4, 9.0-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.0/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+9.0.0-preview.5, 9.0-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.0/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
 
 ### Linux arm64 Tags
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 8.2.1, 8.2, 8 | [Dockerfile](src/aspire-dashboard/8.2/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
-9.0.0-preview.4, 9.0-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.0/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+9.0.0-preview.5, 9.0-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.0/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md). See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/nightly/aspire-dashboard/tags/list) for all supported and unsupported tags.*

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -15,13 +15,13 @@
     "aspire-dashboard|8.2|base-url|main": "$(base-url|public|preview|nightly)",
     "aspire-dashboard|8.2|base-url|nightly": "$(base-url|public|preview|nightly)",
 
-    "aspire-dashboard|9.0|build-version": "9.0.0-preview.4.24511.1",
-    "aspire-dashboard|9.0|product-version": "9.0.0-preview.4",
+    "aspire-dashboard|9.0|build-version": "9.0.0-preview.5.24528.2",
+    "aspire-dashboard|9.0|product-version": "9.0.0-preview.5",
     "aspire-dashboard|9.0|fixed-tag": "$(aspire-dashboard|9.0|product-version)",
     "aspire-dashboard|9.0|minor-tag": "9.0-preview",
     "aspire-dashboard|9|major-tag": "9-preview",
-    "aspire-dashboard|9.0|linux|x64|sha": "d53df2c93730ff2fb6ebc16f5f7054352048fba31d77b887c60e6a6f48198017638fa69083a64eb0583ae68be5342be776b14de6442423f7d3511e4d5897dbea",
-    "aspire-dashboard|9.0|linux|arm64|sha": "aedcc1170afeb9130aad3bb73b383ff58bee63b69019c03732c46df10396725f513bb79d8da33db3eab909a232fba808b3ed3ce6aa025270ba4813136d1954e4",
+    "aspire-dashboard|9.0|linux|x64|sha": "c64bd99012441d37b3f12a5985f9ea4073cdae60ecd91f7fb1338e2b3070af83a05b12325197d76d6eb806a4567f362a44c4d2d82d024000ab0c5088f3b1c772",
+    "aspire-dashboard|9.0|linux|arm64|sha": "3fcd601a346df0171c6281ae225a31c0119c93cc3d94ab0bcd5e13e91805b368293512a190873a236746a1056af8fe0911def48105e9bc6afce852e72bd9f4a0",
     "aspire-dashboard|9.0|base-url|main": "$(base-url|public|preview|nightly)",
     "aspire-dashboard|9.0|base-url|nightly": "$(base-url|public|preview|nightly)",
 

--- a/src/aspire-dashboard/9.0/cbl-mariner-distroless/amd64/Dockerfile
+++ b/src/aspire-dashboard/9.0/cbl-mariner-distroless/amd64/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=9.0.0-preview.4.24511.1 \
+RUN dotnet_aspire_version=9.0.0-preview.5.24528.2 \
     && curl -fSL --output aspire_dashboard.zip https://dotnetbuilds.azureedge.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip \
-    && aspire_dashboard_sha512='d53df2c93730ff2fb6ebc16f5f7054352048fba31d77b887c60e6a6f48198017638fa69083a64eb0583ae68be5342be776b14de6442423f7d3511e4d5897dbea' \
+    && aspire_dashboard_sha512='c64bd99012441d37b3f12a5985f9ea4073cdae60ecd91f7fb1338e2b3070af83a05b12325197d76d6eb806a4567f362a44c4d2d82d024000ab0c5088f3b1c772' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \
     && unzip aspire_dashboard.zip -d /app \

--- a/src/aspire-dashboard/9.0/cbl-mariner-distroless/arm64v8/Dockerfile
+++ b/src/aspire-dashboard/9.0/cbl-mariner-distroless/arm64v8/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=9.0.0-preview.4.24511.1 \
+RUN dotnet_aspire_version=9.0.0-preview.5.24528.2 \
     && curl -fSL --output aspire_dashboard.zip https://dotnetbuilds.azureedge.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip \
-    && aspire_dashboard_sha512='aedcc1170afeb9130aad3bb73b383ff58bee63b69019c03732c46df10396725f513bb79d8da33db3eab909a232fba808b3ed3ce6aa025270ba4813136d1954e4' \
+    && aspire_dashboard_sha512='3fcd601a346df0171c6281ae225a31c0119c93cc3d94ab0bcd5e13e91805b368293512a190873a236746a1056af8fe0911def48105e9bc6afce852e72bd9f4a0' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \
     && unzip aspire_dashboard.zip -d /app \


### PR DESCRIPTION
Updating Aspire-dashboard image to contain a more recent build of the dashboard.