### PR TITLE
Enable consuming public .NET SDK builds from the VMR using DarcLib

### DIFF
--- a/eng/pipelines/jobs/update-tools.yml
+++ b/eng/pipelines/jobs/update-tools.yml
@@ -8,20 +8,14 @@ jobs:
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
-    - powershell: |
-        Import-Module -force $(engPath)/DependencyManagement.psm1
-
-        $args=("9.0" + `
-            " --tool ${{ tool }}" + `
-            " --version-source-name ${{ tool }}" + `
-            " --source-branch nightly" + `
-            " --org dnceng" + `
-            " --project $(System.TeamProject)" + `
-            " --repo $(Build.Repository.Name)" + `
-            " --target-branch $(Get-Branch)")
-
-        echo "##vso[task.setvariable variable=customArgsArray]$($args | ConvertTo-Json -Compress -AsArray)"
-      displayName: Set up args
     - template: /eng/pipelines/steps/update-dependencies.yml
       parameters:
-        customArgsArray: "$(customArgsArray)"
+        args: >
+          specific 9.0
+          --tool ${{ tool }}
+          --version-source-name ${{ tool }}
+          --source-branch nightly
+          --target-branch nightly
+          --org dnceng
+          --project $(System.TeamProject)
+          --repo $(Build.Repository.Name)

--- a/eng/pipelines/steps/update-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dependencies-specific.yml
@@ -1,0 +1,39 @@
+parameters:
+  # The customArgsArray parameter is used to specify the configuration for multiple Dockerfile versions.
+  # This allows for a single branch to be generated for different internal .NET build versions.
+  customArgsArray: ""
+
+  useInternalBuild: false
+
+steps:
+- script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
+  displayName: Build Update Dependencies Tool
+- script: docker run --name update-dependencies -d -t --entrypoint /bin/sh -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
+  displayName: Create Update Dependencies container
+- powershell: |
+    if ("${{ parameters.useInternalBuild }}" -eq "true") {
+      $pat="$(dn-bot-devdiv-dnceng-rw-code-pat)"
+    } else {
+      $pat="$(BotAccount-dotnet-docker-bot-PAT)"
+    }
+
+    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
+
+    # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions
+    # Ensure that the value is treated as an array by wrapping it in an array literal. This deals with the quirk of
+    # how PowerShell treats a single item as a string instead of an array.
+    $customArgsArray = @('${{ parameters.customArgsArray }}' | ConvertFrom-Json)
+    foreach ($customArgs in $customArgsArray) {
+      # If this is the last iteration, include the credentials to cause a PR to be generated.
+      # For internal builds this will cause branch to be pushed to AzDO, but no PRs will be generated.
+      if ($customArgs -eq $customArgsArray[-1]) {
+        $customArgs += " $credArgs"
+      }
+
+      $command = "docker exec update-dependencies update-dependencies $customArgs"
+      Invoke-Expression $command
+    }
+  displayName: Run Update Dependencies
+- script: docker rm -f update-dependencies
+  displayName: Remove Update Dependencies container
+  condition: always()

--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -1,39 +1,34 @@
 parameters:
-  # The customArgsArray parameter is used to specify the configuration for multiple Dockerfile versions.
-  # This allows for a single branch to be generated for different internal .NET build versions.
-  customArgsArray: ""
-
-  useInternalBuild: false
+  serviceConnection: ""
+  args: ""
 
 steps:
 - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
-  displayName: Build Update Dependencies Tool
+  displayName: Build Update Dependencies image
 - script: docker run --name update-dependencies -d -t --entrypoint /bin/sh -v /var/run/docker.sock:/var/run/docker.sock update-dependencies
-  displayName: Create Update Dependencies container
+  displayName: Start Update Dependencies container
+
+- ${{ if ne(parameters.serviceConnection, '') }}:
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      displayName: Az login
+      serviceConnection: ${{ parameters.serviceConnection }}
+      command: |
+        $azLogin = "az login --service-principal --tenant $env:tenantId --username $env:servicePrincipalId --federated-token $env:idToken";
+        $loginCommand = "docker exec update-dependencies $azLogin";
+        Write-Host "Executing $loginCommand";
+        Invoke-Expression $loginCommand;
+
 - powershell: |
-    if ("${{ parameters.useInternalBuild }}" -eq "true") {
-      $pat="$(dn-bot-devdiv-dnceng-rw-code-pat)"
-    } else {
-      $pat="$(BotAccount-dotnet-docker-bot-PAT)"
-    }
-
+    $args = "${{ parameters.args }}"
+    $pat="$(BotAccount-dotnet-docker-bot-PAT)"
     $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
+    $args += " $credArgs"
 
-    # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions
-    # Ensure that the value is treated as an array by wrapping it in an array literal. This deals with the quirk of
-    # how PowerShell treats a single item as a string instead of an array.
-    $customArgsArray = @('${{ parameters.customArgsArray }}' | ConvertFrom-Json)
-    foreach ($customArgs in $customArgsArray) {
-      # If this is the last iteration, include the credentials to cause a PR to be generated.
-      # For internal builds this will cause branch to be pushed to AzDO, but no PRs will be generated.
-      if ($customArgs -eq $customArgsArray[-1]) {
-        $customArgs += " $credArgs"
-      }
-
-      $command = "docker exec update-dependencies update-dependencies $customArgs"
-      Invoke-Expression $command
-    }
+    $command = "docker exec update-dependencies update-dependencies $args"
+    Invoke-Expression $command
   displayName: Run Update Dependencies
+
 - script: docker rm -f update-dependencies
   displayName: Remove Update Dependencies container
   condition: always()

--- a/eng/pipelines/steps/update-dotnet-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies-specific.yml
@@ -1,0 +1,89 @@
+parameters:
+  useInternalBuild: false
+
+  # Comma-delimited list of SDK versions to target (overrides the use of channel var to determine latest version)
+  sdkVersions: ""
+
+  buildId: ""
+
+steps:
+- powershell: |
+    if ("${{ parameters.sdkVersions }}" -ne "") {
+      $args = @{
+        SdkVersions = "${{ parameters.sdkVersions }}" -split ","
+      }
+    }
+    elseif ("${{ parameters.useInternalBuild }}" -eq "false") {
+      $args = @{
+        Channel = "$(channel)"
+      }
+    }
+    else {
+      $args = @{
+        BuildId = "${{ parameters.buildId }}"
+      }
+    }
+
+    if ("${{ parameters.useInternalBuild }}" -eq "true") {
+      $args["UseInternalBuild"] = $true
+      $args["InternalAccessToken"] = '$(System.AccessToken)'
+      $args["AzdoVersionsRepoInfoAccessToken"] = "$(dn-bot-devdiv-dnceng-rw-code-pat)"
+    }
+
+    $(engPath)/Get-DropVersions.ps1 @args
+  displayName: Get Versions
+- powershell: |
+    Import-Module -force $(engPath)/DependencyManagement.psm1
+
+    $versionInfos = '$(versionInfos)' | ConvertFrom-Json
+
+    $index=0
+    foreach ($versionInfo in $versionInfos) {
+      $args = @{
+        ProductVersion = $versionInfo.DockerfileVersion
+        RuntimeVersion = $versionInfo.RuntimeVersion
+        AspnetVersion = $versionInfo.AspnetVersion
+        SdkVersion = $versionInfo.SdkVersion
+        ComputeShas = $true
+        AzdoVariableName = "updateDepsArgs-$index"
+        UseStableBranding = $versionInfo.StableBranding
+      }
+
+      if ("${{ parameters.useInternalBuild }}" -eq "true") {
+        $args["InternalAccessToken"] = '$(System.AccessToken)'
+        $args["InternalBaseUrl"] = '"$(internalBaseUrl)"'
+      } else {
+        $args["ReleaseState"] = $(Get-ProductReleaseState)
+      }
+
+      Write-Host "Executing Set-DotnetVersions.ps1 for $($versionInfo.DockerfileVersion)"
+      $(engPath)/Set-DotnetVersions.ps1 @args
+      $index++
+    }
+  displayName: Get update-dependencies args
+- powershell: |
+    Import-Module -force $(engPath)/DependencyManagement.psm1
+
+    $targetBranch = $(Get-Branch)
+    if ("${{ parameters.useInternalBuild }}" -eq "true") {
+      $targetBranch = "staging-${{ parameters.buildId }}-pipeline-$(Build.BuildId)"
+    }
+
+    $customArgsArray = @()
+    $index=0
+
+    # Grab the variables that were set by the multiple calls to Set-DotnetVersions.ps1 and
+    # add them to an array. This allows us to pass args for multiple Dockerfile versions.
+    while ([Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index") -ne $null) {
+      $updateDepsArgs = [Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index")
+      $updateDepsArgs = "$updateDepsArgs --org dnceng --project $(System.TeamProject) --repo $(Build.Repository.Name) --target-branch $targetBranch"
+      $customArgsArray += $updateDepsArgs
+      $index++
+    }
+
+    echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
+  displayName: Set Custom Args
+- template: update-dependencies-specific.yml
+  parameters:
+    customArgsArray: "$(customArgsArray)"
+    useInternalBuild: ${{ parameters.useInternalBuild }}

--- a/eng/pipelines/steps/update-dotnet-dependencies.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies.yml
@@ -1,89 +1,12 @@
 parameters:
-  useInternalBuild: false
-
-  # Comma-delimited list of SDK versions to target (overrides the use of channel var to determine latest version)
-  sdkVersions: ""
-
-  buildId: ""
+  serviceConnection: ""
+  channel: ""
+  repo: "https://github.com/dotnet/dotnet"
+  versionSourceName: ""
 
 steps:
-- powershell: |
-    if ("${{ parameters.sdkVersions }}" -ne "") {
-      $args = @{
-        SdkVersions = "${{ parameters.sdkVersions }}" -split ","
-      }
-    }
-    elseif ("${{ parameters.useInternalBuild }}" -eq "false") {
-      $args = @{
-        Channel = "$(channel)"
-      }
-    }
-    else {
-      $args = @{
-        BuildId = "${{ parameters.buildId }}"
-      }
-    }
-
-    if ("${{ parameters.useInternalBuild }}" -eq "true") {
-      $args["UseInternalBuild"] = $true
-      $args["InternalAccessToken"] = '$(System.AccessToken)'
-      $args["AzdoVersionsRepoInfoAccessToken"] = "$(dn-bot-devdiv-dnceng-rw-code-pat)"
-    }
-
-    $(engPath)/Get-DropVersions.ps1 @args
-  displayName: Get Versions
-- powershell: |
-    Import-Module -force $(engPath)/DependencyManagement.psm1
-
-    $versionInfos = '$(versionInfos)' | ConvertFrom-Json
-
-    $index=0
-    foreach ($versionInfo in $versionInfos) {
-      $args = @{
-        ProductVersion = $versionInfo.DockerfileVersion
-        RuntimeVersion = $versionInfo.RuntimeVersion
-        AspnetVersion = $versionInfo.AspnetVersion
-        SdkVersion = $versionInfo.SdkVersion
-        ComputeShas = $true
-        AzdoVariableName = "updateDepsArgs-$index"
-        UseStableBranding = $versionInfo.StableBranding
-      }
-
-      if ("${{ parameters.useInternalBuild }}" -eq "true") {
-        $args["InternalAccessToken"] = '$(System.AccessToken)'
-        $args["InternalBaseUrl"] = '"$(internalBaseUrl)"'
-      } else {
-        $args["ReleaseState"] = $(Get-ProductReleaseState)
-      }
-
-      Write-Host "Executing Set-DotnetVersions.ps1 for $($versionInfo.DockerfileVersion)"
-      $(engPath)/Set-DotnetVersions.ps1 @args
-      $index++
-    }
-  displayName: Get update-dependencies args
-- powershell: |
-    Import-Module -force $(engPath)/DependencyManagement.psm1
-
-    $targetBranch = $(Get-Branch)
-    if ("${{ parameters.useInternalBuild }}" -eq "true") {
-      $targetBranch = "staging-${{ parameters.buildId }}-pipeline-$(Build.BuildId)"
-    }
-
-    $customArgsArray = @()
-    $index=0
-
-    # Grab the variables that were set by the multiple calls to Set-DotnetVersions.ps1 and
-    # add them to an array. This allows us to pass args for multiple Dockerfile versions.
-    while ([Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index") -ne $null) {
-      $updateDepsArgs = [Environment]::GetEnvironmentVariable("UPDATEDEPSARGS-$index")
-      $updateDepsArgs = "$updateDepsArgs --org dnceng --project $(System.TeamProject) --repo $(Build.Repository.Name) --target-branch $targetBranch"
-      $customArgsArray += $updateDepsArgs
-      $index++
-    }
-
-    echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
-  displayName: Set Custom Args
 - template: update-dependencies.yml
   parameters:
-    customArgsArray: "$(customArgsArray)"
-    useInternalBuild: ${{ parameters.useInternalBuild }}
+    args: "from-channel ${{ parameters.channel }} ${{ parameters.repo }} --version-source-name '${{ parameters.versionSourceName }}'"
+    useInternalBuild: false
+    serviceConnection: ${{ parameters.serviceConnection }}

--- a/eng/pipelines/update-dependencies-internal.yml
+++ b/eng/pipelines/update-dependencies-internal.yml
@@ -12,7 +12,7 @@ stages:
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
-    - template: steps/update-dotnet-dependencies.yml
+    - template: steps/update-dotnet-dependencies-specific.yml
       parameters:
         useInternalBuild: true
         buildId: $(buildId)

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -20,6 +20,11 @@ stages:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:
     - template: steps/update-dotnet-dependencies.yml
+      parameters:
+        channel: "${{ variables['channel'] }}"
+        repo: "https://github.com/dotnet/dotnet"
+        versionSourceName: "dotnet/dotnet"
+        serviceConnection: "Darc: Maestro Production"
   - template: jobs/update-tools.yml
     parameters:
       tools: ["chisel", "rocks-toolbox", "syft", "mingit"]

--- a/eng/update-dependencies/BuildAssetService.cs
+++ b/eng/update-dependencies/BuildAssetService.cs
@@ -60,7 +60,8 @@ internal class BuildAssetService(
             response.EnsureSuccessStatusCode();
             string content = await response.Content.ReadAsStringAsync();
             _logger.LogInformation("Successfully fetched contents from {url}", url);
-            return content;
+            // Remove trailing newlines
+            return content.Trim();
         }
         catch (Exception ex)
         {

--- a/eng/update-dependencies/BuildAssetService.cs
+++ b/eng/update-dependencies/BuildAssetService.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Dotnet.Docker;
+
+internal interface IBuildAssetService
+{
+    string ResolveAssetUrl(Asset asset);
+
+    Task<string> GetAssetContentsAsync(Asset asset);
+}
+
+internal class BuildAssetService(
+    HttpClient httpClient,
+    ILogger<BuildAssetService> logger)
+    : IBuildAssetService
+{
+    private readonly HttpClient _httpClient = httpClient;
+    private readonly ILogger<BuildAssetService> _logger = logger;
+
+    public string ResolveAssetUrl(Asset asset)
+    {
+        var blobStorageLocations = asset.Locations.Where(l => l.Location.Contains("blob.core.windows.net"));
+        var azdoLocations = asset.Locations.Where(l => l.Location.Contains("dev.azure.com"));
+
+        string allLocations =
+            string.Join(Environment.NewLine, asset.Locations.Select(l => $"Type: {l.Type}; Url: {l.Location}"));
+        _logger.LogInformation(
+            """
+            Asset {asset.Name} has {asset.Locations.Count} locations:
+            {allLocations}
+            """,
+            asset.Name, asset.Locations.Count, allLocations);
+
+        // Prefer public blob storage locations over azdo locations
+        AssetLocation bestLocation =
+            blobStorageLocations.FirstOrDefault()
+            ?? azdoLocations.FirstOrDefault()
+            ?? throw new InvalidOperationException(FormatErrorMessage(asset, "does not have any valid locations"));
+
+        string url = $"{bestLocation.Location}/{asset.Name}";
+        _logger.LogInformation("Using location {url}", url);
+        return url;
+    }
+
+    public async Task<string> GetAssetContentsAsync(Asset asset)
+    {
+        string url = ResolveAssetUrl(asset);
+        try
+        {
+            _logger.LogInformation("Fetching contents from {url}", url);
+            var response = await _httpClient.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+            string content = await response.Content.ReadAsStringAsync();
+            _logger.LogInformation("Successfully fetched contents from {url}", url);
+            return content;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fetch contents from {url}", url);
+            throw;
+        }
+    }
+
+    private static string FormatErrorMessage(Asset asset, string message)
+    {
+        return $"Build {asset.BuildId} Asset {asset.Name} (version {asset.Version}) {message}";
+    }
+}

--- a/eng/update-dependencies/BuildAssetService.cs
+++ b/eng/update-dependencies/BuildAssetService.cs
@@ -59,7 +59,12 @@ internal class BuildAssetService(
             var response = await _httpClient.GetAsync(url);
             response.EnsureSuccessStatusCode();
             string content = await response.Content.ReadAsStringAsync();
-            _logger.LogInformation("Successfully fetched contents from {url}", url);
+            _logger.LogInformation(
+                """
+                Successfully fetched contents from {url}:
+                {content}
+                """,
+                url, content);
             // Remove trailing newlines
             return content.Trim();
         }

--- a/eng/update-dependencies/CreatePullRequestOptions.cs
+++ b/eng/update-dependencies/CreatePullRequestOptions.cs
@@ -10,12 +10,13 @@ public abstract class CreatePullRequestOptions
 {
     private string? _targetBranch = null;
 
-    public string? Owner { get; init; } = null;
-    public string? Project { get; init; } = null;
-    public string? User { get; init; } = null;
-    public string? Email { get; init; } = null;
-    public string? Password { get; init; } = null;
-
+    public string User { get; init; } = "";
+    public string Email { get; init; } = "";
+    public string Password { get; init; } = "";
+    public string AzdoOrganization { get; init; } = "";
+    public string AzdoProject { get; init; } = "";
+    public string AzdoRepo { get; init; } = "";
+    public string VersionSourceName { get; init; } = "";
     public string SourceBranch { get; init; } = "nightly";
     public string TargetBranch
     {
@@ -25,13 +26,15 @@ public abstract class CreatePullRequestOptions
 
     public static List<Option> Options =>
     [
-        new Option<string>("--owner") { Description = "Owner of the fork where the branch should be pushed" },
-        new Option<string>("--project") { Description = "Name of the repo" },
-        new Option<string>("--user") { Description = "GitHub login used to create PR" },
-        new Option<string>("--email") { Description = "GitHub email used to create PR" },
-        new Option<string>("--password") { Description = "GitHub password used to create PR" },
-        new Option<string>("--source-branch") { Description = "Source branch from which the changes are derived" },
-        new Option<string>("--target-branch") { Description = "Target branch for the generated PR (defaults to --source-branch)" },
+        new Option<string>("--user") { Description = "GitHub or AzDO user used to make PR (if not specified, a PR will not be created)" },
+        new Option<string>("--email") { Description = "GitHub or AzDO email used to make PR (if not specified, a PR will not be created)" },
+        new Option<string>("--password") { Description = "GitHub or AzDO password used to make PR (if not specified, a PR will not be created)" },
+        new Option<string>("--azdo-organization", "--org") { Description = "Name of the AzDO organization" },
+        new Option<string>("--azdo-project", "--project") { Description = "Name of the AzDO project" },
+        new Option<string>("--azdo-repo", "--repo") { Description = "Name of the AzDO repo" },
+        new Option<string>("--version-source-name") { Description = "The name of the source from which the version information was acquired." },
+        new Option<string>("--source-branch") { Description = "Branch where the Dockerfiles are hosted" },
+        new Option<string>("--target-branch") { Description = "Target branch of the generated PR (defaults to value of source-branch)" },
     ];
 
     public static List<Argument> Arguments => [];

--- a/eng/update-dependencies/CreatePullRequestOptions.cs
+++ b/eng/update-dependencies/CreatePullRequestOptions.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.CommandLine;
+
+namespace Dotnet.Docker;
+
+public abstract class CreatePullRequestOptions
+{
+    private string? _targetBranch = null;
+
+    public string? Owner { get; init; } = null;
+    public string? Project { get; init; } = null;
+    public string? User { get; init; } = null;
+    public string? Email { get; init; } = null;
+    public string? Password { get; init; } = null;
+
+    public string SourceBranch { get; init; } = "nightly";
+    public string TargetBranch
+    {
+        get => _targetBranch ?? SourceBranch;
+        init => _targetBranch = value;
+    }
+
+    public static List<Option> Options =>
+    [
+        new Option<string>("--owner") { Description = "Owner of the fork where the branch should be pushed" },
+        new Option<string>("--project") { Description = "Name of the repo" },
+        new Option<string>("--user") { Description = "GitHub login used to create PR" },
+        new Option<string>("--email") { Description = "GitHub email used to create PR" },
+        new Option<string>("--password") { Description = "GitHub password used to create PR" },
+        new Option<string>("--source-branch") { Description = "Source branch from which the changes are derived" },
+        new Option<string>("--target-branch") { Description = "Target branch for the generated PR (defaults to --source-branch)" },
+    ];
+
+    public static List<Argument> Arguments => [];
+}

--- a/eng/update-dependencies/FromChannelCommand.cs
+++ b/eng/update-dependencies/FromChannelCommand.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.ProductConstructionService.Client.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Dotnet.Docker;
+
+internal partial class FromChannelCommand(
+    IBuildAssetService buildAssetService,
+    IBasicBarClient barClient,
+    ILogger<FromChannelCommand> logger)
+    : BaseCommand<FromChannelOptions>
+{
+    private readonly IBuildAssetService _buildAssetService = buildAssetService;
+    private readonly IBasicBarClient _barClient = barClient;
+    private readonly ILogger<FromChannelCommand> _logger = logger;
+
+    public override async Task<int> ExecuteAsync(FromChannelOptions options)
+    {
+        _logger.LogInformation("Getting latest build for {options.Repo} from channel {options.Channel}",
+            options.Repo, options.Channel);
+
+        Build latestBuild = await _barClient.GetLatestBuildAsync(options.Repo, options.Channel);
+        string? channelName = latestBuild.Channels.FirstOrDefault(c => c.Id == options.Channel)?.Name;
+
+        _logger.LogInformation("Channel {options.Channel} is '{channel.Name}'",
+            options.Channel, latestBuild.Channels.FirstOrDefault(c => c.Id == options.Channel)?.Name);
+        _logger.LogInformation("Got latest build {latestBuild.Id} with commit {options.Repo}@{latestBuild.Commit}",
+            latestBuild.Id, latestBuild.AzureDevOpsRepository ?? latestBuild.GitHubRepository, latestBuild.Commit);
+
+        if (!IsVmrBuild(latestBuild))
+        {
+            throw new InvalidOperationException(
+                "Expected a build of the VMR, but got a build of " +
+                $"{latestBuild.AzureDevOpsRepository ?? latestBuild.GitHubRepository} instead.");
+        }
+
+        IEnumerable<Asset> assets = await _barClient.GetAssetsAsync(buildId: latestBuild.Id);
+
+        // The asset containing product commit info will let us confirm the exact versions for SDK, ASP.NET Core, etc.
+        Asset productCommitAsset = assets.FirstOrDefault(a => ProductCommitInfos.AssetRegex.IsMatch(a.Name))
+            ?? throw new InvalidOperationException($"Could not find product commit version in assets.");
+
+        string productCommitVersionResponse = await _buildAssetService.GetAssetContentsAsync(productCommitAsset);
+        var productInfos = ProductCommitInfos.FromJson(productCommitVersionResponse);
+
+        // Run old update-dependencies command using the resolved versions
+        var updateDependencies = new SpecificCommand();
+
+        Version majorMinorVersion = ResolveMajorMinorVersion(productInfos.Sdk.Version);
+        var updateDependenciesOptions = new SpecificCommandOptions()
+        {
+            DockerfileVersion = majorMinorVersion.ToString(),
+            ProductVersions = new Dictionary<string, string?>()
+            {
+                { "runtime", productInfos.Runtime.Version },
+                { "aspnet", productInfos.AspNetCore.Version },
+                { "aspnet-composite", productInfos.AspNetCore.Version },
+                { "sdk", productInfos.Sdk.Version },
+            },
+        };
+
+        return await updateDependencies.ExecuteAsync(updateDependenciesOptions);
+    }
+
+    private static Version ResolveMajorMinorVersion(string versionString)
+    {
+        string[] versionParts = versionString.Split('.');
+        if (versionParts.Length < 2)
+        {
+            throw new InvalidOperationException($"Could not parse major-minor version from '{versionString}'.");
+        }
+
+        return new Version(major: int.Parse(versionParts[0]), minor: int.Parse(versionParts[1]));
+    }
+
+    private static bool IsVmrBuild(Build build)
+    {
+        string repo = build.GitHubRepository ?? build.AzureDevOpsRepository;
+        return repo == "https://github.com/dotnet/dotnet"
+            || repo == "https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet";
+    }
+
+    private partial record ProductCommitInfos(
+        ProductCommitInfo Sdk,
+        ProductCommitInfo Runtime,
+        ProductCommitInfo AspNetCore)
+    {
+        [GeneratedRegex("productCommit-linux-x64.json$")]
+        public static partial Regex AssetRegex { get; }
+
+        public static ProductCommitInfos FromJson(string json)
+        {
+            return JsonSerializer.Deserialize<ProductCommitInfos>(json, JsonOptions)
+                ?? throw new InvalidOperationException($"Could not deserialize product commit versions.");
+        }
+
+        private static JsonSerializerOptions JsonOptions { get; } = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    };
+
+    private record ProductCommitInfo(string Commit, string Version);
+}

--- a/eng/update-dependencies/FromChannelCommand.cs
+++ b/eng/update-dependencies/FromChannelCommand.cs
@@ -66,6 +66,17 @@ internal partial class FromChannelCommand(
                 { "aspnet-composite", productInfos.AspNetCore.Version },
                 { "sdk", productInfos.Sdk.Version },
             },
+
+            // Pass through all properties of CreatePullRequestOptions
+            User = options.User,
+            Email = options.Email,
+            Password = options.Password,
+            AzdoOrganization = options.AzdoOrganization,
+            AzdoProject = options.AzdoProject,
+            AzdoRepo = options.AzdoRepo,
+            VersionSourceName = options.VersionSourceName,
+            SourceBranch = options.SourceBranch,
+            TargetBranch = options.TargetBranch,
         };
 
         return await updateDependencies.ExecuteAsync(updateDependenciesOptions);

--- a/eng/update-dependencies/FromChannelOptions.cs
+++ b/eng/update-dependencies/FromChannelOptions.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.CommandLine;
+
+namespace Dotnet.Docker;
+
+internal class FromChannelOptions : CreatePullRequestOptions, IOptions
+{
+    public required int Channel { get; init; }
+    public required string Repo { get; init; }
+
+    public static new List<Argument> Arguments { get; } =
+    [
+        new Argument<int>("channel")
+        {
+            Arity = ArgumentArity.ExactlyOne,
+            Description = "The BAR channel ID to use as a source for the update (see https://aka.ms/bar)"
+        },
+        new Argument<string>("repo")
+        {
+            Arity = ArgumentArity.ExactlyOne,
+            Description = "The repository to get the latest build from (e.g. https://github.com/dotnet/dotnet)"
+        },
+        ..CreatePullRequestOptions.Arguments,
+    ];
+
+    public static new List<Option> Options { get; } =
+    [
+        ..CreatePullRequestOptions.Options,
+    ];
+}

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -3,11 +3,17 @@
 
 using System.CommandLine;
 using System.CommandLine.Hosting;
+using System.Net.Http;
 using Dotnet.Docker;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var rootCommand = new RootCommand()
 {
+    FromChannelCommand.Create(
+        name: "from-channel",
+        description: "Update dependencies using the latest build from a channel"),
     SpecificCommand.Create(
         name: "specific",
         description: "Update dependencies using specific product versions"),
@@ -19,6 +25,11 @@ config.UseHost(
     _ => Host.CreateDefaultBuilder(),
     host => host.ConfigureServices(services =>
         {
+            services.AddSingleton<IBasicBarClient>(_ => new BarApiClient(null, null, false));
+            services.AddSingleton<IBuildAssetService, BuildAssetService>();
+            services.AddSingleton<HttpClient>();
+
+            FromChannelCommand.Register<FromChannelCommand>(services);
             SpecificCommand.Register<SpecificCommand>(services);
         })
     );

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -25,7 +25,8 @@ config.UseHost(
     _ => Host.CreateDefaultBuilder(),
     host => host.ConfigureServices(services =>
         {
-            services.AddSingleton<IBasicBarClient>(_ => new BarApiClient(null, null, false));
+            services.AddSingleton<IBasicBarClient>(_ =>
+                new BarApiClient(null, null, disableInteractiveAuth: true));
             services.AddSingleton<IBuildAssetService, BuildAssetService>();
             services.AddSingleton<HttpClient>();
 

--- a/eng/update-dependencies/SpecificCommandOptions.cs
+++ b/eng/update-dependencies/SpecificCommandOptions.cs
@@ -7,10 +7,8 @@ using System.Linq;
 
 namespace Dotnet.Docker
 {
-    public class SpecificCommandOptions : IOptions
+    public class SpecificCommandOptions : CreatePullRequestOptions, IOptions
     {
-        private string? _targetBranch = null;
-
         public string GitHubProject { get; } = "dotnet-docker";
         public string GitHubUpstreamOwner { get; } = "dotnet";
 
@@ -24,21 +22,6 @@ namespace Dotnet.Docker
         // Tool/image component version options
         public IEnumerable<string> Tools { get; init; } = [];
 
-        // Pull request options
-        public string User { get; init; } = "";
-        public string Email { get; init; } = "";
-        public string Password { get; init; } = "";
-        public string AzdoOrganization { get; init; } = "";
-        public string AzdoProject { get; init; } = "";
-        public string AzdoRepo { get; init; } = "";
-        public string VersionSourceName { get; init; } = "";
-        public string SourceBranch { get; init; } = "nightly";
-        public string TargetBranch
-        {
-            get => _targetBranch ?? SourceBranch;
-            init => _targetBranch = value;
-        }
-
         public bool UpdateOnly =>
             string.IsNullOrEmpty(Email)
             || string.IsNullOrEmpty(Password)
@@ -50,12 +33,17 @@ namespace Dotnet.Docker
         public string InternalAccessToken { get; init; } = "";
         public bool IsInternal => !string.IsNullOrEmpty(InternalBaseUrl);
 
-        public static List<Argument> Arguments =>
+        public static new List<Argument> Arguments =>
         [
             new Argument<string>("dockerfile-version"),
+            ..CreatePullRequestOptions.Arguments,
         ];
 
-        public static List<Option> Options => GetOptions();
+        public static new List<Option> Options =>
+        [
+            ..GetOptions(),
+            ..CreatePullRequestOptions.Options,
+        ];
 
         private static List<Option> GetOptions()
         {
@@ -101,16 +89,6 @@ namespace Dotnet.Docker
                 new Option<bool>("--stable-branding") { Description = "Use stable branding version numbers to compute paths" },
                 new Option<string>("--checksums-file") { Description = "File containing a list of checksums for each product asset" },
                 toolsOption,
-
-                new Option<string>("--user") { Description = "GitHub or AzDO user used to make PR (if not specified, a PR will not be created)" },
-                new Option<string>("--email") { Description = "GitHub or AzDO email used to make PR (if not specified, a PR will not be created)" },
-                new Option<string>("--password") { Description = "GitHub or AzDO password used to make PR (if not specified, a PR will not be created)" },
-                new Option<string>("--azdo-organization", "--org") { Description = "Name of the AzDO organization" },
-                new Option<string>("--azdo-project", "--project") { Description = "Name of the AzDO project" },
-                new Option<string>("--azdo-repo", "--repo") { Description = "Name of the AzDO repo" },
-                new Option<string>("--version-source-name") { Description = "The name of the source from which the version information was acquired." },
-                new Option<string>("--source-branch") { Description = "Branch where the Dockerfiles are hosted" },
-                new Option<string>("--target-branch") { Description = "Target branch of the generated PR (defaults to value of source-branch)" },
 
                 new Option<string>("--internal-base-url") { Description = "Base Url for internal build artifacts" },
                 new Option<string>("--internal-access-token") { Description = "PAT for accessing internal build artifacts" },

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
+    <PackageReference Include="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.25210.2" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />


### PR DESCRIPTION
This PR is a draft since it's based on #6378. It will be rebased once that PR is merged.

Adds a new command `from-channel` which takes a channel and repo to get the latest build from. It should only work for the VMR for now. In the future maybe we'll allow other repos like monitor, yarp, aspire, etc..

This iteration of the code simply gets the new .NET versions from BAR by reading a single build asset containing those versions. Then it sets up a call to the `specific` versions command and executes it. So, we are still relying on `SpecificCommand` and all its code for resolving product version hashes. In the future, all versions and hashes should be read directly from the BAR build. But this is the MVP for consuming VMR builds.

Todo:
- [ ] Authentication for automated version updates