### PR TITLE
Add ACCESSTOKEN support to Aspire Dashboard and YARP internal Dockerfiles 

### DIFF
--- a/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux
@@ -1,6 +1,7 @@
 {{
-    set dotnetMajor to split(PRODUCT_VERSION, ".")[0] ^
-    set dotnetMajorMinor to cat(dotnetMajor, ".0") ^
+    set aspireVersionParts to split(PRODUCT_VERSION, ".") ^
+    set aspireMajorMinor to cat(aspireVersionParts[0], ".", aspireVersionParts[1]) ^
+
     set isAzureLinux to find(OS_VERSION, "mariner") >= 0 || find(OS_VERSION, "azurelinux") >= 0 ^
     set aspnetBaseTag to
         cat("$REPO:", VARIABLES[cat("dotnet|8.0|product-version")], "-", OS_VERSION, "-extra", ARCH_TAG_SUFFIX) ^
@@ -10,8 +11,12 @@
             when(find(OS_VERSION, "3.0") >= 0, "azurelinux", "cbl-mariner"),
             "/base/core:",
             OS_VERSION_NUMBER),
-        cat(ARCH_VERSIONED, "/buildpack-deps:", osVersionBase, "-curl"))
-}}ARG REPO=mcr.microsoft.com/dotnet/aspnet
+        cat(ARCH_VERSIONED, "/buildpack-deps:", osVersionBase, "-curl")) ^
+
+    set baseUrl to VARIABLES[cat("aspire-dashboard|", aspireMajorMinor, "|base-url|", VARIABLES["branch"])] ^
+    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0
+}}ARG REPO=mcr.microsoft.com/dotnet/aspnet{{if isInternal:
+ARG ACCESSTOKEN}}
 
 # Installer image
 FROM {{installerImageTag}} AS installer
@@ -19,7 +24,11 @@ FROM {{installerImageTag}} AS installer
 {{InsertTemplate("../Dockerfile.linux.distroless-azurelinux-installer-prereqs", [ "is-zip": "true" ])}}
 }}
 # Retrieve Aspire Dashboard
-{{InsertTemplate("Dockerfile.linux.install-aspire-dashboard", [ "is-zip": "true" ])}}
+{{InsertTemplate("Dockerfile.linux.install-aspire-dashboard",
+    [
+        "is-zip": "true",
+        "is-internal": isInternal
+    ])}}
 
 
 # Aspire Dashboard image

--- a/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux
@@ -15,11 +15,11 @@
 
     set baseUrl to VARIABLES[cat("aspire-dashboard|", aspireMajorMinor, "|base-url|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0
-}}ARG REPO=mcr.microsoft.com/dotnet/aspnet{{if isInternal:
-ARG ACCESSTOKEN}}
+}}ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM {{installerImageTag}} AS installer
+FROM {{installerImageTag}} AS installer{{if isInternal:
+ARG ACCESSTOKEN}}
 {{if isAzureLinux:
 {{InsertTemplate("../Dockerfile.linux.distroless-azurelinux-installer-prereqs", [ "is-zip": "true" ])}}
 }}

--- a/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux.install-aspire-dashboard
+++ b/eng/dockerfile-templates/aspire-dashboard/Dockerfile.linux.install-aspire-dashboard
@@ -1,4 +1,7 @@
 {{
+    _ ARGS:
+        is-internal (optional): whether the Dockerfile is targeting an internal build of Aspire Dashboard ^
+
     set aspireMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set buildVersion to VARIABLES[cat("aspire-dashboard|", aspireMajorMinor, "|build-version")] ^
     set aspireVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^

--- a/eng/dockerfile-templates/yarp/Dockerfile.linux
+++ b/eng/dockerfile-templates/yarp/Dockerfile.linux
@@ -1,19 +1,23 @@
 {{
-    set yarpMajor to split(PRODUCT_VERSION, ".")[0] ^
-    set yarpMajorMinor to cat(yarpMajor, ".0") ^
-    set dotnetMajorMinor to VARIABLES[cat("yarp|", yarpMajorMinor, "|dotnet-version")] ^
+    set yarpVersionParts to split(PRODUCT_VERSION, ".") ^
+    set yarpMajorMinor to cat(yarpVersionParts[0], ".", yarpVersionParts[1]) ^
     set aspnetBaseTag to
         cat("$REPO:", VARIABLES[cat("dotnet|9.0|fixed-tag")], "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
-    set installerImageTag to cat("mcr.microsoft.com/azurelinux", "/base/core:", OS_VERSION_NUMBER)
+    set installerImageTag to cat("mcr.microsoft.com/azurelinux", "/base/core:", OS_VERSION_NUMBER) ^
+
+    set baseUrl to VARIABLES[cat("yarp|", yarpMajorMinor, "|base-url|", VARIABLES["branch"])] ^
+    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0
+
 }}ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
-FROM {{installerImageTag}} AS installer
+FROM {{installerImageTag}} AS installer{{if isInternal:
+ARG ACCESSTOKEN}}
 
 {{InsertTemplate("../Dockerfile.linux.distroless-azurelinux-installer-prereqs", [ "is-zip": "true" ])}}
 
 # Retrieve YARP
-{{InsertTemplate("Dockerfile.linux.install-yarp")}}
+{{InsertTemplate("Dockerfile.linux.install-yarp", [ "is-internal": isInternal ])}}
 
 
 # YARP image

--- a/eng/dockerfile-templates/yarp/Dockerfile.linux.install-yarp
+++ b/eng/dockerfile-templates/yarp/Dockerfile.linux.install-yarp
@@ -1,9 +1,19 @@
 {{
+    _ ARGS:
+        is-internal (optional): whether the Dockerfile is targeting an internal build of YARP ^
+
     set yarpMajorMinor to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set buildVersion to VARIABLES[cat("yarp|", yarpMajorMinor, "|build-version")] ^
     set yarpVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
     set yarpVersion to VARIABLES[cat("yarp|", yarpMajorMinor, "|", yarpVersionVariable)] ^
-    set versionFolder to when(buildVersion != yarpVersion, buildVersion, '$yarp_version') ^
+
+    set versionFolder to
+        when(ARGS["is-internal"],
+            buildVersion,
+            when(buildVersion != yarpVersion,
+                buildVersion,
+                '$yarp_version')) ^
+
     set yarpBaseUrl to cat(VARIABLES[cat("yarp|", yarpMajorMinor, "|base-url|", VARIABLES["branch"])], "/reverse-proxy/", versionFolder, "/") ^
     set files to [
         [

--- a/eng/dockerfile-templates/yarp/Dockerfile.linux.install-yarp
+++ b/eng/dockerfile-templates/yarp/Dockerfile.linux.install-yarp
@@ -6,14 +6,7 @@
     set buildVersion to VARIABLES[cat("yarp|", yarpMajorMinor, "|build-version")] ^
     set yarpVersionVariable to when(find(buildVersion, '-rtm') >= 0 || find(buildVersion, '-servicing') >= 0, "product-version", "build-version") ^
     set yarpVersion to VARIABLES[cat("yarp|", yarpMajorMinor, "|", yarpVersionVariable)] ^
-
-    set versionFolder to
-        when(ARGS["is-internal"],
-            buildVersion,
-            when(buildVersion != yarpVersion,
-                buildVersion,
-                '$yarp_version')) ^
-
+    set versionFolder to when(buildVersion != yarpVersion, buildVersion, '$yarp_version') ^
     set yarpBaseUrl to cat(VARIABLES[cat("yarp|", yarpMajorMinor, "|base-url|", VARIABLES["branch"])], "/reverse-proxy/", versionFolder, "/") ^
     set files to [
         [

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG ACCESSTOKEN
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -1,8 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-ARG ACCESSTOKEN
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -1,4 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG ACCESSTOKEN
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -1,8 +1,8 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-ARG ACCESSTOKEN
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -2,6 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \
@@ -10,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve YARP
 RUN yarp_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-x64.zip" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/0.0.0/reverse-proxy-linux-x64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  yarp.zip" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve YARP
 RUN yarp_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/0.0.0/reverse-proxy-linux-x64.zip" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-x64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  yarp.zip" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -2,6 +2,7 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
+ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \
@@ -10,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve YARP
 RUN yarp_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-arm64.zip" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/0.0.0/reverse-proxy-linux-arm64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  yarp.zip" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve YARP
 RUN yarp_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/0.0.0/reverse-proxy-linux-arm64.zip" \
+    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-arm64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  yarp.zip" | sha512sum -c - \
     && mkdir -p /app \


### PR DESCRIPTION
This is part of #6254 and #6255. 

As there isn't yet support for Aspire Dashboard or YARP in the update-dependencies tooling, I can't tell what the precise download paths will be, so I didn't change them yet. However, this PR sets up the plumbing for using the ACCESSTOKEN arg for these Dockerfile builds so we don't have to do it later.