### PR TITLE
Cache result of Docker OS to speed up XUnit test discovery

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -16,7 +16,9 @@ namespace Microsoft.DotNet.Docker.Tests
 {
     public class DockerHelper
     {
-        public static string DockerOS => GetDockerOS();
+        private static readonly Lazy<string> s_dockerOS = new(GetDockerOS);
+        public static string DockerOS => s_dockerOS.Value;
+
         public static string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
         public static bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
         public static string TestArtifactsDir { get; } = Path.Combine(Directory.GetCurrentDirectory(), "TestAppArtifacts");


### PR DESCRIPTION
I got frustrated with slow Test Discovery and used PerfView on a run of our unit tests to see why it took so long. `DockerOS` was being accessed many times during test discovery because we have the custom `LinuxImageTheory` attribute. Each time it was accessed, it took two seconds to call `docker.exe`, even though the result never changes during a single test run.

Wrapping it in a Lazy<> speeds up test discovery by a factor of ~60.

Before - **27.64 seconds**

```
Starting test discovery, please wait...
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.5+1caef2f33e (64-bit .NET 9.0.1)
[xUnit.net 00:00:00.70]   Discovering: Microsoft.DotNet.Docker.Tests
[xUnit.net 00:00:28.34]   Discovered:  Microsoft.DotNet.Docker.Tests
```

After - **0.44 seconds**

```
Starting test discovery, please wait...
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.5+1caef2f33e (64-bit .NET 9.0.1)
[xUnit.net 00:00:00.66]   Discovering: Microsoft.DotNet.Docker.Tests
[xUnit.net 00:00:01.10]   Discovered:  Microsoft.DotNet.Docker.Tests
```