### PR TITLE
Test testdata

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageData.cs
@@ -136,10 +136,15 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public static string GetImageName(string tag, string repoName, string repoNameModifier = null)
         {
-            string repo = $"dotnet{repoNameModifier ?? GetRepoNameModifier()}/{repoName}";
+            string repo = GetRepoName(repoName, repoNameModifier);
             string registry = GetRegistryName(repo, tag);
 
             return $"{registry}{repo}:{tag}";
+        }
+
+        public static string GetRepoName(string repoName, string repoNameModifier = null)
+        {
+            return $"dotnet{repoNameModifier ?? GetRepoNameModifier()}/{repoName}";
         }
 
         protected string GetTagName(string tagPrefix, string os, string tagPostfix = null)
@@ -149,9 +154,9 @@ namespace Microsoft.DotNet.Docker.Tests
             return string.Join('-', tagParts);
         }
 
-        protected virtual string GetArchTagSuffix() => (Arch == Arch.Amd64 && !DockerHelper.IsLinuxContainerModeEnabled)
-            ? string.Empty
-            : GetArchLabel();
+        protected virtual string GetArchTagSuffix() => (Arch == Arch.Amd64 && IsWindows)
+                ? string.Empty
+                : GetArchLabel();
 
         protected string GetArchLabel() =>
             Arch switch

--- a/tests/Microsoft.DotNet.Docker.Tests/ManifestHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ManifestHelper.cs
@@ -10,68 +10,67 @@ using System.Text.RegularExpressions;
 
 #nullable enable
 
-namespace Microsoft.DotNet.Docker.Tests
+namespace Microsoft.DotNet.Docker.Tests;
+
+public static class ManifestHelper
 {
-    public static class ManifestHelper
+    public record DockerfileInfo(string Repo, string MajorMinor, string Os, string Architecture);
+
+    public static Manifest GetManifest() =>
+        JsonConvert.DeserializeObject<Manifest>(Config.Manifest.Value.ToString()) ??
+        throw new Exception("Failed to deserialize manifest");
+
+    public static string GetResolvedProductVersion(Image image) =>
+        GetVariableValue(image.ProductVersion);
+
+    public static IEnumerable<string> GetResolvedProductVersions(Repo repo) =>
+        repo.Images.Select(GetResolvedProductVersion).Distinct();
+
+    public static List<string> GetResolvedSharedTags(Image image) =>
+        image.SharedTags.Keys.Select(GetVariableValue).ToList();
+
+    public static List<string> GetResolvedTags(Platform platform) =>
+        platform.Tags.Keys.Select(GetVariableValue).ToList();
+
+    private static readonly string DockerfileRegex = @"src/(?<repo>.+)/(?<major_minor>\d+\.\d+)/(?<os>.+)/(?<architecture>.+)";
+
+    public static Dictionary<DockerfileInfo, List<string>> GetDockerfileTags(Repo repo)
     {
-        public record DockerfileInfo(string Repo, string MajorMinor, string Os, string Architecture);
-
-        public static Manifest GetManifest() =>
-            JsonConvert.DeserializeObject<Manifest>(Config.Manifest.Value.ToString()) ??
-            throw new Exception("Failed to deserialize manifest");
-
-        public static string GetResolvedProductVersion(Image image) =>
-            GetVariableValue(image.ProductVersion);
-
-        public static IEnumerable<string> GetResolvedProductVersions(Repo repo) =>
-            repo.Images.Select(GetResolvedProductVersion).Distinct();
-
-        public static List<string> GetResolvedSharedTags(Image image) =>
-            image.SharedTags.Keys.Select(GetVariableValue).ToList();
-
-        public static List<string> GetResolvedTags(Platform platform) =>
-            platform.Tags.Keys.Select(GetVariableValue).ToList();
-
-        private static readonly string DockerfileRegex = @"src/(?<repo>.+)/(?<major_minor>\d+\.\d+)/(?<os>.+)/(?<architecture>.+)";
-
-        public static Dictionary<DockerfileInfo, List<string>> GetDockerfileTags(Repo repo)
+        Dictionary<DockerfileInfo, List<string>> dockerfileTags = new Dictionary<DockerfileInfo, List<string>>();
+        foreach (Image image in repo.Images)
         {
-            Dictionary<DockerfileInfo, List<string>> dockerfileTags = new Dictionary<DockerfileInfo, List<string>>();
-            foreach (Image image in repo.Images)
+            foreach (Platform platform in image.Platforms)
             {
-                foreach (Platform platform in image.Platforms)
+                DockerfileInfo dockerfileInfo = GetDockerfileInfo(platform.Dockerfile);
+                if (!dockerfileTags.ContainsKey(dockerfileInfo))
                 {
-                    DockerfileInfo dockerfileInfo = GetDockerfileInfo(platform.Dockerfile);
-                    if (!dockerfileTags.ContainsKey(dockerfileInfo))
-                    {
-                        dockerfileTags[dockerfileInfo] = new List<string>();
-                    }
-                    dockerfileTags[dockerfileInfo].AddRange(GetResolvedTags(platform));
-                    dockerfileTags[dockerfileInfo].AddRange(GetResolvedSharedTags(image));
+                    dockerfileTags[dockerfileInfo] = new List<string>();
                 }
+                dockerfileTags[dockerfileInfo].AddRange(GetResolvedTags(platform));
+                dockerfileTags[dockerfileInfo].AddRange(GetResolvedSharedTags(image));
             }
-            return dockerfileTags;
         }
+        return dockerfileTags;
+    }
 
-        public static DockerfileInfo GetDockerfileInfo(string dockerfile)
+    public static DockerfileInfo GetDockerfileInfo(string dockerfile)
+    {
+        var match = Regex.Match(dockerfile, DockerfileRegex);
+        if (!match.Success)
         {
-            var match = Regex.Match(dockerfile, DockerfileRegex);
-            if (!match.Success)
-            {
-                throw new Exception($"Failed to parse dockerfile: {dockerfile}");
-            }
-            return new DockerfileInfo(match.Groups["repo"].Value, match.Groups["major_minor"].Value, match.Groups["os"].Value, match.Groups["architecture"].Value);
+            throw new Exception($"Failed to parse dockerfile: {dockerfile}");
         }
+        return new DockerfileInfo(match.Groups["repo"].Value, match.Groups["major_minor"].Value, match.Groups["os"].Value, match.Groups["architecture"].Value);
+    }
 
-        private static string GetVariableValue(string input)
+    private static string GetVariableValue(string input)
+    {
+        string variablePattern = @"\$\((?<variable>.+)\)";
+        foreach (Match match in Regex.Matches(input, variablePattern))
         {
-            string variablePattern = @"\$\((?<variable>.+)\)";
-            foreach (Match match in Regex.Matches(input, variablePattern))
-            {
-                string variableName = Config.GetVariableValue(match.Groups["variable"].Value);
-                input = input.Replace(match.Value, variableName);
-            }
-            return input;
+            string variableName = Config.GetVariableValue(match.Groups["variable"].Value);
+            input = input.Replace(match.Value, variableName);
         }
+        return input;
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Docker.Tests
             IEnumerable<string> pathComponents =
             [
                 "src",
-                GetImageRepoName(imageRepo),
+                GetDotNetImageRepoName(imageRepo),
                 Version.ToString(),
                 OSDir + GetVariantSuffix(),
                 GetArchLabel()
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public override string GetIdentifier(string type) => $"{VersionString}-{base.GetIdentifier(type)}";
 
-        public static string GetImageRepoName(DotNetImageRepo imageRepo) =>
+        public static string GetDotNetImageRepoName(DotNetImageRepo imageRepo) =>
             Enum.GetName(typeof(DotNetImageRepo), imageRepo).ToLowerInvariant().Replace('_', '-');
 
         public static string GetImageVariantName(DotNetImageVariant imageVariant)
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
 
             string tag = GetTagName(imageRepo);
-            string imageName = GetImageName(tag, GetImageRepoName(imageRepo));
+            string imageName = GetImageName(tag, GetDotNetImageRepoName(imageRepo));
 
             if (!skipPull)
             {

--- a/tests/Microsoft.DotNet.Docker.Tests/StaticTagTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/StaticTagTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Docker.Tests
             VersionType versionType,
             bool checkOs,
             bool checkArchitecture,
-            Func<ManifestHelper.DockerfileInfo, bool> skipDockerFileOn)
+            Func<DockerfileInfo, bool> skipDockerFileOn)
         {
 
             if (!checkOs && !checkArchitecture)
@@ -128,10 +128,10 @@ namespace Microsoft.DotNet.Docker.Tests
                     "Please use the VersionTag tests for this scenario.");
             }
 
-            Dictionary<ManifestHelper.DockerfileInfo, List<string>> dockerfileTags = ManifestHelper.GetDockerfileTags(repo);
-            foreach (KeyValuePair<ManifestHelper.DockerfileInfo, List<string>> dockerfileTag in dockerfileTags)
+            Dictionary<DockerfileInfo, List<string>> dockerfileTags = ManifestHelper.GetDockerfileTags(repo);
+            foreach (KeyValuePair<DockerfileInfo, List<string>> dockerfileTag in dockerfileTags)
             {
-                ManifestHelper.DockerfileInfo dockerfileInfo = dockerfileTag.Key;
+                DockerfileInfo dockerfileInfo = dockerfileTag.Key;
                 if (skipDockerFileOn(dockerfileInfo))
                 {
                     continue;
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public void VersionTag_SameOsAndVersion(Repo repo, VersionType versionType)
         {
             // Group tags -> dockerfiles
-            Dictionary<string, List<ManifestHelper.DockerfileInfo>> tagsToDockerfiles = ManifestHelper.GetDockerfileTags(repo)
+            Dictionary<string, List<DockerfileInfo>> tagsToDockerfiles = ManifestHelper.GetDockerfileTags(repo)
                 .SelectMany(pair => pair.Value
                     .Where(tag => IsTagOfFormat(
                         tag,
@@ -223,10 +223,10 @@ namespace Microsoft.DotNet.Docker.Tests
                 .GroupBy(pair => pair.tag, pair => pair.Key)
                 .ToDictionary(group => group.Key, group => group.ToList());
 
-            foreach (KeyValuePair<string, List<ManifestHelper.DockerfileInfo>> tagToDockerfiles in tagsToDockerfiles)
+            foreach (KeyValuePair<string, List<DockerfileInfo>> tagToDockerfiles in tagsToDockerfiles)
             {
                 string tag = tagToDockerfiles.Key;
-                List<ManifestHelper.DockerfileInfo> dockerfiles = tagToDockerfiles.Value;
+                List<DockerfileInfo> dockerfiles = tagToDockerfiles.Value;
 
                 List<string> dockerfileVersions = dockerfiles
                     .Select(dockerfile => dockerfile.MajorMinor)
@@ -495,7 +495,7 @@ namespace Microsoft.DotNet.Docker.Tests
             VersionType? versionType = null,
             bool? checkOs = false,
             bool? checkArchitecture = false,
-            Func<ManifestHelper.DockerfileInfo, bool>? skipDockerfileOn = null)
+            Func<DockerfileInfo, bool>? skipDockerfileOn = null)
         {
             switch (testType)
             {
@@ -528,18 +528,18 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        private static bool IsWindows(ManifestHelper.DockerfileInfo dockerfileInfo) =>
+        private static bool IsWindows(DockerfileInfo dockerfileInfo) =>
             dockerfileInfo.Os.Contains("windowsservercore") || dockerfileInfo.Os.Contains("nanoserver");
 
         // Certain versions of appliance repos use a new tag schema.
         // This new schema excludes the OS from all tags.
         // The aspire-dashboard repo uses this schema for all versions.
         // The monitor and monitor-base repos use this schema for versions 9 and above.
-        private static bool IsApplianceVersionUsingOldSchema(ManifestHelper.DockerfileInfo dockerfileInfo) =>
+        private static bool IsApplianceVersionUsingOldSchema(DockerfileInfo dockerfileInfo) =>
             dockerfileInfo.Repo.Contains("monitor") && GetVersion(dockerfileInfo.MajorMinor).Major <= 8;
 
         // <cref="IsApplianceVersionUsingOldSchema"/>
-        private static bool IsApplianceVersionUsingNewSchema(ManifestHelper.DockerfileInfo dockerfileInfo) =>
+        private static bool IsApplianceVersionUsingNewSchema(DockerfileInfo dockerfileInfo) =>
             !IsApplianceVersionUsingOldSchema(dockerfileInfo);
 
         private static bool IsExpectedMajorMinorVersion(Repo repo, string version)
@@ -608,7 +608,7 @@ namespace Microsoft.DotNet.Docker.Tests
             return new Regex($"^{tagRegex}" + (os != null ? $"-{os}" : string.Empty) + (architecture != null ? $"-{architecture}" : string.Empty) + "$");
         }
 
-        private static Version GetAlpineVersion(ManifestHelper.DockerfileInfo dockerfileInfo)
+        private static Version GetAlpineVersion(DockerfileInfo dockerfileInfo)
         {
             string parsedOs = dockerfileInfo.Os.Replace(OS.Alpine, string.Empty);
             parsedOs.Should().NotBeNullOrWhiteSpace(

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -80,6 +80,8 @@ namespace Microsoft.DotNet.Docker.Tests
                     ImageVariant = DotNetImageVariant.Composite, SupportedImageRepos = DotNetImageRepo.Aspnet },
             new ProductImageData { Version = V8_0, OS = OS.AzureLinux30Distroless, Arch = Arch.Arm64,   SdkOS = OS.AzureLinux30,
                     ImageVariant = DotNetImageVariant.Composite | DotNetImageVariant.Extra, SupportedImageRepos = DotNetImageRepo.Aspnet },
+            new ProductImageData { Version = V8_0, OS = OS.AzureLinux30Distroless, Arch = Arch.Arm64,   SdkOS = OS.AzureLinux30, SdkImageVariant = DotNetImageVariant.AOT,
+                    ImageVariant = DotNetImageVariant.AOT, SupportedImageRepos = DotNetImageRepo.Runtime_Deps },
             new ProductImageData { Version = V8_0, OS = OS.Mariner20,           Arch = Arch.Arm64 },
             new ProductImageData { Version = V8_0, OS = OS.Mariner20Distroless, Arch = Arch.Arm64,   SdkOS = OS.Mariner20 },
             new ProductImageData { Version = V8_0, OS = OS.Mariner20Distroless, Arch = Arch.Arm64,   SdkOS = OS.Mariner20,
@@ -88,6 +90,8 @@ namespace Microsoft.DotNet.Docker.Tests
                     ImageVariant = DotNetImageVariant.Composite, SupportedImageRepos = DotNetImageRepo.Aspnet },
             new ProductImageData { Version = V8_0, OS = OS.Mariner20Distroless, Arch = Arch.Arm64,   SdkOS = OS.Mariner20,
                     ImageVariant = DotNetImageVariant.Composite | DotNetImageVariant.Extra, SupportedImageRepos = DotNetImageRepo.Aspnet },
+            new ProductImageData { Version = V8_0, OS = OS.Mariner20Distroless, Arch = Arch.Arm64,   SdkOS = OS.Mariner20, SdkImageVariant = DotNetImageVariant.AOT,
+                    ImageVariant = DotNetImageVariant.AOT, SupportedImageRepos = DotNetImageRepo.Runtime_Deps },
             new ProductImageData { Version = V8_0, OS = OS.BookwormSlim,        Arch = Arch.Arm64 },
             new ProductImageData { Version = V8_0, OS = OS.Jammy,               Arch = Arch.Arm64 },
             new ProductImageData { Version = V8_0, OS = OS.JammyChiseled,       Arch = Arch.Arm64,   SdkOS = OS.Jammy },
@@ -196,6 +200,8 @@ namespace Microsoft.DotNet.Docker.Tests
                     ImageVariant = DotNetImageVariant.Composite, SupportedImageRepos = DotNetImageRepo.Aspnet },
             new ProductImageData { Version = V9_0, OS = OS.AzureLinux30Distroless, Arch = Arch.Arm64,   SdkOS = OS.AzureLinux30,
                     ImageVariant = DotNetImageVariant.Composite | DotNetImageVariant.Extra, SupportedImageRepos = DotNetImageRepo.Aspnet },
+            new ProductImageData { Version = V9_0, OS = OS.AzureLinux30Distroless, Arch = Arch.Arm64,   SdkOS = OS.AzureLinux30, SdkImageVariant = DotNetImageVariant.AOT,
+                    ImageVariant = DotNetImageVariant.AOT, SupportedImageRepos = DotNetImageRepo.Runtime_Deps },
             new ProductImageData { Version = V9_0, OS = OS.BookwormSlim,        Arch = Arch.Arm64 },
             new ProductImageData { Version = V9_0, OS = OS.Noble,               Arch = Arch.Arm64 },
             new ProductImageData { Version = V9_0, OS = OS.NobleChiseled,       Arch = Arch.Arm64,   SdkOS = OS.Noble },
@@ -327,6 +333,13 @@ namespace Microsoft.DotNet.Docker.Tests
             new ProductImageData { Version = V9_0, OS = OS.ServerCoreLtsc2019, Arch = Arch.Amd64 },
             new ProductImageData { Version = V9_0, OS = OS.ServerCoreLtsc2022, Arch = Arch.Amd64 },
             new ProductImageData { Version = V9_0, OS = OS.ServerCoreLtsc2025, Arch = Arch.Amd64 },
+
+            new ProductImageData { Version = V10_0_Preview, OS = OS.NanoServer1809,     Arch = Arch.Amd64 },
+            new ProductImageData { Version = V10_0_Preview, OS = OS.NanoServerLtsc2022, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V10_0_Preview, OS = OS.NanoServerLtsc2025, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V10_0_Preview, OS = OS.ServerCoreLtsc2019, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V10_0_Preview, OS = OS.ServerCoreLtsc2022, Arch = Arch.Amd64 },
+            new ProductImageData { Version = V10_0_Preview, OS = OS.ServerCoreLtsc2025, Arch = Arch.Amd64 },
         };
 
         private static readonly SampleImageData[] s_linuxSampleTestData =
@@ -431,6 +444,16 @@ namespace Microsoft.DotNet.Docker.Tests
                 Arch = Arch.Arm64,
                 SupportedImageRepos = DotNetImageRepo.Reverse_Proxy
             },
+        ];
+
+        public static IEnumerable<ProductImageData> AllImageData =>
+        [
+            ..s_linuxTestData,
+            ..s_windowsTestData,
+            ..s_AspireDashboardTestData,
+            ..s_linuxMonitorTestData,
+            ..s_windowsMonitorTestData,
+            ..s_ReverseProxyTestData,
         ];
 
         public static IEnumerable<ProductImageData> GetImageData(

--- a/tests/Microsoft.DotNet.Docker.Tests/TestDataTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestDataTests.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+namespace Microsoft.DotNet.Docker.Tests;
+
+[Trait("Category", "pre-build")]
+public class TestDataTests(ITestOutputHelper outputHelper)
+{
+    private readonly DockerHelper _dockerHelper = new(outputHelper);
+
+    private readonly ITestOutputHelper _outputHelper = outputHelper;
+
+    private readonly Manifest _manifest = ManifestHelper.GetManifest();
+
+    public static readonly IEnumerable<object[]> ImageRepos =
+        Enum.GetValues<DotNetImageRepo>()
+            .Select(repo => new object[] { repo })
+            .ToArray();
+
+    // Verifies that all images described in the manifest are present in the test data
+    [Theory]
+    [MemberData(nameof(ImageRepos))]
+    public void VerifyTestData(DotNetImageRepo imageRepo)
+    {
+        string repoName = ImageData.GetRepoName(ProductImageData.GetDotNetImageRepoName(imageRepo));
+
+        if (repoName.Contains("base"))
+        {
+            return;
+        }
+
+        Repo manifestRepo = _manifest.Repos.First(r => r.Name == repoName);
+
+        List<string> testDataTags =
+            GetTestData(imageRepo)
+                .Select(productImageData =>
+                    productImageData
+                        .GetImage(imageRepo, _dockerHelper, skipPull: true)
+                        .Split(':')[1])
+                .ToList();
+
+        // Account for SDK AOT images. They are tested based on the runtime-deps images.
+        if (imageRepo == DotNetImageRepo.SDK)
+        {
+            testDataTags =
+            [
+                ..testDataTags,
+                ..GetTestData(DotNetImageRepo.Runtime_Deps)
+                    .Where(productImageData => productImageData.SdkImageVariant.HasFlag(DotNetImageVariant.AOT))
+                    .Select(productImageData =>
+                        productImageData
+                            .GetImage(imageRepo, _dockerHelper, skipPull: true)
+                            .Split(':')[1])
+            ];
+        }
+
+        IEnumerable<List<string>> manifestTagsByPlatform = ManifestHelper.GetDockerfileTags(manifestRepo).Values;
+
+        Action[] conditions = manifestTagsByPlatform
+            .Select<List<string>, Action>(imageTags => () =>
+                imageTags.ShouldContain(
+                    tag => testDataTags.Contains(tag),
+                    "Expected one of the following tags to be represented in test data: " + string.Join(", ", imageTags)))
+            .ToArray();
+
+        manifestTagsByPlatform.ShouldSatisfyAllConditions(conditions);
+    }
+
+    private static IEnumerable<ProductImageData> GetTestData(DotNetImageRepo repo) =>
+        TestData.AllImageData.Where(p => p.SupportedImageRepos.HasFlag(repo));
+}


### PR DESCRIPTION
Issues like https://github.com/dotnet/dotnet-docker/issues/6199 should not be possible. We need to have confidence that we're testing all of our images.

There is an issue, https://github.com/dotnet/dotnet-docker/issues/5337, which tracks eliminating the test data by using the manifest/image info files instead, but that work is more complicated. @mthalman suggested [generating the test data](https://github.com/dotnet/dotnet-docker/pull/6203#pullrequestreview-2595818985). However, we would first need a way to have confidence that what we generate covers all of the images we have.

With all that in mind, I implemented this low-cost test which reads the tags from the manifest, and validates that each image in the manifest has an associated entry in the TestData. It already found several missing test datas which is a win in itself.