### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,7 @@
                 "remote.otherPortsAttributes": {
                     "onAutoForward": "ignore"
                 },
-                "terminal.integrated.defaultProfile.linux": "bash",
-                "dotnet.defaultSolution": "tests/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj"
+                "terminal.integrated.defaultProfile.linux": "bash"
             }
         }
     },


### PR DESCRIPTION
This will enable:

- Codespaces
- GitHub Copilot Workspaces (preview)

I validated that I can run comands like `Get-GeneratedDockerfiles.ps1` successfully. Non-root user is not currently working with the Docker-in-Docker feature. I will file an issue on https://github.com/devcontainers/features for that.