### PR TITLE
Add NLS test scenario

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [WindowsImageTheory]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyNLSScenario(ProductImageData imageData) =>
-            await VerifyNLSScenarioBase(imageData);
+            await VerifyNlsScenarioBase(imageData);
 
         [DotNetTheory]
         [MemberData(nameof(GetImageData))]

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -35,6 +35,11 @@ namespace Microsoft.DotNet.Docker.Tests
         public async Task VerifyGlobalizationScenario(ProductImageData imageData) =>
             await VerifyGlobalizationScenarioBase(imageData);
 
+        [WindowsImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public async Task VerifyNLSScenario(ProductImageData imageData) =>
+            await VerifyNLSScenarioBase(imageData);
+
         [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ProductImageData imageData)

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -82,5 +82,11 @@ namespace Microsoft.DotNet.Docker.Tests
             using var testScenario = new GlobalizationScenario(imageData, ImageRepo, DockerHelper);
             await testScenario.ExecuteAsync();
         }
+
+        protected async Task VerifyNLSScenarioBase(ProductImageData imageData)
+        {
+            using var testScenario = new NLSScenario(imageData, ImageRepo, DockerHelper);
+            await testScenario.ExecuteAsync();
+        }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Docker.Tests
             await testScenario.ExecuteAsync();
         }
 
-        protected async Task VerifyNLSScenarioBase(ProductImageData imageData)
+        protected async Task VerifyNlsScenarioBase(ProductImageData imageData)
         {
             using var testScenario = new NLSScenario(imageData, ImageRepo, DockerHelper);
             await testScenario.ExecuteAsync();

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         protected async Task VerifyNlsScenarioBase(ProductImageData imageData)
         {
-            using var testScenario = new NLSScenario(imageData, ImageRepo, DockerHelper);
+            using var testScenario = new NlsScenario(imageData, ImageRepo, DockerHelper);
             await testScenario.ExecuteAsync();
         }
     }

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -26,8 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="TestAppArtifacts\GlobalizationTest.cs" />
-    <Compile Remove="TestAppArtifacts\UnitTests.cs" />
+    <Compile Remove="TestAppArtifacts/*.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [WindowsImageTheory]
         [MemberData(nameof(GetImageData))]
         public async Task VerifyNLSScenario(ProductImageData imageData) =>
-            await VerifyNLSScenarioBase(imageData);
+            await VerifyNlsScenarioBase(imageData);
 
         [DotNetTheory]
         [MemberData(nameof(GetImageData))]

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -47,6 +47,11 @@ namespace Microsoft.DotNet.Docker.Tests
         public async Task VerifyGlobalizationScenario(ProductImageData imageData) =>
             await VerifyGlobalizationScenarioBase(imageData);
 
+        [WindowsImageTheory]
+        [MemberData(nameof(GetImageData))]
+        public async Task VerifyNLSScenario(ProductImageData imageData) =>
+            await VerifyNLSScenarioBase(imageData);
+
         [DotNetTheory]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ProductImageData imageData)

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NLSTest.Dockerfile
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NLSTest.Dockerfile
@@ -1,0 +1,15 @@
+ARG sdk_image
+ARG runtime_image
+
+FROM ${sdk_image} AS sdk
+RUN dotnet new console -n App -o /src --no-restore
+WORKDIR /src
+COPY NLSTest.cs /src/Program.cs
+RUN dotnet restore
+RUN dotnet publish --no-restore -o /app
+
+FROM ${runtime_image} AS runtime
+ARG icu_expected
+ENV ICU_EXPECTED=${icu_expected}
+COPY --from=sdk /app /app/
+ENTRYPOINT ["/app/App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NLSTest.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NLSTest.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using static System.Console;
+
+const string nlsVar = "DOTNET_SYSTEM_GLOBALIZATION_USENLS";
+const string icuVar = "ICU_EXPECTED";
+
+GetEnvironmentVariableValue(nlsVar);
+bool icuExpected = GetEnvironmentVariableValue(icuVar);
+
+bool icuMode = ICUMode();
+WriteLine($"Detected ICU mode: {icuMode}");
+
+if (icuMode != icuExpected)
+{
+    throw new Exception($"ICU mode detected as {icuMode}, expected {icuExpected}");
+}
+
+// https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#stringendswith
+Assert(
+    """ "abc".EndsWith("\0")""",
+    "abc".EndsWith("\0").ToString(),
+    icuResult: true.ToString(),
+    nlsResult: false.ToString(),
+    icuMode);
+Assert(
+    """ "abc".EndsWith("\0", StringComparison.CurrentCulture)""",
+    "abc".EndsWith("\0", StringComparison.CurrentCulture).ToString(),
+    icuResult: true.ToString(),
+    nlsResult: false.ToString(),
+    icuMode);
+
+// https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#stringstartswith
+Assert(
+    """ "foo".StartsWith("\0")""",
+    "foo".StartsWith("\0").ToString(),
+    icuResult: true.ToString(),
+    nlsResult: false.ToString(),
+    icuMode);
+Assert(
+    """ "foo".StartsWith("\0", StringComparison.CurrentCulture)""",
+    "foo".StartsWith("\0", StringComparison.CurrentCulture).ToString(),
+    icuResult: true.ToString(),
+    nlsResult: false.ToString(),
+    icuMode);
+
+// https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#stringindexof
+Assert(
+    """ "Hel\0lo".IndexOf("\0")""",
+    "Hel\0lo".IndexOf("\0").ToString(),
+    icuResult: "0",
+    nlsResult: "3",
+    icuMode);
+Assert(
+    """ "Hel\0lo".IndexOf("\0", StringComparison.CurrentCulture)""",
+    "Hel\0lo".IndexOf("\0", StringComparison.CurrentCulture).ToString(),
+    icuResult: "0",
+    nlsResult: "3",
+    icuMode);
+
+WriteLine("All assertions passed!");
+
+// https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
+bool ICUMode()
+{
+    SortVersion sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
+    byte[] bytes = sortVersion.SortId.ToByteArray();
+    int version = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
+    return version != 0 && version == sortVersion.FullVersion;
+}
+
+void Assert(string functionText, string actualResult, string icuResult, string nlsResult, bool icuExpected)
+{
+    string expectedResult = icuExpected ? icuResult : nlsResult;
+    Console.WriteLine($"{functionText} returned {actualResult}");
+    if (actualResult != expectedResult)
+    {
+        throw new Exception($"Assertion failed: {functionText} returned {actualResult}, expected {expectedResult}");
+    }
+}
+
+bool GetEnvironmentVariableValue(string variable)
+{
+    string value = Environment.GetEnvironmentVariable(variable);
+    bool parsedValue = !string.IsNullOrWhiteSpace(value) && bool.Parse(value);
+    WriteLine($"{variable} evaluated to {parsedValue}");
+    return parsedValue;
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NLSTest.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NLSTest.cs
@@ -7,7 +7,7 @@ const string icuVar = "ICU_EXPECTED";
 GetEnvironmentVariableValue(nlsVar);
 bool icuExpected = GetEnvironmentVariableValue(icuVar);
 
-bool icuMode = ICUMode();
+bool icuMode = IsIcuMode();
 WriteLine($"Detected ICU mode: {icuMode}");
 
 if (icuMode != icuExpected)
@@ -60,7 +60,7 @@ Assert(
 WriteLine("All assertions passed!");
 
 // https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
-bool ICUMode()
+bool IsIcuMode()
 {
     SortVersion sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
     byte[] bytes = sortVersion.SortId.ToByteArray();

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
@@ -37,7 +37,7 @@ public sealed class NLSScenario : ITestScenario, IDisposable
     // ICU is not supported on Nano Server
     private bool IsIcuSupported => _imageData.OS.Contains(OS.ServerCore);
 
-    public async Task ExecuteAsync()
+    public Task ExecuteAsync()
     {
         // Setup project in temp dir
         string dockerfilePath = Path.Combine(_tempFolderContext.Path, "Dockerfile");
@@ -75,6 +75,8 @@ public sealed class NLSScenario : ITestScenario, IDisposable
         string justification = $"image {runtimeImage} should{(IsIcuSupported ? "" : " not")} support ICU";
         runImage.Should().NotThrow(because: justification)
             .Which.Should().ContainEquivalentOf("All assertions passed", Exactly.Once());
+
+        return Task.CompletedTask;
     }
 
     public void Dispose() => _tempFolderContext.Dispose();

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
@@ -35,7 +35,7 @@ public sealed class NLSScenario : ITestScenario, IDisposable
     }
 
     // ICU is not supported on Nano Server
-    private bool ICUSupported => _imageData.OS.Contains(OS.ServerCore);
+    private bool IsIcuSupported => _imageData.OS.Contains(OS.ServerCore);
 
     public async Task ExecuteAsync()
     {
@@ -56,9 +56,9 @@ public sealed class NLSScenario : ITestScenario, IDisposable
             $"runtime_image={runtimeImage}",
         ];
 
-        if (ICUSupported)
+        if (IsIcuSupported)
         {
-            buildArgs = [..buildArgs, $"icu_expected={ICUSupported}"];
+            buildArgs = [..buildArgs, $"icu_expected={IsIcuSupported}"];
         }
 
         string tag = nameof(NLSScenario).ToLowerInvariant();
@@ -72,7 +72,7 @@ public sealed class NLSScenario : ITestScenario, IDisposable
         string containerName = ImageData.GenerateContainerName(nameof(NLSScenario));
         Func<string> runImage = () => _dockerHelper.Run(tag, containerName);
 
-        string justification = $"image {runtimeImage} should{(ICUSupported ? "" : " not")} support ICU";
+        string justification = $"image {runtimeImage} should{(IsIcuSupported ? "" : " not")} support ICU";
         runImage.Should().NotThrow(because: justification)
             .Which.Should().NotBeNullOrWhiteSpace()
             .And.ContainEquivalentOf("All assertions passed", Exactly.Once());

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Docker.Tests.TestScenarios;
+
+#nullable enable
+public sealed class NLSScenario : ITestScenario, IDisposable
+{
+    private const string DockerfileName = "NLSTest.Dockerfile";
+
+    private const string TestSourceFileName = "NLSTest.cs";
+
+    private readonly TempFolderContext _tempFolderContext = FileHelper.UseTempFolder();
+
+    private readonly ProductImageData _imageData;
+
+    private readonly DotNetImageRepo _repo;
+
+    private readonly DockerHelper _dockerHelper;
+
+    public NLSScenario(
+        ProductImageData imageData,
+        DotNetImageRepo repo,
+        DockerHelper dockerHelper)
+    {
+        _imageData = imageData;
+        _repo = repo;
+        _dockerHelper = dockerHelper;
+    }
+
+    // ICU is not supported on Nano Server
+    private bool ICUSupported => _imageData.OS.Contains(OS.ServerCore);
+
+    public async Task ExecuteAsync()
+    {
+        // Setup project in temp dir
+        string dockerfilePath = Path.Combine(_tempFolderContext.Path, "Dockerfile");
+        File.Copy(
+            sourceFileName: Path.Combine(DockerHelper.TestArtifactsDir, DockerfileName),
+            destFileName: dockerfilePath);
+        File.Copy(
+            sourceFileName: Path.Combine(DockerHelper.TestArtifactsDir, TestSourceFileName),
+            destFileName: Path.Combine(_tempFolderContext.Path, TestSourceFileName));
+
+        string sdkImage = _imageData.GetImage(DotNetImageRepo.SDK, _dockerHelper);
+        string runtimeImage = _imageData.GetImage(_repo, _dockerHelper);
+        string[] buildArgs =
+        [
+            $"sdk_image={sdkImage}",
+            $"runtime_image={runtimeImage}",
+        ];
+
+        if (ICUSupported)
+        {
+            buildArgs = [..buildArgs, $"icu_expected={ICUSupported}"];
+        }
+
+        string tag = nameof(NLSScenario).ToLowerInvariant();
+        _dockerHelper.Build(
+            tag: tag,
+            dockerfile: dockerfilePath,
+            contextDir: _tempFolderContext.Path,
+            pull: Config.PullImages,
+            buildArgs: buildArgs);
+
+        string containerName = ImageData.GenerateContainerName(nameof(NLSScenario));
+        Func<string> runImage = () => _dockerHelper.Run(tag, containerName);
+
+        string justification = $"image {runtimeImage} should{(ICUSupported ? "" : " not")} support ICU";
+        runImage.Should().NotThrow(because: justification)
+            .Which.Should().NotBeNullOrWhiteSpace()
+            .And.ContainEquivalentOf("All assertions passed", Exactly.Once());
+    }
+
+    public void Dispose() => _tempFolderContext.Dispose();
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NLSScenario.cs
@@ -74,8 +74,7 @@ public sealed class NLSScenario : ITestScenario, IDisposable
 
         string justification = $"image {runtimeImage} should{(IsIcuSupported ? "" : " not")} support ICU";
         runImage.Should().NotThrow(because: justification)
-            .Which.Should().NotBeNullOrWhiteSpace()
-            .And.ContainEquivalentOf("All assertions passed", Exactly.Once());
+            .Which.Should().ContainEquivalentOf("All assertions passed", Exactly.Once());
     }
 
     public void Dispose() => _tempFolderContext.Dispose();

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NlsScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/NlsScenario.cs
@@ -10,7 +10,7 @@ using FluentAssertions;
 namespace Microsoft.DotNet.Docker.Tests.TestScenarios;
 
 #nullable enable
-public sealed class NLSScenario : ITestScenario, IDisposable
+public sealed class NlsScenario : ITestScenario, IDisposable
 {
     private const string DockerfileName = "NLSTest.Dockerfile";
 
@@ -24,7 +24,7 @@ public sealed class NLSScenario : ITestScenario, IDisposable
 
     private readonly DockerHelper _dockerHelper;
 
-    public NLSScenario(
+    public NlsScenario(
         ProductImageData imageData,
         DotNetImageRepo repo,
         DockerHelper dockerHelper)
@@ -61,7 +61,7 @@ public sealed class NLSScenario : ITestScenario, IDisposable
             buildArgs = [..buildArgs, $"icu_expected={IsIcuSupported}"];
         }
 
-        string tag = nameof(NLSScenario).ToLowerInvariant();
+        string tag = nameof(NlsScenario).ToLowerInvariant();
         _dockerHelper.Build(
             tag: tag,
             dockerfile: dockerfilePath,
@@ -69,7 +69,7 @@ public sealed class NLSScenario : ITestScenario, IDisposable
             pull: Config.PullImages,
             buildArgs: buildArgs);
 
-        string containerName = ImageData.GenerateContainerName(nameof(NLSScenario));
+        string containerName = ImageData.GenerateContainerName(nameof(NlsScenario));
         Func<string> runImage = () => _dockerHelper.Run(tag, containerName);
 
         string justification = $"image {runtimeImage} should{(IsIcuSupported ? "" : " not")} support ICU";

--- a/tests/Microsoft.DotNet.Docker.Tests/WindowsImageTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/WindowsImageTheoryAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Docker.Tests;
+
+public class WindowsImageTheoryAttribute : DotNetTheoryAttribute
+{
+    public WindowsImageTheoryAttribute()
+    {
+        if (DockerHelper.IsLinuxContainerModeEnabled)
+        {
+            Skip = "Windows image test not applicable when running in Linux Container mode";
+        }
+    }
+}


### PR DESCRIPTION
- Fixes #6034 

NLS is Windows-only, so I defined a completely separate scenario for it that runs only on Windows.

The test uses the [recommended method](https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu) for determining whether or not we're using ICU, and then validates some of the differences between NLS and ICU behavior based on what it finds.

For now, we will expect that NLS is used on all Nano Server images, and ICU is used on all Windows Server Core images. ICU has been the default on Server Core since .NET 7 and Server Core LTSC 2019. See https://learn.microsoft.com/en-us/dotnet/core/compatibility/globalization/7.0/icu-globalization-api for more context there.