### PR TITLE
Fix update-dependencies-monitor pipeline

### DIFF
--- a/eng/pipelines/update-dependencies-monitor.yml
+++ b/eng/pipelines/update-dependencies-monitor.yml
@@ -46,6 +46,6 @@ stages:
         $customArgsArray = @("$(updateDepsArgs)")
         echo "##vso[task.setvariable variable=customArgsArray]$($customArgsArray | ConvertTo-Json -Compress -AsArray)"
       displayName: Set Custom Args
-    - template: steps/update-dependencies.yml
+    - template: steps/update-dependencies-specific.yml
       parameters:
         customArgsArray: $(customArgsArray)


### PR DESCRIPTION
This pipeline had not responded to breaking changes in [Enable consuming public .NET SDK builds from the VMR using DarcLib (dotnet/dotnet-docker#6379)](https://github.com/dotnet/dotnet-docker/pull/6379), and it started failing since [Show help output when there are unmatched tokens passed to update-dependencies CLI (dotnet/dotnet-docker#6402)](https://github.com/dotnet/dotnet-docker/pull/6402) was fixed. Prior to that fix, it was silently failing with a no-op.