### PR TITLE
Add staging pipeline support to update-dependencies tool

### DIFF
--- a/eng/update-dependencies/BuildUpdaterService.cs
+++ b/eng/update-dependencies/BuildUpdaterService.cs
@@ -57,7 +57,7 @@ internal class BuildUpdaterService(
         string productCommitsJson = await _buildAssetService.GetAssetTextContentsAsync(productCommitsAsset);
         ProductCommits productCommits = ProductCommits.FromJson(productCommitsJson);
 
-        Version dockerfileVersion = ResolveMajorMinorVersion(productCommits.Sdk.Version);
+        Version dockerfileVersion = VersionHelper.ResolveMajorMinorVersion(productCommits.Sdk.Version);
 
         // Run old update-dependencies command using the resolved versions
         var updateDependencies = new SpecificCommand();
@@ -82,23 +82,13 @@ internal class BuildUpdaterService(
             AzdoOrganization = pullRequestOptions.AzdoOrganization,
             AzdoProject = pullRequestOptions.AzdoProject,
             AzdoRepo = pullRequestOptions.AzdoRepo,
+            AzdoToken = pullRequestOptions.AzdoToken,
             VersionSourceName = pullRequestOptions.VersionSourceName,
             SourceBranch = pullRequestOptions.SourceBranch,
             TargetBranch = pullRequestOptions.TargetBranch,
         };
 
         return await updateDependencies.ExecuteAsync(updateDependenciesOptions);
-    }
-
-    private static Version ResolveMajorMinorVersion(string versionString)
-    {
-        string[] versionParts = versionString.Split('.');
-        if (versionParts.Length < 2)
-        {
-            throw new InvalidOperationException($"Could not parse major-minor version from '{versionString}'.");
-        }
-
-        return new Version(major: int.Parse(versionParts[0]), minor: int.Parse(versionParts[1]));
     }
 
     private static bool IsVmrBuild(Build build)

--- a/eng/update-dependencies/CreatePullRequestOptions.cs
+++ b/eng/update-dependencies/CreatePullRequestOptions.cs
@@ -16,7 +16,6 @@ public abstract record CreatePullRequestOptions
     public string AzdoOrganization { get; init; } = "";
     public string AzdoProject { get; init; } = "";
     public string AzdoRepo { get; init; } = "";
-    public string AzdoToken { get; init; } = "";
     public string VersionSourceName { get; init; } = "";
     public string SourceBranch { get; init; } = "nightly";
     public string TargetBranch

--- a/eng/update-dependencies/CreatePullRequestOptions.cs
+++ b/eng/update-dependencies/CreatePullRequestOptions.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 
 namespace Dotnet.Docker;
 
-public abstract class CreatePullRequestOptions
+public abstract record CreatePullRequestOptions
 {
     private string? _targetBranch = null;
 
@@ -16,6 +16,7 @@ public abstract class CreatePullRequestOptions
     public string AzdoOrganization { get; init; } = "";
     public string AzdoProject { get; init; } = "";
     public string AzdoRepo { get; init; } = "";
+    public string AzdoToken { get; init; } = "";
     public string VersionSourceName { get; init; } = "";
     public string SourceBranch { get; init; } = "nightly";
     public string TargetBranch

--- a/eng/update-dependencies/FromBuildOptions.cs
+++ b/eng/update-dependencies/FromBuildOptions.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 
 namespace Dotnet.Docker;
 
-internal class FromBuildOptions : CreatePullRequestOptions, IOptions
+internal record FromBuildOptions : CreatePullRequestOptions, IOptions
 {
     public required int Id { get; init; }
 

--- a/eng/update-dependencies/FromChannelOptions.cs
+++ b/eng/update-dependencies/FromChannelOptions.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 
 namespace Dotnet.Docker;
 
-internal class FromChannelOptions : CreatePullRequestOptions, IOptions
+internal record FromChannelOptions : CreatePullRequestOptions, IOptions
 {
     public required int Channel { get; init; }
     public required string Repo { get; init; }

--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -40,8 +40,8 @@ internal partial class FromStagingPipelineCommand(ILogger<FromStagingPipelineCom
             containerName: $"stage-{options.StagingPipelineRunId}",
             blobPath: "metadata/ReleaseManifest.json");
 
-        var releaseManifest = ReleaseManifest.FromJson(releaseManifestJson);
-        var allAssets = releaseManifest.AllAssets.ToList();
+        var buildManifest = BuildManifest.FromJson(releaseManifestJson);
+        var allAssets = buildManifest.AllAssets.ToList();
 
         // Look through all the assets and get the version of the highest SDK feature band
         var sdkAssets = allAssets

--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Dotnet.Docker;
+
+internal class FromStagingPipelineCommand(
+    ILogger<FromStagingPipelineCommand> logger)
+    : BaseCommand<FromStagingPipelineOptions>
+{
+    private readonly ILogger<FromStagingPipelineCommand> _logger = logger;
+
+    public override async Task<int> ExecuteAsync(FromStagingPipelineOptions options)
+    {
+        _logger.LogInformation(
+            "Processing staging pipeline run with ID {options.StagingPipelineRunId}",
+            options.StagingPipelineRunId);
+
+        return 0; // Return success for now
+    }
+}

--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -1,23 +1,119 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Dotnet.Docker.Model.Release;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Dotnet.Docker;
 
-internal class FromStagingPipelineCommand(
-    ILogger<FromStagingPipelineCommand> logger)
+internal partial class FromStagingPipelineCommand(ILogger<FromStagingPipelineCommand> logger)
     : BaseCommand<FromStagingPipelineOptions>
 {
     private readonly ILogger<FromStagingPipelineCommand> _logger = logger;
 
     public override async Task<int> ExecuteAsync(FromStagingPipelineOptions options)
     {
+        if (options.Internal)
+        {
+            throw new NotImplementedException("Updating Dockerfiles for internal builds is not implemented yet.");
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.AzdoOrganization);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.AzdoProject);
+
         _logger.LogInformation(
-            "Processing staging pipeline run with ID {options.StagingPipelineRunId}",
+            "Updating dependencies based on staging pipeline run ID {options.StagingPipelineRunId}",
             options.StagingPipelineRunId);
 
-        return 0; // Return success for now
+        // Each pipeline run has a corresponding blob container named stage-${options.StagingPipelineRunId}.
+        // Release metadata is stored in metadata/ReleaseManifest.json.
+        // Release assets are stored individually under in assets/shipping/assets/[Sdk|Runtime|aspnetcore|...].
+
+        // Get release manifest from staging storage account
+        var storageAccount = new StorageAccount(options.StagingStorageAccount);
+        var releaseManifestJson = await storageAccount.DownloadTextAsync(
+            containerName: $"stage-{options.StagingPipelineRunId}",
+            blobPath: "metadata/ReleaseManifest.json");
+
+        var releaseManifest = ReleaseManifest.FromJson(releaseManifestJson);
+        var allAssets = releaseManifest.AllAssets.ToList();
+
+        // Look through all the assets and get the version of the highest SDK feature band
+        var sdkAssets = allAssets
+            .Where(asset => SdkRegex.IsMatch(asset.Name))
+            .ToList();
+        var sdkVersions = sdkAssets.Select(asset => asset.Version);
+        string highestSdkVersion = VersionHelper.GetHighestSdkVersion(sdkVersions);
+        string dockerfileVersion = VersionHelper.ResolveMajorMinorVersion(highestSdkVersion).ToString();
+
+        string runtimeVersion = allAssets
+            .Where(asset => RuntimeRegex.IsMatch(asset.Name))
+            .Select(asset => asset.Version)
+            .First();
+
+        string aspnetVersion = allAssets
+            .Where(asset => AspNetCoreRegex.IsMatch(asset.Name))
+            .Select(asset => asset.Version)
+            .First();
+
+        _logger.LogInformation(
+            """
+            Resolved .NET versions:
+            .NET: {dockerfileVersion}
+            - SDK: {highestSdkVersion}
+            - Runtime: {runtimeVersion}
+            - ASP.NET Core: {aspnetVersion}
+            """,
+            dockerfileVersion, highestSdkVersion, runtimeVersion, aspnetVersion);
+
+        // Run old update-dependencies command using the resolved versions
+        var updateDependencies = new SpecificCommand();
+        var updateDependenciesOptions = new SpecificCommandOptions()
+        {
+            DockerfileVersion = dockerfileVersion.ToString(),
+            ProductVersions = new Dictionary<string, string?>()
+            {
+                // "dotnet" version is required. It sets the "dotnet|*|product-version"
+                // variable which is used for runtime-deps, runtime, and aspnet tags.
+                { "dotnet", runtimeVersion },
+                { "runtime",  runtimeVersion },
+                { "aspnet", aspnetVersion },
+                { "aspnet-composite", aspnetVersion },
+                { "sdk", highestSdkVersion },
+            },
+
+            // Pass through all properties of CreatePullRequestOptions
+            User = options.User,
+            Email = options.Email,
+            Password = options.Password,
+            AzdoOrganization = options.AzdoOrganization,
+            AzdoProject = options.AzdoProject,
+            AzdoRepo = options.AzdoRepo,
+            AzdoToken = options.AzdoToken,
+            VersionSourceName = options.VersionSourceName,
+            SourceBranch = options.SourceBranch,
+            TargetBranch = options.TargetBranch,
+        };
+
+        return await updateDependencies.ExecuteAsync(updateDependenciesOptions);
     }
+
+    // Examples:
+    // - "Sdk/8.0.117-servicing.25269.14/dotnet-sdk-8.0.117-linux-x64.tar.gz"
+    // - "Sdk/8.0.310-servicing.25113.14/dotnet-sdk-8.0.310-linux-musl-arm64.tar.gz"
+    [GeneratedRegex(@"Sdk/.*/dotnet-sdk-.*-linux-x64.tar.gz$")]
+    private static partial Regex SdkRegex { get; }
+
+    // "aspnetcore/Runtime/8.0.14-servicing.25112.21/aspnetcore-runtime-8.0.14-linux-x64.tar.gz",
+    [GeneratedRegex(@"aspnetcore/Runtime/.*/aspnetcore-runtime-.*-linux-x64.tar.gz")]
+    private static partial Regex AspNetCoreRegex { get; }
+
+    // "Runtime/8.0.14-servicing.25111.18/dotnet-runtime-8.0.14-linux-x64.tar.gz"
+    [GeneratedRegex(@"Runtime/.*/dotnet-runtime-.*-linux-x64.tar.gz")]
+    private static partial Regex RuntimeRegex { get; }
 }

--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -94,7 +94,6 @@ internal partial class FromStagingPipelineCommand(ILogger<FromStagingPipelineCom
             AzdoOrganization = options.AzdoOrganization,
             AzdoProject = options.AzdoProject,
             AzdoRepo = options.AzdoRepo,
-            AzdoToken = options.AzdoToken,
             VersionSourceName = options.VersionSourceName,
             SourceBranch = options.SourceBranch,
             TargetBranch = options.TargetBranch,

--- a/eng/update-dependencies/FromStagingPipelineOptions.cs
+++ b/eng/update-dependencies/FromStagingPipelineOptions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.CommandLine;
+
+namespace Dotnet.Docker;
+
+internal class FromStagingPipelineOptions : CreatePullRequestOptions, IOptions
+{
+    public required string StagingPipelineRunId { get; init; }
+
+    public static new List<Argument> Arguments { get; } =
+    [
+        new Argument<string>("stagingPipelineRunId")
+        {
+            Arity = ArgumentArity.ExactlyOne,
+            Description = "The staging pipeline run ID to use as a source for the update"
+        },
+        ..CreatePullRequestOptions.Arguments,
+    ];
+
+    public static new List<Option> Options { get; } =
+    [
+        ..CreatePullRequestOptions.Options,
+    ];
+}

--- a/eng/update-dependencies/FromStagingPipelineOptions.cs
+++ b/eng/update-dependencies/FromStagingPipelineOptions.cs
@@ -6,22 +6,50 @@ using System.CommandLine;
 
 namespace Dotnet.Docker;
 
-internal class FromStagingPipelineOptions : CreatePullRequestOptions, IOptions
+internal record FromStagingPipelineOptions : CreatePullRequestOptions, IOptions
 {
-    public required string StagingPipelineRunId { get; init; }
+    /// <summary>
+    /// The staging pipeline run ID to use as a source for the update.
+    /// </summary>
+    public required int StagingPipelineRunId { get; init; }
+
+    /// <summary>
+    /// Whether or not to use the internal versions of the staged build.
+    /// </summary>
+    public bool Internal { get; init; } = false;
+
+    /// <summary>
+    /// This Azure Storage Account will be used as a source for the update.
+    /// This should be one of two storage accounts: dotnetstagetest or dotnetstage.
+    /// </summary>
+    public required string StagingStorageAccount { get; init; }
 
     public static new List<Argument> Arguments { get; } =
     [
-        new Argument<string>("stagingPipelineRunId")
+        new Argument<int>("staging-pipeline-run-id")
         {
             Arity = ArgumentArity.ExactlyOne,
             Description = "The staging pipeline run ID to use as a source for the update"
+        },
+        new Argument<string>("staging-storage-account")
+        {
+            Arity = ArgumentArity.ExactlyOne,
+            Description = "The Azure Storage Account to use as a source for the update."
+                + " This should be one of two storage accounts: dotnetstagetest or dotnetstage."
+                + " For example: https://dotnetstagetest.blob.core.windows.net/"
         },
         ..CreatePullRequestOptions.Arguments,
     ];
 
     public static new List<Option> Options { get; } =
     [
+        new Option<bool>("--internal")
+        {
+            Description = "Whether or not to use the internal versions of the staged build. When not using an internal"
+                + " build, Dockerfiles will be updated as if the staged build has already been released. When using an"
+                + " internal build, Dockerfiles will be updated with internal download links and will only be buildable"
+                + " by using an internal Azure DevOps access token."
+        },
         ..CreatePullRequestOptions.Options,
     ];
 }

--- a/eng/update-dependencies/Model/Release/BuildManifest.cs
+++ b/eng/update-dependencies/Model/Release/BuildManifest.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 
 namespace Dotnet.Docker.Model.Release;
 
-public record ReleaseManifest
+public record BuildManifest
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -28,9 +28,9 @@ public record ReleaseManifest
     public override string ToString() =>
         JsonSerializer.Serialize(this, s_jsonOptions);
 
-    public static ReleaseManifest FromJson(string json) =>
-        JsonSerializer.Deserialize<ReleaseManifest>(json, s_jsonOptions)
-            ?? throw new InvalidOperationException($"Failed to deserialize {nameof(ReleaseManifest)}: " + json);
+    public static BuildManifest FromJson(string json) =>
+        JsonSerializer.Deserialize<BuildManifest>(json, s_jsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize {nameof(BuildManifest)}: " + json);
 }
 
 public record Build

--- a/eng/update-dependencies/Model/Release/BuildManifest.cs
+++ b/eng/update-dependencies/Model/Release/BuildManifest.cs
@@ -8,6 +8,15 @@ using System.Text.Json;
 
 namespace Dotnet.Docker.Model.Release;
 
+// The models in this file are a subset of the BuildManifest models used by the .NET release infrastructure.
+// They should stay in sync.
+// https://dev.azure.com/dnceng/internal/_git/dotnet-release?path=/src/Microsoft.DotNet.Release/Microsoft.DotNet.ReleaseLib/Models/BuildManifest.cs
+
+/// <summary>
+/// Represents a single release of .NET. This can contain multiple channels but typically spans only one major version
+/// of .NET. For example, a .NET 8.0 BuildManifest would contain all .NET 8.0.1XX/2XX/3XX SDKs, but no versions of .NET
+/// 9.0.
+/// </summary>
 public record BuildManifest
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
@@ -29,6 +38,10 @@ public record BuildManifest
             ?? throw new InvalidOperationException($"Failed to deserialize {nameof(BuildManifest)}: " + json);
 }
 
+/// <summary>
+/// Represents a single, unique build on the .NET build asset registry (BAR). This is a unique build of a single commit
+/// of a single repository.
+/// </summary>
 public record Build
 {
     public required Uri Repo { get; init; }
@@ -41,6 +54,10 @@ public record Build
     public required Asset[] Assets { get; init; }
 }
 
+/// <summary>
+/// Represents one single downloadable asset from a .NET build. Can be a binary, NuGet package, text file, or any other
+/// type of file that is produced by a .NET build.
+/// </summary>
 public record Asset
 {
     public required string Name { get; init; }
@@ -52,4 +69,10 @@ public record Asset
     public required long BarAssetId { get; init; }
 }
 
+/// <summary>
+/// Represents a .NET build asset registry (BAR) channel. Channels group together builds of different repositories that
+/// must ship together. An example channel might be something like ".NET SDK 10.0.100-preview.1".
+/// </summary>
+/// <param name="Id">The ID of the channel</param>
+/// <param name="Name">The name of the channel</param>
 public record Channel(long Id, string Name);

--- a/eng/update-dependencies/Model/Release/BuildManifest.cs
+++ b/eng/update-dependencies/Model/Release/BuildManifest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;

--- a/eng/update-dependencies/Model/Release/BuildManifest.cs
+++ b/eng/update-dependencies/Model/Release/BuildManifest.cs
@@ -24,9 +24,6 @@ public record BuildManifest
             .SelectMany(build => build.Assets)
             .Concat(ExtraAssets);
 
-    public override string ToString() =>
-        JsonSerializer.Serialize(this, s_jsonOptions);
-
     public static BuildManifest FromJson(string json) =>
         JsonSerializer.Deserialize<BuildManifest>(json, s_jsonOptions)
             ?? throw new InvalidOperationException($"Failed to deserialize {nameof(BuildManifest)}: " + json);

--- a/eng/update-dependencies/Model/Release/ReleaseManifest.cs
+++ b/eng/update-dependencies/Model/Release/ReleaseManifest.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Dotnet.Docker.Model.Release;
+
+public record ReleaseManifest
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public required Build[] Builds { get; init; }
+    public required Asset[] ExtraAssets { get; init; }
+
+    public IEnumerable<Asset> AllAssets =>
+        Builds
+            .SelectMany(build => build.Assets)
+            .Concat(ExtraAssets);
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(this, s_jsonOptions);
+
+    public static ReleaseManifest FromJson(string json) =>
+        JsonSerializer.Deserialize<ReleaseManifest>(json, s_jsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize {nameof(ReleaseManifest)}: " + json);
+}
+
+public record Build
+{
+    public required Uri Repo { get; init; }
+    public required string Commit { get; init; }
+    public required string Branch { get; init; }
+    public required DateTimeOffset Produced { get; init; }
+    public required string BuildNumber { get; init; }
+    public required long BarBuildId { get; init; }
+    public required Channel[] Channels { get; init; }
+    public required Asset[] Assets { get; init; }
+}
+
+public record Asset
+{
+    public required string Name { get; init; }
+    public string? Origin { get; init; } = null;
+    public bool? DotnetReleaseShipping { get; init; } = false;
+    public required string Version { get; init; }
+    public required bool NonShipping { get; init; }
+    public required Uri Source { get; init; }
+    public required long BarAssetId { get; init; }
+}
+
+public record Channel(long Id, string Name);

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -20,6 +20,9 @@ var rootCommand = new RootCommand()
     FromChannelCommand.Create(
         name: "from-channel",
         description: "Update dependencies using the latest build from a channel"),
+    FromStagingPipelineCommand.Create(
+        name: "from-staging-pipeline",
+        description: "Update dependencies using a specific staging pipeline run"),
     SpecificCommand.Create(
         name: "specific",
         description: "Update dependencies using specific product versions"),
@@ -51,6 +54,7 @@ config.UseHost(
 
             FromBuildCommand.Register<FromBuildCommand>(services);
             FromChannelCommand.Register<FromChannelCommand>(services);
+            FromStagingPipelineCommand.Register<FromStagingPipelineCommand>(services);
             SpecificCommand.Register<SpecificCommand>(services);
         })
     );

--- a/eng/update-dependencies/ReleaseConfig.cs
+++ b/eng/update-dependencies/ReleaseConfig.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dotnet.Docker;
+
+/// <summary>
+/// This represents the configuration for a single run of the .NET release and staging pipelines. It contains
+/// information about the .NET versions to be released as well as other information about the release.
+/// </summary>
+/// <remarks>
+/// This record is a subset of the model used by the .NET staging and release pipelines.
+/// This MUST stay in sync with https://dev.azure.com/dnceng/internal/_git/dotnet-release?path=%2Fsrc%2FMicrosoft.DotNet.Release%2FMicrosoft.DotNet.ReleaseLib%2FModels%2FMetadataConfig.cs
+/// </remarks>
+internal record ReleaseConfig
+{
+    public required string Channel { get; init; }
+
+    public required string MajorVersion { get; init; }
+
+    public required string Release { get; init; }
+
+    public required string Runtime { get; init; }
+
+    public required string Asp { get; init; }
+
+    public required List<string> Sdks { get; init; }
+
+    [JsonPropertyName("Runtime_Build")]
+    public required string RuntimeBuild { get; init; }
+
+    [JsonPropertyName("Asp_Build")]
+    public required string AspBuild { get; init; }
+
+    [JsonPropertyName("Sdk_Builds")]
+    public required List<string> SdkBuilds { get; init; }
+
+    [JsonPropertyName("Release_Date")]
+    public required string ReleaseDate { get; init; }
+
+    public required bool Security { get; init; }
+
+    [JsonPropertyName("Support_Phase")]
+    public required string SupportPhase { get; init; }
+
+    public required bool Internal { get; init; }
+
+    public required bool SdkOnly { get; init; }
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(this, s_jsonOptions);
+
+    public static ReleaseConfig FromJson(string json) =>
+        JsonSerializer.Deserialize<ReleaseConfig>(json)
+            ?? throw new InvalidOperationException("Failed to deserialize release config: " + json);
+};

--- a/eng/update-dependencies/SpecificCommandOptions.cs
+++ b/eng/update-dependencies/SpecificCommandOptions.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Dotnet.Docker
 {
-    public class SpecificCommandOptions : CreatePullRequestOptions, IOptions
+    public record SpecificCommandOptions : CreatePullRequestOptions, IOptions
     {
         public string GitHubProject { get; } = "dotnet-docker";
         public string GitHubUpstreamOwner { get; } = "dotnet";

--- a/eng/update-dependencies/StorageAccount.cs
+++ b/eng/update-dependencies/StorageAccount.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+
+namespace Dotnet.Docker;
+
+/// <summary>
+/// Provides generic blob storage operations for Azure Storage Accounts.
+/// </summary>
+internal class StorageAccount
+{
+    private readonly BlobServiceClient _blobServiceClient;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="StorageAccount"/>.
+    /// </summary>
+    /// <param name="url">The url of the storage account, for example <c>https://foo.blob.core.windows.net/</c></param>
+    public StorageAccount(string url)
+    {
+        var credential = new DefaultAzureCredential();
+        var storageAccountUri = new Uri(url);
+        _blobServiceClient = new BlobServiceClient(storageAccountUri, credential);
+    }
+
+    /// <summary>
+    /// Downloads a blob as text from the specified container.
+    /// </summary>
+    /// <param name="containerName">The name of the blob container</param>
+    /// <param name="blobPath">The path to the blob within the container</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The blob content as a string</returns>
+    public async Task<string> DownloadTextAsync(
+        string containerName,
+        string blobPath,
+        CancellationToken cancellationToken = default)
+    {
+        var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+        var blobClient = containerClient.GetBlobClient(blobPath);
+
+        var response = await blobClient.DownloadContentAsync(cancellationToken);
+        return response.Value.Content.ToString();
+    }
+}

--- a/eng/update-dependencies/VersionHelper.cs
+++ b/eng/update-dependencies/VersionHelper.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Dotnet.Docker;
+
+internal static class VersionHelper
+{
+    public static Version ResolveMajorMinorVersion(string versionString)
+    {
+        string[] versionParts = versionString.Split('.');
+        if (versionParts.Length < 2)
+        {
+            throw new InvalidOperationException($"Could not parse major-minor version from '{versionString}'.");
+        }
+
+        return new Version(major: int.Parse(versionParts[0]), minor: int.Parse(versionParts[1]));
+    }
+
+    /// <summary>
+    /// Given a list of .NET SDK versions, return the highest version. For example, given the
+    /// following versions:
+    /// <code>
+    /// 8.0.409-servicing.25218.4
+    /// 8.0.312-servicing.25218.5
+    /// 8.0.116-servicing.25218.9
+    /// </code>
+    /// The version <c>8.0.409-servicing.25218.4</c> will be returned.
+    /// </summary>
+    /// <param name="sdkVersions">List of versions</param>
+    /// <returns>The highest version</returns>
+    public static string GetHighestSdkVersion(IEnumerable<string> sdkVersions) =>
+        sdkVersions
+            .OrderByDescending(version => new Version(version.Split('-')[0]))
+            .First();
+}

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.14.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     <PackageReference Include="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.25210.2" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />


### PR DESCRIPTION
- New command: `from-staging-pipeline`
  - This command supplants `Get-DropVersions.ps1 -BuildId ...` and accomplishes the same things.
  - This command does _not_ yet update dependencies with internal versions. This means the base urls won't be updated and the Dockerfiles won't be generated with the internal versions of the templates just yet.
  - The reason for that is the old update-dependencies code depends on using the base URL for accessing the sha files, so that will need to be updated or replaced separately.