### PR TITLE
Move Alpine floating tags from 3.20 to 3.21

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -86,10 +86,10 @@ For more information, see the [composite images section in the Image Variants do
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/aspnet/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.1-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-composite-amd64, 9.0-alpine3.21-composite-amd64, 9.0.1-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0-alpine-amd64, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-composite-amd64, 9.0-alpine3.20-composite-amd64, 9.0-alpine-composite-amd64, 9.0.1-alpine3.20-composite, 9.0-alpine3.20-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.20-composite/amd64/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-composite-amd64, 9.0-alpine3.21-composite-amd64, 9.0-alpine-composite-amd64, 9.0.1-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/aspnet/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-composite-amd64, 9.0-alpine3.20-composite-amd64, 9.0.1-alpine3.20-composite, 9.0-alpine3.20-composite | [Dockerfile](src/aspnet/9.0/alpine3.20-composite/amd64/Dockerfile) | Alpine 3.20
 9.0.1-noble-amd64, 9.0-noble-amd64, 9.0.1-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.1-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -101,10 +101,10 @@ Tags | Dockerfile | OS Version
 9.0.1-azurelinux3.0-distroless-composite-amd64, 9.0-azurelinux3.0-distroless-composite-amd64, 9.0.1-azurelinux3.0-distroless-composite, 9.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite/amd64/Dockerfile) | Azure Linux 3.0
 9.0.1-azurelinux3.0-distroless-composite-extra-amd64, 9.0-azurelinux3.0-distroless-composite-extra-amd64, 9.0.1-azurelinux3.0-distroless-composite-extra, 9.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.12-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.12-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-composite-amd64, 8.0-alpine3.21-composite-amd64, 8.0.12-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0-alpine-amd64, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-composite-amd64, 8.0-alpine3.20-composite-amd64, 8.0-alpine-composite-amd64, 8.0.12-alpine3.20-composite, 8.0-alpine3.20-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.20-composite/amd64/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-composite-amd64, 8.0-alpine3.21-composite-amd64, 8.0-alpine-composite-amd64, 8.0.12-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/aspnet/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-composite-amd64, 8.0-alpine3.20-composite-amd64, 8.0.12-alpine3.20-composite, 8.0-alpine3.20-composite | [Dockerfile](src/aspnet/8.0/alpine3.20-composite/amd64/Dockerfile) | Alpine 3.20
 8.0.12-noble-amd64, 8.0-noble-amd64, 8.0.12-noble, 8.0-noble | [Dockerfile](src/aspnet/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.12-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/aspnet/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.12-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/aspnet/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -149,10 +149,10 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/aspnet/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.1-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-composite-arm64v8, 9.0-alpine3.21-composite-arm64v8, 9.0.1-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0-alpine-arm64v8, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-composite-arm64v8, 9.0-alpine3.20-composite-arm64v8, 9.0-alpine-composite-arm64v8, 9.0.1-alpine3.20-composite, 9.0-alpine3.20-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.20-composite/arm64v8/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-composite-arm64v8, 9.0-alpine3.21-composite-arm64v8, 9.0-alpine-composite-arm64v8, 9.0.1-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/aspnet/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-composite-arm64v8, 9.0-alpine3.20-composite-arm64v8, 9.0.1-alpine3.20-composite, 9.0-alpine3.20-composite | [Dockerfile](src/aspnet/9.0/alpine3.20-composite/arm64v8/Dockerfile) | Alpine 3.20
 9.0.1-noble-arm64v8, 9.0-noble-arm64v8, 9.0.1-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.1-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -164,10 +164,10 @@ Tags | Dockerfile | OS Version
 9.0.1-azurelinux3.0-distroless-composite-arm64v8, 9.0-azurelinux3.0-distroless-composite-arm64v8, 9.0.1-azurelinux3.0-distroless-composite, 9.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.1-azurelinux3.0-distroless-composite-extra-arm64v8, 9.0-azurelinux3.0-distroless-composite-extra-arm64v8, 9.0.1-azurelinux3.0-distroless-composite-extra, 9.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.12-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.12-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-composite-arm64v8, 8.0-alpine3.21-composite-arm64v8, 8.0.12-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0-alpine-arm64v8, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-composite-arm64v8, 8.0-alpine3.20-composite-arm64v8, 8.0-alpine-composite-arm64v8, 8.0.12-alpine3.20-composite, 8.0-alpine3.20-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.20-composite/arm64v8/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-composite-arm64v8, 8.0-alpine3.21-composite-arm64v8, 8.0-alpine-composite-arm64v8, 8.0.12-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/aspnet/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-composite-arm64v8, 8.0-alpine3.20-composite-arm64v8, 8.0.12-alpine3.20-composite, 8.0-alpine3.20-composite | [Dockerfile](src/aspnet/8.0/alpine3.20-composite/arm64v8/Dockerfile) | Alpine 3.20
 8.0.12-noble-arm64v8, 8.0-noble-arm64v8, 8.0.12-noble, 8.0-noble | [Dockerfile](src/aspnet/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.12-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/aspnet/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.12-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/aspnet/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -212,20 +212,20 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/aspnet/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.1-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-composite-arm32v7, 9.0-alpine3.21-composite-arm32v7, 9.0.1-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0-alpine-arm32v7, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-composite-arm32v7, 9.0-alpine3.20-composite-arm32v7, 9.0-alpine-composite-arm32v7, 9.0.1-alpine3.20-composite, 9.0-alpine3.20-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.20-composite/arm32v7/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-composite-arm32v7, 9.0-alpine3.21-composite-arm32v7, 9.0-alpine-composite-arm32v7, 9.0.1-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/aspnet/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-composite-arm32v7, 9.0-alpine3.20-composite-arm32v7, 9.0.1-alpine3.20-composite, 9.0-alpine3.20-composite | [Dockerfile](src/aspnet/9.0/alpine3.20-composite/arm32v7/Dockerfile) | Alpine 3.20
 9.0.1-noble-arm32v7, 9.0-noble-arm32v7, 9.0.1-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.1-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-composite-arm32v7, 9.0-noble-chiseled-composite-arm32v7, 9.0.1-noble-chiseled-composite, 9.0-noble-chiseled-composite | [Dockerfile](src/aspnet/9.0/noble-chiseled-composite/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-composite-extra-arm32v7, 9.0-noble-chiseled-composite-extra-arm32v7, 9.0.1-noble-chiseled-composite-extra, 9.0-noble-chiseled-composite-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-composite-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.12-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.12-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-composite-arm32v7, 8.0-alpine3.21-composite-arm32v7, 8.0.12-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0-alpine-arm32v7, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-composite-arm32v7, 8.0-alpine3.20-composite-arm32v7, 8.0-alpine-composite-arm32v7, 8.0.12-alpine3.20-composite, 8.0-alpine3.20-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.20-composite/arm32v7/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-composite-arm32v7, 8.0-alpine3.21-composite-arm32v7, 8.0-alpine-composite-arm32v7, 8.0.12-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/aspnet/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-composite-arm32v7, 8.0-alpine3.20-composite-arm32v7, 8.0.12-alpine3.20-composite, 8.0-alpine3.20-composite | [Dockerfile](src/aspnet/8.0/alpine3.20-composite/arm32v7/Dockerfile) | Alpine 3.20
 8.0.12-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.12-jammy, 8.0-jammy | [Dockerfile](src/aspnet/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.12-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.12-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/aspnet/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.12-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.12-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/aspnet/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -67,12 +67,12 @@ They contain the following features:
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.1-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-aot-amd64, 9.0-alpine3.21-aot-amd64, 9.0.1-alpine3.21-aot, 9.0-alpine3.21-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-extra-amd64, 9.0-alpine3.21-extra-amd64, 9.0.1-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0-alpine-amd64, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-aot-amd64, 9.0-alpine3.20-aot-amd64, 9.0-alpine-aot-amd64, 9.0.1-alpine3.20-aot, 9.0-alpine3.20-aot, 9.0-alpine-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-extra-amd64, 9.0-alpine3.20-extra-amd64, 9.0-alpine-extra-amd64, 9.0.1-alpine3.20-extra, 9.0-alpine3.20-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.20-extra/amd64/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-aot-amd64, 9.0-alpine3.21-aot-amd64, 9.0-alpine-aot-amd64, 9.0.1-alpine3.21-aot, 9.0-alpine3.21-aot, 9.0-alpine-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-extra-amd64, 9.0-alpine3.21-extra-amd64, 9.0-alpine-extra-amd64, 9.0.1-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/runtime-deps/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-aot-amd64, 9.0-alpine3.20-aot-amd64, 9.0.1-alpine3.20-aot, 9.0-alpine3.20-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-extra-amd64, 9.0-alpine3.20-extra-amd64, 9.0.1-alpine3.20-extra, 9.0-alpine3.20-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.20-extra/amd64/Dockerfile) | Alpine 3.20
 9.0.1-noble-amd64, 9.0-noble-amd64, 9.0.1-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-aot-amd64, 9.0-noble-chiseled-aot-amd64, 9.0.1-noble-chiseled-aot, 9.0-noble-chiseled-aot | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-aot/amd64/Dockerfile) | Ubuntu 24.04
@@ -82,12 +82,12 @@ Tags | Dockerfile | OS Version
 9.0.1-azurelinux3.0-distroless-aot-amd64, 9.0-azurelinux3.0-distroless-aot-amd64, 9.0.1-azurelinux3.0-distroless-aot, 9.0-azurelinux3.0-distroless-aot | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-aot/amd64/Dockerfile) | Azure Linux 3.0
 9.0.1-azurelinux3.0-distroless-extra-amd64, 9.0-azurelinux3.0-distroless-extra-amd64, 9.0.1-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.12-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.12-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-aot-amd64, 8.0-alpine3.21-aot-amd64, 8.0.12-alpine3.21-aot, 8.0-alpine3.21-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-extra-amd64, 8.0-alpine3.21-extra-amd64, 8.0.12-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0-alpine-amd64, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-aot-amd64, 8.0-alpine3.20-aot-amd64, 8.0-alpine-aot-amd64, 8.0.12-alpine3.20-aot, 8.0-alpine3.20-aot, 8.0-alpine-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-extra-amd64, 8.0-alpine3.20-extra-amd64, 8.0-alpine-extra-amd64, 8.0.12-alpine3.20-extra, 8.0-alpine3.20-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.20-extra/amd64/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-aot-amd64, 8.0-alpine3.21-aot-amd64, 8.0-alpine-aot-amd64, 8.0.12-alpine3.21-aot, 8.0-alpine3.21-aot, 8.0-alpine-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-extra-amd64, 8.0-alpine3.21-extra-amd64, 8.0-alpine-extra-amd64, 8.0.12-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/runtime-deps/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-aot-amd64, 8.0-alpine3.20-aot-amd64, 8.0.12-alpine3.20-aot, 8.0-alpine3.20-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-extra-amd64, 8.0-alpine3.20-extra-amd64, 8.0.12-alpine3.20-extra, 8.0-alpine3.20-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.20-extra/amd64/Dockerfile) | Alpine 3.20
 8.0.12-noble-amd64, 8.0-noble-amd64, 8.0.12-noble, 8.0-noble | [Dockerfile](src/runtime-deps/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.12-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-aot-amd64, 8.0-noble-chiseled-aot-amd64, 8.0.12-noble-chiseled-aot, 8.0-noble-chiseled-aot | [Dockerfile](src/runtime-deps/8.0/noble-chiseled-aot/amd64/Dockerfile) | Ubuntu 24.04
@@ -124,12 +124,12 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.1-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-aot-arm64v8, 9.0-alpine3.21-aot-arm64v8, 9.0.1-alpine3.21-aot, 9.0-alpine3.21-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-extra-arm64v8, 9.0-alpine3.21-extra-arm64v8, 9.0.1-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0-alpine-arm64v8, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-aot-arm64v8, 9.0-alpine3.20-aot-arm64v8, 9.0-alpine-aot-arm64v8, 9.0.1-alpine3.20-aot, 9.0-alpine3.20-aot, 9.0-alpine-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-extra-arm64v8, 9.0-alpine3.20-extra-arm64v8, 9.0-alpine-extra-arm64v8, 9.0.1-alpine3.20-extra, 9.0-alpine3.20-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.20-extra/arm64v8/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-aot-arm64v8, 9.0-alpine3.21-aot-arm64v8, 9.0-alpine-aot-arm64v8, 9.0.1-alpine3.21-aot, 9.0-alpine3.21-aot, 9.0-alpine-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-extra-arm64v8, 9.0-alpine3.21-extra-arm64v8, 9.0-alpine-extra-arm64v8, 9.0.1-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/runtime-deps/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-aot-arm64v8, 9.0-alpine3.20-aot-arm64v8, 9.0.1-alpine3.20-aot, 9.0-alpine3.20-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-extra-arm64v8, 9.0-alpine3.20-extra-arm64v8, 9.0.1-alpine3.20-extra, 9.0-alpine3.20-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.20-extra/arm64v8/Dockerfile) | Alpine 3.20
 9.0.1-noble-arm64v8, 9.0-noble-arm64v8, 9.0.1-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-aot-arm64v8, 9.0-noble-chiseled-aot-arm64v8, 9.0.1-noble-chiseled-aot, 9.0-noble-chiseled-aot | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-aot/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -139,12 +139,12 @@ Tags | Dockerfile | OS Version
 9.0.1-azurelinux3.0-distroless-aot-arm64v8, 9.0-azurelinux3.0-distroless-aot-arm64v8, 9.0.1-azurelinux3.0-distroless-aot, 9.0-azurelinux3.0-distroless-aot | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-aot/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.1-azurelinux3.0-distroless-extra-arm64v8, 9.0-azurelinux3.0-distroless-extra-arm64v8, 9.0.1-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.12-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.12-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-aot-arm64v8, 8.0-alpine3.21-aot-arm64v8, 8.0.12-alpine3.21-aot, 8.0-alpine3.21-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-extra-arm64v8, 8.0-alpine3.21-extra-arm64v8, 8.0.12-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0-alpine-arm64v8, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-aot-arm64v8, 8.0-alpine3.20-aot-arm64v8, 8.0-alpine-aot-arm64v8, 8.0.12-alpine3.20-aot, 8.0-alpine3.20-aot, 8.0-alpine-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-extra-arm64v8, 8.0-alpine3.20-extra-arm64v8, 8.0-alpine-extra-arm64v8, 8.0.12-alpine3.20-extra, 8.0-alpine3.20-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.20-extra/arm64v8/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-aot-arm64v8, 8.0-alpine3.21-aot-arm64v8, 8.0-alpine-aot-arm64v8, 8.0.12-alpine3.21-aot, 8.0-alpine3.21-aot, 8.0-alpine-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-extra-arm64v8, 8.0-alpine3.21-extra-arm64v8, 8.0-alpine-extra-arm64v8, 8.0.12-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/runtime-deps/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-aot-arm64v8, 8.0-alpine3.20-aot-arm64v8, 8.0.12-alpine3.20-aot, 8.0-alpine3.20-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-extra-arm64v8, 8.0-alpine3.20-extra-arm64v8, 8.0.12-alpine3.20-extra, 8.0-alpine3.20-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.20-extra/arm64v8/Dockerfile) | Alpine 3.20
 8.0.12-noble-arm64v8, 8.0-noble-arm64v8, 8.0.12-noble, 8.0-noble | [Dockerfile](src/runtime-deps/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.12-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-aot-arm64v8, 8.0-noble-chiseled-aot-arm64v8, 8.0.12-noble-chiseled-aot, 8.0-noble-chiseled-aot | [Dockerfile](src/runtime-deps/8.0/noble-chiseled-aot/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -181,23 +181,23 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.1-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-aot-arm32v7, 9.0-alpine3.21-aot-arm32v7, 9.0.1-alpine3.21-aot, 9.0-alpine3.21-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.21-aot/arm32v7/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.21-extra-arm32v7, 9.0-alpine3.21-extra-arm32v7, 9.0.1-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0-alpine-arm32v7, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-aot-arm32v7, 9.0-alpine3.20-aot-arm32v7, 9.0-alpine-aot-arm32v7, 9.0.1-alpine3.20-aot, 9.0-alpine3.20-aot, 9.0-alpine-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.20-aot/arm32v7/Dockerfile) | Alpine 3.20
-9.0.1-alpine3.20-extra-arm32v7, 9.0-alpine3.20-extra-arm32v7, 9.0-alpine-extra-arm32v7, 9.0.1-alpine3.20-extra, 9.0-alpine3.20-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.20-extra/arm32v7/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-aot-arm32v7, 9.0-alpine3.21-aot-arm32v7, 9.0-alpine-aot-arm32v7, 9.0.1-alpine3.21-aot, 9.0-alpine3.21-aot, 9.0-alpine-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.21-aot/arm32v7/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.21-extra-arm32v7, 9.0-alpine3.21-extra-arm32v7, 9.0-alpine-extra-arm32v7, 9.0.1-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/runtime-deps/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-aot-arm32v7, 9.0-alpine3.20-aot-arm32v7, 9.0.1-alpine3.20-aot, 9.0-alpine3.20-aot | [Dockerfile](src/runtime-deps/9.0/alpine3.20-aot/arm32v7/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.20-extra-arm32v7, 9.0-alpine3.20-extra-arm32v7, 9.0.1-alpine3.20-extra, 9.0-alpine3.20-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.20-extra/arm32v7/Dockerfile) | Alpine 3.20
 9.0.1-noble-arm32v7, 9.0-noble-arm32v7, 9.0.1-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-aot-arm32v7, 9.0-noble-chiseled-aot-arm32v7, 9.0.1-noble-chiseled-aot, 9.0-noble-chiseled-aot | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-aot/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.1-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.12-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.12-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-aot-arm32v7, 8.0-alpine3.21-aot-arm32v7, 8.0.12-alpine3.21-aot, 8.0-alpine3.21-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.21-aot/arm32v7/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.21-extra-arm32v7, 8.0-alpine3.21-extra-arm32v7, 8.0.12-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0-alpine-arm32v7, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-aot-arm32v7, 8.0-alpine3.20-aot-arm32v7, 8.0-alpine-aot-arm32v7, 8.0.12-alpine3.20-aot, 8.0-alpine3.20-aot, 8.0-alpine-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.20-aot/arm32v7/Dockerfile) | Alpine 3.20
-8.0.12-alpine3.20-extra-arm32v7, 8.0-alpine3.20-extra-arm32v7, 8.0-alpine-extra-arm32v7, 8.0.12-alpine3.20-extra, 8.0-alpine3.20-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.20-extra/arm32v7/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-aot-arm32v7, 8.0-alpine3.21-aot-arm32v7, 8.0-alpine-aot-arm32v7, 8.0.12-alpine3.21-aot, 8.0-alpine3.21-aot, 8.0-alpine-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.21-aot/arm32v7/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.21-extra-arm32v7, 8.0-alpine3.21-extra-arm32v7, 8.0-alpine-extra-arm32v7, 8.0.12-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/runtime-deps/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-aot-arm32v7, 8.0-alpine3.20-aot-arm32v7, 8.0.12-alpine3.20-aot, 8.0-alpine3.20-aot | [Dockerfile](src/runtime-deps/8.0/alpine3.20-aot/arm32v7/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.20-extra-arm32v7, 8.0-alpine3.20-extra-arm32v7, 8.0.12-alpine3.20-extra, 8.0-alpine3.20-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.20-extra/arm32v7/Dockerfile) | Alpine 3.20
 8.0.12-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.12-jammy, 8.0-jammy | [Dockerfile](src/runtime-deps/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.12-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.12-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.12-jammy-chiseled-aot-arm32v7, 8.0-jammy-chiseled-aot-arm32v7, 8.0.12-jammy-chiseled-aot, 8.0-jammy-chiseled-aot | [Dockerfile](src/runtime-deps/8.0/jammy-chiseled-aot/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -75,8 +75,8 @@ They contain the following features:
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/runtime/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.1-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0-alpine-amd64, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/runtime/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
 9.0.1-noble-amd64, 9.0-noble-amd64, 9.0.1-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.1-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -84,8 +84,8 @@ Tags | Dockerfile | OS Version
 9.0.1-azurelinux3.0-distroless-amd64, 9.0-azurelinux3.0-distroless-amd64, 9.0.1-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless/amd64/Dockerfile) | Azure Linux 3.0
 9.0.1-azurelinux3.0-distroless-extra-amd64, 9.0-azurelinux3.0-distroless-extra-amd64, 9.0.1-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.12-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.12-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0-alpine-amd64, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/runtime/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
 8.0.12-noble-amd64, 8.0-noble-amd64, 8.0.12-noble, 8.0-noble | [Dockerfile](src/runtime/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.12-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.12-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -117,8 +117,8 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/runtime/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.1-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0-alpine-arm64v8, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/runtime/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
 9.0.1-noble-arm64v8, 9.0-noble-arm64v8, 9.0.1-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.1-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -126,8 +126,8 @@ Tags | Dockerfile | OS Version
 9.0.1-azurelinux3.0-distroless-arm64v8, 9.0-azurelinux3.0-distroless-arm64v8, 9.0.1-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.1-azurelinux3.0-distroless-extra-arm64v8, 9.0-azurelinux3.0-distroless-extra-arm64v8, 9.0.1-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.12-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.12-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0-alpine-arm64v8, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/runtime/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
 8.0.12-noble-arm64v8, 8.0-noble-arm64v8, 8.0.12-noble, 8.0-noble | [Dockerfile](src/runtime/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.12-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.12-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.12-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -159,14 +159,14 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.1-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.1-bookworm-slim, 9.0-bookworm-slim, 9.0.1, 9.0 | [Dockerfile](src/runtime/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.1-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.1-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.1-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0-alpine-arm32v7, 9.0.1-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+9.0.1-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.1-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.1-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0.1-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/runtime/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
 9.0.1-noble-arm32v7, 9.0-noble-arm32v7, 9.0.1-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.1-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.1-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.1-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.12-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.12-bookworm-slim, 8.0-bookworm-slim, 8.0.12, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.12-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.12-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.12-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0-alpine-arm32v7, 8.0.12-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+8.0.12-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.12-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.12-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0.12-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/runtime/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
 8.0.12-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.12-jammy, 8.0-jammy | [Dockerfile](src/runtime/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.12-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.12-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/runtime/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.12-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.12-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/runtime/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -71,19 +71,19 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.102-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.102-bookworm-slim, 9.0-bookworm-slim, 9.0.102, 9.0 | [Dockerfile](src/sdk/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.102-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.102-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.102-alpine3.21-aot-amd64, 9.0-alpine3.21-aot-amd64, 9.0.102-alpine3.21-aot, 9.0-alpine3.21-aot | [Dockerfile](src/sdk/9.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
-9.0.102-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0-alpine-amd64, 9.0.102-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
-9.0.102-alpine3.20-aot-amd64, 9.0-alpine3.20-aot-amd64, 9.0-alpine-aot-amd64, 9.0.102-alpine3.20-aot, 9.0-alpine3.20-aot, 9.0-alpine-aot | [Dockerfile](src/sdk/9.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
+9.0.102-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.102-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.102-alpine3.21-aot-amd64, 9.0-alpine3.21-aot-amd64, 9.0-alpine-aot-amd64, 9.0.102-alpine3.21-aot, 9.0-alpine3.21-aot, 9.0-alpine-aot | [Dockerfile](src/sdk/9.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
+9.0.102-alpine3.20-amd64, 9.0-alpine3.20-amd64, 9.0.102-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/sdk/9.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+9.0.102-alpine3.20-aot-amd64, 9.0-alpine3.20-aot-amd64, 9.0.102-alpine3.20-aot, 9.0-alpine3.20-aot | [Dockerfile](src/sdk/9.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
 9.0.102-noble-amd64, 9.0-noble-amd64, 9.0.102-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.102-noble-aot-amd64, 9.0-noble-aot-amd64, 9.0.102-noble-aot, 9.0-noble-aot | [Dockerfile](src/sdk/9.0/noble-aot/amd64/Dockerfile) | Ubuntu 24.04
 9.0.102-azurelinux3.0-amd64, 9.0-azurelinux3.0-amd64, 9.0.102-azurelinux3.0, 9.0-azurelinux3.0 | [Dockerfile](src/sdk/9.0/azurelinux3.0/amd64/Dockerfile) | Azure Linux 3.0
 9.0.102-azurelinux3.0-aot-amd64, 9.0-azurelinux3.0-aot-amd64, 9.0.102-azurelinux3.0-aot, 9.0-azurelinux3.0-aot | [Dockerfile](src/sdk/9.0/azurelinux3.0-aot/amd64/Dockerfile) | Azure Linux 3.0
 8.0.405-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.405-bookworm-slim, 8.0-bookworm-slim, 8.0.405, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.405-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.405-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.405-alpine3.21-aot-amd64, 8.0-alpine3.21-aot-amd64, 8.0.405-alpine3.21-aot, 8.0-alpine3.21-aot | [Dockerfile](src/sdk/8.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
-8.0.405-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0-alpine-amd64, 8.0.405-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
-8.0.405-alpine3.20-aot-amd64, 8.0-alpine3.20-aot-amd64, 8.0-alpine-aot-amd64, 8.0.405-alpine3.20-aot, 8.0-alpine3.20-aot, 8.0-alpine-aot | [Dockerfile](src/sdk/8.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
+8.0.405-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.405-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.405-alpine3.21-aot-amd64, 8.0-alpine3.21-aot-amd64, 8.0-alpine-aot-amd64, 8.0.405-alpine3.21-aot, 8.0-alpine3.21-aot, 8.0-alpine-aot | [Dockerfile](src/sdk/8.0/alpine3.21-aot/amd64/Dockerfile) | Alpine 3.21
+8.0.405-alpine3.20-amd64, 8.0-alpine3.20-amd64, 8.0.405-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/sdk/8.0/alpine3.20/amd64/Dockerfile) | Alpine 3.20
+8.0.405-alpine3.20-aot-amd64, 8.0-alpine3.20-aot-amd64, 8.0.405-alpine3.20-aot, 8.0-alpine3.20-aot | [Dockerfile](src/sdk/8.0/alpine3.20-aot/amd64/Dockerfile) | Alpine 3.20
 8.0.405-noble-amd64, 8.0-noble-amd64, 8.0.405-noble, 8.0-noble | [Dockerfile](src/sdk/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.405-noble-aot-amd64, 8.0-noble-aot-amd64, 8.0.405-noble-aot, 8.0-noble-aot | [Dockerfile](src/sdk/8.0/noble-aot/amd64/Dockerfile) | Ubuntu 24.04
 8.0.405-jammy-amd64, 8.0-jammy-amd64, 8.0.405-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
@@ -107,19 +107,19 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.102-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.102-bookworm-slim, 9.0-bookworm-slim, 9.0.102, 9.0 | [Dockerfile](src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.102-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.102-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.102-alpine3.21-aot-arm64v8, 9.0-alpine3.21-aot-arm64v8, 9.0.102-alpine3.21-aot, 9.0-alpine3.21-aot | [Dockerfile](src/sdk/9.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
-9.0.102-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0-alpine-arm64v8, 9.0.102-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
-9.0.102-alpine3.20-aot-arm64v8, 9.0-alpine3.20-aot-arm64v8, 9.0-alpine-aot-arm64v8, 9.0.102-alpine3.20-aot, 9.0-alpine3.20-aot, 9.0-alpine-aot | [Dockerfile](src/sdk/9.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
+9.0.102-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.102-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.102-alpine3.21-aot-arm64v8, 9.0-alpine3.21-aot-arm64v8, 9.0-alpine-aot-arm64v8, 9.0.102-alpine3.21-aot, 9.0-alpine3.21-aot, 9.0-alpine-aot | [Dockerfile](src/sdk/9.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
+9.0.102-alpine3.20-arm64v8, 9.0-alpine3.20-arm64v8, 9.0.102-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/sdk/9.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+9.0.102-alpine3.20-aot-arm64v8, 9.0-alpine3.20-aot-arm64v8, 9.0.102-alpine3.20-aot, 9.0-alpine3.20-aot | [Dockerfile](src/sdk/9.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
 9.0.102-noble-arm64v8, 9.0-noble-arm64v8, 9.0.102-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.102-noble-aot-arm64v8, 9.0-noble-aot-arm64v8, 9.0.102-noble-aot, 9.0-noble-aot | [Dockerfile](src/sdk/9.0/noble-aot/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.102-azurelinux3.0-arm64v8, 9.0-azurelinux3.0-arm64v8, 9.0.102-azurelinux3.0, 9.0-azurelinux3.0 | [Dockerfile](src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.102-azurelinux3.0-aot-arm64v8, 9.0-azurelinux3.0-aot-arm64v8, 9.0.102-azurelinux3.0-aot, 9.0-azurelinux3.0-aot | [Dockerfile](src/sdk/9.0/azurelinux3.0-aot/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.405-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.405-bookworm-slim, 8.0-bookworm-slim, 8.0.405, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.405-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.405-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.405-alpine3.21-aot-arm64v8, 8.0-alpine3.21-aot-arm64v8, 8.0.405-alpine3.21-aot, 8.0-alpine3.21-aot | [Dockerfile](src/sdk/8.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
-8.0.405-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0-alpine-arm64v8, 8.0.405-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
-8.0.405-alpine3.20-aot-arm64v8, 8.0-alpine3.20-aot-arm64v8, 8.0-alpine-aot-arm64v8, 8.0.405-alpine3.20-aot, 8.0-alpine3.20-aot, 8.0-alpine-aot | [Dockerfile](src/sdk/8.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
+8.0.405-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.405-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.405-alpine3.21-aot-arm64v8, 8.0-alpine3.21-aot-arm64v8, 8.0-alpine-aot-arm64v8, 8.0.405-alpine3.21-aot, 8.0-alpine3.21-aot, 8.0-alpine-aot | [Dockerfile](src/sdk/8.0/alpine3.21-aot/arm64v8/Dockerfile) | Alpine 3.21
+8.0.405-alpine3.20-arm64v8, 8.0-alpine3.20-arm64v8, 8.0.405-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/sdk/8.0/alpine3.20/arm64v8/Dockerfile) | Alpine 3.20
+8.0.405-alpine3.20-aot-arm64v8, 8.0-alpine3.20-aot-arm64v8, 8.0.405-alpine3.20-aot, 8.0-alpine3.20-aot | [Dockerfile](src/sdk/8.0/alpine3.20-aot/arm64v8/Dockerfile) | Alpine 3.20
 8.0.405-noble-arm64v8, 8.0-noble-arm64v8, 8.0.405-noble, 8.0-noble | [Dockerfile](src/sdk/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.405-noble-aot-arm64v8, 8.0-noble-aot-arm64v8, 8.0.405-noble-aot, 8.0-noble-aot | [Dockerfile](src/sdk/8.0/noble-aot/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.405-jammy-arm64v8, 8.0-jammy-arm64v8, 8.0.405-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
@@ -143,12 +143,12 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.102-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.102-bookworm-slim, 9.0-bookworm-slim, 9.0.102, 9.0 | [Dockerfile](src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.102-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.102-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.102-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0-alpine-arm32v7, 9.0.102-alpine3.20, 9.0-alpine3.20, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+9.0.102-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.102-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.102-alpine3.20-arm32v7, 9.0-alpine3.20-arm32v7, 9.0.102-alpine3.20, 9.0-alpine3.20 | [Dockerfile](src/sdk/9.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
 9.0.102-noble-arm32v7, 9.0-noble-arm32v7, 9.0.102-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.405-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.405-bookworm-slim, 8.0-bookworm-slim, 8.0.405, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.405-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.405-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.405-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0-alpine-arm32v7, 8.0.405-alpine3.20, 8.0-alpine3.20, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
+8.0.405-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.405-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.405-alpine3.20-arm32v7, 8.0-alpine3.20-arm32v7, 8.0.405-alpine3.20, 8.0-alpine3.20 | [Dockerfile](src/sdk/8.0/alpine3.20/arm32v7/Dockerfile) | Alpine 3.20
 8.0.405-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.405-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 
 #### .NET 10 Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -82,8 +82,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.20": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.20": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -93,8 +92,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -105,8 +103,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -118,8 +115,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -129,8 +125,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.20-aot": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.20-aot": {},
-            "$(dotnet|8.0|minor-tag)-alpine-aot": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.20-aot": {}
           },
           "platforms": [
             {
@@ -140,8 +135,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-aot-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-aot-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-aot-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -161,8 +155,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-aot-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-aot-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-aot-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-aot-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -184,8 +177,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-aot-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-aot-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-aot-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -204,8 +196,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.20-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.20-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine-extra": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.20-extra": {}
           },
           "platforms": [
             {
@@ -215,8 +206,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -236,8 +226,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -258,8 +247,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -278,7 +266,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -288,7 +277,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -299,7 +289,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -311,7 +302,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -321,7 +313,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21-aot": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21-aot": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21-aot": {},
+            "$(dotnet|8.0|minor-tag)-alpine-aot": {}
           },
           "platforms": [
             {
@@ -331,7 +324,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-aot-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-aot-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-aot-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -351,7 +345,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-aot-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-aot-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-aot-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-aot-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -373,7 +368,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-aot-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-aot-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-aot-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -392,7 +388,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21-extra": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21-extra": {},
+            "$(dotnet|8.0|minor-tag)-alpine-extra": {}
           },
           "platforms": [
             {
@@ -402,7 +399,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -422,7 +420,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -443,7 +442,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1359,8 +1359,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.20": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.20": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -1370,8 +1369,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -1382,8 +1380,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -1395,8 +1392,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -1406,8 +1402,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.20-aot": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.20-aot": {},
-            "$(dotnet|9.0|minor-tag)-alpine-aot": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.20-aot": {}
           },
           "platforms": [
             {
@@ -1417,8 +1412,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-aot-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-aot-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-aot-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1438,8 +1432,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-aot-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-aot-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-aot-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-aot-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1461,8 +1454,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-aot-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-aot-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-aot-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1481,8 +1473,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.20-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.20-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine-extra": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.20-extra": {}
           },
           "platforms": [
             {
@@ -1492,8 +1483,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1513,8 +1503,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1535,8 +1524,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1555,7 +1543,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -1565,7 +1554,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -1576,7 +1566,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -1588,7 +1579,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -1598,7 +1590,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21-aot": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21-aot": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21-aot": {},
+            "$(dotnet|9.0|minor-tag)-alpine-aot": {}
           },
           "platforms": [
             {
@@ -1608,7 +1601,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-aot-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-aot-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-aot-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1628,7 +1622,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-aot-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-aot-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-aot-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-aot-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1650,7 +1645,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-aot-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-aot-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-aot-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1669,7 +1665,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21-extra": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21-extra": {},
+            "$(dotnet|9.0|minor-tag)-alpine-extra": {}
           },
           "platforms": [
             {
@@ -1679,7 +1676,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1699,7 +1697,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1720,7 +1719,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -2753,8 +2753,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.20": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.20": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -2767,8 +2766,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -2782,8 +2780,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -2798,8 +2795,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -2809,7 +2805,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -2822,7 +2819,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -2836,7 +2834,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -2851,7 +2850,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -3709,8 +3709,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.20": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.20": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -3723,8 +3722,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -3738,8 +3736,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -3754,8 +3751,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -3765,7 +3761,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -3778,7 +3775,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -3792,7 +3790,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -3807,7 +3806,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4967,8 +4967,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.20": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.20": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -4981,8 +4980,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -4996,8 +4994,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5012,8 +5009,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -5023,8 +5019,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.20-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.20-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine-composite": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.20-composite": {}
           },
           "platforms": [
             {
@@ -5037,8 +5032,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-composite-amd64": {}
               }
             },
             {
@@ -5052,8 +5046,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5068,8 +5061,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.20-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.20-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.20-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -5079,7 +5071,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -5092,7 +5085,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -5106,7 +5100,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5121,7 +5116,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -5131,7 +5127,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21-composite": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21-composite": {},
+            "$(dotnet|8.0|minor-tag)-alpine-composite": {}
           },
           "platforms": [
             {
@@ -5144,7 +5141,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-amd64": {}
               }
             },
             {
@@ -5158,7 +5156,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5173,7 +5172,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6465,8 +6465,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.20": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.20": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -6479,8 +6478,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -6494,8 +6492,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6510,8 +6507,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6521,8 +6517,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.20-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.20-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine-composite": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.20-composite": {}
           },
           "platforms": [
             {
@@ -6535,8 +6530,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-composite-amd64": {}
               }
             },
             {
@@ -6550,8 +6544,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6566,8 +6559,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.20-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.20-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.20-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6577,7 +6569,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -6590,7 +6583,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -6604,7 +6598,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6619,7 +6614,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6629,7 +6625,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21-composite": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21-composite": {},
+            "$(dotnet|9.0|minor-tag)-alpine-composite": {}
           },
           "platforms": [
             {
@@ -6642,7 +6639,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-amd64": {}
               }
             },
             {
@@ -6656,7 +6654,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6671,7 +6670,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8435,8 +8435,7 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.20": {},
-            "$(sdk|8.0|minor-tag)-alpine3.20": {},
-            "$(sdk|8.0|minor-tag)-alpine": {}
+            "$(sdk|8.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -8449,8 +8448,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.20-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -8464,8 +8462,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(sdk|8.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8480,8 +8477,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8491,8 +8487,7 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.20-aot": {},
-            "$(sdk|8.0|minor-tag)-alpine3.20-aot": {},
-            "$(sdk|8.0|minor-tag)-alpine-aot": {}
+            "$(sdk|8.0|minor-tag)-alpine3.20-aot": {}
           },
           "platforms": [
             {
@@ -8505,8 +8500,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.20-aot-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.20-aot-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine-aot-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.20-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -8529,8 +8523,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.20-aot-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.20-aot-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine-aot-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.20-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -8549,7 +8542,8 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.21": {},
-            "$(sdk|8.0|minor-tag)-alpine3.21": {}
+            "$(sdk|8.0|minor-tag)-alpine3.21": {},
+            "$(sdk|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -8562,7 +8556,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(sdk|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -8576,7 +8571,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(sdk|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8591,7 +8587,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(sdk|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8601,7 +8598,8 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.21-aot": {},
-            "$(sdk|8.0|minor-tag)-alpine3.21-aot": {}
+            "$(sdk|8.0|minor-tag)-alpine3.21-aot": {},
+            "$(sdk|8.0|minor-tag)-alpine-aot": {}
           },
           "platforms": [
             {
@@ -8614,7 +8612,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-aot-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-aot-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-aot-amd64": {},
+                "$(sdk|8.0|minor-tag)-alpine-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -8637,7 +8636,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-aot-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-aot-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-aot-arm64v8": {},
+                "$(sdk|8.0|minor-tag)-alpine-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -9147,8 +9147,7 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.20": {},
-            "$(sdk|9.0|minor-tag)-alpine3.20": {},
-            "$(sdk|9.0|minor-tag)-alpine": {}
+            "$(sdk|9.0|minor-tag)-alpine3.20": {}
           },
           "platforms": [
             {
@@ -9161,8 +9160,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.20-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.20-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.20-amd64": {}
               }
             },
             {
@@ -9176,8 +9174,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.20-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine3.20-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(sdk|9.0|minor-tag)-alpine3.20-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -9192,8 +9189,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.20-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.20-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.20-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -9203,8 +9199,7 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.20-aot": {},
-            "$(sdk|9.0|minor-tag)-alpine3.20-aot": {},
-            "$(sdk|9.0|minor-tag)-alpine-aot": {}
+            "$(sdk|9.0|minor-tag)-alpine3.20-aot": {}
           },
           "platforms": [
             {
@@ -9217,8 +9212,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.20-aot-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.20-aot-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine-aot-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.20-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -9241,8 +9235,7 @@
               "osVersion": "alpine3.20",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.20-aot-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.20-aot-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine-aot-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.20-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -9261,7 +9254,8 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.21": {},
-            "$(sdk|9.0|minor-tag)-alpine3.21": {}
+            "$(sdk|9.0|minor-tag)-alpine3.21": {},
+            "$(sdk|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -9274,7 +9268,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(sdk|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -9288,7 +9283,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(sdk|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -9303,7 +9299,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(sdk|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -9313,7 +9310,8 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.21-aot": {},
-            "$(sdk|9.0|minor-tag)-alpine3.21-aot": {}
+            "$(sdk|9.0|minor-tag)-alpine3.21-aot": {},
+            "$(sdk|9.0|minor-tag)-alpine-aot": {}
           },
           "platforms": [
             {
@@ -9326,7 +9324,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-aot-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-aot-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-aot-amd64": {},
+                "$(sdk|9.0|minor-tag)-alpine-aot-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -9349,7 +9348,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-aot-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-aot-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-aot-arm64v8": {},
+                "$(sdk|9.0|minor-tag)-alpine-aot-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -5,8 +5,8 @@
     "base-url|public|preview|main": "$(base-url|public|maintenance|main)",
     "base-url|public|preview|nightly": "https://ci.dot.net/public",
 
-    "alpine|floating-tag-version": "alpine3.20",
-    "alpine|10.0|floating-tag-version": "alpine3.21",
+    "alpine|floating-tag-version": "alpine3.21",
+    "alpine|10.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|9.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|8.0|floating-tag-version": "$(alpine|floating-tag-version)",
 


### PR DESCRIPTION
Fixes #6178 

I made this edit using regexes and documented it for future reference. Expand the details to see the patterns that were used.

<details>

## How to replace Alpine floating tags with regex

First, match all Alpine tags.

```
( )*("\$\((?:dotnet|sdk)\|\d+\.0\|minor-tag\))(-alpine)((?:3.\d+)?)((?:-aot)?(?:-extra)?(?:-composite)?(?:-(?:amd64|arm64v8|arm32v7))?")(: \{\})
```

We can modify this to select floating tags only. I chose to match two lines in order to get the previous line which will need to be modified since it has a comma.

```
Regex capture groups:
 1   2                                         3         4           5
(\s+)("\$\((?:dotnet|sdk)\|\d+\.0\|minor-tag\))(-alpine)((?:3.\d+)?)((?:-aot)?(?:-extra)?(?:-composite)?(?:-(?:amd64|arm64v8|arm32v7))?"): \{\}(?:,)?\n\1\2\3\5\{6}: \{\}
```

### Remove all Alpine floating tags

```
(\s+)("\$\((?:dotnet|sdk)\|\d+\.0\|minor-tag\))(-alpine)((?:3.\d+)?)((?:-aot)?(?:-extra)?(?:-composite)?(?:-(?:amd64|arm64v8|arm32v7))?"): \{\}(?:,)?\n\1\2\3\5: \{\}
```

Replace with

```
$1$2$3$4$5: {}
```

### Add new floating tags to precise Alpine version

In this example we want to add floating tags to Alpine 3.21. For each image, Find the last Alpine 3.21 tag without a floating tag (it won't have a comma at the end of the line).

```
                                      Change the number -----,
                                                             V
(\s+)("\$\((?:dotnet|sdk)\|\d+\.0\|minor-tag\))(-alpine)((?:3.21)?)((?:-aot)?(?:-extra)?(?:-composite)?(?:-(?:amd64|arm64v8|arm32v7))?"): \{\}
```

Replace with the following to add the floating tags back.

```
$1$2$3$4$5: {},\n$1$2$3$5: {}
```


</details>