### PR TITLE
Remove .NET 6 references from documentation

### DIFF
--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -4,8 +4,6 @@
   * `docker pull mcr.microsoft.com/dotnet/aspnet:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/aspnet:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/aspnet:6.0`
 
 # About
 

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -4,8 +4,6 @@
   * `docker pull mcr.microsoft.com/dotnet/monitor:9`
 * `8` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/monitor:8`
-* `6` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/monitor:6`
 
 # About
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -4,8 +4,6 @@
   * `docker pull mcr.microsoft.com/dotnet/runtime-deps:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime-deps:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/runtime-deps:6.0`
 
 # About
 

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -4,8 +4,6 @@
   * `docker pull mcr.microsoft.com/dotnet/runtime:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/runtime:6.0`
 
 # About
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -4,8 +4,6 @@
   * `docker pull mcr.microsoft.com/dotnet/sdk:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/sdk:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/sdk:6.0`
 
 # About
 

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -10,8 +10,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
   * `docker pull mcr.microsoft.com/dotnet/aspnet:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/aspnet:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/aspnet:6.0`
 
 ## Related Repositories
 

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -10,8 +10,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
   * `docker pull mcr.microsoft.com/dotnet/monitor:9`
 * `8` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/monitor:8`
-* `6` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/monitor:6`
 
 ## Related Repositories
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -10,8 +10,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
   * `docker pull mcr.microsoft.com/dotnet/runtime-deps:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime-deps:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/runtime-deps:6.0`
 
 ## Related Repositories
 

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -10,8 +10,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
   * `docker pull mcr.microsoft.com/dotnet/runtime:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/runtime:6.0`
 
 ## Related Repositories
 

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -16,8 +16,6 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
   * `docker pull mcr.microsoft.com/dotnet/sdk:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/sdk:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/sdk:6.0`
 
 ## Related Repositories
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -6,8 +6,6 @@
   * `docker pull mcr.microsoft.com/dotnet/aspnet:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/aspnet:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/aspnet:6.0`
 
 ## About
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -6,8 +6,6 @@
   * `docker pull mcr.microsoft.com/dotnet/monitor:9`
 * `8` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/monitor:8`
-* `6` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/monitor:6`
 
 ## About
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -6,8 +6,6 @@
   * `docker pull mcr.microsoft.com/dotnet/runtime-deps:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime-deps:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/runtime-deps:6.0`
 
 ## About
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -6,8 +6,6 @@
   * `docker pull mcr.microsoft.com/dotnet/runtime:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/runtime:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/runtime:6.0`
 
 ## About
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -6,8 +6,6 @@
   * `docker pull mcr.microsoft.com/dotnet/sdk:9.0`
 * `8.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/sdk:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull mcr.microsoft.com/dotnet/sdk:6.0`
 
 ## About
 

--- a/documentation/image-artifact-details.md
+++ b/documentation/image-artifact-details.md
@@ -15,21 +15,21 @@ This document is intended to be complimentary to the [Instructions for Finding L
 * .NET SDK
 * PowerShell
 
-You can see these components installed in the [runtime](https://github.com/dotnet/dotnet-docker/blob/4915d568024f581ee95608e3b93984f15434a5f3/src/runtime/8.0/bookworm-slim/amd64/Dockerfile#L6-L13), [aspnet](https://github.com/dotnet/dotnet-docker/blob/4915d568024f581ee95608e3b93984f15434a5f3/src/aspnet/8.0/bookworm-slim/amd64/Dockerfile#L6-L12), and [sdk](https://github.com/dotnet/dotnet-docker/blob/4915d568024f581ee95608e3b93984f15434a5f3/src/sdk/8.0/bookworm-slim/amd64/Dockerfile#L26-L48) Dockerfiles.
+You can see these components installed in the [runtime](https://github.com/dotnet/dotnet-docker/blob/d90e7bd1d10c8781f0008f5ab1327ca3481e78de/src/runtime/8.0/bookworm-slim/amd64/Dockerfile#L6-L13), [aspnet](https://github.com/dotnet/dotnet-docker/blob/d90e7bd1d10c8781f0008f5ab1327ca3481e78de/src/aspnet/8.0/bookworm-slim/amd64/Dockerfile#L6-L12), and [sdk](https://github.com/dotnet/dotnet-docker/blob/d90e7bd1d10c8781f0008f5ab1327ca3481e78de/src/sdk/8.0/bookworm-slim/amd64/Dockerfile#L26-L48) Dockerfiles.
 
 ### .NET Runtime Image
 
 The [.NET runtime image](../README.runtime.md) includes the .NET runtime, with an associated license and third party notice file.
 
 ```console
-$ docker run --rm mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim /bin/sh -c "find ./usr/share/dotnet | grep LICENSE"
+$ docker run --rm mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim /bin/sh -c "find ./usr/share/dotnet | grep LICENSE"
 ./usr/share/dotnet/LICENSE.txt
 ```
 
 The license can be printed out, as follows.
 
 ```console
-$ docker run --rm mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim cat ./usr/share/dotnet/LICENSE.txt
+$ docker run --rm mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim cat ./usr/share/dotnet/LICENSE.txt
 The MIT License (MIT)
 
 Copyright (c) .NET Foundation and Contributors
@@ -48,7 +48,7 @@ furnished to do so, subject to the following conditions:
 Third party notices can also be found, as demonstrated below.
 
 ```console
-$ docker run --rm mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim /bin/sh -c "find ./usr/share/dotnet | grep -i third"
+$ docker run --rm mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim /bin/sh -c "find ./usr/share/dotnet | grep -i third"
 ./usr/share/dotnet/ThirdPartyNotices.txt
 ```
 
@@ -57,11 +57,12 @@ $ docker run --rm mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim /bin/sh -c 
 The [ASP.NET Core image](../README.aspnet.md) includes ASP.NET Core in addition to .NET, with associated licenses and third party notice files.
 
 ```console
-$ docker run --rm mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim /bin/sh -c "find ./usr/share/dotnet | grep LICENSE"
+$ docker run --rm mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim /bin/sh -c "find ./usr/share/dotnet | grep LICENSE"
 ./usr/share/dotnet/LICENSE.txt
-$ docker run --rm mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim /bin/sh -c "find ./usr/share/dotnet | grep -i third"
+
+$ docker run --rm mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim /bin/sh -c "find ./usr/share/dotnet | grep -i third"
 ./usr/share/dotnet/ThirdPartyNotices.txt
-./usr/share/dotnet/shared/Microsoft.AspNetCore.App/6.0.0/THIRD-PARTY-NOTICES.txt
+./usr/share/dotnet/shared/Microsoft.AspNetCore.App/9.0.0/THIRD-PARTY-NOTICES.txt
 ```
 
 ### .NET SDK Image
@@ -69,19 +70,22 @@ $ docker run --rm mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim /bin/sh -c "
 The [SDK image](../README.sdk.md) includes the .NET SDK, which includes various .NET components, with associated licenses and third party notice files.
 
 ```console
-$ docker run --rm mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim /bin/sh -c "find ./usr/share/dotnet ./usr/share/powershell | grep LICENSE"
+$ docker run --rm mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim /bin/sh -c "find ./usr/share/dotnet ./usr/share/powershell | grep LICENSE"
 ./usr/share/dotnet/LICENSE.txt
-./usr/share/dotnet/sdk/6.0.100/Sdks/Microsoft.NET.Sdk.WindowsDesktop/LICENSE.TXT
-./usr/share/powershell/.store/powershell.linux.x64/7.2.0-preview.10/powershell.linux.x64/7.2.0-preview.10/tools/net6.0/any/LICENSE.txt
-$ docker run --rm mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim /bin/sh -c "find ./usr/share/dotnet | grep -i third"
+./usr/share/dotnet/sdk/9.0.101/Sdks/Microsoft.NET.Sdk.WindowsDesktop/LICENSE.TXT
+./usr/share/powershell/.store/powershell.linux.x64/7.5.0-preview.5/powershell.linux.x64/7.5.0-preview.5/tools/net9.0/any/Modules/Microsoft.PowerShell.PSResourceGet/LICENSE
+./usr/share/powershell/.store/powershell.linux.x64/7.5.0-preview.5/powershell.linux.x64/7.5.0-preview.5/tools/net9.0/any/LICENSE.txt
+
+$ docker run --rm mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim /bin/sh -c "find ./usr/share/dotnet | grep -i third"
 ./usr/share/dotnet/ThirdPartyNotices.txt
-./usr/share/dotnet/shared/Microsoft.AspNetCore.App/6.0.0/THIRD-PARTY-NOTICES.txt
-./usr/share/dotnet/sdk/6.0.100/Sdks/Microsoft.NET.Sdk.WindowsDesktop/THIRD-PARTY-NOTICES.TXT
-$ docker run --rm mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim /bin/sh -c "find ./usr/share/dotnet ./usr/share/powershell | grep -i third"
+./usr/share/dotnet/shared/Microsoft.AspNetCore.App/9.0.0/THIRD-PARTY-NOTICES.txt
+./usr/share/dotnet/sdk/9.0.101/Sdks/Microsoft.NET.Sdk.WindowsDesktop/THIRD-PARTY-NOTICES.TXT
+
+$ docker run --rm mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim /bin/sh -c "find ./usr/share/dotnet ./usr/share/powershell | grep -i third"
 ./usr/share/dotnet/ThirdPartyNotices.txt
-./usr/share/dotnet/shared/Microsoft.AspNetCore.App/6.0.0/THIRD-PARTY-NOTICES.txt
-./usr/share/dotnet/sdk/6.0.100/Sdks/Microsoft.NET.Sdk.WindowsDesktop/THIRD-PARTY-NOTICES.TXT
-./usr/share/powershell/.store/powershell.linux.x64/7.2.0-preview.10/powershell.linux.x64/7.2.0-preview.10/tools/net6.0/any/ThirdPartyNotices.txt
+./usr/share/dotnet/shared/Microsoft.AspNetCore.App/9.0.0/THIRD-PARTY-NOTICES.txt
+./usr/share/dotnet/sdk/9.0.101/Sdks/Microsoft.NET.Sdk.WindowsDesktop/THIRD-PARTY-NOTICES.TXT
+./usr/share/powershell/.store/powershell.linux.x64/7.5.0-preview.5/powershell.linux.x64/7.5.0-preview.5/tools/net9.0/any/ThirdPartyNotices.txt
 ```
 
 ## Distroless Images
@@ -89,55 +93,43 @@ $ docker run --rm mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim /bin/sh -c "fin
 The commands listed above won't work when targeting a distroless image since distroless images don't contain a shell by default.
 Instead, you can copy the distroless image's filesystem into a another image that does contain a shell and inspect it from there.
 
-First, create a Dockerfile that will be used as the wrapper around the distroless container:
+This repo contains a [Dockerfile](./scripts/Dockerfile.distroless-wrapper) that takes a distroless container image as input.
+The dockerfile copies the distroless image's entire filesystem into a non-distroless base image so that its contents can be inspected with shell scripts.
 
-```Dockerfile
-ARG DISTROLESS_IMAGE
-FROM $DISTROLESS_IMAGE AS distroless
-
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
-
-COPY --from=distroless / /distroless
-```
-
-> [!NOTE]
-> The last instruction copies the entire contents of the distroless container's filesystem to the `/distroless` directory in the wrapper.
-> This will be the target location used when executing commands.
-
-Next, build the Dockerfile, specifying the distroless image tag you wish to inspect:
+First, build the Dockerfile, specifying the distroless image tag you wish to inspect:
 
 ```console
-docker build -t distroless-wrapper --build-arg DISTROLESS_IMAGE=mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0-distroless .
+$image="mcr.microsoft.com/dotnet/aspnet:9.0-azurelinux3.0-distroless"
+docker build -t distroless-wrapper -f ./Dockerfile.distroless-wrapper --build-arg DISTROLESS_IMAGE=$image https://github.com/dotnet/dotnet-docker.git#main:documentation/scripts
 ```
 
-Now that you've got the wrapper image, you can execute the [commands that are documented](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md). The only difference here is that you'll need to target the wrapper image and adjust the target path.
+Now that you've got the wrapper image, you can execute the [commands that are documented](https://github.com/dotnet/dotnet-docker/blob/main/documentation/image-artifact-details.md).
+The only difference here is that you'll need to target the wrapper image instead.
 
 For example, instead of executing this command as documented:
 
 ```console
-$ docker run --rm mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0-distroless /bin/sh -c "find ./usr/share/dotnet | grep -i third"
-./usr/share/dotnet/ThirdPartyNotices.txt
+docker run --rm $image /bin/sh -c "find ./usr/share/dotnet | grep -i third"
 ```
 
-You would actually execute this command to use the distroless wrapper image (note the difference in the image tag and path parameter):
+You would actually execute this command using the distroless wrapper image:
 
 ```console
-$ docker run --rm distroless-wrapper /bin/sh -c "find ./distroless/usr/share/dotnet | grep -i third"
-./distroless/usr/share/dotnet/ThirdPartyNotices.txt
+$ docker run --rm distroless-wrapper /bin/sh -c "find ./usr/share/dotnet | grep -i third"
+./usr/share/dotnet/ThirdPartyNotices.txt
+./usr/share/dotnet/shared/Microsoft.AspNetCore.App/9.0.0/THIRD-PARTY-NOTICES.txt
 ```
 
 ## Appliance Images
 
 ### .NET Monitor
 
-The [.NET Monitor image](../README.monitor.md) includes .NET Monitor in addition to ASP.NET Core, with associated licenses and third party notice files. Starting with .NET Monitor 8, the image is based on the distroless ASP.NET Core image; using the instructions from [Distroless Images](#distroless-images) is necessary to gather the licence and notice file paths.
+The [.NET Monitor image](../README.monitor.md) includes .NET Monitor in addition to ASP.NET Core, with associated licenses and third party notice files. The .NET Monitor images are based on distroless ASP.NET Core images. As such, using the instructions from [Distroless Images](#distroless-images) is necessary to gather the licence and notice file paths.
 
-First, create the Dockerfile as specified in [Distroless Images](#distroless-images).
-
-Next, build the wrapper Dockerfile, specifying the image tag you wish to inspect:
+First, build the wrapper Dockerfile, specifying the image tag you wish to inspect:
 
 ```console
-docker build -t distroless-wrapper --build-arg DISTROLESS_IMAGE=mcr.microsoft.com/dotnet/monitor:8 .
+docker build -t distroless-wrapper -f ./Dockerfile.distroless-wrapper --build-arg DISTROLESS_IMAGE=mcr.microsoft.com/dotnet/monitor:8 https://github.com/dotnet/dotnet-docker.git#main:documentation/scripts
 ```
 
 Finally, execute the following to get license and notice file paths:

--- a/documentation/scenarios/installing-dotnet.md
+++ b/documentation/scenarios/installing-dotnet.md
@@ -118,7 +118,7 @@ By having the version of .NET you're installing explicitly defined in the Docker
 * .NET download URL (e.g. `ENV DOTNET_URL=https://download.visualstudio.microsoft.com/...`)
 * SHA value (e.g. `dotnet_sha512='d4d67df5ff5f6dde0d865a6e87559955bd57429df396cf7d05fe77f09e6220c67dc5e66439b1801ca4d301a62f81f666122bf4b623b31a46b861677dcafc62a4'`)
 
-You can track these values by making use of the information contained in the `releases.json` of the relevant release. For example, the [`releases.json`](https://dotnetcli.azureedge.net/dotnet/release-metadata/6.0/releases.json) for 6.0 contains all the metadata for the 6.0 releases including download links of the binary archives as well as their hash values. The release information is described on the main [release notes](https://github.com/dotnet/core/blob/master/release-notes/README.md) page.
+You can track these values by making use of the information contained in the `releases.json` of the relevant release. For example, the [`releases.json`](https://dotnetcli.azureedge.net/dotnet/release-metadata/9.0/releases.json) for 9.0 contains all the metadata for the 9.0 releases including download links of the binary archives as well as their hash values. The release information is described on the main [release notes](https://github.com/dotnet/core/blob/master/release-notes/README.md) page.
 
 ### Installing from a Linux Package Manager
 
@@ -188,7 +188,7 @@ RUN apt-get update \
 
 ### Installing from dotnet-install script
 
-A set of [installation scripts](https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script) are provided to conveniently install .NET on Linux with Bash or Windows with PowerShell. These scripts can be thought of as a happy medium between the two previously mentioned approaches (binary archive link and package manager). They fill a gap on systems where the desired .NET release is not available through a package manager and you don't want to deal with the cost of maintaining a direct link to a binary package. With the installation script, you have flexibility in specifying which version gets installed. You can install a specific version such as 6.0.0, the latest of a release channel such as the latest 6.0 patch, etc.
+A set of [installation scripts](https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script) are provided to conveniently install .NET on Linux with Bash or Windows with PowerShell. These scripts can be thought of as a happy medium between the two previously mentioned approaches (binary archive link and package manager). They fill a gap on systems where the desired .NET release is not available through a package manager and you don't want to deal with the cost of maintaining a direct link to a binary package. With the installation script, you have flexibility in specifying which version gets installed. You can install a specific version such as 9.0.0, the latest of a release channel such as the latest 9.0 patch, etc.
 
 In addition to installing .NET, you'll also need to ensure that the [prerequisites](https://github.com/dotnet/core/blob/main/linux.md#dependencies) are installed. The [.NET Dockerfiles](https://github.com/dotnet/dotnet-docker) also demonstrate how that can be done.
 

--- a/documentation/scripts/Dockerfile.distroless-wrapper
+++ b/documentation/scripts/Dockerfile.distroless-wrapper
@@ -1,0 +1,7 @@
+ARG DISTROLESS_IMAGE
+FROM $DISTROLESS_IMAGE AS distroless
+
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
+
+COPY --from=distroless / /rootfs
+WORKDIR /rootfs

--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -25,11 +25,11 @@ These "fixed version" tags reference an image with a specific `Major.Minor.Patch
 
 Examples:
 
-- `6.0.32-jammy-amd64`
-- `6.0.32-jammy-arm64v8`
-- `6.0.32-nanoserver-ltsc2022`
-- `8.0.7-alpine3.20-arm64v8`
-- `8.0.7-bookworm-slim-arm32v7`
+- `8.0.11-noble-amd64`
+- `8.0.11-noble-arm64v8`
+- `8.0.11-nanoserver-ltsc2022`
+- `8.0.11-alpine3.20-arm64v8`
+- `8.0.11-bookworm-slim-arm32v7`
 
 ### `<Major.Minor .NET Version>-<OS>-<Architecture>`
 
@@ -37,9 +37,9 @@ These "floating version" tags reference an image with a specific `Major.Minor` (
 
 Examples:
 
-- `6.0-jammy-arm64v8`
-- `6.0-jammy-amd64`
-- `6.0-nanoserver-ltsc2022`
+- `8.0-noble-arm64v8`
+- `8.0-noble-amd64`
+- `8.0-nanoserver-ltsc2022`
 - `8.0-alpine3.20-arm64v8`
 - `8.0-bookworm-slim-arm32v7`
 
@@ -71,8 +71,8 @@ These "fixed version" tags reference an image with a specific `Major.Minor.Patch
 
 Examples:
 
-- `6.0.32-jammy`
-- `8.0.7-alpine3.20`
+- `8.0.11-noble`
+- `8.0.11-alpine3.20`
 
 ### `<Major.Minor .NET Version>-<OS version>`
 
@@ -80,8 +80,8 @@ These "floating version" tags reference an image with a specific `Major.Minor` (
 
 Examples:
 
-- `6.0-alpine3.20`
-- `8.0-jammy`
+- `8.0-alpine3.20`
+- `8.0-noble`
 
 ### `<Major.Minor .NET Version>-alpine`
 
@@ -89,13 +89,13 @@ These "floating version" tags reference an image with a specific `Major.Minor` (
 
 Examples:
 
-- `6.0-alpine`
 - `8.0-alpine`
+- `9.0-alpine`
 
 > [!NOTE]
 >
-> - New versions of Alpine will be published with version-specific tags (e.g. `6.0-alpine3.20`).
-> - Floating tag (e.g. `6.0-alpine`) will be updated with the new Alpine version a month later.
+> - New versions of Alpine will be published with version-specific tags (e.g. `8.0-alpine3.20`).
+> - Floating tag (e.g. `8.0-alpine`) will be updated with the new Alpine version a month later.
 > - Tag changes will be [announced](https://github.com/dotnet/dotnet-docker/discussions/categories/announcements) so that users know when the tags they want are available.
 
 ### `<Major.Minor.Patch .NET Version>`
@@ -104,8 +104,8 @@ These "fixed version" tags reference an image with a specific `Major.Minor.Patch
 
 Examples:
 
-- `6.0.32`
-- `8.0.7`
+- `8.0.11`
+- `9.0.11`
 
 ### `<Major.Minor .NET Version>`
 
@@ -113,8 +113,8 @@ These "floating version" tags reference an image with a specific `Major.Minor` (
 
 Examples:
 
-- `6.0`
 - `8.0`
+- `9.0`
 
 ### Image Variants
 
@@ -124,8 +124,8 @@ You can use these variants by appending the variant name (e.g. `extra`, `chisele
 Examples:
 
 - `8.0-noble-chiseled`
-- `8.0.7-noble-chiseled-extra`
-- `8.0.7-alpine3.20-extra`
+- `8.0.11-noble-chiseled-extra`
+- `9.0.0-alpine3.20-extra`
 
 For more information, see the [Image Variants documentation](./image-variants.md).
 
@@ -165,8 +165,8 @@ See [.NET's release policies](https://github.com/dotnet/core/blob/main/release-p
 
 Examples:
 
-- `6.0.32`
-- `8.0.7-alpine3.20`
+- `8.0.11`
+- `8.0.11-alpine3.20`
 - `9.0.0-preview.7`
 - `9.0.0-rc.1`
 
@@ -183,6 +183,7 @@ Examples:
 Examples:
 
 - `8.0`
+- `9.0`
 - `9.0-alpine3.20`
 - `9.0-preview`
 - `9.0-preview-noble`
@@ -198,8 +199,8 @@ Version-specific operating system tags reference an image with a specific OS ver
 
 Examples:
 
-- `6.0-jammy`
-- `8.0-alpine3.20`
+- `8.0-noble`
+- `9.0-alpine3.20`
 
 > [!NOTE]
 >

--- a/documentation/vulnerability-reporting.md
+++ b/documentation/vulnerability-reporting.md
@@ -162,22 +162,24 @@ $dotnetImage="<insert-dotnet-image-tag>" # example: mcr.microsoft.com/dotnet/asp
 
 Switching to a [supported base image tag](supported-tags.md) requires knowing the specific tag usage:
 
-* If you're using an out-of-support .NET version, such as .NET 5, you must upgrade your project and Dockerfiles to target a supported version.
-* If you're using a patch version tag which which has been replaced by a newer patch version, you must switch to the latest patch version. For example, `6.0.<old-version>` => `6.0.<latest-version>`
-* If you're using a version-specific Alpine Linux tag for a version of Alpine that is no longer being maintained via .NET container images, you must move to the latest version. For example, `6.0-alpine3.15` => `6.0-alpine3.16`
-* If you're using a tag for a specific Windows version that is no longer supported, you must move to a supported version of Windows. For example, `6.0-nanoserver-20H2` => `6.0-nanoserver-ltsc2022`
+* If you're using an out-of-support .NET version, you must upgrade your project and Dockerfiles to target a supported version.
+  The [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy) page contains the latest information on supported .NET versions.
+* If you're using a patch version tag which which has been replaced by a newer patch version, you must switch to the latest patch version.
+* If you're using a version-specific Alpine Linux tag for a version of Alpine that is no longer being maintained via .NET container images, you must move to the latest version. For example, `8.0-alpine3.19` => `8.0-alpine3.20`
+* If you're using a tag for a specific Windows version that is no longer supported, you must move to a supported version of Windows.
 
 See our [supported tag policy](supported-tags.md) for more information.
 
 ### E. Is your image built from the latest .NET image?
 
+The [Image Update Policy](/README.md#image-update-policy) describes exactly when we update .NET images.
 A given .NET tag can be updated multiple times over its a lifetime, pointing to a new image each time.
-For example, the `6.0` tag will point to a new image each time a new patch version is released.
-And even a patch version tag, `6.0.x`, can be updated more than once if a new base OS image is released or a security fix for a package is released during the tag's supported lifecycle.
+For example, the `8.0` tag will point to a new image each time a new patch version is released.
+A patch-version tag (such as `8.0.1`) may also be updated due to base image updates or if a security fix is required for a Linux package.
 It's important to realize that these updates likely contain security fixes.
 Even though you may be using a supported tag, it's possible you're using an older image that has since been replaced by a newer version with that same tag.
-Only the latest image for that tag is supported.
-Run one of the scripts below to determine whether your image is built on the latest image for that tag. Provide the [image digest](#what-is-an-image-digest) of your image and tag of the .NET image (e.g. `mcr.microsoft.com/dotnet/aspnet:6.0`) as input.
+Only the latest image for a given tag is supported.
+Run one of the scripts below to determine whether your image is built on the latest image for that tag. Provide the [image digest](#what-is-an-image-digest) of your image and tag of the .NET image (e.g. `mcr.microsoft.com/dotnet/aspnet:8.0`) as input.
 
 A result of `True` means that your image is built from the latest .NET image.
 A result of `False` means it is not built on the latest .NET image and must be updated.
@@ -339,7 +341,7 @@ Requires [PowerShell](https://learn.microsoft.com/powershell/scripting/install/i
 
 ```shell
 packageName="<insert-package-name>"
-imageName="<insert-linux-base-image-name>" # example: amd64/debian:bullseye-slim
+imageName="<insert-linux-base-image-name>" # example: amd64/debian:bookworm-slim
 curl -sSL https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentation/scripts/check-package-install.ps1 | pwsh /dev/stdin $packageName $imageName
 ```
 
@@ -347,7 +349,7 @@ curl -sSL https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentat
 
 ```powershell
 $packageName="<insert-package-name>"
-$imageName="<insert-linux-base-image-name>" # example: amd64/debian:bullseye-slim
+$imageName="<insert-linux-base-image-name>" # example: amd64/debian:bookworm-slim
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/dotnet-docker/main/documentation/scripts/check-package-install.ps1'))) $packageName $imageName
 ```
@@ -478,10 +480,10 @@ If you get the error "image operating system "windows" cannot be used on this pl
 
 ### How can I determine the tag of the Linux distro image that my image is based upon?
 
-You'll first need to get the name of the .NET image (e.g. `mcr.microsoft.com/dotnet/aspnet:6.0`) from your Dockerfile.
+You'll first need to get the name of the .NET image (e.g. `mcr.microsoft.com/dotnet/aspnet:8.0`) from your Dockerfile.
 Take the tag portion of that image name and search for that tag on the [.NET Runtime Dependencies page](../README.runtime-deps.md) within the appropriate "Linux &lt;architecture&gt; Tags" section.
 Navigate to the Dockerfile link associated with that tag.
-The first `FROM` line of the Dockerfile will have the name of the Linux distro base image (e.g. `amd64/debian:bullseye-slim`).
+The first `FROM` line of the Dockerfile will have the name of the Linux distro base image (e.g. `amd64/debian:bookworm-slim`).
 
 ### How can I determine the OS version of a Linux image?
 
@@ -575,6 +577,6 @@ The following are links to the security sites for the Linux distros that we supp
 Within those pages the distro will indicate in which release the vulnerability was fixed or not fixed. Use the distro version/codename to determine which release is relevant.
 
 > It's important that you determine whether a fix is available for the specific version/release of the Linux distro.
-For example, a package may have a vulnerability fixed for Debian Bullseye but not yet available for Debian Buster.
-While you could configure the Debian Buster container to install that package from the Debian Bullseye package repository, that doesn't mean the package will actually be compatible.
+For example, a package may have a vulnerability fixed for Ubuntu Noble but not yet available for Ubuntu Jammy.
+While you could configure the Ubuntu Jammy container to install that package from the Ubuntu Noble package repository, that doesn't mean the package will actually be compatible.
 Doing so is not a supported configuration from .NET's perspective and we will not take such an action with our images.

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -13,9 +13,7 @@
 elif match(SHORT_REPO, "monitor"):* `9` (Standard Support)
   * `docker pull {{FULL_REPO}}:9`
 * `8` (Long-Term Support)
-  * `docker pull {{FULL_REPO}}:8`
-* `6` (Long-Term Support)
-  * `docker pull {{FULL_REPO}}:6`^
+  * `docker pull {{FULL_REPO}}:8`^
 elif match(REPO, "monitor/base"):* `9` (Standard Support)
   * `docker pull {{FULL_REPO}}:9`
 * `8` (Long-Term Support)
@@ -25,6 +23,4 @@ elif match(REPO, "aspire-dashboard"):* `9.0`
 else:* `9.0` (Standard Support)
   * `docker pull {{FULL_REPO}}:9.0`
 * `8.0` (Long-Term Support)
-  * `docker pull {{FULL_REPO}}:8.0`
-* `6.0` (Long-Term Support)
-  * `docker pull {{FULL_REPO}}:6.0`}}
+  * `docker pull {{FULL_REPO}}:8.0`}}

--- a/samples/aspnetapp/README.md
+++ b/samples/aspnetapp/README.md
@@ -46,17 +46,19 @@ d79edc6bfcb6   mcr.microsoft.com/dotnet/samples:aspnetapp   "./aspnetapp"   35 s
 
 ## Change port
 
-You can change the port ASP.NET Core uses with one of the following environment variables. However, port `8080` (set by default) is recommended.
+You can change the port ASP.NET Core uses with one of the following environment variables.
+However, the default port `8080` is recommended.
 
-The following examples change the port to port `80`.
+Note that ports 1 to 1023 are restricted to root users only, and will not work when running as the non-root root user provided in .NET images.
 
-- Supported with .NET 8+: `ASPNETCORE_HTTP_PORTS=80`
-- Supported with .NET Core 1.0+: `ASPNETCORE_URLS=http://+:80`
+The following evnironment variables will change the port to port `80`.
 
-> [!NOTE]
-> `ASPNETCORE_URLS` overwrites `ASPNETCORE_HTTP_PORTS` if set.
+- `ASPNETCORE_HTTP_PORTS=80`
+- `ASPNETCORE_URLS=http://+:80`
 
-These environment variables are used in [.NET 8](https://github.com/dotnet/dotnet-docker/blob/6da64f31944bb16ecde5495b6a53fc170fbe100d/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile#L7C5-L7C31) and [.NET 6](https://github.com/dotnet/dotnet-docker/blob/6da64f31944bb16ecde5495b6a53fc170fbe100d/src/runtime-deps/6.0/bookworm-slim/amd64/Dockerfile#L5) Dockerfiles, respectively.
+`ASPNETCORE_URLS` overrides `ASPNETCORE_HTTP_PORTS` if set.
+The `ASPNETCORE_HTTP_PORTS` envrionment variable is used in the [ASP.NET Core](https://github.com/dotnet/dotnet-docker/blob/d90e7bd1d10c8781f0008f5ab1327ca3481e78de/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile#L7C5-L7C31)
+images to set the default port.
 
 ## Enable HTTPS
 

--- a/samples/dotnetapp/README.md
+++ b/samples/dotnetapp/README.md
@@ -20,7 +20,7 @@ docker run --rm dotnetapp
 ```
 
 Add the argument `-f <Dockerfile>` to build the sample in a different configuration.
-For example, build an [Ubuntu Chiseled](https://devblogs.microsoft.com/dotnet/dotnet-6-is-now-in-ubuntu-2204/#net-in-chiseled-ubuntu-containers) image using [Dockerfile.chiseled](Dockerfile.chiseled):
+For example, build an [Ubuntu Chiseled](../../documentation/ubuntu-chiseled.md) image using [Dockerfile.chiseled](Dockerfile.chiseled):
 
 ```console
 docker build --pull -t dotnetapp -f Dockerfile.chiseled 'https://github.com/dotnet/dotnet-docker.git#:samples/dotnetapp'

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -18,51 +18,31 @@ The repos above are commonly used on the command line and in Dockerfiles. There 
 * [dotnet/nightly](https://github.com/dotnet/dotnet-docker/blob/nightly/README.md) -- A duplicate structure of repos which contain the latest pre-released versions of .NET. (which are not supported in production).
 * [dotnet/samples](../README.samples.md) -- A set of samples that demonstrate .NET being used in console and web scenarios.
 
-## Tags that work everywhere
-
-Each repo exposes a set of tags you can use. There are a set of version number tags, like `6.0`, that you can use on multiple operating systems and are supported on most processor types (x64, ARM64 and ARM32). If you don't see an operating system or processor type in the tag, you know it's a [multi-platform](https://www.docker.com/blog/docker-official-images-now-multi-platform/) tag that will work everywhere.
-
-When you pull these tags, you will get a Debian image for Linux and Windows Nano Server images on Windows (if you are using Windows containers). If you are happy with that behavior, then these are the easiest tags to use and enable you to write Dockerfiles that can be built on multiple machines. However, the images you produce may differ across environments (which may or may not be what you want).
-
-For example, the following command will work in all supported environments:
-
-```console
-docker run --rm mcr.microsoft.com/dotnet/runtime:6.0 dotnet
-```
-
-Similarly, you can build an image with the following `FROM` statement:
-
-```Dockerfile
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
-```
-
-This will work on all operating systems and on all supported chips, but building this Dockerfile on Windows x64 will produce a different image than on Linux ARM64 and they are not interchangeable.
-
 ## Targeting a specific operating system
 
 If you want a specific operating system image, you should use a specific operating system tag. We publish images for [Alpine](#alpine), [Debian](#debian), [Ubuntu](#ubuntu), [Windows Nano Server](#nano-server), and [Windows Server Core](#windows-server-core).
 
-The following tags demonstrate the pattern used to describe each operating system (using .NET 6.0 as the example):
+The following tags demonstrate the pattern used to describe each operating system (using .NET 9.0 as the example):
 
-* `6.0-alpine` (Latest Alpine)
-* `6.0-focal` (Ubuntu 20.04)
-* `6.0-bullseye-slim` (Debian 11)
-* `6.0-nanoserver-ltsc2022` (Nano Server LTSC 2022)
-* `6.0-nanoserver-1809` (Nano Server, version 1809)
-* `6.0-windowsservercore-ltsc2022` (Windows Server Core LTSC 2022)
-* `6.0-windowsservercore-ltsc2019` (Windows Server Core LTSC 2019)
+* `9.0-alpine` (Latest Alpine)
+* `9.0-noble` (Ubuntu 24.04)
+* `9.0-bookworm-slim` (Debian 12)
+* `9.0-nanoserver-ltsc2022` (Nano Server LTSC 2022)
+* `9.0-nanoserver-1809` (Nano Server, version 1809)
+* `9.0-windowsservercore-ltsc2022` (Windows Server Core LTSC 2022)
+* `9.0-windowsservercore-ltsc2019` (Windows Server Core LTSC 2019)
 
-For example, the following command will pull an x64 Alpine image:
+For example, the following command will pull an Alpine image for your machine's architecture:
 
 ```console
-docker pull mcr.microsoft.com/dotnet/runtime:6.0-alpine
+docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 ```
 
 ### Linux
 
 #### [Debian](https://www.debian.org)
 
-* When targeting Linux containers, Debian is the default Linux distro for all tags that do not specify an OS. For example, `latest`, `6.0`, and `6.0.0` will all provide a Debian image.
+* When targeting Linux containers, Debian is the default Linux distro for all tags that do not specify an OS. For example, `latest`, `9.0`, and `9.0.0` will all provide a Debian image.
 * Very stable.
 
 #### [Ubuntu](https://ubuntu.com)
@@ -84,7 +64,6 @@ By default, the `icu-libs` package is not included and the [globalization invari
 
 #### [Nano Server](https://docs.microsoft.com/virtualization/windowscontainers/manage-containers/container-base-images)
 
-* When targeting Windows containers, Nano Server is the default OS for all tags that do not specify an OS. For example, `latest`, `6.0`, and `6.0.0` will all provide a Nano Server image.
 * Small, minimalistic version of Windows.
 * Good option for new application development.
 
@@ -105,31 +84,31 @@ The following tags demonstrate the pattern used to describe each processor, usin
 
 ### x64
 
-* `6.0-alpine-amd64`
-* `6.0-focal-amd64`
-* `6.0-bullseye-slim-amd64`
-* `6.0-nanoserver-1809`
-* `6.0-windowsservercore-ltsc2019`
+* `9.0-alpine-amd64`
+* `9.0-noble-amd64`
+* `9.0-bookworm-slim-amd64`
+* `9.0-nanoserver-ltsc2022`
+* `9.0-windowsservercore-ltsc2022`
 
 ### ARM64
 
-* `6.0-alpine-arm64v8`
-* `6.0-focal-arm64v8`
-* `6.0-bullseye-slim-arm64v8`
+* `9.0-alpine-arm64v8`
+* `9.0-noble-arm64v8`
+* `9.0-bookworm-slim-arm64v8`
 
 ### ARM32
 
-* `6.0-alpine-arm32v7`
-* `6.0-focal-arm32v7`
-* `6.0-bullseye-slim-arm32v7`
+* `9.0-alpine-arm32v7`
+* `9.0-noble-arm32v7`
+* `9.0-bookworm-slim-arm32v7`
 
 ## Matching SDK and Runtime images
 
-As already stated, we offer images for Alpine, Debian and Ubuntu, for Linux. People (and organizations) choose each of these distros for different reasons. Many people likely choose Debian, for example, because it is the default distro (for example, the `6.0` tag in each of the .NET Docker repos will pull a Debian image).
+As already stated, we offer images for Alpine, Debian and Ubuntu, for Linux. People (and organizations) choose each of these distros for different reasons. Many people likely choose Debian, for example, because it is the default distro (for example, the `9.0` tag in each of the .NET Docker repos will pull a Debian image).
 
-For multi-stage Dockerfiles, there are typically at least two tags referenced, an SDK and a runtime tag. You may want to make a conscious choice to make the distros match for those two tags. If you are only targeting Debian, this is easy, because you can just use the simple multi-platform tags we expose (like `6.0`), and you'll always get Debian (when building for Linux containers). If you are targeting Alpine or Ubuntu for your final runtime image (`aspnet` or `runtime`), then you have a choice, as follows:
+For multi-stage Dockerfiles, there are typically at least two tags referenced, an SDK and a runtime tag. You may want to make a conscious choice to make the distros match for those two tags. If you are only targeting Debian, this is easy, because you can just use the simple multi-platform tags we expose (like `9.0`), and you'll always get Debian (when building for Linux containers). If you are targeting Alpine or Ubuntu for your final runtime image (`aspnet` or `runtime`), then you have a choice, as follows:
 
-* Target a multi-platform tag for the SDK (like `6.0`) to make the SDK stage simple and to enable your Dockerfile to be built in multiple environments (with different processor architectures). This is what most of the samples Dockerfiles in this repo do.
+* Target a multi-platform tag for the SDK (like `9.0`) to make the SDK stage simple and to enable your Dockerfile to be built in multiple environments (with different processor architectures). This is what most of the samples Dockerfiles in this repo do.
 * Match SDK and runtime tags to ensure that you are using the same OS (with the associated shell and commands) and package manager for all stages within a Dockerfile.
 
 ## Building for your production environment


### PR DESCRIPTION
Of note:

- I updated the "Determining License and Source Pedigree for .NET Container Images" instructions for distroless images since I needed to update that command output anyways.
- Updated ASP.NET port selection documentation

Remaining to do (I will update this PR):

- [x] `samples/kubernetes` directory
- [x] `samples/selecting-tags.md`