### PR TITLE
Update release staging pipeline to allow internal builds

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -70,6 +70,11 @@ jobs:
         id: $(build.serviceConnection.id)
         tenantId: $(build.serviceConnection.tenantId)
         clientId: $(build.serviceConnection.clientId)
+      - ${{ if parameters.isInternalServicingValidation }}:
+        - name: storage
+          id: $(dotnetstaging.serviceConnection.id)
+          tenantId: $(dotnetstaging.serviceConnection.tenantId)
+          clientId: $(dotnetstaging.serviceConnection.clientId)
       internalProjectName: ${{ parameters.internalProjectName }}
       dockerClientOS: ${{ parameters.dockerClientOS }}
       args: >-

--- a/eng/common/templates/stages/build-and-test.yml
+++ b/eng/common/templates/stages/build-and-test.yml
@@ -51,6 +51,7 @@ stages:
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   dependsOn: []
   jobs:
+
   - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
     parameters:
       name: PreBuildValidation
@@ -69,12 +70,14 @@ stages:
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables
+
   - template: /eng/common/templates/jobs/copy-base-images-staging.yml@self
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
       customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
+
   - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
@@ -90,7 +93,7 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
+
   - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_amd64
@@ -104,7 +107,6 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -123,7 +125,6 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -142,7 +143,6 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -161,7 +161,6 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -180,7 +179,6 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -199,7 +197,6 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}
@@ -220,7 +217,6 @@ stages:
           noCache: ${{ parameters.noCache }}
           internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
           publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-          isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/steps/common-init-for-matrix-and-build.yml
+++ b/eng/common/templates/steps/common-init-for-matrix-and-build.yml
@@ -3,7 +3,6 @@ parameters:
   internalVersionsRepoRef: null
   publicVersionsRepoRef: null
   versionsRepoPath: versions
-  isInternalServicingValidation: false
 
 steps:
 - checkout: self
@@ -15,7 +14,7 @@ steps:
     path: s/${{ parameters.versionsRepoPath }}
 - powershell: |
     $commonMatrixAndBuildOptions = "--source-repo $(publicGitRepoUri)"
-    if ("$(System.TeamProject)" -eq "internal" -and "$(Build.Reason)" -ne "PullRequest" -and "${{ parameters.isInternalServicingValidation }}" -ne "true") {
+    if ("$(System.TeamProject)" -eq "internal" -and "$(Build.Reason)" -ne "PullRequest") {
       $commonMatrixAndBuildOptions = "$commonMatrixAndBuildOptions --source-repo-prefix $(mirrorRepoPrefix) --registry-override $(acr-staging.server)"
     }
 

--- a/eng/pipelines/release-staging.yml
+++ b/eng/pipelines/release-staging.yml
@@ -13,8 +13,20 @@ resources:
     endpoint: dotnet
     name: dotnet/versions
 
+parameters:
+- name: sourceBuildPipelineRunId
+  displayName: >
+    Source build pipeline run ID. This refers to runs of *this pipeline*.
+    Override this parameter in combination with disabling the `Build` stage to
+    test images that were built in a different pipeline run. When
+    building new images, leave this value alone.
+  type: string
+  default: $(Build.BuildId)
+
 variables:
 - template: /eng/pipelines/variables/core.yml@self
+  parameters:
+    sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
 
 extends:
   template: /eng/common/templates/1es-official.yml@self
@@ -27,6 +39,7 @@ extends:
       parameters:
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
+        sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
         # We always want staged images to be as up-to-date as possible,
         # so don't rely on any caching behavior.
         noCache: true

--- a/eng/pipelines/release-staging.yml
+++ b/eng/pipelines/release-staging.yml
@@ -34,12 +34,14 @@ extends:
     serviceConnections:
     - name: $(internal-mirror.serviceConnectionName)
     - name: $(build.serviceConnectionName)
+    - name: $(dotnetstaging.serviceConnection.name)
     stages:
     - template: /eng/pipelines/stages/build-and-test.yml@self
       parameters:
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
         sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
+        isInternalServicingValidation: true
         # We always want staged images to be as up-to-date as possible,
         # so don't rely on any caching behavior.
         noCache: true

--- a/eng/pipelines/stages/build-and-test.yml
+++ b/eng/pipelines/stages/build-and-test.yml
@@ -31,5 +31,9 @@ stages:
           echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
         displayName: Set Custom Build Variables
     - template: /eng/pipelines/steps/set-custom-test-variables.yml@self
+      parameters:
+        isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}
     customTestInitSteps:
     - template: /eng/pipelines/steps/set-custom-test-variables.yml@self
+      parameters:
+        isInternalServicingValidation: ${{ parameters.isInternalServicingValidation }}

--- a/eng/pipelines/stages/build-and-test.yml
+++ b/eng/pipelines/stages/build-and-test.yml
@@ -14,7 +14,7 @@ stages:
   parameters:
     ${{ insert }}: ${{ parameters }}
 
-    ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), and(eq(variables['System.TeamProject'], parameters.internalProjectName), or(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.isInternalServicingValidation, 'true')))) }}:
+    ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), and(eq(variables['System.TeamProject'], parameters.internalProjectName), eq(variables['Build.Reason'], 'PullRequest'))) }}:
       buildMatrixType: platformVersionedOs
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build --custom-build-leg-group test-dependencies
     ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
@@ -25,14 +25,11 @@ stages:
     - template: /eng/pipelines/steps/set-public-source-branch-var.yml@self
     customBuildInitSteps:
     - template: /eng/pipelines/steps/set-public-source-branch-var.yml@self
-    - powershell: |
-        $imageBuilderBuildArgs = "$IMAGEBUILDERBUILDARGS"
-        if ("${{ parameters.IsInternalServicingValidation }}" -eq "true") {
-          $accessToken = "$(System.AccessToken)"
-          $imageBuilderBuildArgs += " --build-arg ACCESSTOKEN='$accessToken'"
-        }
-        echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
-      displayName: Set Custom Build Variables
+    - ${{ if parameters.isInternalServicingValidation }}:
+      - powershell: |
+          $imageBuilderBuildArgs = "$IMAGEBUILDERBUILDARGS --internal"
+          echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
+        displayName: Set Custom Build Variables
     - template: /eng/pipelines/steps/set-custom-test-variables.yml@self
     customTestInitSteps:
     - template: /eng/pipelines/steps/set-custom-test-variables.yml@self

--- a/eng/pipelines/steps/set-custom-test-variables.yml
+++ b/eng/pipelines/steps/set-custom-test-variables.yml
@@ -1,3 +1,6 @@
+parameters:
+  isInternalServicingValidation: false
+
 steps:
 - powershell: |
     # Use public cache registry for pulling external images during tests
@@ -7,7 +10,7 @@ steps:
     $testRunnerOptions="-e SYSTEM_TEAMPROJECT='$env:SYSTEM_TEAMPROJECT'"
     $testInit=""
 
-    if ("$(publishRepoPrefix)".Contains("internal/")) {
+    if (("$(publishRepoPrefix)".Contains("internal/")) -or $${{ parameters.isInternalServicingValidation }}) {
       if ($Env:AGENT_OS -eq 'Linux') {
         $testRunnerOptions="$testRunnerOptions -e INTERNAL_TESTING='1' -e INTERNAL_ACCESS_TOKEN='$(System.AccessToken)'"
       }
@@ -19,7 +22,7 @@ steps:
           $testInit='$Env:INTERNAL_TESTING=''1'' ; $Env:INTERNAL_ACCESS_TOKEN=''$(System.AccessToken)'''
       }
     }
-    
+
     echo "##vso[task.setvariable variable=additionalTestArgs]$additionalTestArgs"
     echo "##vso[task.setvariable variable=testRunner.options]$testRunnerOptions"
     echo "##vso[task.setvariable variable=test.init]$testInit"

--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -33,6 +33,7 @@ internal partial class FromStagingPipelineCommand(ILogger<FromStagingPipelineCom
         // Each pipeline run has a corresponding blob container named stage-${options.StagingPipelineRunId}.
         // Release metadata is stored in metadata/ReleaseManifest.json.
         // Release assets are stored individually under in assets/shipping/assets/[Sdk|Runtime|aspnetcore|...].
+        // Full example: https://dotnetstagetest.blob.core.windows.net/stage-2XXXXXX/assets/shipping/assets/Runtime/10.0.0-preview.N.XXXXX.YYY/dotnet-runtime-10.0.0-preview.N.XXXXX.YYY-linux-arm64.tar.gz
 
         // Get release manifest from staging storage account
         var storageAccount = new StorageAccount(options.StagingStorageAccount);

--- a/eng/update-dependencies/Model/Release/BuildManifest.cs
+++ b/eng/update-dependencies/Model/Release/BuildManifest.cs
@@ -26,7 +26,7 @@ public record BuildManifest
     };
 
     public required Build[] Builds { get; init; }
-    public required Asset[] ExtraAssets { get; init; }
+    public Asset[] ExtraAssets { get; init; } = [];
 
     public IEnumerable<Asset> AllAssets =>
         Builds


### PR DESCRIPTION
Tests are still broken but that can be handled in a follow-up PR.

This PR also includes one very small fix for update-dependencies that I discovered was necessary while validating this.

Depends on ImageBuilder version >= [`2727330`](https://github.com/dotnet/docker-tools/pull/1729/files)