### PR TITLE
Update Debian Trixie to use libicu76

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -117,7 +117,7 @@
     "libicu|focal": 66,
     "libicu|jammy": 70,
     "libicu|noble": 74,
-    "libicu|trixie": 72,
+    "libicu|trixie": 76,
 
     "libssl|alpine3.20": "3",
     "libssl|alpine3.21": "3",

--- a/src/runtime-deps/10.0/trixie-slim/amd64/Dockerfile
+++ b/src/runtime-deps/10.0/trixie-slim/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu72 \
+        libicu76 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/src/runtime-deps/10.0/trixie-slim/arm32v7/Dockerfile
+++ b/src/runtime-deps/10.0/trixie-slim/arm32v7/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu72 \
+        libicu76 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/src/runtime-deps/10.0/trixie-slim/arm64v8/Dockerfile
+++ b/src/runtime-deps/10.0/trixie-slim/arm64v8/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu72 \
+        libicu76 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu72 \
+        libicu76 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu72 \
+        libicu76 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu72 \
+        libicu76 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -398,7 +398,7 @@ namespace Microsoft.DotNet.Docker.Tests
                         "ca-certificates",
                         "libc6",
                         "libgcc-s1",
-                        "libicu72",
+                        "libicu76",
                         "libssl3t64",
                         "tzdata",
                         "libstdc++6"


### PR DESCRIPTION
Debian Trixie is transitioning from `libicu72` to `libicu76`.

The arm32 builds currently fail without this update because, in that package feed, `libicu72` doesn't exist. But for the other architectures, both package versions exist.