### PR TITLE
Add retries to SDK download in VerifyDotnetFolderContents test

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Docker.Tests
         private static readonly Dictionary<string, IEnumerable<SdkContentFileInfo>> s_sdkContentsCache =
             new Dictionary<string, IEnumerable<SdkContentFileInfo>>();
 
-        private static readonly RetryStrategyOptions s_downloadRetryStrategy =
+        private static readonly RetryStrategyOptions s_sdkDownloadRetryStrategy =
             new()
             {
                 BackoffType = DelayBackoffType.Exponential,
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         private static readonly ResiliencePipeline s_sdkDownloadPipeline =
             new ResiliencePipelineBuilder()
-                .AddRetry(s_downloadRetryStrategy)
+                .AddRetry(s_sdkDownloadRetryStrategy)
                 .Build();
 
         private static readonly HttpClient s_httpClient = CreateHttpClient();

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/WebScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/WebScenario.cs
@@ -5,7 +5,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Polly;
-using Polly.CircuitBreaker;
 using Polly.Retry;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
The VerifyDotnetFolderContents test is causing flaky PR validation due to issues with downloading the SDK from the internet. This PR adds retry logic to the test.

Other changes:
- Pulled HttpClient and auth stuff out as static members
- Enabled nullable annotations in the file
- Cleaned up what I saw as unnecessary code
  - `IEqualityComparer`
  - use record value equality instead of `IComparable`