### PR TITLE
Revert "Workaround issue where Update Dependencies tool would sometimes overwrite PRs (#6456)"

### DIFF
--- a/eng/update-dependencies/SpecificCommand.cs
+++ b/eng/update-dependencies/SpecificCommand.cs
@@ -233,17 +233,6 @@ namespace Dotnet.Docker
                 if (pullRequestToUpdate == null || pullRequestToUpdate.Head.Ref != $"{upstreamBranch.Name}-{branchSuffix}")
                 {
                     Trace.WriteLine("Didn't find a PR to update. Submitting a new one.");
-
-                    // Workaround for https://github.com/dotnet/dotnet-docker/issues/6427
-                    //
-                    // CreateOrUpdateAsync has its own internal logic to search for and update PRs, and it doesn't
-                    // check that source branch names match. It only checks if the author matches the current user.
-                    // If we don't force the creation of a new PR here, then we run the risk of overwriting other
-                    // unrelated PRs. The downside is that since SearchPullRequestsAsync only returns one result, we
-                    // may end up submitting a duplicate PR, but that's still better than overwriting an unrelated PR.
-                    // https://github.com/dotnet/docker-tools/issues/1658 tracks migrating off of this library.
-                    prOptions.ForceCreate = true;
-
                     await prCreator.CreateOrUpdateAsync(
                         commitMessage,
                         commitMessage,


### PR DESCRIPTION
This reverts commit 5ca09eea9d04fdd854fa672959650ebb52dc5b71.

We weren't getting dependency updates. Update-dependencies was generating updates, but it was silently exiting without creating a PR.

Turns out that is because the Microsoft.DotNet.VersionTools..etc..PullRequestCreator class _skips all logic_ if you set `ForceCreate = true`.

By reverting this we unblock dependency update PRs. For now I can accept that [Update-dependencies tool can overwrite the wrong pull request (#6427)](https://github.com/dotnet/dotnet-docker/issues/6427) will just happen sometimes.

https://github.com/dotnet/arcade/blob/086a1771875b63404b4a710d27250fe384dc2810/src/VersionTools/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs#L80