### PR TITLE
Undocument dotnet/monitor 8.1 platform tags

### DIFF
--- a/README.monitor.md
+++ b/README.monitor.md
@@ -54,8 +54,8 @@ See [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.2, 9.0, 9 | [Dockerfile](src/monitor/9.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
-8.1.0-ubuntu-chiseled-amd64, 8.1-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.0-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0, 8.1, 8 | [Dockerfile](src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
-8.1.0-cbl-mariner-distroless-amd64, 8.1-cbl-mariner-distroless-amd64, 8-cbl-mariner-distroless-amd64, 8.1.0-cbl-mariner-distroless, 8.1-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](src/monitor/8.1/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+8.1.0-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0, 8.1, 8 | [Dockerfile](src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
+8.1.0-cbl-mariner-distroless, 8.1-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](src/monitor/8.1/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
 8.0.8-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.8, 8.0 | [Dockerfile](src/monitor/8.0/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 8.0.8-cbl-mariner-distroless, 8.0-cbl-mariner-distroless | [Dockerfile](src/monitor/8.0/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
 
@@ -70,8 +70,8 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.2, 9.0, 9 | [Dockerfile](src/monitor/9.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
-8.1.0-ubuntu-chiseled-arm64v8, 8.1-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.0-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0, 8.1, 8 | [Dockerfile](src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
-8.1.0-cbl-mariner-distroless-arm64v8, 8.1-cbl-mariner-distroless-arm64v8, 8-cbl-mariner-distroless-arm64v8, 8.1.0-cbl-mariner-distroless, 8.1-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](src/monitor/8.1/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+8.1.0-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.0, 8.1, 8 | [Dockerfile](src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
+8.1.0-cbl-mariner-distroless, 8.1-cbl-mariner-distroless, 8-cbl-mariner-distroless | [Dockerfile](src/monitor/8.1/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
 8.0.8-ubuntu-chiseled, 8.0-ubuntu-chiseled, 8.0.8, 8.0 | [Dockerfile](src/monitor/8.0/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 8.0.8-cbl-mariner-distroless, 8.0-cbl-mariner-distroless | [Dockerfile](src/monitor/8.0/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
 

--- a/manifest.json
+++ b/manifest.json
@@ -10333,9 +10333,15 @@
               "os": "linux",
               "osVersion": "jammy-chiseled",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-ubuntu-chiseled-amd64": {},
-                "$(monitor|8.1|minor-tag)-ubuntu-chiseled-amd64": {},
-                "$(monitor|8|major-tag)-ubuntu-chiseled-amd64": {}
+                "$(monitor|8.1|fixed-tag)-ubuntu-chiseled-amd64": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8.1|minor-tag)-ubuntu-chiseled-amd64": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8|major-tag)-ubuntu-chiseled-amd64": {
+                  "docType": "Undocumented"
+                }
               }
             },
             {
@@ -10348,9 +10354,15 @@
               "os": "linux",
               "osVersion": "jammy-chiseled",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-ubuntu-chiseled-arm64v8": {},
-                "$(monitor|8.1|minor-tag)-ubuntu-chiseled-arm64v8": {},
-                "$(monitor|8|major-tag)-ubuntu-chiseled-arm64v8": {}
+                "$(monitor|8.1|fixed-tag)-ubuntu-chiseled-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8.1|minor-tag)-ubuntu-chiseled-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8|major-tag)-ubuntu-chiseled-arm64v8": {
+                  "docType": "Undocumented"
+                }
               },
               "variant": "v8"
             }
@@ -10373,9 +10385,15 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-amd64": {},
-                "$(monitor|8|major-tag)-cbl-mariner-distroless-amd64": {}
+                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8|major-tag)-cbl-mariner-distroless-amd64": {
+                  "docType": "Undocumented"
+                }
               }
             },
             {
@@ -10388,9 +10406,15 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0-distroless",
               "tags": {
-                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-arm64v8": {},
-                "$(monitor|8|major-tag)-cbl-mariner-distroless-arm64v8": {}
+                "$(monitor|8.1|fixed-tag)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8.1|minor-tag)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                },
+                "$(monitor|8|major-tag)-cbl-mariner-distroless-arm64v8": {
+                  "docType": "Undocumented"
+                }
               },
               "variant": "v8"
             }


### PR DESCRIPTION
The platform tags for .NET Monitor 8.1 were not undocumented in the nightly branch, whereas in the main branch they are undocumented as expected. This change reconciles that difference so that the platform tags are undocumented in the nightly branch.