### PR TITLE
Remove comment link to closed PowerShell Alpine ARM issue

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageData.cs
@@ -20,9 +20,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public bool GlobalizationInvariantMode => !SupportsGlobalization;
 
-        // PowerShell does not support Arm-based Alpine, skip testing
-        // https://github.com/PowerShell/PowerShell/issues/14667
-        // https://github.com/PowerShell/PowerShell/issues/12937
+        // PowerShell does not support Arm-based Alpine
         public bool SupportsPowerShell => !(OS.Contains("alpine") && IsArm);
 
         public string SdkOS


### PR DESCRIPTION
Closes #2544.

Both Alpine ARM issues are closed and there is not strong enough demand for us to continue pushing the PowerShell team to support musl-arm.