### PR TITLE
Use the new build-and-test template for release staging

### DIFF
--- a/eng/pipelines/release-staging.yml
+++ b/eng/pipelines/release-staging.yml
@@ -1,11 +1,29 @@
+# This pipeline takes the current branch and builds and tests the images,
+# but does not publish them.
+#
+# The images can later be published by running the release-promotion pipeline.
+
 trigger: none
 pr: none
 
+resources:
+  repositories:
+  - repository: InternalVersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+
+variables:
+- template: /eng/pipelines/variables/core.yml@self
+
 extends:
   template: /eng/common/templates/1es-official.yml@self
-  stages:
-  - stage: release-staging
-    jobs:
-    - job: release-staging
-      steps:
-      - script: echo "Hello world"
+  parameters:
+    stages:
+    - template: /eng/pipelines/stages/build-and-test.yml@self
+      parameters:
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}
+        # We always want staged images to be as up-to-date as possible,
+        # so don't rely on any caching behavior.
+        noCache: true


### PR DESCRIPTION
This PR is part of https://github.com/dotnet/dotnet-docker-internal/issues/7413 and a direct follow-up to [Use split build/test and publish templates (#6386)](https://github.com/dotnet/dotnet-docker/pull/6386).

This is an initial implementation for the release-staging pipeline.

It currently does not support publishing internal images. I will revisit that functionality once I have also prototyped out the release-promotion pipeline (https://github.com/dotnet/dotnet-docker-internal/issues/7414).

Successful internal test: https://dev.azure.com/dnceng/internal/_build/results?buildId=2695716&view=results