### PR TITLE
Fix internal download URLs for stable product versions

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.download-dotnet
+++ b/eng/dockerfile-templates/Dockerfile.download-dotnet
@@ -25,23 +25,28 @@
 ", lineContinue), "") ^
 
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
-    set productVersion to VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")] ^
-    set buildVersion to VARIABLES[cat(product, "|", dotnetVersion, "|build-version")] ^
-
     set baseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|", VARIABLES["branch"])] ^
     set checksumsBaseUrl to VARIABLES[cat("dotnet|", dotnetVersion, "|base-url|checksums|", VARIABLES["branch"])] ^
     set isInternal to find(baseUrl, "dotnetstage") >= 0 ^
 
+    set productVersion to when(product = "sdk",
+        VARIABLES[cat(product, "|", dotnetVersion, "|product-version")],
+        VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")]
+    )^
+    set buildVersion to VARIABLES[cat(product, "|", dotnetVersion, "|build-version")] ^
+    set isStableVersion to find(buildVersion, "preview") < 0 ^
+    set fileVersion to when(isStableVersion, productVersion, buildVersion) ^
+
     set archiveExtension to when(isWindows, ".zip", ".tar.gz") ^
 
     if (product = "runtime"):{{
-        set downloadPath to cat("/Runtime/", buildVersion, "/dotnet-runtime-", buildVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
+        set downloadPath to cat("/Runtime/", buildVersion, "/dotnet-runtime-", fileVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
     }}^elif (product = "aspnet"):{{
-        set downloadPath to cat("/aspnetcore/Runtime/", buildVersion, "/aspnetcore-runtime-", buildVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
+        set downloadPath to cat("/aspnetcore/Runtime/", buildVersion, "/aspnetcore-runtime-", fileVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
     }}^elif (product = "aspnet-composite"):{{
-        set downloadPath to cat("/aspnetcore/Runtime/", buildVersion, "/aspnetcore-runtime-composite-", buildVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
+        set downloadPath to cat("/aspnetcore/Runtime/", buildVersion, "/aspnetcore-runtime-composite-", fileVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
     }}^elif (product = "sdk"):{{
-        set downloadPath to cat("/Sdk/", buildVersion, "/dotnet-sdk-", buildVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
+        set downloadPath to cat("/Sdk/", buildVersion, "/dotnet-sdk-", fileVersion, "-", platform, "-", ARCH_SHORT, archiveExtension)
     }}^
     set downloadUrl to cat(baseUrl, downloadPath) ^
 
@@ -122,9 +127,19 @@
         when(product = "sdk",
             "dotnet_sdk_version",
             "dotnet_version")),
-        buildVersion
+        when(isStableVersion, productVersion, buildVersion)
     )
-}}{{if runtimeVersion:{{lineEnd}}
+}}{{if (isInternal && isStableVersion):{{lineEnd}}
+{{continue}}{{
+    assign(
+        when(product = "aspnet" || product = "aspnet-composite",
+            "aspnetcore_build_version",
+        when(product = "sdk",
+            "dotnet_sdk_build_version",
+            "dotnet_build_version")),
+        buildVersion
+    )^_
+}}}}{{if runtimeVersion:{{lineEnd}}
 {{continue}}{{
     assign("dotnet_version", runtimeVersion)
 }}}}{{if useFileVariables:{{lineEnd}}

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.21-composite-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-alpine3.22-composite-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # ASP.NET Composite Image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-composite-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-composite-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-x64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=0.0.0 \
+    && aspnetcore_build_version=$aspnetcore_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
+    && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz \
+        aspnetcore-runtime-$aspnetcore_build_version-linux-arm64.tar.gz.sha512
 
 
 # ASP.NET Core image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/aspnet-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $aspnetcore_version = '0.0.0'; `
-        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
+        $aspnetcore_build_version = $aspnetcore_version + ''; `
+        $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$aspnetcore_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/aspnetcore/Runtime/$aspnetcore_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-cbl-mariner2.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-jammy-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-amd64-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-azurelinux3.0-distroless-extra-arm64v8-Dockerfile.approved.txt
@@ -13,15 +13,16 @@ RUN tdnf install -y \
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-noble-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /usr/share/dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 RUN mkdir /dotnet-symlink \
     && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -7,15 +7,16 @@ ARG ACCESSTOKEN
 
 # Retrieve .NET Runtime
 RUN dotnet_version=0.0.0 \
+    && dotnet_build_version=$dotnet_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
+    && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz \
+        dotnet-runtime-$dotnet_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET runtime image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -11,15 +11,16 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         `
         $dotnet_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
+        $dotnet_build_version = $dotnet_version + ''; `
+        $dotnet_file = 'dotnet-runtime-' + $dotnet_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Runtime/$dotnet_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -10,15 +10,16 @@ RUN tdnf install -y \
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -10,15 +10,16 @@ RUN tdnf install -y \
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-amd64-Dockerfile.approved.txt
@@ -10,15 +10,16 @@ RUN tdnf install -y \
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-cbl-mariner2.0-arm64v8-Dockerfile.approved.txt
@@ -10,15 +10,16 @@ RUN tdnf install -y \
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.21-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.22-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-musl-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -10,15 +10,16 @@ RUN tdnf install -y \
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -10,15 +10,16 @@ RUN tdnf install -y \
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-amd64-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm32v7-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-trixie-slim-arm64v8-Dockerfile.approved.txt
@@ -6,15 +6,16 @@ ARG ACCESSTOKEN
 
 # Install .NET SDK
 RUN dotnet_sdk_version=0.0.0 \
+    && dotnet_sdk_build_version=$dotnet_sdk_version \
     && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        --remote-name https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512 \
+    && echo "$(cat dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz" | sha512sum -c - \
     && mkdir --parents /dotnet \
-    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz --directory /dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
+        dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
 
 # .NET SDK image

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -29,15 +29,16 @@ RUN `
         `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '0.0.0'; `
-        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
+        $dotnet_sdk_build_version = $dotnet_sdk_version + ''; `
+        $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_build_version + '-win-x64.zip'; `
         $dotnet_sha512_file = $dotnet_file + '.sha512'; `
         `
         $Headers = @{ `
             Authorization = \"Bearer $env:ACCESSTOKEN\"; `
             'x-ms-version' = '2017-11-09'; `
         }; `
-        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_file -Headers $Headers; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_version/$dotnet_sha512_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_file -Headers $Headers; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://dotnetstage.blob.core.windows.net/Sdk/$dotnet_sdk_build_version/$dotnet_sha512_file -Headers $Headers; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerfileHelper.cs
@@ -23,6 +23,10 @@ public static partial class DockerfileHelper
     [GeneratedRegex(@"\d+\.\d+\.\d+(\.\d+)?(-[A-Za-z]+(\.\d+)+)?")]
     public static partial Regex VersionRegex { get; }
 
+    // Match unstable versions that have been partially replaced with variables, like `$aspnetcore_version.25326.107`
+    [GeneratedRegex(@"\$[a-zA-Z0-9_]+\.\d+\.\d+")]
+    public static partial Regex VersionWithVariableRegex { get; }
+
     [GeneratedRegex(@"v\d+\.\d+\.\d+\.windows\.\d+")]
     public static partial Regex MinGitVersionRegex { get; }
 

--- a/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/GeneratedArtifactTests.cs
@@ -88,6 +88,7 @@ public class GeneratedArtifactTests
             (DockerfileHelper.Sha386Regex, "{sha386_placeholder}"),
             (DockerfileHelper.Sha256Regex, "{sha256_placeholder}"),
             (DockerfileHelper.VersionRegex, "0.0.0"),
+            (DockerfileHelper.VersionWithVariableRegex, "0.0.0"),
             (DockerfileHelper.MinGitVersionRegex, "v0.0.0.windows.0"),
             (DockerfileHelper.AlpineVersionRegex, "alpine3.XX"),
         ];


### PR DESCRIPTION
Follow up to #6518. This PR updates the Dockerfile templates to make use of the full build versions.

Example pipeline where all internal Dockerfiles were built successfully using this pattern: https://dev.azure.com/dnceng/internal/_build/results?buildId=2742659&view=results (testing is still being worked on).