### PR TITLE
Remove unused Azure Pipelines variable group references

### DIFF
--- a/eng/pipelines/update-dependencies-internal.yml
+++ b/eng/pipelines/update-dependencies-internal.yml
@@ -3,7 +3,6 @@ pr: none
 
 variables:
 - template: ../common/templates/variables/dotnet/common.yml
-- group: DncEng-Partners-Tokens
 - group: DotNet-AllOrgs-Darc-Pats
 stages:
 - stage: DotNet

--- a/eng/pipelines/variables/core.yml
+++ b/eng/pipelines/variables/core.yml
@@ -1,9 +1,6 @@
 variables:
 - template: /eng/common/templates/variables/dotnet/build-test-publish.yml@self
 
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: AzureDevOps-Artifact-Feeds-Pats
-
 - name: manifest
   value: manifest.json
 - name: publishEolAnnotations

--- a/eng/pipelines/variables/internal-core.yml
+++ b/eng/pipelines/variables/internal-core.yml
@@ -2,7 +2,6 @@
 
 variables:
 - template: core.yml
-- group: DncEng-Partners-Tokens
 
 # Since the images published by the pipeline are only available internally, configure variables so that image info
 # is published to an internal repo.


### PR DESCRIPTION
I evaluated all of the pipeline variable groups we reference. I searched our codebase for each variable in each of the groups that aren't managed by the containers team and removed the groups where we no longer reference any of the variables.