### PR TITLE
Use bash instead of sh in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,6 @@
     "image": "mcr.microsoft.com/dotnet/sdk:9.0-noble",
     "features": {
         "ghcr.io/devcontainers/features/common-utils": {
-            "installZsh": true,
-            "configureZshAsDefaultShell": "true",
             "username": "app",
             "userUid": 1654,
             "userGid": 1654
@@ -26,5 +24,5 @@
         }
     },
     "remoteUser": "app",
-    "updateContentCommand": "docker pull mcr.microsoft.com/dotnet-buildtools/image-builder:latest"
+    "onCreateCommand": "sudo chsh -s /bin/bash app"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,5 +24,6 @@
         }
     },
     "remoteUser": "app",
-    "onCreateCommand": "sudo chsh -s /bin/bash app"
+    "onCreateCommand": "sudo chsh -s /bin/bash app",
+    "updateContentCommand": "docker pull mcr.microsoft.com/dotnet-buildtools/image-builder:latest"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,13 @@
 {
     "image": "mcr.microsoft.com/dotnet/sdk:9.0-noble",
     "features": {
+        "ghcr.io/devcontainers/features/common-utils": {
+            "installZsh": true,
+            "configureZshAsDefaultShell": "true",
+            "username": "app",
+            "userUid": 1654,
+            "userGid": 1654
+        },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
     "customizations": {
@@ -14,8 +21,7 @@
                 "remote.autoForwardPortsSource": "hybrid",
                 "remote.otherPortsAttributes": {
                     "onAutoForward": "ignore"
-                },
-                "terminal.integrated.defaultProfile.linux": "bash"
+                }
             }
         }
     },


### PR DESCRIPTION
Some features of GitHub Copilot Workspaces rely on features present in bash/zsh that are not present in sh. Copilot uses the default terminal from the container. In our SDK images, that is sh.

The option that was previously set in devcontainer.json is a VS Code setting, so it doesn't apply to Copilot Workspaces. ~~Running `chsh -s /bin/bash` doesn't work either, since we're running as non-root. That command requires elevation.~~

That leaves two options, which were:
- Use a Dockerfile to set SHELL to bash
- Use the official devcontainers "common-utils" features to install zsh and set it as the default. ~~This is the one I chose. This is also what the dotnet devcontainers images use: https://github.com/devcontainers/images/blob/cd4daf6c6b692cea79c83ff26c60bca44f51e8f7/src/dotnet/.devcontainer/devcontainer.json#L8~~

~~"common-utils" does not provide an option for bash instead of zsh. zsh, however, is the default shell on macOS so it should not be unfamiliar. Most things are similar to bash.~~

PowerShell is installed and works perfectly for running the scripts in this repo (e.g. `pwsh ./eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1`). You can also just start your own `pwsh` session if you prefer it.

I would prefer not to keep a devcontainer Dockerfile around, if possible. Using "common-utils" also gets us a few more features including `sudo` setup using our existing non-root user `app`. Typically, having `sudo` in your container is a bad thing but it's actually helpful in the devcontainer. It means you can install additional packages if you want, or change anything you need to in the devcontainer environment and it will be blown away after you're done.