### PR TITLE
Add VS Code task for verifying internal Dockerfile template baselines

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,6 +55,12 @@
             ]
         },
         {
+            "label": "Verify internal Dockerfiles",
+            "type": "shell",
+            "command": "pwsh ./tests/run-tests.ps1 -paths '*' -TestCategories @('pre-build') -CustomTestFilter 'VerifyInternalDockerfiles'",
+            "group": "test"
+        },
+        {
             "label": "Test with debugger",
             "type": "process",
             "isBackground": true,


### PR DESCRIPTION
As it's useful to run the VerifyInternalDockerfiles test when updating Dockerfile templates, I've added this VS Code task which runs just the one test.