### PR TITLE
Downgrade linkspector GitHub action to Ubuntu 22.04 due to a bug

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   check-markdown-links:
-    runs-on: ubuntu-latest
+    # https://github.com/UmbrellaDocs/action-linkspector/issues/32
+    # Upgrade to `ubuntu-latest` when resolved
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
GitHub Actions recently updated the `ubuntu-latest` runner to 24.04. There is an issue with the linkspector (markdown link check) GH action on 24.04. See https://github.com/UmbrellaDocs/action-linkspector/issues/32.