### PR TITLE
Use productCommit assets to resolve build versions when updating dependencies

### DIFF
--- a/eng/update-dependencies/BuildAssetService.cs
+++ b/eng/update-dependencies/BuildAssetService.cs
@@ -12,7 +12,7 @@ namespace Dotnet.Docker;
 
 internal interface IBuildAssetService
 {
-    Task<string> GetAssetContentsAsync(Asset asset);
+    Task<string> GetAssetTextContentsAsync(Asset asset);
 }
 
 internal class BuildAssetService(
@@ -23,7 +23,7 @@ internal class BuildAssetService(
     private readonly HttpClient _httpClient = httpClient;
     private readonly ILogger<BuildAssetService> _logger = logger;
 
-    public async Task<string> GetAssetContentsAsync(Asset asset)
+    public async Task<string> GetAssetTextContentsAsync(Asset asset)
     {
         string url = ResolveAssetUrl(asset);
         try

--- a/eng/update-dependencies/ProductCommits.cs
+++ b/eng/update-dependencies/ProductCommits.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Dotnet.Docker;
+
+/// <summary>
+/// Represents the product commit versions for the SDK, runtime, and ASP.NET Core.
+/// </summary>
+/// <example>
+/// {
+///   "runtime": { "commit": "721dc7a2a59416b21fc49447d264009d708d6000", "version": "10.0.0-preview.4.25223.119" },
+///   "aspnetcore": { "commit": "721dc7a2a59416b21fc49447d264009d708d6000", "version": "10.0.0-preview.5.25223.119" },
+///   "windowsdesktop": { "commit": "721dc7a2a59416b21fc49447d264009d708d6000", "version": "10.0.0-preview.5.25222.4" },
+///   "sdk": { "commit": "721dc7a2a59416b21fc49447d264009d708d6000", "version": "10.0.100-preview.5.25223.119" }
+/// }
+/// </example>
+internal partial record ProductCommits(
+    ProductCommit Sdk,
+    ProductCommit Runtime,
+    ProductCommit AspNetCore)
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [GeneratedRegex("^Sdk/.*/productCommit-linux-x64.json$")]
+    public static partial Regex SdkAssetRegex { get; }
+
+    public static ProductCommits FromJson(string json)
+    {
+        return JsonSerializer.Deserialize<ProductCommits>(json, s_jsonOptions)
+            ?? throw new InvalidOperationException(
+                $"""
+                Could not deserialize product commit versions from content:
+                {json}
+                """);
+    }
+};
+
+internal record ProductCommit(string Commit, string Version);


### PR DESCRIPTION
In #6379, an incorrect assumption was made about the productVersion* text files. The versions of the Runtime and ASP.NET Core can indeed be different in the same VMR build.

We were using the `Runtime/*/productVersion.txt` file, but instead we should have been using the `Runtime/*/runtime-productVersion.txt` file. However there is no equivalent for ASP.NET.

This PR changes the from-channel command to use the `*productCommit.json` file directly from the SDK instead, which includes the correct product versions for the major SDK components.