### PR TITLE
Add Copilot Instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+# Instructions for GitHub Copilot
+
+## How to edit Dockerfiles and READMEs
+
+- Dockerfiles and READMEs are generated from templates using Cottle. Dockerfile templates are located in the `eng/dockerfile-templates` directory, and README templates are located in the `eng/readme-templates` directory.
+- Do not edit the Dockerfiles in `src/` directly.
+- To generate Dockerfiles, run `pwsh ./eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1`.
+- Do not edit `*README*.md` files directly.
+- To generate READMEs, run `pwsh ./eng/readme-templates/Get-GeneratedReadmes.ps1`.
+
+## Manifests
+
+- `manifest.json` describes the Dockerfiles in this repo and how they should be built, tagged, and published.
+- `manifest.versions.json` contains product version information used by the Dockerfile templates. It is typically updated using the `eng/update-dependencies` tool.
+
+## How to build and test
+
+- Only build and test images that were changed. When changing many images, just build and test a single combination of .NET version and OS as a sanity check.
+- To build Dockerfiles, run `pwsh ./build-and-test.ps1 -mode 'Build' -paths '*glob*pattern*'`. For example, to build all .NET 9.0 Ubuntu Noble images, run `./build-and-test.ps1 -paths '*9.0*noble*'`.
+- To run image tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'`.
+- To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths ` script with the `pre-build` test category. For example, run `./tests/run-tests.ps1 -TestCategories "pre-build" -Version "*"`.
+
+## Other
+
+- Do not edit files in `eng/common/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@
 - To build Dockerfiles, run `pwsh ./build-and-test.ps1 -mode 'Build' -paths '*glob*pattern*'`. For example, to build all .NET 9.0 Ubuntu Noble images, run `./build-and-test.ps1 -paths '*9.0*noble*'`.
 - To run image tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'`.
 - To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'` script with the `pre-build` test category.
+
 ## Other
 
 - Do not edit files in `eng/common/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@
 - Only build and test images that were changed. When changing many images, just build and test a single combination of .NET version and OS as a sanity check.
 - To build Dockerfiles, run `pwsh ./build-and-test.ps1 -mode 'Build' -paths '*glob*pattern*'`. For example, to build all .NET 9.0 Ubuntu Noble images, run `./build-and-test.ps1 -paths '*9.0*noble*'`.
 - To run image tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'`.
-- To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'` script with the `pre-build` test category.
+- To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*' -TestCategories @('pre-build')`.
 
 ## Other
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,7 @@
 - Only build and test images that were changed. When changing many images, just build and test a single combination of .NET version and OS as a sanity check.
 - To build Dockerfiles, run `pwsh ./build-and-test.ps1 -mode 'Build' -paths '*glob*pattern*'`. For example, to build all .NET 9.0 Ubuntu Noble images, run `./build-and-test.ps1 -paths '*9.0*noble*'`.
 - To run image tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'`.
-- To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths ` script with the `pre-build` test category. For example, run `./tests/run-tests.ps1 -TestCategories "pre-build" -Version "*"`.
-
+- To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'` script with the `pre-build` test category.
 ## Other
 
 - Do not edit files in `eng/common/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@
 - Only build and test images that were changed. When changing many images, just build and test a single combination of .NET version and OS as a sanity check.
 - To build Dockerfiles, run `pwsh ./build-and-test.ps1 -mode 'Build' -paths '*glob*pattern*'`. For example, to build all .NET 9.0 Ubuntu Noble images, run `./build-and-test.ps1 -paths '*9.0*noble*'`.
 - To run image tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*'`.
-- To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths '*glob*pattern*' -TestCategories @('pre-build')`.
+- To run only the pre-build validation tests, run `pwsh ./tests/run-tests.ps1 -paths '*' -TestCategories @('pre-build')`.
 
 ## Other
 


### PR DESCRIPTION
These changes add instructions for GitHub Copilot to the `.github/copilot-instructions.md` file.

The documentation for Copilot instructions is at: https://github.blog/changelog/2025-01-21-custom-repository-instructions-are-now-available-for-copilot-on-github-com-public-preview/

Developing these instructions will be an iterative process and this is only the first iteration. There is probably more we can add later.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet/dotnet-docker/pull/6247?shareId=4d3b4d82-8cc3-43e9-b2a4-4c2390ee1d91).