### PR TITLE
When testing staged builds, use public NuGet feeds for public preview releases

### DIFF
--- a/eng/update-dependencies/DotNetVersion.cs
+++ b/eng/update-dependencies/DotNetVersion.cs
@@ -1,15 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Text.RegularExpressions;
+
 namespace Dotnet.Docker;
 
 internal partial class DotNetVersion
 {
     private readonly string _versionString;
+    private readonly Lazy<Match> _match;
 
     public DotNetVersion(string versionString)
     {
         _versionString = versionString;
+        _match = new(() => SemanticVersionRegex.Match(_versionString));
     }
 
     // Allow a string to be implicitly converted to DotNetVersion
@@ -17,4 +22,37 @@ internal partial class DotNetVersion
 
     // Allow implicit conversion to string
     public override string ToString() => _versionString;
+
+    /// <summary>
+    /// .NET major version (e.g. "8", "9", or "10")
+    /// </summary>
+    public string Major => _match.Value.Groups["major"].Value;
+
+    /// <summary>
+    /// .NET minor version (usually "0")
+    /// </summary>
+    public string Minor => _match.Value.Groups["minor"].Value;
+
+    /// <summary>
+    /// .NET patch version. For runtime versions, this is number typically
+    /// starts at 0, and for SDK versions, it typically starts at 100, 200,
+    /// 300, or 400.
+    /// </summary>
+    public string Patch => _match.Value.Groups["patch"].Value;
+
+    /// <summary>
+    /// Refers to the "prerelease" portion of the version string in semantic
+    /// versioning terms. For stable release .NET versions, this is typically
+    /// empty. For preview .NET versions, it is usually a suffix like
+    /// "preview.6.12345.678-shipping". For internal builds of stable verisons,
+    /// it can be a suffix like "servicing.12345.6".
+    /// </summary>
+    /// <remarks>
+    /// Does not include the leading hyphen.
+    /// </remarks>
+    public string Prerelease => _match.Value.Groups["prerelease"].Value;
+
+    // Semantic version 2.0.0 regex from https://semver.org/
+    [GeneratedRegex(@"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")]
+    private static partial Regex SemanticVersionRegex { get; }
 }

--- a/eng/update-dependencies/DotNetVersion.cs
+++ b/eng/update-dependencies/DotNetVersion.cs
@@ -2,55 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Text.RegularExpressions;
 
 namespace Dotnet.Docker;
 
-internal partial class DotNetVersion
+/// <summary>
+/// Represents a .NET version.
+/// </summary>
+/// <remarks>
+/// Additional notes about .NET versions:
+/// - <see cref="SemanticVersion.Patch"/>: For runtime versions, this is number typically starts at
+///   0 and counts up with new releases. For SDK versions, this number starts at 100 and can be as
+///   high as 400+.
+/// - <see cref="SemanticVersion.PreRelease"/>: For stable release .NET versions, this is typically
+///   empty. For preview .NET versions, it is usually a suffix like "preview.6.12345.678-shipping".
+///   For internal builds of stable versions, it can be a suffix like "servicing.12345.6".
+/// </remarks>
+internal record DotNetVersion(string versionString) : SemanticVersion(versionString)
 {
-    private readonly string _versionString;
-    private readonly Lazy<Match> _match;
-
-    public DotNetVersion(string versionString)
-    {
-        _versionString = versionString;
-        _match = new(() => SemanticVersionRegex.Match(_versionString));
-    }
-
-    // Allow a string to be implicitly converted to DotNetVersion
+    /// <summary>
+    /// Implicitly converts a string to a <see cref="DotNetVersion"/>.
+    /// </summary>
     public static implicit operator DotNetVersion(string versionString) => new(versionString);
-
-    // Allow implicit conversion to string
-    public override string ToString() => _versionString;
-
-    /// <summary>
-    /// .NET major version (e.g. "8", "9", or "10")
-    /// </summary>
-    public string Major => _match.Value.Groups["major"].Value;
-
-    /// <summary>
-    /// .NET minor version (usually "0")
-    /// </summary>
-    public string Minor => _match.Value.Groups["minor"].Value;
-
-    /// <summary>
-    /// .NET patch version. For runtime versions, this is number typically
-    /// starts at 0, and for SDK versions, it typically starts at 100, 200,
-    /// 300, or 400.
-    /// </summary>
-    public string Patch => _match.Value.Groups["patch"].Value;
-
-    /// <summary>
-    /// Refers to the "prerelease" portion of the version string in semantic
-    /// versioning terms. For stable release .NET versions, this is typically
-    /// empty. For preview .NET versions, it is usually a suffix like
-    /// "preview.6.12345.678-shipping". For internal builds of stable verisons,
-    /// it can be a suffix like "servicing.12345.6".
-    /// </summary>
-    /// <remarks>
-    /// Does not include the leading hyphen.
-    /// </remarks>
-    public string Prerelease => _match.Value.Groups["prerelease"].Value;
 
     /// <summary>
     /// Whether the .NET version is a public preview version.
@@ -58,9 +30,8 @@ internal partial class DotNetVersion
     public bool IsPublicPreview =>
         // Assume all "preview" versions are public, non-security releases.
         // Assume that all "rc" and "servicing" versions are internal security releases.
-        Prerelease.StartsWith("preview", StringComparison.OrdinalIgnoreCase);
+        PreRelease.StartsWith("preview", StringComparison.OrdinalIgnoreCase);
 
-    // Semantic version 2.0.0 regex from https://semver.org/
-    [GeneratedRegex(@"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")]
-    private static partial Regex SemanticVersionRegex { get; }
+    /// <inheritdoc/>
+    public override string ToString() => VersionString;
 }

--- a/eng/update-dependencies/DotNetVersion.cs
+++ b/eng/update-dependencies/DotNetVersion.cs
@@ -52,6 +52,14 @@ internal partial class DotNetVersion
     /// </remarks>
     public string Prerelease => _match.Value.Groups["prerelease"].Value;
 
+    /// <summary>
+    /// Whether the .NET version is a public preview version.
+    /// </summary>
+    public bool IsPublicPreview =>
+        // Assume all "preview" versions are public, non-security releases.
+        // Assume that all "rc" and "servicing" versions are internal security releases.
+        Prerelease.StartsWith("preview", StringComparison.OrdinalIgnoreCase);
+
     // Semantic version 2.0.0 regex from https://semver.org/
     [GeneratedRegex(@"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")]
     private static partial Regex SemanticVersionRegex { get; }

--- a/eng/update-dependencies/DotNetVersion.cs
+++ b/eng/update-dependencies/DotNetVersion.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Dotnet.Docker;
+
+internal partial class DotNetVersion
+{
+    private readonly string _versionString;
+
+    public DotNetVersion(string versionString)
+    {
+        _versionString = versionString;
+    }
+
+    // Allow a string to be implicitly converted to DotNetVersion
+    public static implicit operator DotNetVersion(string versionString) => new(versionString);
+
+    // Allow implicit conversion to string
+    public override string ToString() => _versionString;
+}

--- a/eng/update-dependencies/SemanticVersion.cs
+++ b/eng/update-dependencies/SemanticVersion.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Dotnet.Docker;
+
+internal partial record SemanticVersion
+{
+    private readonly Match _match;
+
+    public SemanticVersion(string versionString)
+    {
+        VersionString = versionString;
+        _match = SemanticVersionRegex.Match(VersionString);
+
+        Major = int.Parse(_match.Groups["major"].Value);
+        Minor = int.Parse(_match.Groups["minor"].Value);
+        Patch = int.Parse(_match.Groups["patch"].Value);
+        PreRelease = _match.Groups["prerelease"].Value;
+        BuildMetadata = _match.Groups["buildmetadata"].Value;
+    }
+
+    protected string VersionString { get; }
+
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+
+    /// <summary>
+    /// Pre-release build info for the version. May be an empty string. Does
+    /// not include the leading hyphen.
+    /// </summary>
+    public string PreRelease { get; }
+
+    /// <summary>
+    /// Build metadata for the version. May be an empty string if the version
+    /// has no bulid metadata. Does not include the leading plus sign.
+    /// </summary>
+    public string BuildMetadata { get; }
+
+    /// <summary>
+    /// Implicitly converts a string to a <see cref="SemanticVersion"/>.
+    /// </summary>
+    public static implicit operator SemanticVersion(string versionString) => new(versionString);
+
+    /// <inheritdoc/>
+    public override string ToString() => VersionString;
+
+    // Semantic version 2.0.0 regex from https://semver.org/
+    [GeneratedRegex(@"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")]
+    private static partial Regex SemanticVersionRegex { get; }
+}


### PR DESCRIPTION
- Added SemanticVersion (based on official semver spec) and DotNetVersion classes that can slowly start to be used instead of primitives/strings throughout update-dependencies
- Do not use an internal NuGet feed for public preview releases, because they don't exist. Public preview releases use public NuGet feeds. Use that public feed instead.