### PR TITLE
Scrub servicing versions for internal Dockerfile snapshot tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=0.0.0-preview.0.0.0 \
+RUN dotnet_aspire_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip" \
     && aspire_dashboard_sha512='{sha512_placeholder}' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=0.0.0-preview.0.0.0 \
+RUN dotnet_aspire_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip" \
     && aspire_dashboard_sha512='{sha512_placeholder}' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -20,9 +20,9 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -20,9 +20,9 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -20,9 +20,9 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -22,6 +22,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -22,6 +22,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -25,6 +25,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -25,6 +25,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -29,9 +29,9 @@ FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-amd64
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -29,9 +29,9 @@ FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-arm64v8
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -29,9 +29,9 @@ FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-amd64
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -29,9 +29,9 @@ FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-arm64v8
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -25,6 +25,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -25,6 +25,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $aspnetcore_version = '0.0.0-preview.0.0.0'; `
+        $aspnetcore_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -33,6 +33,6 @@ RUN powershell -Command `
 FROM $REPO:0.0.0-preview.1-nanoserver-1809
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $aspnetcore_version = '0.0.0-preview.0.0.0'; `
+        $aspnetcore_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -33,6 +33,6 @@ RUN powershell -Command `
 FROM $REPO:0.0.0-preview.1-nanoserver-ltsc2022
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $aspnetcore_version = '0.0.0-preview.0.0.0'; `
+        $aspnetcore_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -33,6 +33,6 @@ RUN powershell -Command `
 FROM $REPO:0.0.0-preview.1-nanoserver-ltsc2025
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-arm32v7
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -19,6 +19,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -19,6 +19,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-arm32v7
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -19,6 +19,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,9 +23,9 @@ FROM $REPO:0.0.0-preview.1-noble-chiseled-amd64
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,9 +23,9 @@ FROM $REPO:0.0.0-preview.1-noble-chiseled-arm32v7
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,9 +23,9 @@ FROM $REPO:0.0.0-preview.1-noble-chiseled-arm64v8
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,9 +23,9 @@ FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-amd64
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,9 +23,9 @@ FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm32v7
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
-RUN aspnetcore_version=0.0.0-preview.0.0.0  \
+RUN aspnetcore_version=0.0.0  \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,9 +23,9 @@ FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm64v8
 
 ENV \
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_VERSION=0.0.0 \
     # ASP.NET Core version
-    ASPNET_VERSION=0.0.0-preview.0.0.0
+    ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -19,6 +19,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -19,6 +19,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm32v7
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -19,6 +19,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-trixie-slim-amd64
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-trixie-slim-arm32v7
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
-RUN aspnetcore_version=0.0.0-preview.0.0.0 \
+RUN aspnetcore_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
@@ -18,6 +18,6 @@ RUN aspnetcore_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-trixie-slim-arm64v8
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/shared/Microsoft.AspNetCore.App", "/usr/share/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $aspnetcore_version = '0.0.0-preview.0.0.0'; `
+        $aspnetcore_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -33,6 +33,6 @@ RUN powershell -Command `
 FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2019
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $aspnetcore_version = '0.0.0-preview.0.0.0'; `
+        $aspnetcore_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -33,6 +33,6 @@ RUN powershell -Command `
 FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2022
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $aspnetcore_version = '0.0.0-preview.0.0.0'; `
+        $aspnetcore_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -33,6 +33,6 @@ RUN powershell -Command `
 FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2025
 
 # ASP.NET Core version
-ENV ASPNET_VERSION=0.0.0-preview.0.0.0
+ENV ASPNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet/shared/Microsoft.AspNetCore.App", "/Program Files/dotnet/shared/Microsoft.AspNetCore.App"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -5,11 +5,11 @@ FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -5,11 +5,11 @@ FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -5,11 +5,11 @@ FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -5,11 +5,11 @@ FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor extensions
-RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_extension_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor extensions
-RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_extension_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
-RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_extension_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/monitor/base
 FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
-RUN dotnet_monitor_extension_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_extension_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.6/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.6/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.6/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.6/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.0-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.4/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-cbl-mariner-distroless-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-cbl-mariner-distroless-arm64v8-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=0.0.0-alpha.0.0.0 \
+RUN dotnet_monitor_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.6/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.25058.6/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0-servicing.00000.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/reverse-proxy-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/reverse-proxy-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve YARP
-RUN yarp_version=0.0.0-preview.0.0.0 \
+RUN yarp_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output reverse-proxy.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-x64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  reverse-proxy.zip" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/reverse-proxy-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/reverse-proxy-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve YARP
-RUN yarp_version=0.0.0-preview.0.0.0 \
+RUN yarp_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output reverse-proxy.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-arm64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  reverse-proxy.zip" | sha512sum -c - \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,7 +23,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -23,7 +23,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -28,7 +28,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -28,7 +28,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -28,7 +28,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -12,7 +12,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -28,7 +28,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $dotnet_version = '0.0.0-preview.0.0.0'; `
+        $dotnet_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -36,7 +36,7 @@ ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0
+    DOTNET_VERSION=0.0.0
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $dotnet_version = '0.0.0-preview.0.0.0'; `
+        $dotnet_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -36,7 +36,7 @@ ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0
+    DOTNET_VERSION=0.0.0
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $dotnet_version = '0.0.0-preview.0.0.0'; `
+        $dotnet_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -36,7 +36,7 @@ ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0
+    DOTNET_VERSION=0.0.0
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-arm32v7
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-noble-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -22,7 +22,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -22,7 +22,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-arm32v7
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -22,7 +22,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -22,7 +22,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -22,7 +22,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm32v7
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -22,7 +22,7 @@ RUN mkdir /dotnet-symlink \
 FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/usr/share/dotnet", "/usr/share/dotnet"]
 COPY --from=installer ["/dotnet-symlink", "/usr/bin"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM amd64/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-trixie-slim-amd64
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-trixie-slim-arm32v7
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -6,7 +6,7 @@ FROM arm64v8/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
-RUN dotnet_version=0.0.0-preview.0.0.0 \
+RUN dotnet_version=0.0.0 \
     && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
@@ -19,7 +19,7 @@ RUN dotnet_version=0.0.0-preview.0.0.0 \
 FROM $REPO:0.0.0-preview.1-trixie-slim-arm64v8
 
 # .NET Runtime version
-ENV DOTNET_VERSION=0.0.0-preview.0.0.0
+ENV DOTNET_VERSION=0.0.0
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $dotnet_version = '0.0.0-preview.0.0.0'; `
+        $dotnet_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -36,7 +36,7 @@ ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0
+    DOTNET_VERSION=0.0.0
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $dotnet_version = '0.0.0-preview.0.0.0'; `
+        $dotnet_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -36,7 +36,7 @@ ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0
+    DOTNET_VERSION=0.0.0
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -10,7 +10,7 @@ RUN powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
-        $dotnet_version = '0.0.0-preview.0.0.0'; `
+        $dotnet_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -36,7 +36,7 @@ ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
     # .NET Runtime version
-    DOTNET_VERSION=0.0.0-preview.0.0.0
+    DOTNET_VERSION=0.0.0
 
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-musl-x64.tar.gz" \
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Disable the invariant mode (set in base image)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-musl-arm.tar.gz" \
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Disable the invariant mode (set in base image)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-musl-arm64.tar.gz" \
+RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64 -w 0`" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Disable the invariant mode (set in base image)
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     # Enable correct mode for dotnet watch (only mode supported in a container)

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-x64.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
@@ -25,7 +25,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-arm64.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
@@ -25,7 +25,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -28,7 +28,7 @@ RUN `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         # Retrieve .NET SDK
-        $sdk_version = '0.0.0-preview.0.0.0'; `
+        $sdk_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -71,7 +71,7 @@ ENV `
     # Do not show first run text
     DOTNET_NOLOGO=true `
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 `
+    DOTNET_SDK_VERSION=0.0.0 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -28,7 +28,7 @@ RUN `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         # Retrieve .NET SDK
-        $sdk_version = '0.0.0-preview.0.0.0'; `
+        $sdk_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -71,7 +71,7 @@ ENV `
     # Do not show first run text
     DOTNET_NOLOGO=true `
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 `
+    DOTNET_SDK_VERSION=0.0.0 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -28,7 +28,7 @@ RUN `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         # Retrieve .NET SDK
-        $sdk_version = '0.0.0-preview.0.0.0'; `
+        $sdk_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -71,7 +71,7 @@ ENV `
     # Do not show first run text
     DOTNET_NOLOGO=true `
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 `
+    DOTNET_SDK_VERSION=0.0.0 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-x64.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-arm.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-arm64.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-x64.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-arm.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0-preview.0.0.0/dotnet-sdk-0.0.0-preview.0.0.0-linux-arm64.tar.gz" \
+RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -22,7 +22,7 @@ ENV \
     # Do not show first run text
     DOTNET_NOLOGO=true \
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 \
+    DOTNET_SDK_VERSION=0.0.0 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -28,7 +28,7 @@ RUN `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         # Retrieve .NET SDK
-        $sdk_version = '0.0.0-preview.0.0.0'; `
+        $sdk_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -71,7 +71,7 @@ ENV `
     # Do not show first run text
     DOTNET_NOLOGO=true `
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 `
+    DOTNET_SDK_VERSION=0.0.0 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -28,7 +28,7 @@ RUN `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         # Retrieve .NET SDK
-        $sdk_version = '0.0.0-preview.0.0.0'; `
+        $sdk_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -71,7 +71,7 @@ ENV `
     # Do not show first run text
     DOTNET_NOLOGO=true `
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 `
+    DOTNET_SDK_VERSION=0.0.0 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -28,7 +28,7 @@ RUN `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         # Retrieve .NET SDK
-        $sdk_version = '0.0.0-preview.0.0.0'; `
+        $sdk_version = '0.0.0'; `
         `
         $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
         $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
@@ -71,7 +71,7 @@ ENV `
     # Do not show first run text
     DOTNET_NOLOGO=true `
     # SDK version
-    DOTNET_SDK_VERSION=0.0.0-preview.0.0.0 `
+    DOTNET_SDK_VERSION=0.0.0 `
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
@@ -19,12 +19,9 @@ public static partial class DockerfileHelper
     [GeneratedRegex("[A-Fa-f0-9]{64}")]
     public static partial Regex Sha256Regex { get; }
 
-    // Match 1.2.3-servicing.45678.9
-    [GeneratedRegex(@"\d+\.\d+\.\d+-servicing\.\d+.\d+")]
-    public static partial Regex ServicingVersionRegex { get; }
-
-    [GeneratedRegex(@"\d+\.\d+\.\d+")]
-    public static partial Regex SemanticVersionRegex { get; }
+    // Match versions like `1.2.3`, `1.2.3-foo.45678.9`, and `1.2.3-preview.4.56789.0`
+    [GeneratedRegex(@"\d+\.\d+\.\d+ (-\w+(\.\d+){2,})?", RegexOptions.IgnorePatternWhitespace)]
+    public static partial Regex VersionRegex { get; }
 
     [GeneratedRegex(@"v\d+\.\d+\.\d+\.windows\.\d+")]
     public static partial Regex MinGitVersionRegex { get; }

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
@@ -19,7 +19,11 @@ public static partial class DockerfileHelper
     [GeneratedRegex("[A-Fa-f0-9]{64}")]
     public static partial Regex Sha256Regex { get; }
 
-    [GeneratedRegex(@"\d+\.\d+\.\d+(?!\.windows)")]
+    // Match 1.2.3-servicing.45678.9
+    [GeneratedRegex(@"\d+\.\d+\.\d+-servicing\.\d+.\d+")]
+    public static partial Regex ServicingVersionRegex { get; }
+
+    [GeneratedRegex(@"\d+\.\d+\.\d+")]
     public static partial Regex SemanticVersionRegex { get; }
 
     [GeneratedRegex(@"v\d+\.\d+\.\d+\.windows\.\d+")]

--- a/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
@@ -79,8 +79,7 @@ public class GeneratedArtifactTests
             (DockerfileHelper.Sha512Regex, "{sha512_placeholder}"),
             (DockerfileHelper.Sha386Regex, "{sha386_placeholder}"),
             (DockerfileHelper.Sha256Regex, "{sha256_placeholder}"),
-            (DockerfileHelper.ServicingVersionRegex, "0.0.0-servicing.00000.0"),
-            (DockerfileHelper.SemanticVersionRegex, "0.0.0"),
+            (DockerfileHelper.VersionRegex, "0.0.0"),
             (DockerfileHelper.MinGitVersionRegex, "v0.0.0.windows.0"),
             (DockerfileHelper.AlpineVersionRegex, "alpine3.XX"),
         ];
@@ -89,7 +88,7 @@ public class GeneratedArtifactTests
         {
             foreach ((Regex pattern, string replacement) in replacePatterns)
             {
-                content = pattern.Replace(content, replacement);
+                content = pattern.Replace(content, replacement, count: 99);
             }
 
             return content;

--- a/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
@@ -79,6 +79,7 @@ public class GeneratedArtifactTests
             (DockerfileHelper.Sha512Regex, "{sha512_placeholder}"),
             (DockerfileHelper.Sha386Regex, "{sha386_placeholder}"),
             (DockerfileHelper.Sha256Regex, "{sha256_placeholder}"),
+            (DockerfileHelper.ServicingVersionRegex, "0.0.0-servicing.00000.0"),
             (DockerfileHelper.SemanticVersionRegex, "0.0.0"),
             (DockerfileHelper.MinGitVersionRegex, "v0.0.0.windows.0"),
             (DockerfileHelper.AlpineVersionRegex, "alpine3.XX"),

--- a/tests/accept-changes.ps1
+++ b/tests/accept-changes.ps1
@@ -36,5 +36,5 @@ $files = Get-ChildItem `
 if ($Discard) {
     $files | Remove-Item
 } else {
-    $files | Rename-Item -NewName { $_.Name -replace '\.received\.txt$', '.approved.txt' }
+    $files | Move-Item -Force -Destination { $_.DirectoryName + "/" + ($_.Name -replace '\.received\.txt$', '.approved.txt') }
 }


### PR DESCRIPTION
This PR fixes the test failures in:
- https://github.com/dotnet/dotnet-docker/pull/6200
- https://github.com/dotnet/dotnet-docker/pull/6201
- https://github.com/dotnet/dotnet-docker/pull/6202