### PR TITLE
Update Aspire Dashboard image to Azure Linux 3.0

### DIFF
--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -118,13 +118,13 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-9.1.0-preview.1, 9.1-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.1/cbl-mariner-distroless/amd64/Dockerfile) | CBL-Mariner 2.0
+9.1.0-preview.1, 9.1-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.1/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 
 ### Linux arm64 Tags
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-9.1.0-preview.1, 9.1-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.1/cbl-mariner-distroless/arm64v8/Dockerfile) | CBL-Mariner 2.0
+9.1.0-preview.1, 9.1-preview, 9-preview, latest | [Dockerfile](src/aspire-dashboard/9.1/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md). See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/nightly/aspire-dashboard/tags/list) for all supported and unsupported tags.*

--- a/manifest.json
+++ b/manifest.json
@@ -10607,10 +10607,10 @@
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
               },
-              "dockerfile": "src/aspire-dashboard/9.1/cbl-mariner-distroless/amd64",
+              "dockerfile": "src/aspire-dashboard/9.1/azurelinux-distroless/amd64",
               "dockerfileTemplate": "eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
                 "$(aspire-dashboard|9.1|fixed-tag)-amd64": {
                   "docType": "Undocumented"
@@ -10628,10 +10628,10 @@
               "buildArgs": {
                 "REPO": "$(Repo:aspnet)"
               },
-              "dockerfile": "src/aspire-dashboard/9.1/cbl-mariner-distroless/arm64v8",
+              "dockerfile": "src/aspire-dashboard/9.1/azurelinux-distroless/arm64v8",
               "dockerfileTemplate": "eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux",
               "os": "linux",
-              "osVersion": "cbl-mariner2.0-distroless",
+              "osVersion": "azurelinux3.0-distroless",
               "tags": {
                 "$(aspire-dashboard|9.1|fixed-tag)-arm64v8": {
                   "docType": "Undocumented"

--- a/src/aspire-dashboard/9.1/azurelinux-distroless/amd64/Dockerfile
+++ b/src/aspire-dashboard/9.1/azurelinux-distroless/amd64/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip" \
-    && aspire_dashboard_sha512='{sha512_placeholder}' \
+RUN dotnet_aspire_version=9.1.0-preview.1.25121.10 \
+    && curl -fSL --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip \
+    && aspire_dashboard_sha512='fa72cd70f14ef38f1fff46afc7de045c8d25662e4f4ee2b3880e3601a99a7d595a0f387cdfc17ee84384422b6be7382f7126f9b740b6085057d83987b0fb45cc' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \
     && unzip aspire_dashboard.zip -d /app \
@@ -19,7 +19,7 @@ RUN dotnet_aspire_version=0.0.0 \
 
 
 # Aspire Dashboard image
-FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-amd64
+FROM $REPO:8.0.13-azurelinux3.0-distroless-extra-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/src/aspire-dashboard/9.1/azurelinux-distroless/arm64v8/Dockerfile
+++ b/src/aspire-dashboard/9.1/azurelinux-distroless/arm64v8/Dockerfile
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip" \
-    && aspire_dashboard_sha512='{sha512_placeholder}' \
+RUN dotnet_aspire_version=9.1.0-preview.1.25121.10 \
+    && curl -fSL --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip \
+    && aspire_dashboard_sha512='0bd05e484d1db34ac91b3096950cbf663f816a20646804600f90cc965210f49cc333e1ba6ecd5fa39691ac438c84d1c964be6d1094a9d9055a72ac6822a5610e' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \
     && unzip aspire_dashboard.zip -d /app \
@@ -19,7 +19,7 @@ RUN dotnet_aspire_version=0.0.0 \
 
 
 # Aspire Dashboard image
-FROM $REPO:0.0.0-cbl-mariner2.0-distroless-extra-arm64v8
+FROM $REPO:8.0.13-azurelinux3.0-distroless-extra-arm64v8
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=9.1.0-preview.1.25121.10 \
-    && curl -fSL --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip \
-    && aspire_dashboard_sha512='fa72cd70f14ef38f1fff46afc7de045c8d25662e4f4ee2b3880e3601a99a7d595a0f387cdfc17ee84384422b6be7382f7126f9b740b6085057d83987b0fb45cc' \
+RUN dotnet_aspire_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip" \
+    && aspire_dashboard_sha512='{sha512_placeholder}' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \
     && unzip aspire_dashboard.zip -d /app \
@@ -19,7 +19,7 @@ RUN dotnet_aspire_version=9.1.0-preview.1.25121.10 \
 
 
 # Aspire Dashboard image
-FROM $REPO:8.0.13-cbl-mariner2.0-distroless-extra-amd64
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-amd64
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -1,7 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS installer
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
 
 RUN tdnf install -y \
         ca-certificates \
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=9.1.0-preview.1.25121.10 \
-    && curl -fSL --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip \
-    && aspire_dashboard_sha512='0bd05e484d1db34ac91b3096950cbf663f816a20646804600f90cc965210f49cc333e1ba6ecd5fa39691ac438c84d1c964be6d1094a9d9055a72ac6822a5610e' \
+RUN dotnet_aspire_version=0.0.0 \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip" \
+    && aspire_dashboard_sha512='{sha512_placeholder}' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \
     && unzip aspire_dashboard.zip -d /app \
@@ -19,7 +19,7 @@ RUN dotnet_aspire_version=9.1.0-preview.1.25121.10 \
 
 
 # Aspire Dashboard image
-FROM $REPO:8.0.13-cbl-mariner2.0-distroless-extra-arm64v8
+FROM $REPO:0.0.0-azurelinux3.0-distroless-extra-arm64v8
 
 WORKDIR /app
 COPY --from=installer /app .

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -413,18 +413,18 @@ namespace Microsoft.DotNet.Docker.Tests
             new() {
                 Version = V9_1_Preview,
                 VersionFamily = V9_0,
-                OS = OS.Mariner20Distroless,
+                OS = OS.AzureLinux30Distroless,
                 OSTag = "",
-                OSDir = OS.MarinerDistroless,
+                OSDir = OS.AzureLinuxDistroless,
                 Arch = Arch.Amd64,
                 SupportedImageRepos = DotNetImageRepo.Aspire_Dashboard,
             },
             new() {
                 Version = V9_1_Preview,
                 VersionFamily = V9_0,
-                OS = OS.Mariner20Distroless,
+                OS = OS.AzureLinux30Distroless,
                 OSTag = "",
-                OSDir = OS.MarinerDistroless,
+                OSDir = OS.AzureLinuxDistroless,
                 Arch = Arch.Arm64,
                 SupportedImageRepos = DotNetImageRepo.Aspire_Dashboard
             },

--- a/tests/performance/ImageSize.nightly.linux.json
+++ b/tests/performance/ImageSize.nightly.linux.json
@@ -436,8 +436,8 @@
     "src/monitor-base/9.1/azurelinux-distroless/arm64v8": 141390045
   },
   "dotnet/nightly/aspire-dashboard": {
-    "src/aspire-dashboard/9.1/cbl-mariner-distroless/amd64": 142036038,
-    "src/aspire-dashboard/9.1/cbl-mariner-distroless/arm64v8": 148315271
+    "src/aspire-dashboard/9.1/azurelinux-distroless/amd64": 142036038,
+    "src/aspire-dashboard/9.1/azurelinux-distroless/arm64v8": 148315271
   },
   "dotnet/nightly/yarp": {
     "src/yarp/2.3/azurelinux-distroless/amd64": 141557760,


### PR DESCRIPTION
Part 2/2 of [Update .NET 8-based aspire-dashboard and monitor mariner images to 3.0 (#5375)](https://github.com/dotnet/dotnet-docker/issues/5375)

Related to #6257 