### PR TITLE
Add task for updating roadmap to dotnet-release-lifecycle.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/dotnet-release-lifecycle.md
+++ b/.github/ISSUE_TEMPLATE/releases/dotnet-release-lifecycle.md
@@ -14,7 +14,7 @@ Add due dates to each of the issues so that we don't lose track of them.
 ## Alpha
 
 - [ ] Create a new Milestone in this repo for the new .NET version
-  - [ ] Update the `https://aka.ms/netcontainers-roadmap` short link to the new milestone. You can do this from https://aka.ms/. It is linked to from [dotnet/core/roadmap.md](https://github.com/dotnet/core/blob/main/roadmap.md).
+  - [ ] Update the `https://aka.ms/netcontainers-roadmap` short link to the new milestone. You can do this from [aka.ms](https://aka.ms/). It is linked to from [dotnet/core/roadmap.md](https://github.com/dotnet/core/blob/main/roadmap.md).
 - [ ] Add new .NET version images to `nightly` branch
   - [ ] Create new images
     - [ ] Add entries for the new .NET versions in `manifest.versions.json`

--- a/.github/ISSUE_TEMPLATE/releases/dotnet-release-lifecycle.md
+++ b/.github/ISSUE_TEMPLATE/releases/dotnet-release-lifecycle.md
@@ -13,6 +13,8 @@ Add due dates to each of the issues so that we don't lose track of them.
 
 ## Alpha
 
+- [ ] Create a new Milestone in this repo for the new .NET version
+  - [ ] Update the `https://aka.ms/netcontainers-roadmap` short link to the new milestone. You can do this from https://aka.ms/. It is linked to from [dotnet/core/roadmap.md](https://github.com/dotnet/core/blob/main/roadmap.md).
 - [ ] Add new .NET version images to `nightly` branch
   - [ ] Create new images
     - [ ] Add entries for the new .NET versions in `manifest.versions.json`


### PR DESCRIPTION
The .NET containers roadmap has been added to https://github.com/dotnet/core/blob/main/roadmap.md. I added a checklist item for updating it with each new .NET version.