### PR TITLE
Remove `.vscode` directory from `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 **/bin
 **/obj
 **/out
-**/.vscode
 **/.vs
 .dotnet
 .Microsoft.DotNet.ImageBuilder


### PR DESCRIPTION
There are a couple of checked-in files in the `.vscode` directory now. Because `.vscode` is in `.dockerignore`, when we run update-dependencies in a Docker container, it tries to remove those files. For example: https://github.com/dotnet/dotnet-docker/pull/6126/commits/737bd714ed608bc359d9f30e7e872b0d8589f192