### PR TITLE
Update selecting tags documentation

### DIFF
--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -52,18 +52,21 @@ They include:
 - Debian, unless specified (like `8.0-alpine`).
 - All [supported architectures](supported-platforms.md#architectures).
 
-> [!NOTE]
-> Since .NET 8, these multi-platform tags **specifically exclude all Windows versions** due to `containerd`'s platform matching algorithm for Windows hosts.
-
-Please see [#4492 (Switch multi-platform tags to Linux only)](https://github.com/dotnet/dotnet-docker/issues/4492) for more context.
-If you are using Windows, you will need to explicitly specify an OS Version with a single-platform tag like so:
-
-```Dockerfile
-FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022
-FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-1809
-FROM mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2019
-FROM mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2022
-```
+> [!WARNING]
+> These multi-platform tags **specifically exclude all Windows versions** due
+> to `containerd`'s platform matching algorithm for Windows hosts. See
+> [containerd/containerd#6508](https://github.com/containerd/containerd/issues/6508)
+> for more context.
+>
+> If you are using Windows, you will need to explicitly specify an OS Version
+> with a single-platform tag like so:
+>
+> ```Dockerfile
+> FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022
+> FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-1809
+> FROM mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2019
+> FROM mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2022
+> ```
 
 ### `<Major.Minor.Patch .NET Version>-<OS version>`
 

--- a/documentation/supported-tags.md
+++ b/documentation/supported-tags.md
@@ -56,6 +56,7 @@ They include:
 > These multi-platform tags **specifically exclude all Windows versions** due
 > to `containerd`'s platform matching algorithm for Windows hosts. See
 > [containerd/containerd#6508](https://github.com/containerd/containerd/issues/6508)
+> and [dotnet/dotnet-docker#4492](https://github.com/dotnet/dotnet-docker/issues/4492)
 > for more context.
 >
 > If you are using Windows, you will need to explicitly specify an OS Version

--- a/documentation/vulnerability-reporting.md
+++ b/documentation/vulnerability-reporting.md
@@ -327,7 +327,6 @@ Those are unrelated packages that happen to contain the same name as the vulnera
 We can't take any action if a fixed version of the package isn't available from the package repository of the Linux distro version.
 Sometimes fixes aren't ever made available because they are low severity or not applicable in container environments.
 Questions on this matter should be directed to the relevant Linux distro.
-If you're not already using [Alpine Linux](../samples/selecting-tags.md#alpine), you may want to consider using it instead because of its security focus and low number of vulnerabilities.
 
 ### L. Is the package in the Linux distro base image?
 

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -71,7 +71,7 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Support         | [Alpine Linux Community](https://alpinelinux.org/community/)       |
 | Package manager | `apk`                                                              |
 
-#### [Azure Linux](https://azure.microsoft.com/en-us/services/linux/)
+#### [Azure Linux](https://github.com/microsoft/azurelinux)
 
 * Supported by Microsoft.
 * Azure Linux .NET images are full-featured by default, but with the option for

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -6,17 +6,10 @@ You can use the referenced images and tags with the docker CLI, for example with
 
 ## .NET Docker repos
 
-There are multiple [.NET Docker repos](../README.md) that expose various layers of the .NET platform.
-
-* [dotnet/runtime-deps](../README.runtime-deps.md) -- Linux-only images that contains the native dependencies of .NET. Best used for self-contained applications.
-* [dotnet/runtime](../README.runtime.md) -- Images that contains the .NET runtime. Best used for console applications. On Linux, depends on the `runtime-deps` image.
-* [dotnet/aspnet](../README.aspnet.md) -- Images that contains the ASP.NET Core runtime. Best used for web applications and services. Depends on the `runtime` image.
-* [dotnet/sdk](../README.sdk.md) -- An image that contains the .NET SDK (which includes tools and all runtimes). Best used for building and testing applications. Depends on [buildpack-deps](https://hub.docker.com/_/buildpack-deps) for Debian and Ubuntu, on [dotnet/aspnet](../README.aspnet.md) for Alpine and on [windows/nanoserver](https://mcr.microsoft.com/en-us/product/windows/nanoserver/about) for Windows.
-
-The repos above are commonly used on the command line and in Dockerfiles. There are two more repos that may be useful to you:
-
-* [dotnet/nightly](https://github.com/dotnet/dotnet-docker/blob/nightly/README.md) -- A duplicate structure of repos which contain the latest pre-released versions of .NET. (which are not supported in production).
-* [dotnet/samples](../README.samples.md) -- A set of samples that demonstrate .NET being used in console and web scenarios.
+There are multiple [.NET Docker repos](../README.md) that expose various layers
+of the .NET platform. They can be found under [Featured Repos](/README.md#featured-repos).
+Other repos, including preview (nightly) .NET images, can be found under
+[Related Repos](/README.md#related-repositories).
 
 ## Targeting a specific operating system
 

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -34,13 +34,14 @@ more info.
 
 ## Targeting a specific operating system
 
-If you want a specific operating system image, you should use a specific operating system tag. We publish images for [Alpine](#alpine), [Debian](#debian), [Ubuntu](#ubuntu), [Windows Nano Server](#nano-server), and [Windows Server Core](#windows-server-core).
+If you want a specific operating system image, you should use a specific operating system tag. We publish images for [Alpine](#alpine-linux), [Azure Linux](#azure-linux), [Debian](#debian), [Ubuntu](#ubuntu), [Windows Nano Server](#nano-server), and [Windows Server Core](#windows-server-core).
 
 The following tags demonstrate the pattern used to describe each operating system (using .NET 9.0 as the example):
 
 * `9.0-alpine` (Latest Alpine)
-* `9.0-noble` (Ubuntu 24.04)
+* `9.0-azurelinux3.0` (Azure Linux 3.0)
 * `9.0-bookworm-slim` (Debian 12)
+* `9.0-noble` (Ubuntu 24.04)
 * `9.0-nanoserver-ltsc2022` (Nano Server LTSC 2022)
 * `9.0-nanoserver-1809` (Nano Server, version 1809)
 * `9.0-windowsservercore-ltsc2022` (Windows Server Core LTSC 2022)
@@ -54,25 +55,59 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 
 ### Linux
 
-#### [Debian](https://www.debian.org)
+#### [Alpine Linux](https://alpinelinux.org/)
 
-* When targeting Linux containers, Debian is the default Linux distro for all tags that do not specify an OS. For example, `latest`, `9.0`, and `9.0.0` will all provide a Debian image.
-* Very stable.
+* The smallest .NET images that still contain a package manager and shell.
+* Security-oriented, lightweight distro based on [musl
+  libc](https://wiki.musl-libc.org/functional-differences-from-glibc.html) and
+  busybox.
+* Does not support globalization by default. See [enabling globalization
+  functionality](./enable-globalization.md) for more info.
 
-#### [Ubuntu](https://ubuntu.com)
+|                 |                                                                    |
+|-----------------|--------------------------------------------------------------------|
+| Releases        | [Every 6 months](https://alpinelinux.org/releases/)                |
+| Security        | [Alpine Linux Security Tracker](https://security.alpinelinux.org/) |
+| Support         | [Alpine Linux Community](https://alpinelinux.org/community/)       |
+| Package manager | `apk`                                                              |
 
-* Shares Debian's codebase.
-* Feature-rich.
-* Less stable compared to Debian.
+#### [Azure Linux](https://azure.microsoft.com/en-us/services/linux/)
 
-#### [Alpine](https://www.alpinelinux.org)
+* Supported by Microsoft.
+* Azure Linux .NET images are full-featured by default, but with the option for
+  [distroless images](/documentation/distroless.md).
 
-* Security-oriented and lightweight.
-* Uses [musl instead of glibc](https://wiki.musl-libc.org/functional-differences-from-glibc.html) which may have incompatibility with your software.
+|                 |                                                                                            |
+|-----------------|--------------------------------------------------------------------------------------------|
+| Releases        | Approximately every 2 years                                                                |
+| Security        | [Azure Linux Vulnerability Data](https://github.com/microsoft/AzureLinuxVulnerabilityData) |
+| Support         | [Azure Linux GitHub repo](https://github.com/microsoft/azurelinux/issues)                  |
+| Package manager | `tdnf`                                                                                     |
 
-<a name="alpine-globalization">Globalization Support</a>:
+#### [Debian](https://www.debian.org/)
 
-By default, the `icu-libs` package is not included and the [globalization invariant mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md) is enabled. You can opt into globalization support by [following the pattern shown in the sample Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.alpine-icu).
+* Stability-focused, extensive package repository.
+* Full featured .NET images including many packages.
+
+|                 |                                                                 |
+|-----------------|-----------------------------------------------------------------|
+| Releases        | [Approximately every 2 years](https://www.debian.org/releases/) |
+| Security        | [Debian Security Information](https://www.debian.org/security/) |
+| Support         | [Debian User Support](https://www.debian.org/support)           |
+| Package manager | `apt`                                                           |
+
+#### [Ubuntu](https://ubuntu.com/)
+
+* User-friendly, extensive documentation, strong community.
+* Full featured .NET images including many packages, with the option for
+  [Ubuntu Chiseled (distroless)](/documentation/ubuntu-chiseled.md) images.
+
+|                 |                                                                      |
+|-----------------|----------------------------------------------------------------------|
+| Releases        | [LTS releases every 2 years](https://ubuntu.com/about/release-cycle) |
+| Security        | [Ubuntu Security Information](https://ubuntu.com/security/cves)      |
+| Support         | [Ubuntu support](https://ubuntu.com/support)<br> [Launchpad](https://bugs.launchpad.net/ubuntu)<br> [Discourse](https://discourse.ubuntu.com/) |
+| Package manager | `apt`                                                                |
 
 ### Windows
 

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -69,6 +69,7 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Releases        | [Every 6 months](https://alpinelinux.org/releases/)                |
 | Security        | [Alpine Linux Security Tracker](https://security.alpinelinux.org/) |
 | Support         | [Alpine Linux Community](https://alpinelinux.org/community/)       |
+| Package format  | `.apk`                                                             |
 | Package manager | `apk`                                                              |
 
 #### [Azure Linux](https://github.com/microsoft/azurelinux)
@@ -82,6 +83,7 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Releases        | Approximately every 2 years                                                                |
 | Security        | [Azure Linux Vulnerability Data](https://github.com/microsoft/AzureLinuxVulnerabilityData) |
 | Support         | [Azure Linux GitHub repo](https://github.com/microsoft/azurelinux/issues)                  |
+| Package format  | `.rpm`                                                                                     |
 | Package manager | `tdnf`                                                                                     |
 
 #### [Debian](https://www.debian.org/)
@@ -94,7 +96,8 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Releases        | [Approximately every 2 years](https://www.debian.org/releases/) |
 | Security        | [Debian Security Information](https://www.debian.org/security/) |
 | Support         | [Debian User Support](https://www.debian.org/support)           |
-| Package manager | `apt`                                                           |
+| Package format  | `.deb`                                                          |
+| Package manager | `apt`/ `dpkg`                                                   |
 
 #### [Ubuntu](https://ubuntu.com/)
 
@@ -107,7 +110,8 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Releases        | [LTS releases every 2 years](https://ubuntu.com/about/release-cycle) |
 | Security        | [Ubuntu Security Information](https://ubuntu.com/security/cves)      |
 | Support         | [Ubuntu support](https://ubuntu.com/support)<br> [Launchpad](https://bugs.launchpad.net/ubuntu)<br> [Discourse](https://discourse.ubuntu.com/) |
-| Package manager | `apt`                                                                |
+| Package format  | `.deb`                                                               |
+| Package manager | `apt`/ `dpkg`                                                        |
 
 ### Windows
 

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -57,13 +57,6 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 
 #### [Alpine Linux](https://alpinelinux.org/)
 
-* The smallest .NET images that still contain a package manager and shell.
-* Security-oriented, lightweight distro based on [musl
-  libc](https://wiki.musl-libc.org/functional-differences-from-glibc.html) and
-  busybox.
-* Does not support globalization by default. See [enabling globalization
-  functionality](./enable-globalization.md) for more info.
-
 |                 |                                                                    |
 |-----------------|--------------------------------------------------------------------|
 | Releases        | [Every 6 months](https://alpinelinux.org/releases/)                |
@@ -72,11 +65,12 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Package format  | `.apk`                                                             |
 | Package manager | `apk`                                                              |
 
-#### [Azure Linux](https://github.com/microsoft/azurelinux)
+| Supported .NET Features |                            |
+|-------------------------|----------------------------|
+| [Globalization]         | Invariant mode by default.<br>Globalization supported with `-extra` image variant. |
+| [Distroless Images]     | Yes                        |
 
-* Supported by Microsoft.
-* Azure Linux .NET images are full-featured by default, but with the option for
-  [distroless images](/documentation/distroless.md).
+#### [Azure Linux](https://github.com/microsoft/azurelinux)
 
 |                 |                                                                                            |
 |-----------------|--------------------------------------------------------------------------------------------|
@@ -85,6 +79,11 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Support         | [Azure Linux GitHub repo](https://github.com/microsoft/azurelinux/issues)                  |
 | Package format  | `.rpm`                                                                                     |
 | Package manager | `tdnf`                                                                                     |
+
+| Supported .NET Features |                                 |
+|-------------------------|---------------------------------|
+| [Globalization]         | Yes, for non-distroless images.<br>Globalization supported in distroless images with `-extra` image variant. |
+| [Distroless Images]     | No                              |
 
 #### [Debian](https://www.debian.org/)
 
@@ -99,11 +98,12 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Package format  | `.deb`                                                          |
 | Package manager | `apt`/ `dpkg`                                                   |
 
-#### [Ubuntu](https://ubuntu.com/)
+| Supported .NET Features |     |
+|-------------------------|-----|
+| [Globalization]         | Yes |
+| [Distroless Images]     | No  |
 
-* User-friendly, extensive documentation, strong community.
-* Full featured .NET images including many packages, with the option for
-  [Ubuntu Chiseled (distroless)](/documentation/ubuntu-chiseled.md) images.
+#### [Ubuntu](https://ubuntu.com/)
 
 |                 |                                                                      |
 |-----------------|----------------------------------------------------------------------|
@@ -112,6 +112,14 @@ docker pull mcr.microsoft.com/dotnet/runtime:9.0-alpine
 | Support         | [Ubuntu support](https://ubuntu.com/support)<br> [Launchpad](https://bugs.launchpad.net/ubuntu)<br> [Discourse](https://discourse.ubuntu.com/) |
 | Package format  | `.deb`                                                               |
 | Package manager | `apt`/ `dpkg`                                                        |
+
+| Supported .NET Features |                                                            |
+|-------------------------|------------------------------------------------------------|
+| [Globalization]           | Yes, for non-Chiseled images.<br>Globalization supported in Chiseled images with `-extra` image variant. |
+| [Distroless Images]     | Yes - [Ubuntu Chiseled](/documentation/ubuntu-chiseled.md) |
+
+[Globalization]: ./enable-globalization.md
+[Distroless Images]: /documentation/distroless.md
 
 ### Windows
 

--- a/samples/selecting-tags.md
+++ b/samples/selecting-tags.md
@@ -11,6 +11,27 @@ of the .NET platform. They can be found under [Featured Repos](/README.md#featur
 Other repos, including preview (nightly) .NET images, can be found under
 [Related Repos](/README.md#related-repositories).
 
+## Default Linux tags
+
+The `runtime-deps`, `runtime`, `aspnet`, and `sdk` repos provide version-only
+manifest list tags. These tags can sometimes be referred to as "convenience
+tags".
+
+* `9.0`
+* `9.0.X`
+* `latest`
+
+For .NET 8 and .NET 9, these tags refer to Debian 12 (Bookworm). All three
+of the above tags will provide a Debian image.
+
+> [!CAUTION]
+> For .NET 10 and subsequent releases, [these tags will refer to Ubuntu 24.04
+> ("Noble")](https://github.com/dotnet/dotnet-docker/discussions/5709).
+
+These convenience tags don't support Windows. See the [Multi-Platform
+Tags](/documentation/supported-tags.md#multi-platform-tags) documentation for
+more info.
+
 ## Targeting a specific operating system
 
 If you want a specific operating system image, you should use a specific operating system tag. We publish images for [Alpine](#alpine), [Debian](#debian), [Ubuntu](#ubuntu), [Windows Nano Server](#nano-server), and [Windows Server Core](#windows-server-core).


### PR DESCRIPTION
Attempting to fix [Define doc providing guidance on Linux distros (#5063)](https://github.com/dotnet/dotnet-docker/issues/5063) while also cleaning up some stale documentation at the same time.

Related: [Remove .NET 6 references from documentation (#6101)](https://github.com/dotnet/dotnet-docker/pull/6101)
