### PR TITLE
Merge main to nightly

### DIFF
--- a/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
@@ -17,8 +17,6 @@ resources:
 
 variables:
 - template: variables/core.yml
-- name: publishEolAnnotations
-  value: true
 
 stages:
 - template: stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-nightly-pr.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr.yml
@@ -21,8 +21,6 @@ resources:
 
 variables:
 - template: variables/core.yml
-- name: publishEolAnnotations
-  value: true
 
 stages:
 - template: stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-core-nightly.yml
+++ b/eng/pipelines/dotnet-core-nightly.yml
@@ -22,8 +22,6 @@ variables:
 - name: officialBranches
   # comma-delimited list of branch names
   value: nightly
-- name: publishEolAnnotations
-  value: true
 
 extends:
   template: /eng/common/templates/1es-official.yml@self

--- a/eng/pipelines/variables/core.yml
+++ b/eng/pipelines/variables/core.yml
@@ -6,8 +6,7 @@ variables:
 
 - name: manifest
   value: manifest.json
-
+- name: publishEolAnnotations
+  value: true
 - name: generateEolAnnotationDataExtraOptions
-  value: ""
-  # TODO: Temporary workaround: see https://github.com/dotnet/docker-tools/issues/1507
-  #value: "--annotate-eol-products"
+  value: "--annotate-eol-products"


### PR DESCRIPTION
This also cleans up usage of `publishEolAnnotations` in nightly pipeline. These are obsolete now that it's incorporated into `core.yml` which is referenced by all those pipelines.