### PR TITLE
Add SymCrypt packages to expected list for Azure Linux 3

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -313,6 +313,8 @@ namespace Microsoft.DotNet.Docker.Tests
             {
                 { OS: string os } when os.Contains(OS.AzureLinux) => new[]
                     {
+                        "SymCrypt",
+                        "SymCrypt-OpenSSL",
                         "azurelinux-release",
                         "distroless-packages-minimal",
                         "filesystem",


### PR DESCRIPTION
When installing `openssl-libs` in the Azure Linux 3.0 Dockerfile, it causes new dependency packages to be installed: `SymCrypt`, `SymCrypt-OpenSSL`.

This is causing failures in the distroless unit tests where we validate which packages get installed:

```
 Expected Packages: [ azurelinux-release, distroless-packages-minimal, filesystem, glibc, libgcc, libstdc++, openssl, openssl-libs, prebuilt-ca-certificates, tzdata, zlib ]
 Actual Packages: [ SymCrypt, SymCrypt-OpenSSL, azurelinux-release, distroless-packages-minimal, filesystem, glibc, libgcc, libstdc++, openssl, openssl-libs, prebuilt-ca-certificates, tzdata, zlib ]
```

Adding these to the expected list.

cc @jslobodzian 