### PR TITLE
[main] Disable internal Dockerfile tests for internal builds

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
@@ -51,6 +51,14 @@ public class GeneratedArtifactTests
     [Fact]
     public void VerifyInternalDockerfilesOutput()
     {
+        if (Config.IsInternal)
+        {
+            OutputHelper.WriteLine(
+                "Skipping test since it is not useful for internal build scenarios. " +
+                "If there are issues with internal Dockerfiles, then internal builds will fail.");
+            return;
+        }
+
         const string InternalDockerfilesSubfolder = "Baselines";
 
         using TempFolderContext outputDirectory = FileHelper.UseTempFolder();


### PR DESCRIPTION
Port of https://github.com/dotnet/dotnet-docker/pull/6273 to main branch.