### PR TITLE
Show help output when there are unmatched tokens passed to update-dependencies CLI

### DIFF
--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -30,7 +30,7 @@ config.UseHost(
             if (unmatchedArgs.Length > 0)
             {
                 var helpBuilder = new HelpBuilder();
-                var stringWriter = new StringWriter();
+                using var stringWriter = new StringWriter();
                 helpBuilder.Write(rootCommand, stringWriter);
                 Console.WriteLine(stringWriter.ToString());
                 throw new InvalidOperationException($"Unmatched tokens: {string.Join(" ", unmatchedArgs)}");

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.CommandLine;
+using System.CommandLine.Help;
 using System.CommandLine.Hosting;
+using System.IO;
 using System.Net.Http;
 using Dotnet.Docker;
 using Microsoft.DotNet.DarcLib;
@@ -22,8 +25,20 @@ var rootCommand = new RootCommand()
 var config = new CommandLineConfiguration(rootCommand);
 
 config.UseHost(
-    _ => Host.CreateDefaultBuilder(),
-    host => host.ConfigureServices(services =>
+    hostBuilderFactory: unmatchedArgs =>
+        {
+            if (unmatchedArgs.Length > 0)
+            {
+                var helpBuilder = new HelpBuilder();
+                var stringWriter = new StringWriter();
+                helpBuilder.Write(rootCommand, stringWriter);
+                Console.WriteLine(stringWriter.ToString());
+                throw new InvalidOperationException($"Unmatched tokens: {string.Join(" ", unmatchedArgs)}");
+            }
+
+            return Host.CreateDefaultBuilder();
+        },
+    configureHost: host => host.ConfigureServices(services =>
         {
             services.AddSingleton<IBasicBarClient>(_ =>
                 new BarApiClient(null, null, disableInteractiveAuth: true));


### PR DESCRIPTION
Fixes #6394

`System.Commandline.Hosting` forcibly sets `yourCommand.TreatUnmatchedTokensAsErrors = false` and also overrides the command's action, so we can't fix this behavior by either of those means.

However, unmatched tokens are passed to the `hostBuilderFactory`, which allows you to configure additional hosting options based on those extra tokens. Since we don't need those extra arguments, we can use that opportunity to print the help output and throw an exception.

https://github.com/dotnet/command-line-api/blob/a91bcf488ba7d0112b2637b505f8de32aded6825/src/System.CommandLine.Hosting/HostingAction.cs#L26-L27