### PR TITLE
Fix AOT tests in nightly

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -19,9 +19,11 @@ namespace Microsoft.DotNet.Docker.Tests
         {
         }
 
-        public static IEnumerable<object[]> GetImageData(DotNetImageRepo imageRepo)
+        public static IEnumerable<object[]> GetImageData(
+            DotNetImageRepo imageRepo,
+            DotNetImageVariant variant = DotNetImageVariant.None)
         {
-            return TestData.GetImageData(imageRepo)
+            return TestData.GetImageData(imageRepo, variant)
                 .Select(imageData => new object[] { imageData });
         }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.Docker.Tests
     public class DockerHelper
     {
         public static string DockerOS => GetDockerOS();
-        public static string DockerArchitecture => GetDockerArch();
         public static string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
         public static bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
         public static string TestArtifactsDir { get; } = Path.Combine(Directory.GetCurrentDirectory(), "TestAppArtifacts");
@@ -233,7 +232,6 @@ namespace Microsoft.DotNet.Docker.Tests
         }
 
         private static string GetDockerOS() => Execute("version -f \"{{ .Server.Os }}\"");
-        private static string GetDockerArch() => Execute("version -f \"{{ .Server.Arch }}\"");
 
         public string GetImageUser(string image) => ExecuteWithLogging($"inspect -f \"{{{{ .Config.User }}}}\" {image}");
 

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -20,7 +20,11 @@ namespace Microsoft.DotNet.Docker.Tests
 
         protected override DotNetImageRepo ImageRepo => DotNetImageRepo.Runtime_Deps;
 
-        public static IEnumerable<object[]> GetImageData() => GetImageData(DotNetImageRepo.Runtime_Deps);
+        public static IEnumerable<object[]> GetImageData() =>
+            GetImageData(DotNetImageRepo.Runtime_Deps);
+
+        public static IEnumerable<object[]> GetAotImageData() =>
+            GetImageData(DotNetImageRepo.Runtime_Deps, DotNetImageVariant.AOT);
 
         [LinuxImageTheory]
         [MemberData(nameof(GetImageData))]
@@ -28,10 +32,8 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             if (imageData.ImageVariant.HasFlag(DotNetImageVariant.AOT))
             {
-                OutputHelper.WriteLine("""
-                Temporarily disable test due to https://github.com/dotnet/dotnet-docker/issues/6049
-                Re-enable once the issue is resolved.
-                """);
+                OutputHelper.WriteLine(
+                    $"Test is not applicable to AOT images. See {nameof(VerifyAotWebScenario)} instead.");
                 return;
             }
 
@@ -46,10 +48,8 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             if (imageData.ImageVariant.HasFlag(DotNetImageVariant.AOT))
             {
-                OutputHelper.WriteLine("""
-                Temporarily disable test due to https://github.com/dotnet/dotnet-docker/issues/6049
-                Re-enable once the issue is resolved.
-                """);
+                OutputHelper.WriteLine(
+                    $"Test is not applicable to AOT images. See {nameof(VerifyAotWebScenario)} instead.");
                 return;
             }
 
@@ -59,15 +59,9 @@ namespace Microsoft.DotNet.Docker.Tests
         }
 
         [LinuxImageTheory]
-        [MemberData(nameof(GetImageData))]
-        public async Task VerifyAotAppScenario(ProductImageData imageData)
+        [MemberData(nameof(GetAotImageData))]
+        public async Task VerifyAotWebScenario(ProductImageData imageData)
         {
-            if (!imageData.ImageVariant.HasFlag(DotNetImageVariant.AOT))
-            {
-                OutputHelper.WriteLine("Test is only relevant to AOT images.");
-                return;
-            }
-
             if (imageData.Arch == Arch.Arm)
             {
                 OutputHelper.WriteLine("Skipping test due to https://github.com/dotnet/docker-tools/issues/1177. "
@@ -75,12 +69,6 @@ namespace Microsoft.DotNet.Docker.Tests
                         + "Re-enable once fixed.");
                 return;
             }
-
-            OutputHelper.WriteLine("""
-            Temporarily disable test due to https://github.com/dotnet/dotnet-docker/issues/6049
-            Re-enable once the issue is resolved.
-            """);
-            return;
 
             using WebScenario scenario = new WebScenario.Aot(imageData, DockerHelper, OutputHelper);
             await scenario.ExecuteAsync();

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -363,10 +363,13 @@ namespace Microsoft.DotNet.Docker.Tests
             },
         };
 
-        public static IEnumerable<ProductImageData> GetImageData(DotNetImageRepo imageRepo)
+        public static IEnumerable<ProductImageData> GetImageData(
+            DotNetImageRepo imageRepo,
+            DotNetImageVariant variant = DotNetImageVariant.None)
         {
             return (DockerHelper.IsLinuxContainerModeEnabled ? s_linuxTestData : s_windowsTestData)
                 .FilterImagesBySupportedRepo(imageRepo)
+                .FilterImagesByVariant(variant)
                 .FilterImagesByPath(imageRepo)
                 .FilterImagesByArch()
                 .FilterImagesByOs()
@@ -443,9 +446,21 @@ namespace Microsoft.DotNet.Docker.Tests
             return filteredImageData;
         }
 
-        public static IEnumerable<ProductImageData> FilterImagesBySupportedRepo(this IEnumerable<ProductImageData> imageData, DotNetImageRepo imageRepo)
+        public static IEnumerable<ProductImageData> FilterImagesBySupportedRepo(
+            this IEnumerable<ProductImageData> imageData,
+            DotNetImageRepo imageRepo)
         {
-            var images = imageData.Where(imageData => imageData.ImageRepoIsSupported(imageRepo));
+            IEnumerable<ProductImageData> images = imageData.Where(imageData =>
+                imageData.ImageRepoIsSupported(imageRepo));
+            return images;
+        }
+
+        public static IEnumerable<ProductImageData> FilterImagesByVariant(
+            this IEnumerable<ProductImageData> imageData,
+            DotNetImageVariant variant)
+        {
+            IEnumerable<ProductImageData> images = imageData.Where(imageData =>
+                imageData.ImageVariant.HasFlag(variant));
             return images;
         }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ConsoleAppScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ConsoleAppScenario.cs
@@ -54,18 +54,12 @@ public abstract class ConsoleAppScenario : ProjectTemplateTestScenario
             TestDockerfileBuilder.GetDefaultDockerfile(PublishConfig.SelfContained);
     }
 
-    public class Aot(ProductImageData imageData, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
-        : ConsoleAppScenario(imageData, dockerHelper, outputHelper)
-    {
-        protected override TestDockerfile Dockerfile =>
-            TestDockerfileBuilder.GetDefaultDockerfile(PublishConfig.Aot);
-    }
-
     public class TestProject(ProductImageData imageData, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
         : ConsoleAppScenario(imageData, dockerHelper, outputHelper)
     {
         protected override bool NonRootUserSupported => false;
-        protected override TestDockerfile Dockerfile { get; } =
+
+        protected override TestDockerfile Dockerfile =>
             TestDockerfileBuilder.GetTestProjectDockerfile();
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ConsoleAppScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ConsoleAppScenario.cs
@@ -58,8 +58,7 @@ public abstract class ConsoleAppScenario : ProjectTemplateTestScenario
         : ConsoleAppScenario(imageData, dockerHelper, outputHelper)
     {
         protected override bool NonRootUserSupported => false;
-
-        protected override TestDockerfile Dockerfile =>
+        protected override TestDockerfile Dockerfile { get; } =
             TestDockerfileBuilder.GetTestProjectDockerfile();
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/WebScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/WebScenario.cs
@@ -159,7 +159,7 @@ public abstract class WebScenario(ProductImageData imageData, DockerHelper docke
             TestDockerfileBuilder.GetDefaultDockerfile(PublishConfig.SelfContained);
     }
 
-    public new class Aot(ProductImageData imageData, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
+    public class Aot(ProductImageData imageData, DockerHelper dockerHelper, ITestOutputHelper outputHelper)
         : WebScenario(imageData, dockerHelper, outputHelper)
     {
         protected override string? Endpoint { get; } = "todos";


### PR DESCRIPTION
This PR is built off of [Accept more types of failures when retrying HTTP requests in tests (#6063)](https://github.com/dotnet/dotnet-docker/pull/6063) since that change was necessary for more reliable local testing. That's commit 3f88859af81adde500b8bcd4bafc4f45cc1b994b.

Fixes #6049 

Basically, once the test filtering was fixed in https://github.com/dotnet/dotnet-docker/pull/5983/commits/1c0e89dca3f55199194063b2fd47f9fc3ec2d97b, some AOT tests were failing. Here is a summary of what was happening:

- AOT scenario tests were running on non-AOT images which was failing.
  - This is resolved by filtering test data by variant.
- Self-contained publish scenario tests were running on AOT images which will never work since AOT images don't contain the correct dependencies.
- Console app "AOT" scenario test was failing
  - This is because we were using the `console` template. For web tests, there is the `webapiaot` template. There is no equivalent non-web template so we defaulted to the `console` template. Since the `console` template does not have AOT-specific MSBuild properties in its project file, this test was failing when it tried to run. It complained there was no .NET installation (duh).
  - I removed the scenario since it was never functional and it needs a re-think.

There should be follow-up work to:
- Enable AOT tests on non-AOT images
  - For example, by installing additional packages on the SDK images. This will require additional test Dockerfile refactoring.
- Enable console app AOT tests
  - There are probably multiple approaches to this - a checked-in project file, a string based project file, passing the requisite MSBuild properties via command line, etc.

After review/merge, I'll file issues for the above two scenarios.