### PR TITLE
Temporarily revert MAR Docs publishing GitHub App auth authentication changes

### DIFF
--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -15,14 +15,11 @@ variables:
   value: public/,internal/private/,unlisted/
 
 - name: mcrDocsRepoInfo.authArgs
-  value: >-
-    --gh-private-key '$(GitHubApp-NET-Docker-MAR-Docs-Updater-PrivateKey)'
-    --gh-app-client-id '$(gitHubApp.marDocsUpdater.clientId)'
-    --gh-app-installation-id '$(gitHubApp.marDocsUpdater.microsoft.installationId)'
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 - name: mcrDocsRepoInfo.userName
-  value: $(gitHubApp.marDocsUpdater.userName)
+  value: $(dotnetDockerBot.userName)
 - name: mcrDocsRepoInfo.email
-  value: $(gitHubApp.marDocsUpdater.email)
+  value: $(dotnetDockerBot.email)
 
 - name: publishNotificationsEnabled
   value: true


### PR DESCRIPTION
Related: https://github.com/dotnet/docker-tools/issues/1656

Temporarily revert these changes in order to unblock pushing tags for new images. These changes should be added back once the GitHub App has the correct permissions to push changes.