### PR TITLE
Update internal Dockerfile templates to support managed identity OAuth token

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.download-file
+++ b/eng/dockerfile-templates/Dockerfile.linux.download-file
@@ -8,14 +8,15 @@
         sha-var-name: Name of variable that stores the checksum
         sha-function: SHA function to use ^
 
-    set isInternal to find(ARGS["url"], "artifacts.visualstudio.com") >= 0 ^
-    set alpineSetTokenCmd to 'token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0)' ^
-    set additionalWgetArgs to when(isInternal, '--header="Authorization: Basic $token" ', '') ^
-    set additionalCurlArgs to when(isInternal, '-u :$ACCESSTOKEN --basic ', '') ^
+    _ Documentation for using Managed Identity/OAuth tokens to access Azure storage accounts:
+        https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory#call-storage-operations-with-oauth-tokens ^
+
+    set isInternal to find(ARGS["url"], "dotnetstage") >= 0 ^
+    set additionalWgetArgs to when(isInternal, '--header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" ', '') ^
+    set additionalCurlArgs to when(isInternal, '-H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" ', '') ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set shaFunction to ARGS["sha-function"] ^
     set shaFunction to when(shaFunction, shaFunction, "512")
-}}{{if isAlpine:{{if isInternal:{{alpineSetTokenCmd}} \
-&& }}wget {{additionalWgetArgs}}-O^else:curl {{additionalCurlArgs}}-fSL --output}} {{ARGS["out-file"]}} {{if isInternal:"{{ARGS["url"]}}"^else:{{ARGS["url"]}}}}{{if ARGS["sha"]: \
+}}{{if isAlpine:wget {{additionalWgetArgs}}-O^else:curl {{additionalCurlArgs}}-fSL --output}} {{ARGS["out-file"]}} {{if isInternal:"{{ARGS["url"]}}"^else:{{ARGS["url"]}}}}{{if ARGS["sha"]: \
 && {{ARGS["sha-var-name"]}}='{{ARGS["sha"]}}' \
 && echo "${{ARGS["sha-var-name"]}}  {{ARGS["out-file"]}}" | sha{{shaFunction}}sum -c -}}

--- a/eng/dockerfile-templates/Dockerfile.windows.download-file
+++ b/eng/dockerfile-templates/Dockerfile.windows.download-file
@@ -8,11 +8,16 @@
         sha-var-name: Name of variable that stores the checksum
         hash-algorithm: Algorithm type to use to get the checksum. Defaults to sha512 ^
 
-    set isInternal to find(ARGS["url"], "artifacts.visualstudio.com") >= 0 ^
+    _ Documentation for using Managed Identity/OAuth tokens to access Azure storage accounts:
+        https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory#call-storage-operations-with-oauth-tokens ^
+
+    set isInternal to find(ARGS["url"], "dotnetstage") >= 0 ^
     set hashAlgorithm to when(ARGS["hash-algorithm"], ARGS["hash-algorithm"], "sha512")
 }}{{if isInternal:`
-$Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-$Headers = @@{Authorization = \"Basic $Base64AuthInfo\"}; `
+$Headers = @@{ `
+    Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+    'x-ms-version' = '2017-11-09'; `
+}; `
 Invoke-WebRequest -OutFile {{ARGS["out-file"]}} \"{{ARGS["url"]}}\" -Headers $Headers; `
 `^else:Invoke-WebRequest -OutFile {{ARGS["out-file"]}} {{ARGS["url"]}}; `}}
 ${{ARGS["sha-var-name"]}} = '{{ARGS["sha"]}}'; `

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux
@@ -10,7 +10,7 @@
     set isFullAzureLinux to isAzureLinux && !isDistroless ^
     set isDistrolessAzureLinux to isAzureLinux && isDistroless ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
     set runtimeDepsVariant to when(ARGS["is-extra"], "-extra", "") ^
     set tagVersion to when(dotnetVersion = "8.0",
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
@@ -6,7 +6,7 @@
     set isFullAzureLinux to isAzureLinux && !isDistroless ^
     set isDistrolessAzureLinux to isAzureLinux && isDistroless ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
     set isSingleStage to isAlpine && !isInternal ^
     set runtimeDepsVariant to when(ARGS["is-extra"], "-extra", "") ^
     set tagVersion to when(dotnetVersion = "8.0",

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux.install-aspnet
@@ -7,34 +7,44 @@
         - installer-stage (optional): Name of the Dockerfile stage responsible for installation ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set productVersion to VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")] ^
+    set buildVersion to VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")] ^
+
     set isFullAzureLinux to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) ^
     set isDistroless to find(OS_VERSION, "distroless") >= 0 || find(OS_VERSION, "chiseled") >= 0 ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set platform to when(isAlpine, "linux-musl", "linux") ^
     set destDir to "/dotnet" ^
-    set aspnetVersionDir to when(ARGS["use-local-version-var"],
-        "$aspnetcore_version",
-        when(ARGS["is-internal"],
-            VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")],
-            "$ASPNET_VERSION")) ^
-    set isStableBranding to (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
-        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
-    set aspnetVersionFile to when(isStableBranding,
-        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
-        aspnetVersionDir) ^
-    set url to cat(
-        VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])],
-        "/aspnetcore/Runtime/", aspnetVersionDir, "/aspnetcore-runtime-", aspnetVersionFile,
-        "-", platform, "-", ARCH_SHORT, ".tar.gz") ^
+
+    set versionDir to
+        when(ARGS["use-local-version-var"],
+            "$aspnetcore_version",
+            "$ASPNET_VERSION") ^
+
+    set sdkBuildVersion to VARIABLES[cat("sdk|", dotnetVersion, "|build-version")] ^
+    set isStableBranding to find(sdkBuildVersion, "-servicing") >= 0 || find(sdkBuildVersion, "-rtm") >= 0 ^
+
+    set fileVersion to when(isStableBranding, productVersion, versionDir) ^
+
+    if (ARGS["is-internal"]):{{
+        set versionDir to buildVersion ^
+        set fileVersion to productVersion
+    }} ^
+
+    set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
+    set downloadUrl to cat(baseUrl, "/aspnetcore/Runtime/", versionDir, "/aspnetcore-runtime-", fileVersion, "-", platform, "-", ARCH_SHORT, ".tar.gz") ^
+    set sha to VARIABLES[join(["aspnet", dotnetVersion, platform, ARCH_SHORT, "sha"], "|")] ^
+
     set files to [
         [
             "filename": "aspnetcore.tar.gz",
-            "url": url,
-            "sha": VARIABLES[join(["aspnet", dotnetVersion, platform, ARCH_SHORT, "sha"], "|")],
+            "url": downloadUrl,
+            "sha": sha,
             "sha-var-name": "aspnetcore_sha512",
             "extract-paths": ["./shared/Microsoft.AspNetCore.App"]
         ]
     ] ^
+
     set copyEnabled to ARGS["install-method"] = "copy-and-install" ^
     set downloadEnabled to ARGS["install-method"] = "download" || ARGS["install-method"] = "download-and-install" ^
     set installEnabled to ARGS["install-method"] = "download-and-install" || ARGS["install-method"] = "copy-and-install"
@@ -46,7 +56,7 @@ if copyEnabled:{{InsertTemplate("../Dockerfile.linux.copy-files",
         "destination": ""
     ])
 }}
-}}RUN {{if ARGS["use-local-version-var"]:aspnetcore_version={{VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")]}} \
+}}RUN {{if ARGS["use-local-version-var"]:aspnetcore_version={{buildVersion}} \
     && }}{{InsertTemplate("../Dockerfile.linux.download-and-install",
         [
             "files": files,

--- a/eng/dockerfile-templates/aspnet/Dockerfile.windows
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.windows
@@ -3,7 +3,7 @@
     set isServerCore to find(OS_VERSION, "windowsservercore") >= 0 ^
 
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
 
     set installerStageFromImage to cat("mcr.microsoft.com/windows/servercore:", OS_VERSION_NUMBER, "-amd64") ^
 

--- a/eng/dockerfile-templates/runtime-deps/Dockerfile
+++ b/eng/dockerfile-templates/runtime-deps/Dockerfile
@@ -12,7 +12,7 @@
     set isAzureLinux to isCblMariner || defined(match(OS_VERSION, "^azurelinux\d+\.\d+$")) ^
 
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
 
     set baseImageRepo to when(isAlpine,
         cat(ARCH_VERSIONED, "/alpine"),

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -10,7 +10,7 @@
     set isFullAzureLinux to isAzureLinux && !isDistroless ^
     set isDistrolessAzureLinux to isAzureLinux && isDistroless ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
     set runtimeDepsVariant to when(ARGS["is-extra"], "-extra", "") ^
     set tagVersion to VARIABLES[cat("dotnet|", dotnetVersion, "|fixed-tag")] ^
     set runtimeDepsBaseTag to cat(

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux.install-runtime
@@ -10,48 +10,55 @@
         is-composite-runtime (optional): Whether to install aspnetcore composite version ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
-    set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
-    set varPlatform to when(isAlpine, "linux-musl", "linux") ^
-    set runtimeVersionDir to when(ARGS["use-local-version-var"],
-        "$dotnet_version",
-        when(ARGS["is-internal"],
-            VARIABLES[cat("runtime|", dotnetVersion, "|build-version")],
-            "$DOTNET_VERSION")) ^
-    set aspnetCompositeVersionDir to when(ARGS["use-local-version-var"],
-        "$aspnetcore_version",
-        when(ARGS["is-internal"],
+    set productVersion to VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")] ^
+    set buildVersion to
+        when(ARGS["is-composite-runtime"],
             VARIABLES[cat("aspnet|", dotnetVersion, "|build-version")],
-            "$ASPNET_VERSION")) ^
-    set isStableBranding to (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
-        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
-    set runtimeVersionFile to when(isStableBranding,
-        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
-        runtimeVersionDir) ^
-    set aspnetCompositeVersionFile to when(isStableBranding,
-        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
-        aspnetCompositeVersionDir) ^
-    set filePlatform to when(isAlpine, "-linux-musl", "-linux") ^
+            VARIABLES[cat("runtime|", dotnetVersion, "|build-version")]) ^
+
+    set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
+    set platform to when(isAlpine, "linux-musl", "linux") ^
+
+    set versionDir to
+        when(ARGS["is-composite-runtime"],
+            when(ARGS["use-local-version-var"],
+                "$aspnetcore_version",
+                "$ASPNET_VERSION"),
+            when(ARGS["use-local-version-var"],
+                "$dotnet_version",
+                "$DOTNET_VERSION")) ^
+
+    set sdkBuildVersion to VARIABLES[cat("sdk|", dotnetVersion, "|build-version")] ^
+    set isStableBranding to find(sdkBuildVersion, "-servicing") >= 0 || find(sdkBuildVersion, "-rtm") >= 0 ^
+
+    set fileVersion to when(isStableBranding, productVersion, versionDir) ^
+
+    _ This is specific to the layout of the staging storage account blob containers. ^
+    if (ARGS["is-internal"]):{{
+        set versionDir to buildVersion ^
+        set fileVersion to productVersion
+    }} ^
+
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set runtimeBaseUrl to cat(baseUrl, "/Runtime/", runtimeVersionDir, "/") ^
-    set aspnetCompositeUrl to cat(baseUrl, "/aspnetcore/Runtime/", aspnetCompositeVersionDir, "/aspnetcore-runtime-composite-", aspnetCompositeVersionFile,
-        filePlatform, "-", ARCH_SHORT, ".tar.gz") ^
-    set files to when(ARGS["is-composite-runtime"],
+    set downloadUrl to
+        when(ARGS["is-composite-runtime"],
+            cat(baseUrl, "/aspnetcore/Runtime/", versionDir, "/aspnetcore-runtime-composite-", fileVersion, "-", platform, "-", ARCH_SHORT, ".tar.gz"),
+            cat(baseUrl, "/Runtime/",            versionDir, "/dotnet-runtime-",               fileVersion, "-", platform, "-", ARCH_SHORT, ".tar.gz")) ^
+    set sha to
+        when(ARGS["is-composite-runtime"],
+            VARIABLES[join(["aspnet-composite", dotnetVersion, platform, ARCH_SHORT, "sha"], "|")],
+            VARIABLES[join(["runtime",          dotnetVersion, platform, ARCH_SHORT, "sha"], "|")]) ^
+
+    set files to
         [
             [
                 "filename": "dotnet.tar.gz",
-                "url": aspnetCompositeUrl,
-                "sha": VARIABLES[join(["aspnet-composite", dotnetVersion, varPlatform, ARCH_SHORT, "sha"], "|")],
+                "url": downloadUrl,
+                "sha": sha,
                 "sha-var-name": "dotnet_sha512"
             ]
-        ],
-        [
-            [
-                "filename": "dotnet.tar.gz",
-                "url": cat(runtimeBaseUrl, "dotnet-runtime-", runtimeVersionFile, "-", varPlatform, "-", ARCH_SHORT, ".tar.gz"),
-                "sha": VARIABLES[join(["runtime", dotnetVersion, varPlatform, ARCH_SHORT, "sha"], "|")],
-                "sha-var-name": "dotnet_sha512"
-            ]
-        ]) ^
+        ] ^
+
     set copyEnabled to ARGS["install-method"] = "copy-and-install" ^
     set downloadEnabled to ARGS["install-method"] = "download" || ARGS["install-method"] = "download-and-install" ^
     set installEnabled to ARGS["install-method"] = "download-and-install" || ARGS["install-method"] = "copy-and-install"

--- a/eng/dockerfile-templates/runtime/Dockerfile.windows
+++ b/eng/dockerfile-templates/runtime/Dockerfile.windows
@@ -4,7 +4,7 @@
     set isServer2025 to find(OS_VERSION_NUMBER, "2025") >= 0 ^
 
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
 
     set installerStageRepo to cat("mcr.microsoft.com/windows/", "servercore") ^
     set runtimeStageRepo to cat("mcr.microsoft.com/windows/", when(isServerCore, "servercore", "nanoserver")) ^

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -4,7 +4,7 @@
     set isMariner to find(OS_VERSION, "cbl-mariner") >= 0 ^
     set isAzureLinux to isMariner || find(OS_VERSION, "azurelinux") >= 0 ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
     set tagVersion to VARIABLES[cat("dotnet|", dotnetVersion, "|fixed-tag")] ^
     set baseImageTag to cat("$REPO:", tagVersion, "-", OS_VERSION, ARCH_TAG_SUFFIX) ^
 

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.install-sdk
@@ -11,41 +11,39 @@
         no-version-env-var (optional): Force reading the from the versions file instead of using DOTNET_SDK_VERSION env var ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set buildVersion to VARIABLES[cat("sdk|", dotnetVersion, "|build-version")] ^
+    set productVersion to VARIABLES[cat("sdk|", dotnetVersion, "|product-version")] ^
+
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isFullAzureLinux to defined(match(OS_VERSION, "^cbl-mariner\d+\.\d+$")) || defined(match(OS_VERSION, "^azurelinux\d+\.\d+$")) ^
     set platform to when(isAlpine, "linux-musl", "linux") ^
     set installDir to "/dotnet" ^
-    set url to cat(
-        VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])],
-        "/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-", platform, "-", ARCH_SHORT, ".tar.gz") ^
-    set sdkVersionDir to when(ARGS["use-local-version-var"],
-        "$sdk_version",
-        when(ARGS["is-internal"] || ARGS["no-version-env-var"],
-            VARIABLES[cat("sdk|", dotnetVersion, "|build-version")]
+
+    set versionDir to
+        when(ARGS["no-version-env-var"],
+            buildVersion,
+        when(ARGS["use-local-version-var"],
+            "$sdk_version",
             "$DOTNET_SDK_VERSION")) ^
-    set isStableBranding to (find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0 ||
-        find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0) ^
-    set sdkVersionFile to when(isStableBranding,
-        VARIABLES[cat("sdk|", dotnetVersion, "|product-version")],
-        sdkVersionDir) ^
-    set runtimeVersionDir to when(ARGS["use-local-version-var"], "$dotnet_version", "$DOTNET_VERSION") ^
-    set runtimeVersionFile to when(isStableBranding,
-        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],
-        runtimeVersionDir) ^
-    set runtimeTargetingPackVersionFile to when(isStableBranding,
-        split(VARIABLES[cat("runtime|", dotnetVersion, "|targeting-pack-version")], "-")[0],
-        VARIABLES[cat("runtime|", dotnetVersion, "|targeting-pack-version")]) ^
-    set aspnetTargetingPackVersionFile to when(isStableBranding,
-        split(VARIABLES[cat("aspnet|", dotnetVersion, "|targeting-pack-version")], "-")[0],
-        VARIABLES[cat("aspnet|", dotnetVersion, "|targeting-pack-version")]) ^
+
+    set isStableBranding to find(buildVersion, "-servicing") >= 0 || find(buildVersion, "-rtm") >= 0 ^
+    set fileVersion to when(isStableBranding, productVersion, versionDir) ^
+
+    if (ARGS["is-internal"]):{{
+        set versionDir to buildVersion ^
+        set fileVersion to productVersion
+    }} ^
+
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set commonShaVarName to "dotnet_sha512" ^
+    set downloadUrl to cat(baseUrl, "/Sdk/", versionDir, "/dotnet-sdk-", fileVersion, "-", platform, "-", ARCH_SHORT, ".tar.gz") ^
+    set sha to VARIABLES[join(["sdk", dotnetVersion, platform, ARCH_SHORT, "sha"], "|")] ^
+
     set files to [
         [
             "filename": "dotnet.tar.gz",
-            "url": cat(baseUrl, "/Sdk/", sdkVersionDir, "/dotnet-sdk-", sdkVersionFile, "-", platform, "-", ARCH_SHORT, ".tar.gz"),
-            "sha": VARIABLES[join(["sdk", dotnetVersion, platform, ARCH_SHORT, "sha"], "|")],
-            "sha-var-name": commonShaVarName,
+            "url": downloadUrl,
+            "sha": sha,
+            "sha-var-name": "dotnet_sha512",
             "extract-paths": [
                 "./packs",
                 "./sdk",

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows
@@ -1,7 +1,7 @@
 {{
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
-    set isInternal to find(baseUrl, "artifacts.visualstudio.com") >= 0 ^
+    set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
     set isSingleStage to (find(OS_VERSION, "windowsservercore") >= 0 && !isInternal) ^
 
     set installerStageFromImage to cat("mcr.microsoft.com/windows/servercore:", OS_VERSION_NUMBER, "-amd64") ^

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -2,7 +2,6 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
-ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \
@@ -11,7 +10,7 @@ RUN tdnf install -y \
 
 # Retrieve Aspire Dashboard
 RUN dotnet_aspire_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspire_dashboard.zip "https://dotnetstage.blob.core.windows.net/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip" \
     && aspire_dashboard_sha512='{sha512_placeholder}' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspire-dashboard-9.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -2,7 +2,6 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
-ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \
@@ -11,7 +10,7 @@ RUN tdnf install -y \
 
 # Retrieve Aspire Dashboard
 RUN dotnet_aspire_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspire_dashboard.zip "https://artifacts.visualstudio.com/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspire_dashboard.zip "https://dotnetstage.blob.core.windows.net/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip" \
     && aspire_dashboard_sha512='{sha512_placeholder}' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0  \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output aspnetcore.tar.gz "https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output aspnetcore.tar.gz "https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" \
     && aspnetcore_sha512='{sha512_placeholder}' \
     && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -14,9 +14,11 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile aspnetcore.zip \"https://artifacts.visualstudio.com/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile aspnetcore.zip \"https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-win-x64.zip\" -Headers $Headers; `
         `
         $aspnetcore_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash aspnetcore.zip -Algorithm sha512).Hash -ne $aspnetcore_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -5,11 +5,11 @@ FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -5,11 +5,11 @@ FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,11 +11,11 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor extensions
 RUN dotnet_monitor_extension_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-azureblobstorage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-azureblobstorage.tar.gz" | sha512sum -c - \
     \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-egress-s3storage.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz" \
     && dotnet_monitor_extension_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_extension_sha512  dotnet-monitor-egress-s3storage.tar.gz" | sha512sum -c - \
     \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-8.1-ubuntu-chiseled-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:jammy-curl AS installer
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.0-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/0.0.0/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.1-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/monitor-base-9.1-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Monitor Base
 RUN dotnet_monitor_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet-monitor-base.tar.gz "https://artifacts.visualstudio.com/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet-monitor-base.tar.gz "https://dotnetstage.blob.core.windows.net/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz" \
     && dotnet_monitor_base_sha512='{sha512_placeholder}' \
     && echo "$dotnet_monitor_base_sha512  dotnet-monitor-base.tar.gz" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,8 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,7 +11,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,7 +13,7 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,7 +7,7 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -12,9 +12,11 @@ RUN powershell -Command `
         `
         $dotnet_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-amd64 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm32v7 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -5,8 +5,7 @@ FROM $REPO:0.0.0-alpine3.XX-arm64v8 AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN token=$(echo "${ACCESSTOKEN}:${ACCESSTOKEN}" | base64 -w 0) \
-    && wget --header="Authorization: Basic $token" -O dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
+RUN wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" -O dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-musl-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -9,7 +9,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:noble-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM amd64/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-x64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm32v7/buildpack-deps:bookworm-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -5,7 +5,7 @@ FROM arm64v8/buildpack-deps:trixie-curl AS installer
 ARG ACCESSTOKEN
 
 # Install .NET SDK
-RUN curl -u :$ACCESSTOKEN --basic -fSL --output dotnet.tar.gz "https://artifacts.visualstudio.com/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
+RUN curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output dotnet.tar.gz "https://dotnetstage.blob.core.windows.net/Sdk/0.0.0/dotnet-sdk-0.0.0-linux-arm64.tar.gz" \
     && dotnet_sha512='{sha512_placeholder}' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /dotnet \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -30,9 +30,11 @@ RUN `
         # Retrieve .NET SDK
         $sdk_version = '0.0.0'; `
         `
-        $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(\":$($Env:ACCESSTOKEN)\")); `
-        $Headers = @{Authorization = \"Basic $Base64AuthInfo\"}; `
-        Invoke-WebRequest -OutFile dotnet.zip \"https://artifacts.visualstudio.com/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile dotnet.zip \"https://dotnetstage.blob.core.windows.net/Sdk/$sdk_version/dotnet-sdk-$sdk_version-win-x64.zip\" -Headers $Headers; `
         `
         $dotnet_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-amd64-Dockerfile.approved.txt
@@ -2,7 +2,6 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
-ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \
@@ -11,7 +10,7 @@ RUN tdnf install -y \
 
 # Retrieve YARP
 RUN yarp_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-x64.zip" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output yarp.zip "https://dotnetstage.blob.core.windows.net/reverse-proxy/$yarp_version/reverse-proxy-linux-x64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  yarp.zip" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/yarp-2.3-azurelinux-distroless-arm64v8-Dockerfile.approved.txt
@@ -2,7 +2,6 @@ ARG REPO=mcr.microsoft.com/dotnet/aspnet
 
 # Installer image
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS installer
-ARG ACCESSTOKEN
 
 RUN tdnf install -y \
         ca-certificates \
@@ -11,7 +10,7 @@ RUN tdnf install -y \
 
 # Retrieve YARP
 RUN yarp_version=0.0.0 \
-    && curl -u :$ACCESSTOKEN --basic -fSL --output yarp.zip "https://artifacts.visualstudio.com/reverse-proxy/$yarp_version/reverse-proxy-linux-arm64.zip" \
+    && curl -H "Authorization: Bearer $ACCESSTOKEN" -H "x-ms-version: 2017-11-09" -fSL --output yarp.zip "https://dotnetstage.blob.core.windows.net/reverse-proxy/$yarp_version/reverse-proxy-linux-arm64.zip" \
     && yarp_sha512='{sha512_placeholder}' \
     && echo "$yarp_sha512  yarp.zip" | sha512sum -c - \
     && mkdir -p /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
@@ -66,7 +66,7 @@ public class GeneratedArtifactTests
         string errorMessage = $"Failed to generate Dockerfiles using `{s_generateDockerfilesScript}`.";
 
         // Override base URLs to make templates generate internal versions of Dockerfiles
-        const string InternalBaseUrl = "https://artifacts.visualstudio.com";
+        const string InternalBaseUrl = "https://dotnetstage.blob.core.windows.net";
         string customImageBuilderArgs =
             $" --var 'base-url|public|maintenance|main={InternalBaseUrl}'" +
             $" --var 'base-url|public|maintenance|nightly={InternalBaseUrl}'" +


### PR DESCRIPTION
Part of https://github.com/dotnet/dotnet-docker-internal/issues/7413

The internal Dockerfile templates have been updated to use the new staging storage account. We will use managed identity to access it instead of the azure pipelines system access token.

The existing internal Dockerfile templates did not work with managed identity tokens, so this PR also contains updates to the templates and download commands that are required.