### PR TITLE
Fix bug where package tests were not using syft image from cache registry

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -271,7 +271,20 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public void Pull(string image) => ExecuteWithLogging($"pull {image}", autoRetry: true);
 
-        public void PullExternalImage(string image)
+        /// <summary>
+        /// Pulls an image from DockerHub, optionally redirecting it through a
+        /// cache registry.
+        /// </summary>
+        /// <param name="image">
+        /// The image to pull, in the format "repo:tag". Since the image is
+        /// assumed to be from DockerHub, do not include a registry.
+        /// </param>
+        /// <returns>
+        /// A tag for the image that was pulled. Use this value to refer to the
+        /// image in subsequent operations. Do not use the original value of
+        /// <paramref name="image"/>.
+        /// </returns>
+        public string PullDockerHubImage(string image)
         {
             if (!string.IsNullOrEmpty(Config.CacheRegistry))
             {
@@ -279,6 +292,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
 
             Pull(image);
+            return image;
         }
 
         public string GetHistory(string image) =>

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.Docker.Tests
             IEnumerable<string> extraExcludePaths = null)
         {
             string syftImage = $"{Config.GetVariableValue("syft|repo")}:{Config.GetVariableValue("syft|tag")}";
-            dockerHelper.PullExternalImage(syftImage);
+            syftImage = dockerHelper.PullDockerHubImage(syftImage);
 
             string imageToInspect = imageData.GetImage(imageRepo, dockerHelper);
 


### PR DESCRIPTION
Although the sift image was being pulled from the cache registry, subsequent commands in the package tests continued to refer directly to the syft tag on DockerHub instead of the image from the cache ACR.