### PR TITLE
Use 'specific' command when setting updateDepsArgs from Set-DotnetVersions.ps1

### DIFF
--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -68,7 +68,8 @@ param(
 
 Import-Module -force $PSScriptRoot/DependencyManagement.psm1
 
-$updateDepsArgs = @($ProductVersion)
+# Use 'specific' command to set product versions to specific values
+$updateDepsArgs = @("specific", $ProductVersion)
 
 if ($SdkVersion) {
     $updateDepsArgs += @("--product-version", "sdk=$SdkVersion")
@@ -149,5 +150,5 @@ if ($AzdoVariableName) {
     Write-Host "##vso[task.setvariable variable=$AzdoVariableName]$updateDepsArgs"
 }
 else {
-    & dotnet run --project $PSScriptRoot/update-dependencies/update-dependencies.csproj specific @updateDepsArgs
+    & dotnet run --project $PSScriptRoot/update-dependencies/update-dependencies.csproj @updateDepsArgs
 }

--- a/eng/pipelines/steps/update-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dependencies-specific.yml
@@ -1,12 +1,8 @@
 parameters:
   # The customArgsArray parameter is used to specify the configuration for multiple Dockerfile versions.
   # This allows for a single branch to be generated for different internal .NET build versions.
-- name: customArgsArray
-  type: string
-  default: ""
-- name: useInternalBuild
-  type: boolean
-  default: false
+  customArgsArray: ""
+  useInternalBuild: false
 
 steps:
 - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
@@ -19,7 +15,7 @@ steps:
     } else {
       $pat="$(BotAccount-dotnet-docker-bot-PAT)"
     }
-    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat";
+    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
 
     # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions
     # Ensure that the value is treated as an array by wrapping it in an array literal. This deals with the quirk of

--- a/eng/pipelines/steps/update-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dependencies-specific.yml
@@ -1,9 +1,12 @@
 parameters:
   # The customArgsArray parameter is used to specify the configuration for multiple Dockerfile versions.
   # This allows for a single branch to be generated for different internal .NET build versions.
-  customArgsArray: ""
-
-  useInternalBuild: false
+- name: customArgsArray
+  type: string
+  default: ""
+- name: useInternalBuild
+  type: boolean
+  default: false
 
 steps:
 - script: docker build -t update-dependencies -f $(engPath)/update-dependencies/Dockerfile --pull .
@@ -16,8 +19,7 @@ steps:
     } else {
       $pat="$(BotAccount-dotnet-docker-bot-PAT)"
     }
-
-    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
+    $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat";
 
     # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions
     # Ensure that the value is treated as an array by wrapping it in an array literal. This deals with the quirk of
@@ -31,6 +33,7 @@ steps:
       }
 
       $command = "docker exec update-dependencies update-dependencies $customArgs"
+      Write-Host "Executing: $command"
       Invoke-Expression $command
     }
   displayName: Run Update Dependencies

--- a/eng/pipelines/steps/update-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dependencies-specific.yml
@@ -2,6 +2,7 @@ parameters:
   # The customArgsArray parameter is used to specify the configuration for multiple Dockerfile versions.
   # This allows for a single branch to be generated for different internal .NET build versions.
   customArgsArray: ""
+
   useInternalBuild: false
 
 steps:
@@ -15,6 +16,7 @@ steps:
     } else {
       $pat="$(BotAccount-dotnet-docker-bot-PAT)"
     }
+
     $credArgs = "--user $(dotnetDockerBot.userName) --email $(dotnetDockerBot.email) --password $pat"
 
     # Execute update-deps for each of the items in the customArgsArray, representing different Dockerfile versions


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/dotnet-docker/pull/6410 - that PR was an incomplete fix.

When using Set-DotnetVersions.ps1, it would only use the correct update-dependencies subcommand correctly when calling the tool directly, but not when setting the arguments as an azure pipelines variable. This PR fixes that and also logs the command before it's run so that it's easier to troubleshoot.