### PR TITLE
Allow major version preview tags to exist with GA tags within a major version group

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/StaticTagTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/StaticTagTests.cs
@@ -137,6 +137,10 @@ namespace Microsoft.DotNet.Docker.Tests
                     continue;
                 }
 
+                Version dockerfileVersion = GetVersion(dockerfileInfo.MajorMinor);
+
+                bool hasPreviewInMajorVersionGroup = HasPreviewProductVersion(repo, dockerfileVersion.Major);
+
                 IEnumerable<string> tags = dockerfileTag.Value
                     .Where(tag => IsTagOfFormat(
                         tag,
@@ -145,12 +149,12 @@ namespace Microsoft.DotNet.Docker.Tests
                         checkOs ? dockerfileInfo.Os : null,
                         checkArchitecture ? dockerfileInfo.Architecture : null));
 
-                if (versionType == VersionType.Major && !IsExpectedMajorMinorVersion(repo, dockerfileInfo.MajorMinor))
+                if (versionType == VersionType.Major && !IsLatestInMajorVersionGroup(repo, dockerfileInfo.MajorMinor, hasPreviewInMajorVersionGroup))
                 {
                     // Special case for major version tags
-                    // These tags should be on the most up-to-date Major.Minor version for the respective major version
+                    // These tags should be on the latest Major.Minor GA version for the respective major version
                     tags.Should().BeEmpty("expected tag to be on latest Major.Minor version for version " +
-                        GetVersion(dockerfileInfo.MajorMinor).Major + ", but found the tag on " + dockerfileInfo);
+                        dockerfileVersion.Major + ", but found the tag on " + dockerfileInfo);
                 }
                 else
                 {
@@ -242,8 +246,8 @@ namespace Microsoft.DotNet.Docker.Tests
 
                     // Special case for major version tags
                     // These tags should be on the most up-to-date Major.Minor version for the respective major version
-                    IsExpectedMajorMinorVersion(repo, dockerfileVersion).Should().BeTrue(
-                        "expected tag to be on the latest Major.Minor version for the major version " +
+                    IsLatestInMajorVersionGroup(repo, dockerfileVersion, tag.Contains("-preview")).Should().BeTrue(
+                        "expected tag to be on the latest Major.Minor GA version for the major version " +
                         GetVersion(dockerfileVersion).Major + ", but found the tag on " + dockerfileVersion);
                 }
 
@@ -542,7 +546,14 @@ namespace Microsoft.DotNet.Docker.Tests
         private static bool IsApplianceVersionUsingNewSchema(DockerfileInfo dockerfileInfo) =>
             !IsApplianceVersionUsingOldSchema(dockerfileInfo);
 
-        private static bool IsExpectedMajorMinorVersion(Repo repo, string version)
+        /// <summary>
+        /// Determines if the <paramref name="majorMinorVersion"/> is the latest in its major version group.
+        /// </summary>
+        /// <remarks>
+        /// By default, this will only consider GA versions within the major version group (unless there are no GA versions).
+        /// The <paramref name="includePreviewVersions"/> parameter can be set to include preview versions in the check.
+        /// </remarks>
+        private static bool IsLatestInMajorVersionGroup(Repo repo, string majorMinorVersion, bool includePreviewVersions)
         {
             IEnumerable<string> productVersions = ManifestHelper.GetResolvedProductVersions(repo);
 
@@ -552,19 +563,17 @@ namespace Microsoft.DotNet.Docker.Tests
                 .GroupBy(version => GetVersion(version).Major)
                 .Select(group =>
                 {
-                    if (!Config.IsNightlyRepo)
+                    if (includePreviewVersions)
                     {
-                        // Use the latest GA major version on the main branch
-                        // Assumes that non-GA versions have a hyphen in them
-                        // e.g. non-GA: 5.0.0-preview.1, GA: 5.0.0
-                        // RTM versions are also accepted as GA versions for internal testing purposes
+                        return group;
+                    }
+                    else
+                    {
+                        // Use the latest GA major version.
                         // If there are no GA versions, use the latest preview version.
-                        IEnumerable<string> gaVersions = group.Where(version =>
-                            !version.Contains('-') || version.Contains("rtm"));
+                        IEnumerable<string> gaVersions = group.Where(version => IsGAVersion(version));
                         return gaVersions.Any() ? gaVersions : group;
                     }
-                    // Use the latest major version on the nightly branch
-                    return group;
                 })
                 .Select(group => group.Select(version =>
                 {
@@ -575,8 +584,38 @@ namespace Microsoft.DotNet.Docker.Tests
                 }).OrderByDescending(version => version).First())
                 .ToList();
 
-            Version inputVersion = GetVersion(version);
+            Version inputVersion = GetVersion(majorMinorVersion);
             return majorMinorVersions.Contains(new Version(inputVersion.Major, inputVersion.Minor));
+        }
+
+        /// <summary>
+        /// Determines if a major product version has a preview version.
+        /// </summary>
+        private static bool HasPreviewProductVersion(Repo repo, int majorVersion)
+        {
+            IEnumerable<string> productVersions = ManifestHelper.GetResolvedProductVersions(repo);
+
+            IGrouping<int, string>? matchingMajorVersionGroup = productVersions
+                .GroupBy(version => GetVersion(version).Major)
+                .SingleOrDefault(group => group.Key == majorVersion);
+
+            if (null == matchingMajorVersionGroup)
+                return false;
+
+            return matchingMajorVersionGroup.Any(version => !IsGAVersion(version));
+        }
+
+        /// <summary>
+        /// Determines if the version is considered a GA version.
+        /// </summary>
+        /// <remarks>
+        /// Assumes that non-GA versions have a hyphen in them
+        /// e.g. non-GA: 5.0.0-preview.1, GA: 5.0.0
+        /// RTM versions are also accepted as GA versions.
+        /// </remarks>
+        private static bool IsGAVersion(string version)
+        {
+            return !version.Contains('-') || version.Contains("rtm");
         }
 
         private static bool IsTagOfFormat(


### PR DESCRIPTION
This change updates the StaticTagTests to allow major version preview tags to be used on the latest preview version of a product while the GA tags are on the latest GA version of a product within a major version group. For example, we are trying to add .NET Monitor 9.1 images to the manifest and would like to have the following tags:
- .NET Monitor 9.0: `9`, `9.0`
- .NET Monitor 9.1: `9-preview`, `9.1-preview`

As the StaticTagTests are today, they would require that the `9` tag be placed on the .NET Monitor 9.1 images even though they are still in preview. These changes make sure that the major version GA tags are only on the latest major.minor version within a major version group.

These changes should work with the existing images in the manifest (because there are no images that have a mixture of preview and GA tags within the same major version group) as well as the changes in #6230 