### PR TITLE
Update Dockerfile to Azure Linux 3.0 and add Azure CLI

### DIFF
--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -1,38 +1,35 @@
-# build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build-env
-ARG TARGETARCH
-# The rid must be version-specific to workaround a libgit2sharp issue (see https://github.com/dotnet/dotnet-docker/pull/2111)
-ARG RID=linux-musl-$TARGETARCH
+FROM mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0 AS build-env
 WORKDIR /update-dependencies
 
-# copy csproj and restore as distinct layers
-COPY eng/update-dependencies/*.csproj ./
-COPY NuGet.config ./
+# Build update-dependencies
+COPY --link . .
+RUN --mount=type=cache,target=/root/.nuget \
+    --mount=type=cache,target=/source/bin \
+    --mount=type=cache,target=/source/obj \
+    dotnet publish -o out
 
-# Set UseRidGraph=true to enable non-portable RIDs: https://aka.ms/netsdk1083
-RUN dotnet restore -r $RID /p:UseRidGraph=true
+# Runtime image
+FROM mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0
 
-# copy everything else and build
-COPY eng/update-dependencies/. ./
+RUN tdnf install -y \
+        ca-certificates \
+        # Install Docker
+        # Docker is needed to run ImageBuilder to regenerate Dockerfiles and Readmes
+        moby-engine \
+        docker-buildx \
+        docker-cli \
+        # Azure CLI is needed for BAR authentication
+        # https://github.com/dotnet/arcade-services/pull/4700
+        azure-cli \
+    && tdnf clean all
 
-# Set UseRidGraph=true to enable non-portable RIDs: https://aka.ms/netsdk1083
-RUN dotnet publish -r $RID /p:UseRidGraph=true -c Release -o out --no-restore
-
-
-# runtime image
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine
-
-# install Docker
-RUN apk add --no-cache \
-        docker
-
-# copy update-dependencies
+# Copy update-dependencies app
 WORKDIR /update-dependencies
-COPY --from=build-env /update-dependencies/out ./
+COPY --link --from=build-env /update-dependencies/out ./
 
-# copy repo
+# Copy repo contents
 WORKDIR /repo
-COPY . ./
+COPY --link . ./
 
 RUN ln -s /update-dependencies/update-dependencies /usr/local/bin/update-dependencies
 


### PR DESCRIPTION
Azure CLI is currently needed in order to authenticate to the build asset registry.

In order to make acquiring Azure CLI easier I switched the Dockerfile to Azure Linux 3.0.

I also modernized the build instructions where possible.