### PR TITLE
Remove unused compute-shas argument

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ The following examples illustrate how to run `update-dependencies`:
 - Update the PowerShell version used in the 9.0 images
 
     ``` console
-    > dotnet run --project .\eng\update-dependencies\ -- 9.0 --product-version powershell=7.5.0 --compute-shas
+    > dotnet run --project .\eng\update-dependencies\ -- 9.0 --product-version powershell=7.5.0
     ```
 
 #### Checking Markdown links locally

--- a/eng/Set-DotnetVersions.ps1
+++ b/eng/Set-DotnetVersions.ps1
@@ -36,10 +36,6 @@ param(
     [string]
     $AspireVersion,
 
-    # Compute the checksum if a published checksum cannot be found
-    [Switch]
-    $ComputeShas,
-
     # Use stable branding version numbers to compute paths
     [Switch]
     $UseStableBranding,
@@ -107,10 +103,6 @@ if ($MonitorVersion) {
 if ($AspireVersion) {
     $updateDepsArgs += @("--product-version", "aspire-dashboard=$AspireVersion")
     $productMajorVersion = $ProductVersion.Split('.', 2)[0]
-}
-
-if ($ComputeShas) {
-    $updateDepsArgs += "--compute-shas"
 }
 
 if ($ChecksumsFile) {

--- a/eng/pipelines/steps/update-dotnet-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies-specific.yml
@@ -43,7 +43,6 @@ steps:
         RuntimeVersion = $versionInfo.RuntimeVersion
         AspnetVersion = $versionInfo.AspnetVersion
         SdkVersion = $versionInfo.SdkVersion
-        ComputeShas = $true
         AzdoVariableName = "updateDepsArgs-$index"
         UseStableBranding = $versionInfo.StableBranding
       }


### PR DESCRIPTION
The compute-shas variable was unused in update-dependencies and was removed in a previous change (https://github.com/dotnet/dotnet-docker/pull/6378). The behavior is automatic now. The argument was still referenced from some places which was causing issues when running the Set-DotnetVersions script and when running some pipelines. This removes the last references to the argument.