### PR TITLE
Update CG pipeline to use .NET 10

### DIFF
--- a/eng/pipelines/cg-code.yml
+++ b/eng/pipelines/cg-code.yml
@@ -29,4 +29,7 @@ extends:
       jobs:
       - template: /eng/common/templates/jobs/cg-build-projects.yml@self
         parameters:
+          # This should match the latest .NET version used across all projects in the repo, including samples.
+          # Otherwise, the pipeline will fail to build projects.
+          dotnetVersionChannel: '10.0'
           cgDryRun: ${{ parameters.cgDryRun }}


### PR DESCRIPTION
This PR fixes the CG build pipeline, which is failing due to #6307.

Related:
- https://github.com/dotnet/docker-tools/pull/1659