### PR TITLE
Fix minor issues with update-dependencies pipeline

### DIFF
--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -20,13 +20,14 @@ steps:
         Invoke-Expression $loginCommand;
 
 - powershell: |
-    $args = "${{ parameters.args }}"
-    $pat="$(BotAccount-dotnet-docker-bot-PAT)"
-    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
-    $args += " $credArgs"
+    $args = "${{ parameters.args }}";
+    $pat="$(BotAccount-dotnet-docker-bot-PAT)";
+    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat";
+    $args += " $credArgs";
 
-    $command = "docker exec update-dependencies update-dependencies $args"
-    Invoke-Expression $command
+    $command = "docker exec update-dependencies update-dependencies $args";
+    Write-Host "Executing '$command'";
+    Invoke-Expression '$command';
   displayName: Run Update Dependencies
 
 - script: docker rm -f update-dependencies

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -21,7 +21,7 @@ stages:
     steps:
     - template: steps/update-dotnet-dependencies.yml
       parameters:
-        channel: ${{ variables.channel }}
+        channel: $(channel)
         repo: "https://github.com/dotnet/dotnet"
         versionSourceName: "dotnet/dotnet"
         serviceConnection: "Darc: Maestro Production"

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -15,7 +15,7 @@ stages:
 - stage: DotNet
   jobs:
   - job: UpdateDotNet
-    displayName: Update .NET (dotnet/sdk)
+    displayName: Update .NET (dotnet/dotnet)
     pool:
       vmImage: $(defaultLinuxAmd64PoolImage)
     steps:

--- a/eng/pipelines/update-dependencies.yml
+++ b/eng/pipelines/update-dependencies.yml
@@ -21,7 +21,7 @@ stages:
     steps:
     - template: steps/update-dotnet-dependencies.yml
       parameters:
-        channel: "${{ variables['channel'] }}"
+        channel: ${{ variables.channel }}
         repo: "https://github.com/dotnet/dotnet"
         versionSourceName: "dotnet/dotnet"
         serviceConnection: "Darc: Maestro Production"


### PR DESCRIPTION
1. The `channel` variable expansion didn't work (testing was only done with hard-coded parameters)
2. There was a weird issue with Invoke-Expression for tool updates: `Missing expression after unary operator '--'`. Adding quotes seems to have fixed it in my testing.
3. Updated the stage name.

Related: #6379 