### PR TITLE
Enable EOL annotation publishing for samples pipeline

### DIFF
--- a/eng/pipelines/variables/samples.yml
+++ b/eng/pipelines/variables/samples.yml
@@ -6,3 +6,5 @@ variables:
   value: sample
 - name: imageInfoVariant
   value: "-samples"
+- name: publishEolAnnotations
+  value: true


### PR DESCRIPTION
Running the samples pipeline does not cause EOL annotations to be published. This is because the `publishEolAnnotations` variable is not set. It's set here: https://github.com/dotnet/dotnet-docker/blob/569867de6c98363ae8a41b854b6615e4548c5caa/eng/pipelines/variables/core.yml#L9-L10

But that is not used by the samples pipeline. Added the variable to the template that will be used by the samples pipeline.