### PR TITLE
Update .NET 8 SDK PowerShell version to 7.4.10

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -181,12 +181,12 @@
     "monitor-ext-s3storage|9.1|linux|x64|sha": "82b550ad9432b86ff58f0bb0f959cd52341b2225d3806fd7211b28462bb216b99ddd828fc36146fca2e92c6c545bc6d81c629ee8dd691d69cd2232528b81d48b",
     "monitor-ext-s3storage|9.1|linux|arm64|sha": "3854991fe4a6bbbd18f7504d8e4da8ade88133a8db0172facd8a50b8057967fbc8ad5643776c68f04b5bcdd5fd901bc2d298d2007a88a2046261c0cfb57226aa",
 
-    "powershell|8.0|build-version": "7.4.7",
-    "powershell|8.0|Linux.Alpine|sha": "9c5fbb87edf9f1b3da05beeeacd69ae361cb60b0eb16079c26a5c6b477a17e4ed1deef31cdb23de43c959eae2a2731cf16188b491db2ad5d398276ca0e71faaf",
-    "powershell|8.0|Linux|arm32|sha": "727c67c3d29e3f3216366b5e2487b14baf926ab36da58833aecb84d663e4a6f61d2c073d7a99f7b05294cea71f3d37c90bbd237cd4cad6491dd8031544c16841",
-    "powershell|8.0|Linux|arm64|sha": "6c72dfc5bcbac7b135e5152d0ec599e9f639255ff3be2c28eb64015e6df948b2a9c216fc2bd9b26b876a11e32182adad249b88551dd650a4342f5ac2fbed56d6",
-    "powershell|8.0|Linux|x64|sha": "3f4ff718b982b5cbcbc3ceef2602f681af8029e716aa00a65e60edd81c94fcea3d2e4d6c6f18b5f3cadfba2558f70dbe810397c6bf73757d132ec7bec77dfdba",
-    "powershell|8.0|Windows|x64|sha": "fb23e5cdaf53790e66b6b9767f8e112aa60a37f0a2b49109ba8e495ead862e058ffd90b16ad5c60c0ea5d4f03ea49566f1aa7e2ab1803afd2bdf4a37e0cd258c",
+    "powershell|8.0|build-version": "7.4.10",
+    "powershell|8.0|Linux.Alpine|sha": "06bc91beeb0d2ade83100432ebd54ae121a4fdca77080fbbfd9355a8f3e33c196c90385557bc82b5f0fcb1941cf369b56f08643448dcdd2271c61849ed9499b8",
+    "powershell|8.0|Linux|arm32|sha": "dc7f9fe7f0bc821d6fd1c14cc87eb32a8b781daa1448923b023c71afecf1d8a06249f24c3e318f12686a056389e00e986aa03f112a31e9100061f11ef84719ff",
+    "powershell|8.0|Linux|arm64|sha": "8a354c031efed49ffbbb37455f0bb7197ba7e6cef558ba4e2eec1aa3d60bc197a296b9e6235cdc90cbd52dc4419fb21e78d55707e3f9b59a7a7960ccb3fbb053",
+    "powershell|8.0|Linux|x64|sha": "2784c06b0c2ecd8acecef30abc8401e3fec36e2ceca4ff75c5c11f4239df6def73f319779cefde2340bce11bd269c1fc8fbe060759714eeee3fe105ce27da907",
+    "powershell|8.0|Windows|x64|sha": "18b64ab0159508e84c74e198306ef82d1f1590b2eebce343ed2bf9cb959fe215f5c780ced864b471370894b0ea95d4ff91bef1a3e8eb9e6df10ba8f1ec823440",
 
     "powershell|9.0|build-version": "7.5.1",
     "powershell|9.0|Linux.Alpine|sha": "5be83dbc97bebe12588ef82bb31188b5be305c42445bcc87100c5532396cc2e790f3db8128671d5cc647e95f5fe06903fdfc0960a8f4d009282e3cd7e1f9f42c",

--- a/src/sdk/8.0/alpine3.21/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.21/amd64/Dockerfile
@@ -43,9 +43,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && wget -O PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='9c5fbb87edf9f1b3da05beeeacd69ae361cb60b0eb16079c26a5c6b477a17e4ed1deef31cdb23de43c959eae2a2731cf16188b491db2ad5d398276ca0e71faaf' \
+    && powershell_sha512='06bc91beeb0d2ade83100432ebd54ae121a4fdca77080fbbfd9355a8f3e33c196c90385557bc82b5f0fcb1941cf369b56f08643448dcdd2271c61849ed9499b8' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \

--- a/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
@@ -44,9 +44,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='3f4ff718b982b5cbcbc3ceef2602f681af8029e716aa00a65e60edd81c94fcea3d2e4d6c6f18b5f3cadfba2558f70dbe810397c6bf73757d132ec7bec77dfdba' \
+    && powershell_sha512='2784c06b0c2ecd8acecef30abc8401e3fec36e2ceca4ff75c5c11f4239df6def73f319779cefde2340bce11bd269c1fc8fbe060759714eeee3fe105ce27da907' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -44,9 +44,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='6c72dfc5bcbac7b135e5152d0ec599e9f639255ff3be2c28eb64015e6df948b2a9c216fc2bd9b26b876a11e32182adad249b88551dd650a4342f5ac2fbed56d6' \
+    && powershell_sha512='8a354c031efed49ffbbb37455f0bb7197ba7e6cef558ba4e2eec1aa3d60bc197a296b9e6235cdc90cbd52dc4419fb21e78d55707e3f9b59a7a7960ccb3fbb053' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='3f4ff718b982b5cbcbc3ceef2602f681af8029e716aa00a65e60edd81c94fcea3d2e4d6c6f18b5f3cadfba2558f70dbe810397c6bf73757d132ec7bec77dfdba' \
+    && powershell_sha512='2784c06b0c2ecd8acecef30abc8401e3fec36e2ceca4ff75c5c11f4239df6def73f319779cefde2340bce11bd269c1fc8fbe060759714eeee3fe105ce27da907' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='727c67c3d29e3f3216366b5e2487b14baf926ab36da58833aecb84d663e4a6f61d2c073d7a99f7b05294cea71f3d37c90bbd237cd4cad6491dd8031544c16841' \
+    && powershell_sha512='dc7f9fe7f0bc821d6fd1c14cc87eb32a8b781daa1448923b023c71afecf1d8a06249f24c3e318f12686a056389e00e986aa03f112a31e9100061f11ef84719ff' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='6c72dfc5bcbac7b135e5152d0ec599e9f639255ff3be2c28eb64015e6df948b2a9c216fc2bd9b26b876a11e32182adad249b88551dd650a4342f5ac2fbed56d6' \
+    && powershell_sha512='8a354c031efed49ffbbb37455f0bb7197ba7e6cef558ba4e2eec1aa3d60bc197a296b9e6235cdc90cbd52dc4419fb21e78d55707e3f9b59a7a7960ccb3fbb053' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile
@@ -44,9 +44,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='3f4ff718b982b5cbcbc3ceef2602f681af8029e716aa00a65e60edd81c94fcea3d2e4d6c6f18b5f3cadfba2558f70dbe810397c6bf73757d132ec7bec77dfdba' \
+    && powershell_sha512='2784c06b0c2ecd8acecef30abc8401e3fec36e2ceca4ff75c5c11f4239df6def73f319779cefde2340bce11bd269c1fc8fbe060759714eeee3fe105ce27da907' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -44,9 +44,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='6c72dfc5bcbac7b135e5152d0ec599e9f639255ff3be2c28eb64015e6df948b2a9c216fc2bd9b26b876a11e32182adad249b88551dd650a4342f5ac2fbed56d6' \
+    && powershell_sha512='8a354c031efed49ffbbb37455f0bb7197ba7e6cef558ba4e2eec1aa3d60bc197a296b9e6235cdc90cbd52dc4419fb21e78d55707e3f9b59a7a7960ccb3fbb053' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/jammy/amd64/Dockerfile
+++ b/src/sdk/8.0/jammy/amd64/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='3f4ff718b982b5cbcbc3ceef2602f681af8029e716aa00a65e60edd81c94fcea3d2e4d6c6f18b5f3cadfba2558f70dbe810397c6bf73757d132ec7bec77dfdba' \
+    && powershell_sha512='2784c06b0c2ecd8acecef30abc8401e3fec36e2ceca4ff75c5c11f4239df6def73f319779cefde2340bce11bd269c1fc8fbe060759714eeee3fe105ce27da907' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/8.0/jammy/arm32v7/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='727c67c3d29e3f3216366b5e2487b14baf926ab36da58833aecb84d663e4a6f61d2c073d7a99f7b05294cea71f3d37c90bbd237cd4cad6491dd8031544c16841' \
+    && powershell_sha512='dc7f9fe7f0bc821d6fd1c14cc87eb32a8b781daa1448923b023c71afecf1d8a06249f24c3e318f12686a056389e00e986aa03f112a31e9100061f11ef84719ff' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/8.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/8.0/jammy/arm64v8/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='6c72dfc5bcbac7b135e5152d0ec599e9f639255ff3be2c28eb64015e6df948b2a9c216fc2bd9b26b876a11e32182adad249b88551dd650a4342f5ac2fbed56d6' \
+    && powershell_sha512='8a354c031efed49ffbbb37455f0bb7197ba7e6cef558ba4e2eec1aa3d60bc197a296b9e6235cdc90cbd52dc4419fb21e78d55707e3f9b59a7a7960ccb3fbb053' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.7'; `
+        $powershell_version = '7.4.10'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'fb23e5cdaf53790e66b6b9767f8e112aa60a37f0a2b49109ba8e495ead862e058ffd90b16ad5c60c0ea5d4f03ea49566f1aa7e2ab1803afd2bdf4a37e0cd258c'; `
+        $powershell_sha512 = '18b64ab0159508e84c74e198306ef82d1f1590b2eebce343ed2bf9cb959fe215f5c780ced864b471370894b0ea95d4ff91bef1a3e8eb9e6df10ba8f1ec823440'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.7'; `
+        $powershell_version = '7.4.10'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'fb23e5cdaf53790e66b6b9767f8e112aa60a37f0a2b49109ba8e495ead862e058ffd90b16ad5c60c0ea5d4f03ea49566f1aa7e2ab1803afd2bdf4a37e0cd258c'; `
+        $powershell_sha512 = '18b64ab0159508e84c74e198306ef82d1f1590b2eebce343ed2bf9cb959fe215f5c780ced864b471370894b0ea95d4ff91bef1a3e8eb9e6df10ba8f1ec823440'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.7'; `
+        $powershell_version = '7.4.10'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'fb23e5cdaf53790e66b6b9767f8e112aa60a37f0a2b49109ba8e495ead862e058ffd90b16ad5c60c0ea5d4f03ea49566f1aa7e2ab1803afd2bdf4a37e0cd258c'; `
+        $powershell_sha512 = '18b64ab0159508e84c74e198306ef82d1f1590b2eebce343ed2bf9cb959fe215f5c780ced864b471370894b0ea95d4ff91bef1a3e8eb9e6df10ba8f1ec823440'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/noble/amd64/Dockerfile
+++ b/src/sdk/8.0/noble/amd64/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='3f4ff718b982b5cbcbc3ceef2602f681af8029e716aa00a65e60edd81c94fcea3d2e4d6c6f18b5f3cadfba2558f70dbe810397c6bf73757d132ec7bec77dfdba' \
+    && powershell_sha512='2784c06b0c2ecd8acecef30abc8401e3fec36e2ceca4ff75c5c11f4239df6def73f319779cefde2340bce11bd269c1fc8fbe060759714eeee3fe105ce27da907' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/8.0/noble/arm64v8/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='6c72dfc5bcbac7b135e5152d0ec599e9f639255ff3be2c28eb64015e6df948b2a9c216fc2bd9b26b876a11e32182adad249b88551dd650a4342f5ac2fbed56d6' \
+    && powershell_sha512='8a354c031efed49ffbbb37455f0bb7197ba7e6cef558ba4e2eec1aa3d60bc197a296b9e6235cdc90cbd52dc4419fb21e78d55707e3f9b59a7a7960ccb3fbb053' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/trixie-slim/amd64/Dockerfile
+++ b/src/sdk/8.0/trixie-slim/amd64/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='3f4ff718b982b5cbcbc3ceef2602f681af8029e716aa00a65e60edd81c94fcea3d2e4d6c6f18b5f3cadfba2558f70dbe810397c6bf73757d132ec7bec77dfdba' \
+    && powershell_sha512='2784c06b0c2ecd8acecef30abc8401e3fec36e2ceca4ff75c5c11f4239df6def73f319779cefde2340bce11bd269c1fc8fbe060759714eeee3fe105ce27da907' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/trixie-slim/arm64v8/Dockerfile
+++ b/src/sdk/8.0/trixie-slim/arm64v8/Dockerfile
@@ -42,9 +42,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.7 \
+RUN powershell_version=7.4.10 \
     && curl -fSL --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='6c72dfc5bcbac7b135e5152d0ec599e9f639255ff3be2c28eb64015e6df948b2a9c216fc2bd9b26b876a11e32182adad249b88551dd650a4342f5ac2fbed56d6' \
+    && powershell_sha512='8a354c031efed49ffbbb37455f0bb7197ba7e6cef558ba4e2eec1aa3d60bc197a296b9e6235cdc90cbd52dc4419fb21e78d55707e3f9b59a7a7960ccb3fbb053' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir -p /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.7'; `
+        $powershell_version = '7.4.10'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'fb23e5cdaf53790e66b6b9767f8e112aa60a37f0a2b49109ba8e495ead862e058ffd90b16ad5c60c0ea5d4f03ea49566f1aa7e2ab1803afd2bdf4a37e0cd258c'; `
+        $powershell_sha512 = '18b64ab0159508e84c74e198306ef82d1f1590b2eebce343ed2bf9cb959fe215f5c780ced864b471370894b0ea95d4ff91bef1a3e8eb9e6df10ba8f1ec823440'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.7'; `
+        $powershell_version = '7.4.10'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'fb23e5cdaf53790e66b6b9767f8e112aa60a37f0a2b49109ba8e495ead862e058ffd90b16ad5c60c0ea5d4f03ea49566f1aa7e2ab1803afd2bdf4a37e0cd258c'; `
+        $powershell_sha512 = '18b64ab0159508e84c74e198306ef82d1f1590b2eebce343ed2bf9cb959fe215f5c780ced864b471370894b0ea95d4ff91bef1a3e8eb9e6df10ba8f1ec823440'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -37,9 +37,9 @@ RUN powershell -Command " `
         Remove-Item -Force dotnet.zip; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.7'; `
+        $powershell_version = '7.4.10'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'fb23e5cdaf53790e66b6b9767f8e112aa60a37f0a2b49109ba8e495ead862e058ffd90b16ad5c60c0ea5d4f03ea49566f1aa7e2ab1803afd2bdf4a37e0cd258c'; `
+        $powershell_sha512 = '18b64ab0159508e84c74e198306ef82d1f1590b2eebce343ed2bf9cb959fe215f5c780ced864b471370894b0ea95d4ff91bef1a3e8eb9e6df10ba8f1ec823440'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `


### PR DESCRIPTION
This pull request updates the PowerShell version from `7.4.7` to `7.4.10` across multiple Dockerfiles and the `manifest.versions.json` file. The changes ensure consistency in the PowerShell version and its associated SHA-512 checksums for various platforms and architectures.

### Updates to PowerShell version and checksums:

* **Manifest updates**:
  - Updated the PowerShell version and associated SHA-512 checksums for multiple platforms in `manifest.versions.json`. This includes Linux (Alpine, ARM32, ARM64, x64) and Windows x64 platforms.

* **Linux-based Dockerfiles**:
  - Updated PowerShell version and SHA-512 checksums in Dockerfiles for Alpine, Bookworm-Slim, CBL-Mariner, Jammy, Noble, and Trixie-Slim distributions across `amd64`, `arm32v7`, and `arm64v8` architectures. [[1]](diffhunk://#diff-fa0866fc7721bf997cd2bf89e9b53bbdef26e2bbdef701d07d4955a552311430L46-R48) [[2]](diffhunk://#diff-1f65f50deb5fcf972030edf337837161c4a676fb64fc96fc6407c4f266dafc1bL47-R49) [[3]](diffhunk://#diff-63ce660de3fcecee34e09d4884d46e8e5426a7f314db6ce0a2364834cc2896f2L47-R49) [[4]](diffhunk://#diff-6ac4aa00b18490c4047c4ea9895a0b02bcc9cdd30a5373ff3a5c5f294a73758dL45-R47) [[5]](diffhunk://#diff-557400b5d1f9d0a2f5c67352d55b6475d6be6dc55b0dbceeffc6f58aadb95b58L45-R47) [[6]](diffhunk://#diff-6bdc3dc207e866e027a8114fc7676613441e8f45639abbbe15b893f664970ac9L45-R47) [[7]](diffhunk://#diff-5803307fb43c9a449108cc74b465b1172006e9cad39be8460c1fb2a67a4fb169L47-R49) [[8]](diffhunk://#diff-c7da1754d25935dd3b8233d1532fbb3f93120643d80df1a51d5996cfc7c00d6bL47-R49) [[9]](diffhunk://#diff-fad7f562851dadf082f7f6dbbb964dfd66e91c1600a8bc1f723224b95f4d750cL45-R47) [[10]](diffhunk://#diff-cb40d1dcd3e48d8f6d823b0eec6859087c8df0614e78ca3700bb45ef5898015dL45-R47) [[11]](diffhunk://#diff-66448e8f2f0b5d53446c87853ff1affbe6642f8969d39a3811b8f5fbf064f7c4L45-R47) [[12]](diffhunk://#diff-42506bb10a71be4cb781a3c3a6e51e0bba841afded5f264da579a3dde463ab62L45-R47) [[13]](diffhunk://#diff-6e49965484ab2f0b325d99c913fcb2d0b66460220678279643382b60ba80add9L45-R47) [[14]](diffhunk://#diff-6170547d3ee4699500234b56d6437c50b2f3593269eec0125a71dd35f6ab6c25L45-R47)

* **Windows-based Dockerfiles**:
  - Updated PowerShell version and SHA-512 checksums in Dockerfiles for NanoServer distributions (1809, LTSC2022, LTSC2025) for the `amd64` architecture. [[1]](diffhunk://#diff-9842a3a6860ec3ad0fabfbc0e9f4fd092e3f412adb6ae4cc9702a8a7ab1c0c14L40-R42) [[2]](diffhunk://#diff-68590b1c5f0a83ba4f5cffc66df5ef3a7eb32f26fdd4131d69949cd44b6ca5f0L40-R42) [[3]](diffhunk://#diff-b2b0b363d46e7e98ff4630e58bdbd03f6093a32a7cd3bafdae51ed3b70e6f078L40-R42)

These updates ensure that the latest PowerShell version is used consistently across all supported platforms, improving security and compatibility.