### PR TITLE
[main] Ignore https://aka.ms/ in markdown link checker

### DIFF
--- a/.github/linters/.linkspector.yml
+++ b/.github/linters/.linkspector.yml
@@ -13,4 +13,5 @@ excludedDirs:
 ignorePatterns:
   - pattern: "^https://github.com/microsoft/mcr.*$"
   - pattern: "^https://github.com/dotnet/release.*$"
+  - pattern: "^https://aka.ms/$"
 useGitIgnore: true


### PR DESCRIPTION
This ignores https://aka.ms/ in the markdown link checker since it leads to an internal site. Please note that it does not ignore all aka.ms/* links, only https://aka.ms/ itself.