### PR TITLE
Revert "Update mcrdocs access token variable"

### DIFF
--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -15,7 +15,7 @@ variables:
   value: public/,internal/private/,unlisted/
 
 - name: mcrDocsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT-fine-grained-all-repositories-contents-rw)
+  value: $(BotAccount-dotnet-docker-bot-PAT)
 - name: mcrDocsRepoInfo.userName
   value: $(dotnetDockerBot.userName)
 - name: mcrDocsRepoInfo.email


### PR DESCRIPTION
Reverts dotnet/dotnet-docker#6341 - the fine-grained token didn't work for now and the original token has been updated to use a shorter expiration date.