### PR TITLE
Temporarily disable product EOL handling

### DIFF
--- a/eng/pipelines/variables/core.yml
+++ b/eng/pipelines/variables/core.yml
@@ -8,4 +8,6 @@ variables:
   value: manifest.json
 
 - name: generateEolAnnotationDataExtraOptions
-  value: "--annotate-eol-products"
+  value: ""
+  # TODO: Temporary workaround: see https://github.com/dotnet/docker-tools/issues/1507
+  #value: "--annotate-eol-products"


### PR DESCRIPTION
This disables the product EOL option for annotations which will prevent the issue described in https://github.com/dotnet/docker-tools/issues/1507 from occurring. This is just a temporary workaround until the real fix can be addressed.