### PR TITLE
Pass paths to test script from build-and-test

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -36,9 +36,20 @@ if ($Version -notmatch '^\d+\.\d+(\.[\d*])?|\*$') {
     }
 }
 
-if (($Mode -eq "BuildAndTest" -or $Mode -eq "Test") -and $TestCategories.Contains("pre-build")) {
-    & ./tests/run-tests.ps1 -TestCategories "pre-build" -Version "*"
-    $TestCategories.Remove("pre-build")
+if (($Mode -eq "BuildAndTest" -or $Mode -eq "Test")) {
+
+    Write-Host "`nTests will run with TestCategories: $TestCategories"
+
+    if ($TestCategories.Contains("pre-build"))
+    {
+        & ./tests/run-tests.ps1 -TestCategories "pre-build" -Version "*"
+        $TestCategories.Remove("pre-build")
+    }
+    else
+    {
+        Write-Host "Skipping pre-build validation tests."
+        Write-Host "To run pre-build tests, use the 'pre-build' test category.`n"
+    }
 }
 
 if ($Mode -eq "BuildAndTest" -or $Mode -eq "Build") {

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -21,8 +21,10 @@ param(
 
     # Categories of tests to run
     [ValidateSet("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size", "monitor", "aspire-dashboard")]
-    [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size", "monitor", "aspire-dashboard")
+    [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk", "monitor", "aspire-dashboard")
 )
+
+[System.Collections.ArrayList]$TestCategories = $TestCategories
 
 if ($Version -notmatch '^\d+\.\d+(\.[\d*])?|\*$') {
     Write-Error "Error: Input version '$Version' is not in the expected format of X.Y or X.Y.*"
@@ -36,6 +38,7 @@ if ($Version -notmatch '^\d+\.\d+(\.[\d*])?|\*$') {
 
 if (($Mode -eq "BuildAndTest" -or $Mode -eq "Test") -and $TestCategories.Contains("pre-build")) {
     & ./tests/run-tests.ps1 -TestCategories "pre-build" -Version "*"
+    $TestCategories.Remove("pre-build")
 }
 
 if ($Mode -eq "BuildAndTest" -or $Mode -eq "Build") {
@@ -54,15 +57,24 @@ if ($Mode -eq "BuildAndTest" -or $Mode -eq "Build") {
         $OS = "nanoserver-$windowsReleaseId"
     }
 
-    # Build the sample images
-    & ./eng/common/build.ps1 `
-        -Version $Version `
-        -OS @($OS) `
-        -Architecture $Architecture `
-        -Paths $Paths `
-        -OptionalImageBuilderArgs $OptionalImageBuilderArgs `
-        -Manifest manifest.samples.json
+    $buildSamples = $Paths -match "samples"
+    if ($buildSamples)
+    {
+        # Build the sample images
+        & ./eng/common/build.ps1 `
+            -Version $Version `
+            -OS @($OS) `
+            -Architecture $Architecture `
+            -Paths $Paths `
+            -OptionalImageBuilderArgs $OptionalImageBuilderArgs `
+            -Manifest manifest.samples.json
+    }
+    else
+    {
+        Write-Host "Skipping samples builds since no input paths contained samples"
+    }
 }
+
 if ($Mode -eq "BuildAndTest" -or $Mode -eq "Test") {
 
     $VersionParts = $Version.Split('.')
@@ -75,9 +87,17 @@ if ($Mode -eq "BuildAndTest" -or $Mode -eq "Test") {
         Write-Warning "Skipping sample image testing since Version was set"
     }
 
-    & ./tests/run-tests.ps1 `
-        -Version $TestVersion `
-        -OSVersions @($OS) `
-        -Architecture $Architecture `
-        -TestCategories $localTestCategories
+
+    if ($Paths -ne $null -and $Paths.Count -gt 0) {
+        & ./tests/run-tests.ps1 `
+            -Architecture $Architecture `
+            -Paths $Paths `
+            -TestCategories $localTestCategories
+    } else {
+        & ./tests/run-tests.ps1 `
+            -Version $TestVersion `
+            -OSVersions @($OS) `
+            -Architecture $Architecture `
+            -TestCategories @localTestCategories
+    }
 }

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -31,6 +31,8 @@ param(
     [ValidateSet("runtime", "runtime-deps", "aspnet", "sdk", "pre-build", "sample", "image-size", "monitor", "aspire-dashboard")]
     [string[]]$TestCategories = @("runtime", "runtime-deps", "aspnet", "sdk", "monitor", "aspire-dashboard"),
 
+    [string]$CustomTestFilter,
+
     [string]$InternalAccessToken
 )
 
@@ -143,9 +145,15 @@ Try {
             exit;
         }
 
-        $testFilter = "--filter `"$testFilter`""
+        if ($CustomTestFilter)
+        {
+            $testFilter = "$CustomTestFilter&($testFilter)"
+        }
+
+        $testFilter = "--filter '$testFilter'"
     }
 
+    Write-Host "`nRunning tests with $testFilter`n"
     Exec "$DotnetInstallDir/dotnet test $testFilter --logger:trx"
 
     if ($TestCategories.Contains('image-size')) {


### PR DESCRIPTION
This fixes a bug which prevented you from running the correct tests when passing paths to `build-and-test.ps1`

Other changes:

- Avoid running the `pre-build` tests twice by removing it from the test categories if it is ran before the build step.
- Don't run the build twice if we aren't building samples.
- Adjust the default test categories to make building and testing faster by default.