### PR TITLE
Enable testing of internal stable-versioned servicing builds

### DIFF
--- a/eng/Get-DropVersions.ps1
+++ b/eng/Get-DropVersions.ps1
@@ -170,12 +170,22 @@ function GetVersionInfoFromBuildId([string]$buildId) {
 
         $isStableVersion = Get-IsStableBranding -Version $config.Sdk_Builds[0]
 
-        return [PSCustomObject]@{
-            DockerfileVersion = $config.Channel
-            SdkVersion = @($config.Sdks | Sort-Object -Descending)[0]
-            RuntimeVersion = $config.Runtime
-            AspnetVersion = $config.Asp
-            StableBranding = $isStableVersion
+        if ($UseInternalBuild) {
+            return [PSCustomObject]@{
+                DockerfileVersion = $config.Channel
+                SdkVersion = @($config.Sdk_Builds | Sort-Object -Descending)[0]
+                RuntimeVersion = $config.Runtime_Build
+                AspnetVersion = $config.Asp_Build
+                StableBranding = $isStableVersion
+            }
+        } else {
+            return [PSCustomObject]@{
+                DockerfileVersion = $config.Channel
+                SdkVersion = @($config.Sdks | Sort-Object -Descending)[0]
+                RuntimeVersion = $config.Runtime
+                AspnetVersion = $config.Asp
+                StableBranding = $isStableVersion
+            }
         }
     }
     catch [System.Management.Automation.CommandNotFoundException] {
@@ -321,6 +331,10 @@ if ($UpdateDependencies)
         Write-Host "Runtime version: $($versionInfo.RuntimeVersion)"
         Write-Host "ASP.NET Core version: $($versionInfo.AspnetVersion)"
         Write-Host
+
+        if ($versionInfo.StableBranding) {
+            $additionalArgs += @{ UseStableBranding = $versionInfo.StableBranding }
+        }
 
         $setVersionsScript = Join-Path $PSScriptRoot "Set-DotnetVersions.ps1"
         & $setVersionsScript `

--- a/eng/dockerfile-templates/aspnet/Dockerfile.envs
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.envs
@@ -1,15 +1,24 @@
 {{
     _ ARGS:
-        is-composite-runtime (optional): Whether to include the runtime version ^
+        is-composite-runtime (optional): Whether to include the runtime version
+        is-internal (optional): Whether the Dockerfile is targeting an internal build of the product ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isWindows to find(OS_VERSION, "nanoserver") >= 0 || find(OS_VERSION, "windowsservercore") >= 0 ^
+    set isStableBranding to (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set runtimeVersion to when(isStableBranding && ARGS["is-internal"],
+        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
+        VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]) ^
+    set aspnetVersion to when(isStableBranding && ARGS["is-internal"],
+        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
+        VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]) ^
     set lineContinuation to when(isWindows, "`", "\") ^
     set aspnetComment to "# ASP.NET Core version"
 }}{{if ARGS["is-composite-runtime"]:ENV {{lineContinuation}}
     # .NET Runtime version
-    DOTNET_VERSION={{VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]}} {{lineContinuation}}
+    DOTNET_VERSION={{runtimeVersion}} {{lineContinuation}}
     {{aspnetComment}}
-    ASPNET_VERSION={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}}
+    ASPNET_VERSION={{aspnetVersion}}
 ^else:{{aspnetComment}}
-ENV ASPNET_VERSION={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}}}}
+ENV ASPNET_VERSION={{aspnetVersion}}}}

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux
@@ -43,7 +43,7 @@
 {{if isAlpine:
 {{InsertTemplate("../Dockerfile.alpine.invariant-mode")}}
 }}
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 
 # Install ASP.NET Core
 {{InsertTemplate("Dockerfile.linux.install-aspnet",
@@ -81,7 +81,7 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 # ASP.NET Core image
 FROM {{runtimeBaseTag}}
 
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 {{if isInternal && isRpmInstall:
 {{InsertTemplate("Dockerfile.linux.install-aspnet",
     [

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
@@ -36,7 +36,11 @@
 {{ if isAlpine:
 {{InsertTemplate("../Dockerfile.alpine.invariant-mode")}}
 }}
-{{InsertTemplate("Dockerfile.envs", [ "is-composite-runtime": "true" ])}}
+{{InsertTemplate("Dockerfile.envs",
+    [
+        "is-composite-runtime": "true",
+        "is-internal": isInternal
+    ])}}
 
 # Install ASP.NET Composite Runtime
 {{InsertTemplate("../runtime/Dockerfile.linux.install-runtime",
@@ -82,7 +86,11 @@ RUN mkdir /dotnet-symlink \
 # ASP.NET Composite Image
 FROM {{runtimeDepsBaseTag}}
 
-{{InsertTemplate("Dockerfile.envs", [ "is-composite-runtime": "true" ])}}{{ if isDistroless:
+{{InsertTemplate("Dockerfile.envs",
+    [
+        "is-composite-runtime": "true",
+        "is-internal": isInternal
+    ])}}{{ if isDistroless:
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
 

--- a/eng/dockerfile-templates/aspnet/Dockerfile.windows
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.windows
@@ -16,7 +16,7 @@ ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 }}FROM {{runtimeBaseTag}}
 
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 
 {{InsertTemplate("Dockerfile.windows.install-aspnet")}}^else:
 {{
@@ -38,6 +38,6 @@ ARG ACCESSTOKEN
 # ASP.NET Core image
 FROM {{runtimeBaseTag}}
 
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.envs
+++ b/eng/dockerfile-templates/runtime/Dockerfile.envs
@@ -1,4 +1,12 @@
 {{
-    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".")
+    _ ARGS:
+        is-internal (optional): Whether the Dockerfile is targeting an internal build of the product ^
+
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set isStableBranding to (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set runtimeVersion to when(isStableBranding && ARGS["is-internal"],
+        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
+        VARIABLES[cat("runtime|", dotnetVersion, "|build-version")])
 }}# .NET Runtime version
-{{if INDENT ="":ENV }}DOTNET_VERSION={{VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]}}
+{{if INDENT ="":ENV }}DOTNET_VERSION={{runtimeVersion}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -41,7 +41,7 @@ _ SINGLE STAGE
 {{if isAlpine:
 {{InsertTemplate("../Dockerfile.alpine.invariant-mode")}}
 }}
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 
 # Install .NET Runtime
 {{InsertTemplate("Dockerfile.linux.install-runtime",
@@ -86,7 +86,7 @@ RUN mkdir /dotnet-symlink \
 # .NET runtime image
 FROM {{runtimeDepsBaseTag}}
 
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 {{ if isInternal && isRpmInstall:
 {{InsertTemplate("Dockerfile.linux.install-runtime",
     [

--- a/eng/dockerfile-templates/runtime/Dockerfile.windows
+++ b/eng/dockerfile-templates/runtime/Dockerfile.windows
@@ -15,7 +15,7 @@
 }}FROM {{serverCoreBaseTag}}
 
 {{InsertTemplate("../Dockerfile.common-dotnet-envs")}} `
-    {{InsertTemplate("Dockerfile.envs", [], "    ")}}
+    {{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal], "    ")}}
 
 # Install .NET Runtime
 {{InsertTemplate("Dockerfile.windows.install-runtime")}}
@@ -42,7 +42,7 @@ ARG ACCESSTOKEN
 FROM mcr.microsoft.com/windows/{{finalStageBaseRepo}}:{{OS_VERSION_NUMBER}}-amd64
 
 {{InsertTemplate("../Dockerfile.common-dotnet-envs")}} `
-    {{InsertTemplate("Dockerfile.envs", [], "    ")}}
+    {{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal], "    ")}}
 
 {{InsertTemplate("../Dockerfile.windows.set-path", [ "path": "C:\Program Files\dotnet"])}}
 

--- a/eng/dockerfile-templates/sdk/Dockerfile.envs
+++ b/eng/dockerfile-templates/sdk/Dockerfile.envs
@@ -1,5 +1,13 @@
 {{
+    _ ARGS:
+        is-internal (optional): Whether the Dockerfile is targeting an internal build of the product ^
+
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set isStableBranding to (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
+        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
+    set sdkVersion to when(isStableBranding && ARGS["is-internal"],
+        VARIABLES[cat("sdk|", dotnetVersion, "|product-version")],
+        VARIABLES[cat("sdk|", dotnetVersion, "|build-version")]) ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isWindows to find(OS_VERSION, "nanoserver") >= 0 || find(OS_VERSION, "windowsservercore") >= 0 ^
     set lineContinuation to when(isWindows, "`", "\")
@@ -11,7 +19,7 @@
     # Do not show first run text
     DOTNET_NOLOGO=true {{lineContinuation}}
     # SDK version
-    DOTNET_SDK_VERSION={{VARIABLES[cat("sdk|", dotnetVersion, "|build-version")]}} {{lineContinuation}}{{if isAlpine:
+    DOTNET_SDK_VERSION={{sdkVersion}} {{lineContinuation}}{{if isAlpine:
     # Disable the invariant mode (set in base image)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false {{lineContinuation}}}}
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -97,7 +97,7 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 # .NET SDK image
 }}FROM {{baseImageTag}}
 
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 
 RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 [

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows
@@ -25,7 +25,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 }}FROM {{aspnetBaseTag}}
 
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 
 {{InsertTemplate("Dockerfile.windows.install-components")}}
 
@@ -50,7 +50,7 @@ ARG ACCESSTOKEN
 # SDK image
 FROM {{aspnetBaseTag}}
 
-{{InsertTemplate("Dockerfile.envs")}}
+{{InsertTemplate("Dockerfile.envs", ["is-internal": isInternal])}}
 
 {{InsertTemplate("../Dockerfile.windows.set-path", [ "path": paths ])}}
 


### PR DESCRIPTION
Servicing builds have stable versions. Artifacts are in URLs that contain non-stable version in their path. We will now obtain non-stable build versions, from config.json. This covers all scenarios of dependency update of internal builds.

Additional changes:
- set ENV vars with correct stable version, if build uses stable branding
- pass the `StableBranding` argument to `Set-DotnetVersions.ps1` - this enables developer flow, when using `-updateDependencies` with stable builds
- scope the changes to internal testing scenarios