### PR TITLE
Add snapshot tests for internal Dockerfiles using Verify

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "verify.tool": {
+      "version": "0.6.0",
+      "commands": [
+        "dotnet-verify"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -79,4 +79,4 @@ src/coreclr/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/kn
 src/coreclr/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/knucleotide-input-big.txt text eol=lf
 src/coreclr/tests/src/performance/Scenario/JitBench/Resources/word2vecnet.patch text eol=lf
 
-tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyGeneratedDockerfilesOutput/* -merge linguist-generated=true
+tests/Microsoft.DotNet.Docker.Tests/Baselines/** linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -78,3 +78,5 @@ src/coreclr/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complem
 src/coreclr/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/knucleotide-input.txt text eol=lf
 src/coreclr/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/knucleotide-input-big.txt text eol=lf
 src/coreclr/tests/src/performance/Scenario/JitBench/Resources/word2vecnet.patch text eol=lf
+
+tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyGeneratedDockerfilesOutput/* -merge linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ artifacts/
 
 # ImageBuilder directory
 .Microsoft.DotNet.ImageBuilder
+
+# Verify.Xunit library
+*.received.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ There are several types of [tests](https://github.com/dotnet/dotnet-docker/tree/
     * Scenario tests that run images to validate basic user scenarios.
       For example, use the SDK image to create, build and run a .NET app.
 1. `"pre-build"` tests
-    * Validate that tags adhere to a specific set of rules ([`StaticTagTests.cs`](tests\Microsoft.DotNet.Docker.Tests\StaticTagTests.cs))
+    * Validate that tags adhere to a specific set of rules ([`StaticTagTests.cs`](tests/Microsoft.DotNet.Docker.Tests/StaticTagTests.cs))
     * Verify the state of generated Dockerfile templates (public and internal versions)
 
 When editing Dockerfiles, please ensure the appropriate test changes are also made.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,10 +83,16 @@ The [READMEs](https://github.com/search?q=repo%3Adotnet%2Fdotnet-docker+path%3A*
 
 ### Tests
 
-There are two basic types of [tests](https://github.com/dotnet/dotnet-docker/tree/main/tests) for each of the images produced from this repo.
+There are several types of [tests](https://github.com/dotnet/dotnet-docker/tree/main/tests) in this repo.
 
-1. Unit tests that validate the static state of images.  This includes things like verifing which environment variables are defined.
-1. Scenario tests that validate basic usage scenarios.  For example the SDK image is used to create, build and run a new console app.
+1. Image tests
+    * Unit tests that validate the static state of images, based on their filesystem contents or manifest/image config.
+      This includes things like verifying which environment variables are defined and which packages are installed.
+    * Scenario tests that run images to validate basic user scenarios.
+      For example, use the SDK image to create, build and run a .NET app.
+1. `"pre-build"` tests
+    * Validate that tags adhere to a specific set of rules ([`StaticTagTests.cs`](tests\Microsoft.DotNet.Docker.Tests\StaticTagTests.cs))
+    * Verify the state of generated Dockerfile templates (public and internal versions)
 
 When editing Dockerfiles, please ensure the appropriate test changes are also made.
 
@@ -113,7 +119,21 @@ From the "Run and Debug" sidebar panel, run the "Attach .NET Debugger" launch co
 VS Code will prompt you for a process ID to attach to.
 Type in the PID that was printed to the terminal earlier.
 Now, VS Code is attached to the .NET Debugger.
-You can press F5 (Continue) to start test execution.
+Press F5 (Continue) to start test execution.
+
+#### Verifying Internal Dockerfiles
+
+Internal Dockerfiles are validated using "snapshot" testing, which uses tooling to record and test the accepted state of the Dockerfiles.
+If your changes fail tests due to changes in the internal Dockerfiles, you will need to review the changes before the tests can pass.
+You can use a local dotnet tool to accept or reject the changes.
+
+1. Install local tools: `dotnet tool restore`
+1. Run the failing tests. For example: `.\tests\run-tests.ps1 -Paths "*" -TestCategories "pre-build" -CustomTestFilter "VerifyInternalDockerfilesOutput"`
+1. Review the changes that caused the failing tests: `dotnet tool run dotnet-verify review`.
+   You will be presented with a series of diffs to review, which you can accept or reject.
+   If you accept the changes and check-in the new baselines, the tests will pass.
+   If you reject any changes, you'll need to fix the templates to match the currently accepted baselines.
+1. If there's a large quantity of changes to review, you can blanket accept or reject all changes using `dotnet-verify accept` or `reject` respectively.
 
 ### Metadata Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,13 +86,13 @@ The [READMEs](https://github.com/search?q=repo%3Adotnet%2Fdotnet-docker+path%3A*
 There are several types of [tests](https://github.com/dotnet/dotnet-docker/tree/main/tests) in this repo.
 
 1. Image tests
-    * Unit tests that validate the static state of images, based on their filesystem contents or manifest/image config.
+    - Unit tests that validate the static state of images, based on their filesystem contents or manifest/image config.
       This includes things like verifying which environment variables are defined and which packages are installed.
-    * Scenario tests that run images to validate basic user scenarios.
+    - Scenario tests that run images to validate basic user scenarios.
       For example, use the SDK image to create, build and run a .NET app.
 1. `"pre-build"` tests
-    * Validate that tags adhere to a specific set of rules ([`StaticTagTests.cs`](tests/Microsoft.DotNet.Docker.Tests/StaticTagTests.cs))
-    * Verify the state of generated Dockerfile templates (public and internal versions)
+    - Validate that tags adhere to a specific set of rules ([`StaticTagTests.cs`](tests/Microsoft.DotNet.Docker.Tests/StaticTagTests.cs))
+    - Verify the state of generated Dockerfile templates (public and internal versions)
 
 When editing Dockerfiles, please ensure the appropriate test changes are also made.
 

--- a/eng/dockerfile-templates/Dockerfile.linux.download-file
+++ b/eng/dockerfile-templates/Dockerfile.linux.download-file
@@ -8,7 +8,7 @@
         sha-var-name: Name of variable that stores the checksum
         sha-function: SHA function to use ^
 
-    set isInternal to find(ARGS["url"], "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(ARGS["url"], "artifacts.visualstudio.com") >= 0 ^
     set additionalWgetArgs to when(isInternal, '--header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" ', '') ^
     set additionalCurlArgs to when(isInternal, '-u :$ACCESSTOKEN --basic ', '') ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^

--- a/eng/dockerfile-templates/Dockerfile.windows.download-file
+++ b/eng/dockerfile-templates/Dockerfile.windows.download-file
@@ -8,7 +8,7 @@
         sha-var-name: Name of variable that stores the checksum
         hash-algorithm: Algorithm type to use to get the checksum. Defaults to sha512 ^
 
-    set isInternal to find(ARGS["url"], "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(ARGS["url"], "artifacts.visualstudio.com") >= 0 ^
     set hashAlgorithm to when(ARGS["hash-algorithm"], ARGS["hash-algorithm"], "sha512")
 }}{{if isInternal:`
 $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `

--- a/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
+++ b/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
@@ -1,7 +1,8 @@
 #!/usr/bin/env pwsh
 param(
     [switch]$Validate,
-    [string]$Branch
+    [string]$Branch,
+    [string]$OutputDirectory
 )
 
 Import-Module -force $PSScriptRoot/../DependencyManagement.psm1
@@ -10,13 +11,16 @@ if ($Validate) {
     $customImageBuilderArgs = " --validate"
 }
 
-$repoRoot = (Get-Item "$PSScriptRoot").Parent.Parent.FullName
+if (-Not $OutputDirectory) {
+    $repoRoot = (Get-Item "$PSScriptRoot").Parent.Parent.FullName
+    $OutputDirectory = $repoRoot
+}
 
 $onDockerfilesGenerated = {
     param($ContainerName)
 
     if (-Not $Validate) {
-        Exec "docker cp ${ContainerName}:/repo/src $repoRoot"
+        Exec "docker cp ${ContainerName}:/repo/src $OutputDirectory"
     }
 }
 

--- a/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
+++ b/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
@@ -2,13 +2,20 @@
 param(
     [switch]$Validate,
     [string]$Branch,
-    [string]$OutputDirectory
+    [string]$OutputDirectory,
+    [switch]$IsInternalOverride
 )
 
 Import-Module -force $PSScriptRoot/../DependencyManagement.psm1
 
+$customImageBuilderArgs = ""
+
 if ($Validate) {
-    $customImageBuilderArgs = " --validate"
+    $customImageBuilderArgs += " --validate"
+}
+
+if ($IsInternalOverride) {
+    $customImageBuilderArgs += " --var IsInternal=true"
 }
 
 if (-Not $OutputDirectory) {

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux
@@ -10,7 +10,7 @@
     set isFullAzureLinux to isAzureLinux && !isDistroless ^
     set isDistrolessAzureLinux to isAzureLinux && isDistroless ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
     set isSingleStage to isAlpine && !isInternal ^
     set runtimeDepsVariant to when(ARGS["is-extra"], "-extra", "") ^
     set tagVersion to when(dotnetVersion = "8.0",

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
@@ -6,7 +6,7 @@
     set isFullAzureLinux to isAzureLinux && !isDistroless ^
     set isDistrolessAzureLinux to isAzureLinux && isDistroless ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
     set isSingleStage to isAlpine && !isInternal ^
     set runtimeDepsVariant to when(ARGS["is-extra"], "-extra", "") ^
     set tagVersion to when(dotnetVersion = "8.0",

--- a/eng/dockerfile-templates/aspnet/Dockerfile.windows
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.windows
@@ -3,7 +3,7 @@
     set isServerCore to find(OS_VERSION, "windowsservercore") >= 0 ^
 
     set dotnetBaseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
     set isSingleStage to (find(OS_VERSION, "windowsservercore") >= 0 && !isInternal) ^
 
     set installerStageFromImage to cat("mcr.microsoft.com/windows/servercore:", OS_VERSION_NUMBER, "-amd64") ^

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -12,7 +12,7 @@
     set isAzureLinux to isCblMariner || defined(match(OS_VERSION, "^azurelinux\d+\.\d+$")) ^
 
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
 
     set baseImageRepo to when(isAlpine,
         cat(ARCH_VERSIONED, "/alpine"),

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -10,7 +10,7 @@
     set isFullAzureLinux to isAzureLinux && !isDistroless ^
     set isDistrolessAzureLinux to isAzureLinux && isDistroless ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
     set isSingleStage to isAlpine && !isInternal ^
     set runtimeDepsVariant to when(ARGS["is-extra"], "-extra", "") ^
     set tagVersion to VARIABLES[cat("dotnet|", dotnetVersion, "|fixed-tag")] ^

--- a/eng/dockerfile-templates/runtime/Dockerfile.windows
+++ b/eng/dockerfile-templates/runtime/Dockerfile.windows
@@ -4,7 +4,7 @@
     set isServer2025 to find(OS_VERSION_NUMBER, "2025") >= 0 ^
 
     set dotnetBaseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
     set isSingleStage to (find(OS_VERSION, "windowsservercore") >= 0 && !isInternal) ^
 
     set installerStageRepo to cat("mcr.microsoft.com/windows/", "servercore") ^

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -4,7 +4,7 @@
     set isMariner to find(OS_VERSION, "cbl-mariner") >= 0 ^
     set isAzureLinux to isMariner || find(OS_VERSION, "azurelinux") >= 0 ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
     set tagVersion to VARIABLES[cat("dotnet|", dotnetVersion, "|fixed-tag")] ^
     set baseImageTag to cat("$REPO:", tagVersion, "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
 

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows
@@ -1,7 +1,7 @@
 {{
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to VARIABLES["IsInternal"] || find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
     set isSingleStage to (find(OS_VERSION, "windowsservercore") >= 0 && !isInternal) ^
 
     set installerStageFromImage to cat("mcr.microsoft.com/windows/servercore:", OS_VERSION_NUMBER, "-amd64") ^

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspire-dashboard/9.0/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspire-dashboard/9.0/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,35 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        unzip \
+    && tdnf clean all
+
+# Retrieve Aspire Dashboard
+RUN dotnet_aspire_version=0.0.0-preview.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip" \
+    && aspire_dashboard_sha512='{sha512_placeholder}' \
+    && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
+    && mkdir -p /app \
+    && unzip aspire_dashboard.zip -d /app \
+    && rm aspire_dashboard.zip
+
+
+# Aspire Dashboard image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Aspire Dashboard environment variables
+    ASPNETCORE_URLS=http://+:18888 \
+    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://+:18889 \
+    DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://+:18890
+
+ENTRYPOINT [ "dotnet", "/app/Aspire.Dashboard.dll" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspire-dashboard/9.0/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspire-dashboard/9.0/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,35 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        unzip \
+    && tdnf clean all
+
+# Retrieve Aspire Dashboard
+RUN dotnet_aspire_version=0.0.0-preview.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip" \
+    && aspire_dashboard_sha512='{sha512_placeholder}' \
+    && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
+    && mkdir -p /app \
+    && unzip aspire_dashboard.zip -d /app \
+    && rm aspire_dashboard.zip
+
+
+# Aspire Dashboard image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Aspire Dashboard environment variables
+    ASPNETCORE_URLS=http://+:18888 \
+    DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://+:18889 \
+    DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://+:18890
+
+ENTRYPOINT [ "dotnet", "/app/Aspire.Dashboard.dll" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20-composite/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20-composite/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-bookworm-slim-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-bookworm-slim-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-bookworm-slim-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-cbl-mariner2.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-cbl-mariner2.0-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-cbl-mariner2.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-cbl-mariner2.0-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-jammy-chiseled-extra-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-jammy-chiseled-extra-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-jammy-chiseled-extra-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-jammy-chiseled-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-jammy-chiseled-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-jammy-chiseled-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-chiseled-extra-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-chiseled-extra-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-chiseled-extra-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-chiseled-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-chiseled-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-chiseled-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/jammy/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-jammy-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-nanoserver-1809
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-nanoserver-ltsc2022
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-nanoserver-ltsc2025
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-windowsservercore-ltsc2019
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-windowsservercore-ltsc2022
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/8.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-windowsservercore-ltsc2025
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20-composite/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20-composite/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,28 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,40 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,30 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-bookworm-slim-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-bookworm-slim-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-bookworm-slim-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-nanoserver-1809
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-nanoserver-ltsc2022
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-nanoserver-ltsc2025
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-amd64
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-arm32v7
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-composite/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,34 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Composite Runtime
+RUN aspnetcore_version=0.0.0  \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# ASP.NET Composite Image
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
+
+ENV \
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0 \
+    # ASP.NET Core version
+    ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,24 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf aspnetcore.tar.gz -C /dotnet ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-amd64
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-arm32v7
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve ASP.NET Core
+RUN aspnetcore_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && aspnetcore_sha512='{sha512_placeholder}' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && tar -oxzf aspnetcore.tar.gz ./shared/Microsoft.AspNetCore.App \
+    && rm aspnetcore.tar.gz
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-noble-arm64v8
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-windowsservercore-ltsc2019
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-windowsservercore-ltsc2022
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/aspnet/9.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,38 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install ASP.NET Core Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $aspnetcore_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $aspnetcore_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet/shared/Microsoft.AspNetCore.App; `
+        tar -oxzf aspnetcore.zip -C dotnet ./shared/Microsoft.AspNetCore.App; `
+        Remove-Item -Force aspnetcore.zip
+
+
+# ASP.NET Core image
+FROM $REPO:0.0.0-windowsservercore-ltsc2025
+
+# ASP.NET Core version
+ENV ASPNET_VERSION=0.0.0
+
+COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-jammy-chiseled-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.0/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-jammy-chiseled-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-jammy-chiseled-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,44 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-jammy-chiseled-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/9.0/azurelinux-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/9.0/azurelinux-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/9.0/azurelinux-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor-base/9.0/azurelinux-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,50 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor Base
+RUN dotnet_monitor_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_base_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-base.tar.gz -C /app \
+    && rm dotnet-monitor-base.tar.gz
+
+
+# .NET Monitor Base image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
+
+WORKDIR /app
+COPY --from=installer /app .
+
+ENV \
+    # Unset ASPNETCORE_HTTP_PORTS from aspnet base image
+    ASPNETCORE_HTTP_PORTS= \
+    # Disable debugger and profiler diagnostics to avoid diagnosing self.
+    COMPlus_EnableDiagnostics=0 \
+    # Default Filter
+    DefaultProcess__Filters__0__Key=ProcessId \
+    DefaultProcess__Filters__0__Value=1 \
+    # Remove Unix Domain Socket before starting diagnostic port server
+    DiagnosticPort__DeleteEndpointOnStartup=true \
+    # Server GC mode
+    DOTNET_gcServer=1 \
+    # Logging: JSON format so that analytic platforms can get discrete entry information
+    Logging__Console__FormatterName=json \
+    # Logging: Use round-trip date/time format without timezone information (always logged in UTC)
+    Logging__Console__FormatterOptions__TimestampFormat=yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z' \
+    # Logging: Write timestamps using UTC offset (+0:00)
+    Logging__Console__FormatterOptions__UseUtcTimestamp=true \
+    # Add dotnet-monitor path to front of PATH for easier, prioritized execution
+    PATH="/app:${PATH}"
+
+ENTRYPOINT [ "dotnet-monitor" ]
+CMD [ "collect", "--urls", "https://+:52323", "--metricUrls", "http://+:52325" ]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-cbl-mariner-distroless-amd64
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-cbl-mariner-distroless-arm64v8
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,26 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-ubuntu-chiseled-amd64
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,26 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-ubuntu-chiseled-arm64v8
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/cbl-mariner-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-alpha.1-cbl-mariner-distroless-amd64
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/cbl-mariner-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-alpha.1-cbl-mariner-distroless-arm64v8
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,26 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-alpha.1-ubuntu-chiseled-amd64
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,26 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-alpha.1-ubuntu-chiseled-arm64v8
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/9.0/azurelinux-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/9.0/azurelinux-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-amd64
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/9.0/azurelinux-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/monitor/9.0/azurelinux-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,32 @@
+ARG REPO=mcr.microsoft.com/dotnet/monitor/base
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Monitor extensions
+RUN dotnet_monitor_extension_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
+    \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://builds.dotnet.microsoft.com/dotnet/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
+    \
+    && mkdir -p /app \
+    && tar -oxzf dotnet-monitor-egress-azureblobstorage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-azureblobstorage.tar.gz \
+    && tar -oxzf dotnet-monitor-egress-s3storage.tar.gz -C /app \
+    && rm dotnet-monitor-egress-s3storage.tar.gz
+
+
+# .NET Monitor image
+FROM $REPO:0.0.0-arm64v8
+
+COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM amd64/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-aot/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-aot/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm32v7/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm64v8/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,49 @@
+FROM amd64/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,49 @@
+FROM arm32v7/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,49 @@
+FROM arm64v8/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM amd64/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm32v7/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm64v8/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM amd64/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-aot/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-aot/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm32v7/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm64v8/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,49 @@
+FROM amd64/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,49 @@
+FROM arm32v7/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,49 @@
+FROM arm64v8/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM amd64/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm32v7/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm64v8/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        zlib
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN tdnf install -y \
+        ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all
+
+
+FROM base AS installer
+
+RUN tdnf install -y \
+        shadow-utils \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN tdnf install -y \
+        shadow-utils \
+    && groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && tdnf autoremove -y \
+        shadow-utils \
+    && tdnf clean all \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN tdnf install -y \
+        ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all
+
+
+FROM base AS installer
+
+RUN tdnf install -y \
+        shadow-utils \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN tdnf install -y \
+        shadow-utils \
+    && groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && tdnf autoremove -y \
+        shadow-utils \
+    && tdnf clean all \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM amd64/debian:bookworm-slim AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu72 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM arm32v7/debian:bookworm-slim AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu72 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM arm64v8/debian:bookworm-slim AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu72 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER app

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER app

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER app

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER app

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER app

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,73 @@
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=2.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        zlib \
+    && tdnf clean all --releasever=2.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER app

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,51 @@
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN tdnf install -y \
+        ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all
+
+
+FROM base AS installer
+
+RUN tdnf install -y \
+        shadow-utils \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,51 @@
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN tdnf install -y \
+        ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+        zlib \
+    && tdnf clean all
+
+
+FROM base AS installer
+
+RUN tdnf install -y \
+        shadow-utils \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM amd64/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-aot/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-aot/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM arm32v7/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM arm64v8/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,57 @@
+FROM amd64/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu70_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            tzdata_zoneinfo \
+            tzdata_zoneinfo-icu \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,57 @@
+FROM arm32v7/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu70_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            tzdata_zoneinfo \
+            tzdata_zoneinfo-icu \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,57 @@
+FROM arm64v8/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu70_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            tzdata_zoneinfo \
+            tzdata_zoneinfo-icu \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM amd64/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM arm32v7/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM arm64v8/buildpack-deps:jammy-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-22.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3_libs \
+            libstdc++6_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM ubuntu.azurecr.io/ubuntu:jammy AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu70 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM ubuntu.azurecr.io/ubuntu:jammy AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu70 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/jammy/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM ubuntu.azurecr.io/ubuntu:jammy AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu70 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM amd64/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM arm64v8/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,57 @@
+FROM amd64/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu74_libs \
+            libssl3t64_libs \
+            libstdc++6_libs \
+            tzdata-legacy_zoneinfo \
+            tzdata_zoneinfo \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,57 @@
+FROM arm64v8/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu74_libs \
+            libssl3t64_libs \
+            libstdc++6_libs \
+            tzdata-legacy_zoneinfo \
+            tzdata_zoneinfo \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM amd64/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs \
+            libstdc++6_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM arm64v8/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs \
+            libstdc++6_libs \
+            zlib1g_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,53 @@
+FROM ubuntu.azurecr.io/ubuntu:noble AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu74 \
+        libssl3t64 \
+        libstdc++6 \
+        tzdata \
+        tzdata-legacy \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/8.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,53 @@
+FROM ubuntu.azurecr.io/ubuntu:noble AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu74 \
+        libssl3t64 \
+        libstdc++6 \
+        tzdata \
+        tzdata-legacy \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+FROM amd64/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-aot/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-aot/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+FROM arm32v7/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+FROM arm64v8/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM amd64/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm32v7/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm64v8/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM amd64/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm32v7/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm64v8/alpine:3.20 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+FROM amd64/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-aot/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-aot/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+FROM arm32v7/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+FROM arm64v8/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM amd64/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm32v7/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,48 @@
+FROM arm64v8/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        icu-data-full \
+        icu-libs \
+        libgcc \
+        libssl3 \
+        libstdc++ \
+        tzdata
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM amd64/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm32v7/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,47 @@
+FROM arm64v8/alpine:3.21 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+RUN apk add --upgrade --no-cache \
+        ca-certificates-bundle \
+        \
+        # .NET dependencies
+        libgcc \
+        libssl3 \
+        libstdc++
+
+
+FROM base AS installer
+
+RUN apk add --upgrade --no-cache \
+
+# Create a non-root user and group
+RUN addgroup \
+        --gid=$APP_UID \
+        app \
+    && adduser \
+        --uid=$APP_UID \
+        --ingroup=app \
+        --no-create-home \
+        --disabled-password \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,71 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        openssl-libs \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,71 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        openssl-libs \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,72 @@
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+RUN tdnf install -y \
+        gawk \
+        shadow-utils \
+    && tdnf clean all
+
+# Install .NET's dependencies into a staging location
+RUN mkdir /staging \
+    && tdnf install -y --releasever=3.0 --installroot /staging \
+        prebuilt-ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+    && tdnf clean all --releasever=3.0 --installroot /staging
+
+# Generate RPM manifest file by appending to the original manifest file from base distroless image
+COPY --from=mcr.microsoft.com/azurelinux/distroless/minimal:3.0 /var/lib/rpmmanifest/container-manifest-2 /tmp/rpmmanifest
+RUN tmpManifestPath="/tmp/rpmmanifest" \
+    && rpm --query --all --queryformat "%{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t%{EPOCH}\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}\n" --root /staging | grep -v gpg-pubkey >> $tmpManifestPath \
+    && mkdir -p /staging/var/lib/rpmmanifest \
+    # Remove duplicates that match on the first field (package name)
+    && tac $tmpManifestPath | gawk '!x[$1]++' | sort > /staging/var/lib/rpmmanifest/container-manifest-2
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        --create-home \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/staging/home/app" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/staging/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/staging/etc/group"
+
+# Clean up staging
+RUN rm -rf /staging/etc/tdnf \
+    && rm -rf /staging/run/* \
+    && rm -rf /staging/var/cache/tdnf \
+    && rm -rf /staging/var/lib/rpm \
+    && rm -rf /staging/usr/share/doc \
+    && rm -rf /staging/usr/share/man \
+    && find /staging/var/log -type f -size +0 -delete
+
+
+# .NET runtime-deps image
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+COPY --from=installer /staging/ /
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=installer --chown=1654:1654 /staging/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN tdnf install -y \
+        ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+    && tdnf clean all
+
+
+FROM base AS installer
+
+RUN tdnf install -y \
+        shadow-utils \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN tdnf install -y \
+        shadow-utils \
+    && groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && tdnf autoremove -y \
+        shadow-utils \
+    && tdnf clean all \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN tdnf install -y \
+        ca-certificates \
+        \
+        # .NET dependencies
+        glibc \
+        icu \
+        libgcc \
+        libstdc++ \
+        openssl-libs \
+        tzdata \
+    && tdnf clean all
+
+
+FROM base AS installer
+
+RUN tdnf install -y \
+        shadow-utils \
+    && tdnf clean all
+
+# Create a non-root user and group
+RUN tdnf install -y \
+        shadow-utils \
+    && groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && tdnf autoremove -y \
+        shadow-utils \
+    && tdnf clean all \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,51 @@
+FROM amd64/debian:bookworm-slim AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu72 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,51 @@
+FROM arm32v7/debian:bookworm-slim AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu72 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,51 @@
+FROM arm64v8/debian:bookworm-slim AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu72 \
+        libssl3 \
+        libstdc++6 \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,54 @@
+FROM amd64/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-aot/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-aot/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,54 @@
+FROM arm32v7/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,54 @@
+FROM arm64v8/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM amd64/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu74_libs \
+            libssl3t64_libs \
+            libstdc++6_libs \
+            tzdata-legacy_zoneinfo \
+            tzdata_zoneinfo
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM arm32v7/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu74_libs \
+            libssl3t64_libs \
+            libstdc++6_libs \
+            tzdata-legacy_zoneinfo \
+            tzdata_zoneinfo
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,56 @@
+FROM arm64v8/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libicu74_libs \
+            libssl3t64_libs \
+            libstdc++6_libs \
+            tzdata-legacy_zoneinfo \
+            tzdata_zoneinfo
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM amd64/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_amd64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs \
+            libstdc++6_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM arm32v7/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs \
+            libstdc++6_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,55 @@
+FROM arm64v8/buildpack-deps:noble-curl AS chisel
+
+RUN apt-get update && apt-get install -y file
+
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output chisel.tar.gz "https://github.com/canonical/chisel/releases/download/v0.0.0/chisel_v0.0.0_linux_arm64.tar.gz" \
+    && chisel_sha384='{sha386_placeholder}' \
+    && echo "$chisel_sha384  chisel.tar.gz" | sha384sum -c - \
+    && tar -xzf chisel.tar.gz -C /usr/bin/ chisel \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output /usr/bin/chisel-wrapper "https://raw.githubusercontent.com/canonical/rocks-toolbox/v0.0.0/chisel-wrapper" \
+    && chmod 755 /usr/bin/chisel-wrapper
+
+RUN groupadd \
+        --gid=1654 \
+        app \
+    && useradd -l \
+        --uid=1654 \
+        --gid=1654 \
+        --shell /bin/false \
+        app \
+    && install -d -m 0755 -o 1654 -g 1654 "/rootfs/home/app" \
+    && mkdir -p "/rootfs/etc" \
+    && rootOrAppRegex='^\(root\|app\):' \
+    && cat /etc/passwd | grep $rootOrAppRegex > "/rootfs/etc/passwd" \
+    && cat /etc/group | grep $rootOrAppRegex > "/rootfs/etc/group"
+
+RUN mkdir -p /rootfs/var/lib/dpkg/ \
+    && chisel-wrapper --generate-dpkg-status /rootfs/var/lib/dpkg/status -- \
+        --release ubuntu-24.04 --root /rootfs \
+            base-files_base \
+            base-files_release-info \
+            ca-certificates_data \
+            libc6_libs \
+            libgcc-s1_libs \
+            libssl3t64_libs \
+            libstdc++6_libs
+
+
+FROM scratch
+
+COPY --from=chisel /rootfs /
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Set the invariant mode since ICU package isn't included (see https://github.com/dotnet/announcements/issues/20)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=chisel --chown=$APP_UID:$APP_UID /rootfs/home/app /home/app
+
+USER $APP_UID

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM ubuntu.azurecr.io/ubuntu:noble AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu74 \
+        libssl3t64 \
+        libstdc++6 \
+        tzdata \
+        tzdata-legacy \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM ubuntu.azurecr.io/ubuntu:noble AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu74 \
+        libssl3t64 \
+        libstdc++6 \
+        tzdata \
+        tzdata-legacy \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime-deps/9.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,52 @@
+FROM ubuntu.azurecr.io/ubuntu:noble AS base
+
+ENV \
+    # UID of the non-root user 'app'
+    APP_UID=1654 \
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+        # .NET dependencies
+        libc6 \
+        libgcc-s1 \
+        libicu74 \
+        libssl3t64 \
+        libstdc++6 \
+        tzdata \
+        tzdata-legacy \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS installer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user and group
+RUN groupadd \
+        --gid=$APP_UID \
+        app \
+    && useradd -l \
+        --uid=$APP_UID \
+        --gid=$APP_UID \
+        --no-create-home \
+        app \
+    && mkdir -p "/staging/etc" \
+    # Copy user/group info to staging
+    && cp /etc/passwd /staging/etc/passwd \
+    && cp /etc/group /staging/etc/group
+
+
+# Final image
+FROM base
+
+COPY --from=installer /staging/ /
+
+RUN install -d -m 0755 -o $APP_UID -g $APP_UID "/home/app"

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-bookworm-slim-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-bookworm-slim-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-bookworm-slim-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-cbl-mariner2.0-distroless-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-cbl-mariner2.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-cbl-mariner2.0-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-cbl-mariner2.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-cbl-mariner2.0-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-chiseled-extra-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-chiseled-extra-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-chiseled-extra-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-chiseled-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-chiseled-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-chiseled-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/jammy/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-jammy-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2025-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,43 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,43 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/8.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,43 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,37 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        ca-certificates \
+        gzip \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,27 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-bookworm-slim-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-bookworm-slim-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-bookworm-slim-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2025-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled-extra/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled-extra/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled-extra/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled-extra/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble-chiseled/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,31 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /dotnet-symlink \
+    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet-symlink", "/usr/bin"]
+
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["--info"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-amd64
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-arm32v7
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
+
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN dotnet_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /dotnet \
+    && tar -oxzf dotnet.tar.gz -C /dotnet \
+    && rm dotnet.tar.gz
+
+
+# .NET runtime image
+FROM $REPO:0.0.0-noble-arm64v8
+
+# .NET Runtime version
+ENV DOTNET_VERSION=0.0.0
+

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,43 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,43 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/runtime/9.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,43 @@
+# escape=`
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Retrieve .NET Runtime
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        $dotnet_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip
+
+
+# Runtime image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64
+
+ENV `
+    # Configure web servers to bind to port 8080 when present
+    ASPNETCORE_HTTP_PORTS=8080 `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # .NET Runtime version
+    DOTNET_VERSION=0.0.0
+
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,61 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.20
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O PowerShell.Linux.Alpine.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # Add ncurses-terminfo-base to resolve psreadline dependency
+    && apk add --no-cache ncurses-terminfo-base

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,45 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.20-arm32
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,45 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.20-arm64
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,61 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.21
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O PowerShell.Linux.Alpine.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # Add ncurses-terminfo-base to resolve psreadline dependency
+    && apk add --no-cache ncurses-terminfo-base

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,45 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.21-arm32
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,45 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.21-arm64
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+RUN tdnf install -y \
+        build-essential \
+        clang \
+        zlib-devel \
+    && tdnf clean all

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+RUN tdnf install -y \
+        build-essential \
+        clang \
+        zlib-devel \
+    && tdnf clean all

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,59 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0
+
+RUN tdnf install -y \
+        git \
+        libgcc-atomic \
+        tar \
+    && tdnf clean all
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,59 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64
+
+RUN tdnf install -y \
+        git \
+        libgcc-atomic \
+        tar \
+    && tdnf clean all
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM amd64/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-bookworm-slim-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-12
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm32v7/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-bookworm-slim-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-12-arm32
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm64v8/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-bookworm-slim-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-12-arm64
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-cbl-mariner2.0-amd64
+
+RUN tdnf install -y \
+        build-essential \
+        clang \
+        zlib-devel \
+    && tdnf clean all

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-cbl-mariner2.0-arm64v8
+
+RUN tdnf install -y \
+        build-essential \
+        clang \
+        zlib-devel \
+    && tdnf clean all

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,59 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-cbl-mariner2.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-cbl-mariner2.0-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-CBL-Mariner-2.0
+
+RUN tdnf install -y \
+        git \
+        libatomic_ops \
+        tar \
+    && tdnf clean all
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,59 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-cbl-mariner2.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-cbl-mariner2.0-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-CBL-Mariner-2.0-arm64
+
+RUN tdnf install -y \
+        git \
+        libatomic_ops \
+        tar \
+    && tdnf clean all
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-jammy-amd64
+
+RUN echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted" > /etc/apt/sources.list.d/arm64.list \
+    && echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted" >> /etc/apt/sources.list.d/arm64.list \
+    && sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list \
+    && dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        gcc-aarch64-linux-gnu \
+        llvm \
+        zlib1g-dev \
+        zlib1g-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-jammy-arm64v8
+
+RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted" > /etc/apt/sources.list.d/amd64.list \
+    && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted" >> /etc/apt/sources.list.d/amd64.list \
+    && sed -i -e 's/deb http/deb [arch=arm64] http/g' /etc/apt/sources.list \
+    && dpkg --add-architecture amd64 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        gcc-x86-64-linux-gnu \
+        llvm \
+        zlib1g-dev \
+        zlib1g-dev:amd64 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM amd64/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-jammy-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-22.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-jammy-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-22.04-arm32
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/jammy/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm64v8/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-jammy-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-22.04-arm64
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,100 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-nanoserver-1809
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-1809
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,100 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-nanoserver-ltsc2022
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2022
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,100 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-nanoserver-ltsc2025
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-noble-amd64
+
+COPY <<EOF /etc/apt/sources.list.d/arm64.sources
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble noble-updates
+Components: main restricted
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+Architectures: arm64
+EOF
+
+RUN sed -i '/Signed-By/ a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources \
+    && dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        gcc-aarch64-linux-gnu \
+        llvm \
+        zlib1g-dev \
+        zlib1g-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-noble-arm64v8
+
+COPY <<EOF /etc/apt/sources.list.d/amd64.sources
+Types: deb
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates
+Components: main restricted
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+Architectures: amd64
+EOF
+
+RUN sed -i '/Signed-By/ a Architectures: arm64' /etc/apt/sources.list.d/ubuntu.sources \
+    && dpkg --add-architecture amd64 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        gcc-x86-64-linux-gnu \
+        llvm \
+        zlib1g-dev \
+        zlib1g-dev:amd64 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-noble-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-noble-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm64
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,97 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-windowsservercore-ltsc2019
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2019
+
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,97 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-windowsservercore-ltsc2022
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2022
+
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,97 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-windowsservercore-ltsc2025
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025
+
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,62 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.20
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        libatomic \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O PowerShell.Linux.Alpine.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # Add ncurses-terminfo-base to resolve psreadline dependency
+    && apk add --no-cache ncurses-terminfo-base

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.20-arm32
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        libatomic \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.20/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.20-arm64
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        libatomic \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+RUN apk add --upgrade --no-cache \
+        build-base \
+        clang \
+        zlib-dev

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,62 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.21
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        libatomic \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O PowerShell.Linux.Alpine.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm \
+    # Add ncurses-terminfo-base to resolve psreadline dependency
+    && apk add --no-cache ncurses-terminfo-base

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.21-arm32
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        libatomic \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/alpine3.21/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,46 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.21-arm64
+
+RUN apk add --upgrade --no-cache \
+        curl \
+        git \
+        icu-data-full \
+        icu-libs \
+        libatomic \
+        tzdata
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+RUN tdnf install -y \
+        build-essential \
+        clang \
+        zlib-devel \
+    && tdnf clean all

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+RUN tdnf install -y \
+        build-essential \
+        clang \
+        zlib-devel \
+    && tdnf clean all

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,59 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-azurelinux3.0-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0
+
+RUN tdnf install -y \
+        git \
+        libgcc-atomic \
+        tar \
+    && tdnf clean all
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,59 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
+
+ARG ACCESSTOKEN
+
+RUN tdnf install -y \
+        tar \
+    && tdnf clean all
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64
+
+RUN tdnf install -y \
+        git \
+        libgcc-atomic \
+        tar \
+    && tdnf clean all
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/bookworm-slim/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM amd64/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-bookworm-slim-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-12
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/bookworm-slim/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm32v7/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-bookworm-slim-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-12-arm32
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/bookworm-slim/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm64v8/buildpack-deps:bookworm-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-bookworm-slim-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Debian-12-arm64
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/nanoserver-1809/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,100 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:1809-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0-rc.1'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-nanoserver-1809
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-1809
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,100 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0-rc.1'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-nanoserver-ltsc2022
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2022
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/nanoserver-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,100 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0-rc.1'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-nanoserver-ltsc2025
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025
+
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+USER ContainerUser
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble-aot/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble-aot/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-noble-amd64
+
+COPY <<EOF /etc/apt/sources.list.d/arm64.sources
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble noble-updates
+Components: main restricted
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+Architectures: arm64
+EOF
+
+RUN sed -i '/Signed-By/ a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources \
+    && dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        gcc-aarch64-linux-gnu \
+        llvm \
+        zlib1g-dev \
+        zlib1g-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble-aot/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble-aot/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+ARG REPO=mcr.microsoft.com/dotnet/sdk
+FROM $REPO:0.0.0-noble-arm64v8
+
+COPY <<EOF /etc/apt/sources.list.d/amd64.sources
+Types: deb
+URIs: http://archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates
+Components: main restricted
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+Architectures: amd64
+EOF
+
+RUN sed -i '/Signed-By/ a Architectures: arm64' /etc/apt/sources.list.d/ubuntu.sources \
+    && dpkg --add-architecture amd64 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        gcc-x86-64-linux-gnu \
+        llvm \
+        zlib1g-dev \
+        zlib1g-dev:amd64 \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM amd64/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-noble-amd64
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble/arm32v7/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble/arm32v7/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm32v7/buildpack-deps:jammy-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-noble-arm32v7
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm32
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble/arm64v8/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/noble/arm64v8/Dockerfile.verified.noextension
@@ -1,0 +1,58 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+# Installer image
+FROM arm64v8/buildpack-deps:noble-curl AS installer
+
+ARG ACCESSTOKEN
+
+# Install .NET SDK
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://builds.dotnet.microsoft.com/dotnet/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+    && dotnet_sha512='{sha512_placeholder}' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz
+
+
+# .NET SDK image
+FROM $REPO:0.0.0-noble-arm64v8
+
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm64
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        libatomic1 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=0.0.0-rc.1 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg" \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,97 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0-rc.1'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-windowsservercore-ltsc2019
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2019
+
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,97 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0-rc.1'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-windowsservercore-ltsc2022
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2022
+
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests.VerifyInternalDockerfilesOutput/sdk/9.0/windowsservercore-ltsc2025/amd64/Dockerfile.verified.noextension
@@ -1,0 +1,97 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+
+# Installer image
+FROM mcr.microsoft.com/windows/servercore:ltsc2025-amd64 AS installer
+
+ARG ACCESSTOKEN
+
+# Download MinGit
+RUN powershell -Command " `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile mingit.zip \"https://github.com/git-for-windows/git/releases/download/v0.0.0.windows.0/MinGit-0.0.0-64-bit.zip\" -Headers $Headers; `
+        `
+        $mingit_sha256 = '{sha256_placeholder}'; `
+        if ((Get-FileHash mingit.zip -Algorithm sha256).Hash -ne $mingit_sha256) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir MinGit; `
+        tar -oxzf mingit.zip -C MinGit; `
+        Remove-Item -Force mingit.zip"
+
+SHELL ["powershell", "-command"]
+RUN `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        # Retrieve .NET SDK
+        $sdk_version = '0.0.0'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://builds.dotnet.microsoft.com/dotnet/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        `
+        $dotnet_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        mkdir dotnet; `
+        tar -oxzf dotnet.zip -C dotnet; `
+        Remove-Item -Force dotnet.zip; `
+        `
+        # Install PowerShell global tool
+        $powershell_version = '0.0.0-rc.1'; `
+        `
+        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
+        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg \"https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg\" -Headers $Headers; `
+        `
+        $powershell_sha512 = '{sha512_placeholder}'; `
+        if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
+            Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+            exit 1; `
+        }; `
+        & \dotnet\dotnet tool install --add-source . --tool-path \powershell --version $powershell_version PowerShell.Windows.x64; `
+        & \dotnet\dotnet nuget locals all --clear; `
+        Remove-Item -Force PowerShell.Windows.x64.$powershell_version.nupkg; `
+        Remove-Item -Path \powershell\.store\powershell.windows.x64\$powershell_version\powershell.windows.x64\$powershell_version\powershell.windows.x64.$powershell_version.nupkg -Force; `
+        `
+        # Delete everything in the dotnet folder that's not needed in the SDK layer but will instead be derived from base layers
+        Get-ChildItem -Exclude 'LICENSE.txt','ThirdPartyNotices.txt','packs','sdk','sdk-manifests','templates','shared' -Path dotnet `
+            | Remove-Item -Force -Recurse; `
+        Get-ChildItem -Exclude 'Microsoft.WindowsDesktop.App' -Path dotnet\shared `
+            | Remove-Item -Force -Recurse
+
+# SDK image
+FROM $REPO:0.0.0-windowsservercore-ltsc2025
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Do not show first run text
+    DOTNET_NOLOGO=true `
+    # SDK version
+    DOTNET_SDK_VERSION=0.0.0 `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip `
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025
+
+RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
+
+COPY --from=installer ["/dotnet", "/Program Files/dotnet"]
+COPY --from=installer ["/powershell", "/Program Files/powershell"]
+COPY --from=installer ["/MinGit", "/Program Files/MinGit"]
+
+# Trigger first run experience by running arbitrary cmd
+RUN dotnet help

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Docker.Tests;
+
+#nullable enable
+public static partial class DockerfileHelper
+{
+    [GeneratedRegex("[A-Fa-f0-9]{128}")]
+    private static partial Regex Sha512Regex { get; }
+
+    [GeneratedRegex("[A-Fa-f0-9]{96}")]
+    private static partial Regex Sha386Regex { get; }
+
+    [GeneratedRegex("[A-Fa-f0-9]{64}")]
+    private static partial Regex Sha256Regex { get; }
+
+    [GeneratedRegex(@"\d+\.\d+\.\d+(?!\.windows)")]
+    private static partial Regex SemanticVersionRegex { get; }
+
+    [GeneratedRegex(@"v\d+\.\d+\.\d+\.windows\.\d+")]
+    private static partial Regex MinGitVersionRegex { get; }
+
+    [GeneratedRegex(@"alpine\d+\.\d+")]
+    private static partial Regex AlpineVersionRegex { get; }
+
+    private static List<(Regex pattern, string replacement)> Patterns { get; } =
+    [
+        (Sha512Regex, "{sha512_placeholder}"),
+        (Sha386Regex, "{sha386_placeholder}"),
+        (Sha256Regex, "{sha256_placeholder}"),
+        (SemanticVersionRegex, "0.0.0"),
+        (MinGitVersionRegex, "v0.0.0.windows.0"),
+        (AlpineVersionRegex, "alpine3.XX"),
+    ];
+
+    public static async Task ScrubDockerfilesAsync(string path)
+    {
+        string[] dockerfiles =
+            Directory.GetFiles(path, "Dockerfile",
+                new EnumerationOptions { RecurseSubdirectories = true });
+
+        IEnumerable<Task> tasks = dockerfiles.Select(dockerfile => ReplaceTextAsync(dockerfile, Patterns));
+        await Task.WhenAll(tasks);
+    }
+
+    private static async Task ReplaceTextAsync(string filePath, List<(Regex pattern, string replacement)> patterns)
+    {
+        string content = await File.ReadAllTextAsync(filePath);
+        foreach ((Regex pattern, string replacement) in patterns)
+        {
+            content = pattern.Replace(content, replacement);
+        }
+        await File.WriteAllTextAsync(filePath, content);
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using DiffEngine;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Docker.Tests
@@ -43,6 +44,10 @@ namespace Microsoft.DotNet.Docker.Tests
         [Fact]
         public async Task VerifyInternalDockerfilesOutput()
         {
+            // Disable automatic diff editor launching due to quantity of files being compared.
+            // https://github.com/VerifyTests/DiffEngine/blob/main/readme.md#disable-in-code
+            DiffRunner.Disabled = true;
+
             using TempFolderContext outputDirectory = FileHelper.UseTempFolder();
             string dockerfilesPath = Path.Combine(outputDirectory.Path, "src");
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly.Core" Version="8.4.1" />
     <PackageReference Include="SharpCompress" Version="0.32.1" />
+    <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
+    <PackageReference Include="Verify.Xunit" Version="28.7.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Polly.Core" Version="8.4.1" />
     <PackageReference Include="SharpCompress" Version="0.32.1" />
     <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageReference Include="Verify.Xunit" Version="28.7.0" />
+    <PackageReference Include="Verify.Xunit" Version="28.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.DotNet.Docker.Tests/VerifyChecks.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/VerifyChecks.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using VerifyTests.DiffPlex;
 
 namespace Microsoft.DotNet.Docker.Tests;
 
@@ -19,5 +20,5 @@ public static class ModuleInitializer
 {
     [ModuleInitializer]
     public static void Initialize() =>
-        VerifyDiffPlex.Initialize();
+        VerifyDiffPlex.Initialize(OutputType.Compact);
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/VerifyChecks.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/VerifyChecks.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using EmptyFiles;
 using VerifyTests.DiffPlex;
 
 namespace Microsoft.DotNet.Docker.Tests;
@@ -11,6 +12,12 @@ namespace Microsoft.DotNet.Docker.Tests;
 [Trait("Category", "pre-build")]
 public class VerifyChecksTests
 {
+    /// <summary>
+    /// This test verifies that Verify conventions (.gitignore, .editorconfig, etc.) are properly set up.
+    /// Source: https://github.com/VerifyTests/Verify/blob/508f901e76bb241191e6136a5a0ca558b33be268/src/Verify/ConventionCheck/InnerVerifyChecks.cs#L20-L21
+    /// Documentation: https://github.com/VerifyTests/Verify/blob/main/docs/wiz/Linux_Other_Cli_Xunit_AzureDevOps.md#conventions-check
+    /// </summary>
+    /// <returns></returns>
     [Fact]
     public Task Run() =>
         VerifyChecks.Run();
@@ -18,7 +25,20 @@ public class VerifyChecksTests
 
 public static class ModuleInitializer
 {
+    /// <summary>
+    /// Enable DiffPlex output for line-by-line diffs in test output.
+    /// https://github.com/VerifyTests/Verify.DiffPlex/blob/main/readme.md
+    /// </summary>
     [ModuleInitializer]
     public static void Initialize() =>
         VerifyDiffPlex.Initialize(OutputType.Compact);
+
+    /// <summary>
+    /// Enable comparison of Dockerfiles as text files, since they don't have a file extension.
+    /// https://github.com/VerifyTests/Verify/blob/main/docs/verify-directory.md#files-with-no-extension
+    /// </summary>
+    [ModuleInitializer]
+    public static void InitTextFileConvention() =>
+        FileExtensions.AddTextFileConvention(path =>
+            Path.GetFileName(path).Equals("Dockerfile", StringComparison.InvariantCulture));
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/VerifyChecks.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/VerifyChecks.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.DotNet.Docker.Tests;
+
+#nullable enable
+[Trait("Category", "pre-build")]
+public class VerifyChecksTests
+{
+    [Fact]
+    public Task Run() =>
+        VerifyChecks.Run();
+}
+
+public static class ModuleInitializer
+{
+    [ModuleInitializer]
+    public static void Initialize() =>
+        VerifyDiffPlex.Initialize();
+}


### PR DESCRIPTION
Fixes #5935 

Uses https://github.com/VerifyTests/Verify to implement snapshot testing for internal Dockerfiles.

Internal Dockerfiles are scrubbed of versions and shas, and then checked-in to `tests/Microsoft.DotNet.Docker.Tests/Baselines/`. When tests are ran, internal Dockerfiles will be generated and compared to the checked-in versions. If there is a diff, you'll have the opportunity to review and accept differences.

The easiest way to accept or reject new changes is using [Verify.Terminal](https://github.com/VerifyTests/Verify.Terminal) in the repo root:

```
dotnet tool restore
dotnet tool run verify review
```

Todo:
* [ ] CONTRIBUTING documentation for using the review tool
* [ ] Upload new baselines as pipeline artifact when tests fail