### PR TITLE
Fix update-dependencies build failure due to nonexistent property

### DIFF
--- a/eng/update-dependencies/BuildUpdaterService.cs
+++ b/eng/update-dependencies/BuildUpdaterService.cs
@@ -82,7 +82,6 @@ internal class BuildUpdaterService(
             AzdoOrganization = pullRequestOptions.AzdoOrganization,
             AzdoProject = pullRequestOptions.AzdoProject,
             AzdoRepo = pullRequestOptions.AzdoRepo,
-            AzdoToken = pullRequestOptions.AzdoToken,
             VersionSourceName = pullRequestOptions.VersionSourceName,
             SourceBranch = pullRequestOptions.SourceBranch,
             TargetBranch = pullRequestOptions.TargetBranch,


### PR DESCRIPTION
Related: https://github.com/dotnet/dotnet-docker/pull/6473

https://github.com/dotnet/dotnet-docker/pull/6473 had a single build failure which this PR fixes.