### PR TITLE
Add support for internal build URLs to update-dependencies `from-staging-pipeline` command

### DIFF
--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -40,11 +40,8 @@ internal partial class FromStagingPipelineCommand(
             // Release metadata is stored in metadata/ReleaseManifest.json.
             // Release assets are stored individually under in assets/shipping/assets/[Sdk|Runtime|aspnetcore|...].
             // Full example: https://dotnetstagetest.blob.core.windows.net/stage-2XXXXXX/assets/shipping/assets/Runtime/10.0.0-preview.N.XXXXX.YYY/dotnet-runtime-10.0.0-preview.N.XXXXX.YYY-linux-arm64.tar.gz
-
-            var urlBuilder = new StringBuilder();
-            urlBuilder.Append(NormalizeStorageAccountUrl(options.StagingStorageAccount));
-            urlBuilder.Append($"/stage-{options.StagingPipelineRunId}/assets/shipping/assets");
-            internalBaseUrl = urlBuilder.ToString();
+            internalBaseUrl = NormalizeStorageAccountUrl(options.StagingStorageAccount)
+                + $"/stage-{options.StagingPipelineRunId}/assets/shipping/assets";
         }
 
         var buildManifest = await GetBuildManifest(options);

--- a/eng/update-dependencies/FromStagingPipelineOptions.cs
+++ b/eng/update-dependencies/FromStagingPipelineOptions.cs
@@ -8,6 +8,9 @@ namespace Dotnet.Docker;
 
 internal record FromStagingPipelineOptions : CreatePullRequestOptions, IOptions
 {
+    public const string StagingStorageAccountOption = "--staging-storage-account";
+    public const string InternalOption = "--internal";
+
     /// <summary>
     /// The staging pipeline run ID to use as a source for the update.
     /// </summary>
@@ -36,13 +39,13 @@ internal record FromStagingPipelineOptions : CreatePullRequestOptions, IOptions
 
     public static new List<Option> Options { get; } =
     [
-        new Option<string>("--staging-storage-account")
+        new Option<string>(StagingStorageAccountOption)
         {
             Description = "The Azure Storage Account to use as a source for the update."
                 + " This should be one of two storage accounts: dotnetstagetest or dotnetstage."
                 + " For example: https://dotnetstagetest.blob.core.windows.net/"
         },
-        new Option<bool>("--internal")
+        new Option<bool>(InternalOption)
         {
             Description = "Whether or not to use the internal versions of the staged build. When not using an internal"
                 + " build, Dockerfiles will be updated as if the staged build has already been released. When using an"


### PR DESCRIPTION
Usage:

```
update-dependencies \
    from-staging-pipeline \
    2733981 \
    --internal \
    --staging-storage-account $account \
    --azdo-organization $org \
    --azdo-project $project
```

Add or remove the `--internal` flag to control whether Dockerfiles will be updated to target an internal build. If `--internal` is passed, then `--staging-storage-account` is required.