### PR TITLE
Update Dockerfile version regex to handle `preview.*` versions

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64
+FROM $REPO:0.0.0-alpine3.XX-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0  \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64
+FROM $REPO:0.0.0-alpine3.XX-amd64
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0  \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0  \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64 AS installer
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
 
 ARG ACCESSTOKEN
 
@@ -20,7 +20,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64
+FROM $REPO:0.0.0-azurelinux3.0-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8 AS installer
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
 
 ARG ACCESSTOKEN
 
@@ -20,7 +20,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -22,7 +22,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-amd64
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -22,7 +22,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-amd64
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-amd64
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -22,7 +22,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-amd64
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -22,7 +22,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -30,7 +30,7 @@ RUN powershell -Command `
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-nanoserver-1809
+FROM $REPO:0.0.0-nanoserver-1809
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,7 +30,7 @@ RUN powershell -Command `
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-nanoserver-ltsc2022
+FROM $REPO:0.0.0-nanoserver-ltsc2022
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,7 +30,7 @@ RUN powershell -Command `
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-nanoserver-ltsc2025
+FROM $REPO:0.0.0-nanoserver-ltsc2025
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-amd64-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-amd64
+FROM $REPO:0.0.0-noble-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-arm32v7
+FROM $REPO:0.0.0-noble-arm32v7
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-arm64v8
+FROM $REPO:0.0.0-noble-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-amd64
+FROM $REPO:0.0.0-noble-chiseled-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-arm32v7
+FROM $REPO:0.0.0-noble-chiseled-arm32v7
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-arm64v8
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-amd64
+FROM $REPO:0.0.0-noble-chiseled-amd64
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-arm32v7
+FROM $REPO:0.0.0-noble-chiseled-arm32v7
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-arm64v8
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-amd64
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm32v7
+FROM $REPO:0.0.0-noble-chiseled-extra-arm32v7
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # ASP.NET Composite Image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm64v8
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
 
 ENV \
     # .NET Runtime version

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-amd64
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm32v7
+FROM $REPO:0.0.0-noble-chiseled-extra-arm32v7
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm64v8
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-trixie-slim-amd64
+FROM $REPO:0.0.0-trixie-slim-amd64
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-trixie-slim-arm32v7
+FROM $REPO:0.0.0-trixie-slim-arm32v7
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN aspnetcore_version=0.0.0 \
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-trixie-slim-arm64v8
+FROM $REPO:0.0.0-trixie-slim-arm64v8
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -30,7 +30,7 @@ RUN powershell -Command `
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2019
+FROM $REPO:0.0.0-windowsservercore-ltsc2019
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,7 +30,7 @@ RUN powershell -Command `
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2022
+FROM $REPO:0.0.0-windowsservercore-ltsc2022
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,7 +30,7 @@ RUN powershell -Command `
 
 
 # ASP.NET Core image
-FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2025
+FROM $REPO:0.0.0-windowsservercore-ltsc2025
 
 # ASP.NET Core version
 ENV ASPNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -27,6 +27,6 @@ RUN dotnet_monitor_extension_version=0.0.0 \
 
 
 # .NET Monitor image
-FROM $REPO:0.0.0-alpha.1-amd64
+FROM $REPO:0.0.0-amd64
 
 COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -27,6 +27,6 @@ RUN dotnet_monitor_extension_version=0.0.0 \
 
 
 # .NET Monitor image
-FROM $REPO:0.0.0-alpha.1-arm64v8
+FROM $REPO:0.0.0-arm64v8
 
 COPY --from=installer ["/app", "/app"]

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64
+FROM $REPO:0.0.0-alpine3.XX-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 
 ARG ACCESSTOKEN
 
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64 AS installer
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
 
 ARG ACCESSTOKEN
 
@@ -20,7 +20,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64
+FROM $REPO:0.0.0-azurelinux3.0-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime-deps
 
 # Installer image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8 AS installer
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
 
 ARG ACCESSTOKEN
 
@@ -20,7 +20,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-amd64
+FROM $REPO:0.0.0-azurelinux3.0-distroless-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-distroless-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-amd64
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -25,7 +25,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-distroless-extra-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-amd64-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-amd64
+FROM $REPO:0.0.0-noble-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-arm32v7
+FROM $REPO:0.0.0-noble-arm32v7
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-arm64v8
+FROM $REPO:0.0.0-noble-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-amd64
+FROM $REPO:0.0.0-noble-chiseled-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-arm32v7
+FROM $REPO:0.0.0-noble-chiseled-arm32v7
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-arm64v8
+FROM $REPO:0.0.0-noble-chiseled-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-amd64
+FROM $REPO:0.0.0-noble-chiseled-extra-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm32v7
+FROM $REPO:0.0.0-noble-chiseled-extra-arm32v7
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,7 @@ RUN mkdir /dotnet-symlink \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-noble-chiseled-extra-arm64v8
+FROM $REPO:0.0.0-noble-chiseled-extra-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-trixie-slim-amd64
+FROM $REPO:0.0.0-trixie-slim-amd64
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-trixie-slim-arm32v7
+FROM $REPO:0.0.0-trixie-slim-arm32v7
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -16,7 +16,7 @@ RUN dotnet_version=0.0.0 \
 
 
 # .NET runtime image
-FROM $REPO:0.0.0-preview.1-trixie-slim-arm64v8
+FROM $REPO:0.0.0-trixie-slim-arm64v8
 
 # .NET Runtime version
 ENV DOTNET_VERSION=0.0.0

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -1,6 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64 AS installer
+FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 
 ARG ACCESSTOKEN
 
@@ -14,7 +14,7 @@ RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-amd64
+FROM $REPO:0.0.0-alpine3.XX-amd64
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -1,6 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 
 ARG ACCESSTOKEN
 
@@ -14,7 +14,7 @@ RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm32v7
+FROM $REPO:0.0.0-alpine3.XX-arm32v7
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -1,6 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 # Installer image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8 AS installer
+FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 
 ARG ACCESSTOKEN
 
@@ -14,7 +14,7 @@ RUN wget --header="Authorization: Basic `echo $ACCESSTOKEN:$ACCESSTOKEN | base64
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-alpine3.XX-arm64v8
+FROM $REPO:0.0.0-alpine3.XX-arm64v8
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -1,6 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 # Installer image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64 AS installer
+FROM $REPO:0.0.0-azurelinux3.0-amd64 AS installer
 
 ARG ACCESSTOKEN
 
@@ -18,7 +18,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-amd64
+FROM $REPO:0.0.0-azurelinux3.0-amd64
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -1,6 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 # Installer image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8 AS installer
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8 AS installer
 
 ARG ACCESSTOKEN
 
@@ -18,7 +18,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-azurelinux3.0-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-arm64v8
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -64,7 +64,7 @@ RUN `
 
 
 # SDK image
-FROM $REPO:0.0.0-preview.1-nanoserver-1809
+FROM $REPO:0.0.0-nanoserver-1809
 
 ENV `
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -64,7 +64,7 @@ RUN `
 
 
 # SDK image
-FROM $REPO:0.0.0-preview.1-nanoserver-ltsc2022
+FROM $REPO:0.0.0-nanoserver-ltsc2022
 
 ENV `
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -64,7 +64,7 @@ RUN `
 
 
 # SDK image
-FROM $REPO:0.0.0-preview.1-nanoserver-ltsc2025
+FROM $REPO:0.0.0-nanoserver-ltsc2025
 
 ENV `
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
@@ -14,7 +14,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-noble-amd64
+FROM $REPO:0.0.0-noble-amd64
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -14,7 +14,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-noble-arm32v7
+FROM $REPO:0.0.0-noble-arm32v7
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -14,7 +14,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-noble-arm64v8
+FROM $REPO:0.0.0-noble-arm64v8
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -14,7 +14,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-trixie-slim-amd64
+FROM $REPO:0.0.0-trixie-slim-amd64
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -14,7 +14,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-trixie-slim-arm32v7
+FROM $REPO:0.0.0-trixie-slim-arm32v7
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -14,7 +14,7 @@ RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts
 
 
 # .NET SDK image
-FROM $REPO:0.0.0-preview.1-trixie-slim-arm64v8
+FROM $REPO:0.0.0-trixie-slim-arm64v8
 
 ENV \
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -64,7 +64,7 @@ RUN `
 
 
 # SDK image
-FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2019
+FROM $REPO:0.0.0-windowsservercore-ltsc2019
 
 ENV `
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -64,7 +64,7 @@ RUN `
 
 
 # SDK image
-FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2022
+FROM $REPO:0.0.0-windowsservercore-ltsc2022
 
 ENV `
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -64,7 +64,7 @@ RUN `
 
 
 # SDK image
-FROM $REPO:0.0.0-preview.1-windowsservercore-ltsc2025
+FROM $REPO:0.0.0-windowsservercore-ltsc2025
 
 ENV `
     # Do not generate certificate

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
@@ -20,7 +20,7 @@ public static partial class DockerfileHelper
     public static partial Regex Sha256Regex { get; }
 
     // Match versions like `1.2.3`, `1.2.3.4`, `1.2.3-foo.45678.9`, and `1.2.3-preview.4.56789.0`
-    [GeneratedRegex(@"\d+\.\d+\.\d+(\.d+)?(-\w+(\.\d+){2,})?")]
+    [GeneratedRegex(@"\d+\.\d+\.\d+(\.d+)?(-[A-Za-z]+(\.\d+)+)?")]
     public static partial Regex VersionRegex { get; }
 
     [GeneratedRegex(@"v\d+\.\d+\.\d+\.windows\.\d+")]


### PR DESCRIPTION
Fixes baseline diffs due to .NET 10 preview as well as https://github.com/dotnet/dotnet-docker/pull/6267