### PR TITLE
Fix environment variable checks to account for empty value

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/Config.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/Config.cs
@@ -13,33 +13,43 @@ namespace Microsoft.DotNet.Docker.Tests
     {
         private const string VariableGroupName = "variable";
         private const string VariablePattern = $"\\$\\((?<{VariableGroupName}>[\\w:\\-.|]+)\\)";
-        private static Lazy<JObject> ManifestVersions { get; } = new Lazy<JObject>(() => LoadManifest("manifest.versions.json"));
+        private static Lazy<JObject> ManifestVersions { get; } =
+            new Lazy<JObject>(() => LoadManifest("manifest.versions.json"));
 
         public static Lazy<JObject> Manifest { get; } = new Lazy<JObject>(() => LoadManifest("manifest.json"));
-        public static string SourceRepoRoot { get; } = Environment.GetEnvironmentVariable("SOURCE_REPO_ROOT") ?? string.Empty;
+        public static string SourceRepoRoot { get; } =
+            GetEnvironmentVariableOrDefault("SOURCE_REPO_ROOT", string.Empty);
         public static bool IsHttpVerificationDisabled { get; } =
             Environment.GetEnvironmentVariable("DISABLE_HTTP_VERIFICATION") != null;
-        public static bool PullImages { get; } = Environment.GetEnvironmentVariable("PULL_IMAGES") != null;
+        public static bool PullImages { get; } =
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PULL_IMAGES"));
         public static bool IsNightlyRepo { get; } = GetIsNightlyRepo();
         public static bool IsRunningInContainer { get; } =
-            Environment.GetEnvironmentVariable("RUNNING_TESTS_IN_CONTAINER") != null;
-        public static string RepoPrefix { get; } = Environment.GetEnvironmentVariable("REPO_PREFIX") ?? string.Empty;
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("RUNNING_TESTS_IN_CONTAINER"));
+        public static string RepoPrefix { get; } = GetEnvironmentVariableOrDefault("REPO_PREFIX", string.Empty);
         public static string Registry { get; } =
-            Environment.GetEnvironmentVariable("REGISTRY") ?? (string)Manifest.Value["registry"];
+            GetEnvironmentVariableOrDefault("REGISTRY", (string)Manifest.Value["registry"]);
         public static string CacheRegistry { get; } =
-            Environment.GetEnvironmentVariable("CACHE_REGISTRY") ?? string.Empty;
+            GetEnvironmentVariableOrDefault("CACHE_REGISTRY", string.Empty);
         public static string[] OsNames { get; } =
-            (Environment.GetEnvironmentVariable("IMAGE_OS_NAMES") ?? string.Empty).Split(",", StringSplitOptions.RemoveEmptyEntries);
+            GetEnvironmentVariableOrDefault("IMAGE_OS_NAMES", string.Empty)
+                .Split(",", StringSplitOptions.RemoveEmptyEntries);
         public static string SourceBranch { get; } =
-            Environment.GetEnvironmentVariable("SOURCE_BRANCH") ?? string.Empty;
+            GetEnvironmentVariableOrDefault("SOURCE_BRANCH", string.Empty);
         public static string InternalAccessToken { get; } =
-            Environment.GetEnvironmentVariable("INTERNAL_ACCESS_TOKEN") ?? string.Empty;
+            GetEnvironmentVariableOrDefault("INTERNAL_ACCESS_TOKEN", string.Empty);
         public static string[] Paths { get; } =
             Environment.GetEnvironmentVariable("DOCKERFILE_PATHS")?
-                .Split(',', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+                .Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [];
 
         public static bool IsInternal { get; } =
-            Environment.GetEnvironmentVariable("INTERNAL_TESTING") != null;
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("INTERNAL_TESTING"));
+
+        private static string GetEnvironmentVariableOrDefault(string variableName, string defaultValue)
+        {
+            string value = Environment.GetEnvironmentVariable(variableName);
+            return !string.IsNullOrEmpty(value) ? value : defaultValue;
+        }
 
         private static bool GetIsNightlyRepo()
         {


### PR DESCRIPTION
PR builds have suddenly started failing with errors like `/dotnet/nightly/sdk:10.0-preview-alpine3.21-amd64` could not be found on disk.` The image name here is not valid because it is missing the registry name.

The registry doesn't get defaulted to `mcr.microsoft.com` because of this check: https://github.com/dotnet/dotnet-docker/blob/f528525ecaa407f6ba09384c321d4611afc461e0/tests/Microsoft.DotNet.Docker.Tests/Config.cs#L28

In this case, the value returned from `GetEnvironmentVariable` is an empty value instead of `null`. Because it's not null, it doesn't default it to the value from the manifest which is `mcr.microsoft.com`.  This return value is a change in behavior that I haven't been able to account for. Comparing previously successful builds, the same version of .NET SDK is installed and the agent image version is the same.

Regardless, updating the code to account for an empty value resolves the issue.