### PR TITLE
Revert "Update package baseline for Azure Linux 3.0"

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -63,12 +63,6 @@ namespace Microsoft.DotNet.Docker.Tests
                 return;
             }
 
-            if (imageData.OS.Contains(OS.AzureLinux))
-            {
-                OutputHelper.WriteLine("Skipping test for Azure Linux due to https://github.com/dotnet/dotnet-docker/issues/6419");
-                return;
-            }
-
             string imageTag = imageData.GetImage(ImageRepo, DockerHelper);
 
             // Attempting to execute the container's shell should result in an exception.

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -317,36 +317,7 @@ namespace Microsoft.DotNet.Docker.Tests
                         "distroless-packages-minimal",
                         "filesystem",
                         "prebuilt-ca-certificates",
-                        "tzdata",
-                        // The following packages are not desired, but were brought in by an update to SymCrypt
-                        // Tracking issue: https://github.com/dotnet/dotnet-docker/issues/6419
-                        "acl",
-                        "attr",
-                        "bash",
-                        "bzip2-libs",
-                        "coreutils",
-                        "glibc",
-                        "gmp",
-                        "grep",
-                        "libacl",
-                        "libattr",
-                        "libcap",
-                        "libgcc",
-                        "libpcre2-16-0",
-                        "libpcre2-32-0",
-                        "libpcre2-8-0",
-                        "libpcre2-posix2",
-                        "libselinux",
-                        "libsepol",
-                        "libstdc++",
-                        "ncurses",
-                        "ncurses-libs",
-                        "openssl",
-                        "openssl-libs",
-                        "pcre2",
-                        "pcre2-tools",
-                        "readline",
-                        "zlib"
+                        "tzdata"
                     },
                 { OS: string os } when os.Contains(OS.Mariner) => new[]
                     {


### PR DESCRIPTION
The Azure Linux SymCrypt package was updated, and it no longer has a dependency on bash.

- Reverts dotnet/dotnet-docker#6422
- Related
  - dotnet/dotnet-docker#6423
  - https://github.com/dotnet/dotnet-docker/pull/6442
- Fixes #6419