### PR TITLE
Submit separate PRs for each tool's dependency updates

### DIFF
--- a/eng/pipelines/jobs/update-tools.yml
+++ b/eng/pipelines/jobs/update-tools.yml
@@ -1,0 +1,27 @@
+parameters:
+  tools: []
+
+jobs:
+- ${{ each tool in parameters.tools }}:
+  - job: UpdateDependencies_${{ replace(tool, '-', '_') }}
+    displayName: Update ${{ tool }}
+    pool:
+      vmImage: $(defaultLinuxAmd64PoolImage)
+    steps:
+    - powershell: |
+        Import-Module -force $(engPath)/DependencyManagement.psm1
+
+        $args=("9.0" + `
+            " --tool ${{ tool }}" + `
+            " --version-source-name ${{ tool }}" + `
+            " --source-branch nightly" + `
+            " --org dnceng" + `
+            " --project $(System.TeamProject)" + `
+            " --repo $(Build.Repository.Name)" + `
+            " --target-branch $(Get-Branch)")
+
+        echo "##vso[task.setvariable variable=customArgsArray]$($args | ConvertTo-Json -Compress -AsArray)"
+      displayName: Set up args
+    - template: /eng/pipelines/steps/update-dependencies.yml
+      parameters:
+        customArgsArray: "$(customArgsArray)"

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -7,14 +7,19 @@ schedules:
     include:
     - nightly
   always: true
+
 variables:
 - template: ../common/templates/variables/dotnet/common.yml
+
 stages:
 - stage: DotNet
   jobs:
-  - job: UpdateDependencies
-    displayName: Update Dependencies (dotnet/sdk)
+  - job: UpdateDotNet
+    displayName: Update .NET (dotnet/sdk)
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
     - template: steps/update-dotnet-dependencies.yml
+  - template: jobs/update-tools.yml
+    parameters:
+      tools: ["chisel", "rocks-toolbox", "syft", "mingit"]


### PR DESCRIPTION
Fixes #5990 

Each tool will run in a separate job. If one fails, then the others should still run and submit PRs.

https://github.com/dotnet/dotnet-docker/pull/6121 was a test showing that this functionality works.