### PR TITLE
Update some usage and samples links

### DIFF
--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -19,7 +19,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
 ## Container sample: Run a web application
 

--- a/.portal-docs/docker-hub/README.monitor-base.md
+++ b/.portal-docs/docker-hub/README.monitor-base.md
@@ -19,7 +19,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 

--- a/.portal-docs/docker-hub/README.monitor.md
+++ b/.portal-docs/docker-hub/README.monitor.md
@@ -17,7 +17,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 You can run this image as a sidecar container to collect diagnostic information and artifacts from other containers running .NET Core 3.1 or .NET 5 and later.
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -19,9 +19,10 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
-* [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian) builds and runs an application as a self-contained application.
+* [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
 
 # Image Variants
 

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -22,7 +22,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
 * [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
-* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
 
 # Image Variants
 

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -19,7 +19,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ## Container sample: Run a simple application
 

--- a/.portal-docs/docker-hub/README.samples.md
+++ b/.portal-docs/docker-hub/README.samples.md
@@ -15,7 +15,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ## Container sample: Run a simple application
 

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -25,7 +25,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ## Building .NET Apps with Docker
 

--- a/.portal-docs/docker-hub/README.yarp.md
+++ b/.portal-docs/docker-hub/README.yarp.md
@@ -15,7 +15,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 # Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 You can run this image to launch a YARP instance.
 

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -38,7 +38,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
 ### Container sample: Run a web application
 

--- a/.portal-docs/mar/README.monitor-base.portal.md
+++ b/.portal-docs/mar/README.monitor-base.portal.md
@@ -39,7 +39,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 

--- a/.portal-docs/mar/README.monitor.portal.md
+++ b/.portal-docs/mar/README.monitor.portal.md
@@ -37,7 +37,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 You can run this image as a sidecar container to collect diagnostic information and artifacts from other containers running .NET Core 3.1 or .NET 5 and later.
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -41,7 +41,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
 * [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
-* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
 
 ## Image Variants
 

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -38,9 +38,10 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
-* [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian) builds and runs an application as a self-contained application.
+* [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
 
 ## Image Variants
 

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -38,7 +38,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ### Container sample: Run a simple application
 

--- a/.portal-docs/mar/README.samples.portal.md
+++ b/.portal-docs/mar/README.samples.portal.md
@@ -32,7 +32,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ### Container sample: Run a simple application
 

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -44,7 +44,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ### Building .NET Apps with Docker
 

--- a/.portal-docs/mar/README.yarp.portal.md
+++ b/.portal-docs/mar/README.yarp.portal.md
@@ -33,7 +33,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 You can run this image to launch a YARP instance.
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -21,7 +21,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
 ### Container sample: Run a web application
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ### Container sample: Run a simple application
 

--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -21,7 +21,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 The following Dockerfiles demonstrate how you can use this base image to build a .NET Monitor image with a custom set of extensions.
 

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -19,7 +19,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 You can run this image as a sidecar container to collect diagnostic information and artifacts from other containers running .NET Core 3.1 or .NET 5 and later.
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -24,7 +24,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
 * [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
-* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
 
 ## Image Variants
 

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -21,9 +21,10 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) to learn more.
 
-* [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian) builds and runs an application as a self-contained application.
+* [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
 
 ## Image Variants
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -21,7 +21,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ### Container sample: Run a simple application
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -17,7 +17,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ### Container sample: Run a simple application
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -27,7 +27,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 ### Building .NET Apps with Docker
 

--- a/README.yarp.md
+++ b/README.yarp.md
@@ -17,7 +17,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Usage
 
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction) to learn more.
 
 You can run this image to launch a YARP instance.
 

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -8,7 +8,8 @@
 }}{{ARGS["top-header"]}} Usage
 {{ _ Special case while aspire-dashboard image doesn't have any samples. Remove when https://github.com/dotnet/dotnet-docker/issues/5335 is resolved. ^
 if templateQualifier != "aspire-dashboard":
-The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Building Docker Images for .NET Applications](https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images) to learn more.
+The [.NET Docker samples](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) show various ways to use .NET and Docker together. See [Introduction to .NET and Docker](https://learn.microsoft.com/dotnet/core/docker/introduction){{
+    if templateQualifier = "aspnet" || templateQualifier = "runtime-deps": and [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker)}} to learn more.
 }}
 {{InsertTemplate(join(["Use", templateQualifier, "md"], "."),
   [ "top-header": ARGS["top-header"], "readme-host": ARGS["readme-host"]])}}

--- a/eng/readme-templates/Use.runtime-deps.md
+++ b/eng/readme-templates/Use.runtime-deps.md
@@ -2,4 +2,5 @@
     _ ARGS:
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme
-}}* [.NET self-contained Sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/README.md) - This [sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/dotnetapp/Dockerfile.debian) builds and runs an application as a self-contained application.
+}}* [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)

--- a/eng/readme-templates/Use.runtime-deps.md
+++ b/eng/readme-templates/Use.runtime-deps.md
@@ -3,4 +3,4 @@
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme
 }}* [Self-contained sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapp/Dockerfile)
-* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) (Preview) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)
+* [Native AOT sample](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/README.md) - [Dockerfile](https://github.com/dotnet/dotnet-docker/blob/main/samples/releasesapi/Dockerfile)


### PR DESCRIPTION
- Updated main .NET Docker tutorial link
- Added explicit link to [Host ASP.NET Core in Docker containers](https://learn.microsoft.com/aspnet/core/host-and-deploy/docker) for repos that it's relevant for
- Added link to native AOT sample for runtime-deps