### PR TITLE
Disable version logging when generating Dockerfiles/Readmes

### DIFF
--- a/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
+++ b/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
@@ -36,5 +36,5 @@ if (!$Branch) {
 }
 
 & $PSScriptRoot/../common/Invoke-ImageBuilder.ps1 `
-    -ImageBuilderArgs "generateDockerfiles $CustomImageBuilderArgs --var branch=$Branch" `
+    -ImageBuilderArgs "generateDockerfiles $CustomImageBuilderArgs --var branch=$Branch --no-version-logging" `
     -OnCommandExecuted $onDockerfilesGenerated

--- a/eng/readme-templates/Get-GeneratedReadmes.ps1
+++ b/eng/readme-templates/Get-GeneratedReadmes.ps1
@@ -62,7 +62,7 @@ function Invoke-GenerateReadme {
 
     & $PSScriptRoot/../common/Invoke-ImageBuilder.ps1 `
         -ImageBuilderArgs `
-            "generateReadmes --manifest $Manifest --source-branch $SourceBranch$customImageBuilderArgs --var branch=$SourceBranch 'https://github.com/dotnet/dotnet-docker'" `
+            "generateReadmes --manifest $Manifest --source-branch $SourceBranch$customImageBuilderArgs --var branch=$SourceBranch 'https://github.com/dotnet/dotnet-docker' --no-version-logging" `
         -OnCommandExecuted $onDockerfilesGenerated
 }
 


### PR DESCRIPTION
ImageBuilder prints `docker version` and `docker info` by default. This output is not useful when generating templates, so this disables it. Disabling it saves up to 2-3 seconds when generating Dockerfiles/Readmes.