### PR TITLE
Fix remaining issues with update-dependencies pipeline yaml

### DIFF
--- a/eng/pipelines/jobs/update-tools.yml
+++ b/eng/pipelines/jobs/update-tools.yml
@@ -1,3 +1,6 @@
+# This file intentionally has no final newline, otherwise the trailing newline
+# gets added into the arguments string, potentially causing issues with PowerShell
+
 parameters:
   tools: []
 

--- a/eng/pipelines/jobs/update-tools.yml
+++ b/eng/pipelines/jobs/update-tools.yml
@@ -1,6 +1,3 @@
-# This file intentionally has no final newline, otherwise the trailing newline
-# gets added into the arguments string, potentially causing issues with PowerShell
-
 parameters:
   tools: []
 

--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -20,7 +20,7 @@ steps:
         Invoke-Expression $loginCommand;
 
 - powershell: |
-    $args = "${{ parameters.args }}";
+    $args = "${{ parameters.args }}".Trim();
     $pat="$(BotAccount-dotnet-docker-bot-PAT)";
     $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat";
     $args += " $credArgs";

--- a/eng/pipelines/steps/update-dependencies.yml
+++ b/eng/pipelines/steps/update-dependencies.yml
@@ -27,7 +27,7 @@ steps:
 
     $command = "docker exec update-dependencies update-dependencies $args";
     Write-Host "Executing '$command'";
-    Invoke-Expression '$command';
+    Invoke-Expression "$command";
   displayName: Run Update Dependencies
 
 - script: docker rm -f update-dependencies


### PR DESCRIPTION
Related: #6387 

- Quoting around `$command` resulted in no commands being ran at all
- The newline at the end of `update-tools.yml` was being added to the end of the arguments list, causing a problem when interpreting the arguments string in the Invoke-Expression cmdlet:

  > ```
  > Invoke-Expression: /home/vsts/work/_temp/518b6f0d-7f3c-42fc-b864-a14a7949d4e1.ps1:11
  > Line |
  >   11 |  Invoke-Expression "$command";
  >      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  >      | Missing expression after unary operator '--'.
  > ```

You could see this in the rendered yaml output of the pipeline:

```yml
    - task: PowerShell@2
      displayName: Run Update Dependencies
      inputs:
        targetType: inline
        script: >
          $args = "specific 9.0 --tool chisel --version-source-name chisel --source-branch nightly --target-branch nightly --org dnceng --project $(System.TeamProject) --repo $(Build.Repository.Name)

          ";
```