### PR TITLE
Scrub four-part versions for internal Dockerfile validation test

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
@@ -19,8 +19,8 @@ public static partial class DockerfileHelper
     [GeneratedRegex("[A-Fa-f0-9]{64}")]
     public static partial Regex Sha256Regex { get; }
 
-    // Match versions like `1.2.3`, `1.2.3-foo.45678.9`, and `1.2.3-preview.4.56789.0`
-    [GeneratedRegex(@"\d+\.\d+\.\d+ (-\w+(\.\d+){2,})?", RegexOptions.IgnorePatternWhitespace)]
+    // Match versions like `1.2.3`, `1.2.3.4`, `1.2.3-foo.45678.9`, and `1.2.3-preview.4.56789.0`
+    [GeneratedRegex(@"\d+\.\d+\.\d+(\.d+)?(-\w+(\.\d+){2,})?")]
     public static partial Regex VersionRegex { get; }
 
     [GeneratedRegex(@"v\d+\.\d+\.\d+\.windows\.\d+")]


### PR DESCRIPTION
MinGit had a four-part version in its filename, which left the fourth part un-scrubbed in the internal Dockerfile validation tests, requiring a baseline update: https://github.com/dotnet/dotnet-docker/pull/6232/commits/8de81ac20e64575d80b1fe362e3d1ea0a2b38fc6

e.g. MinGit-**2.47.1.2**-64-bit.zip

This PR updates the regex to allow an optional fourth part in the existing version pattern.