### PR TITLE
Add `dnx` symlink to `/usr/bin` in .NET SDK images

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.symlink
+++ b/eng/dockerfile-templates/Dockerfile.linux.symlink
@@ -1,0 +1,8 @@
+{{
+    _ Creates a symbolic link at "to" which links to "from"
+
+    ARGS:
+        from: The target file or directory to link to
+        to: Where to create the symbolic link
+
+}}ln -s {{ARGS["from"]}} {{ARGS["to"]}}

--- a/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.linux-composite
@@ -63,4 +63,7 @@ ENTRYPOINT ["/usr/bin/dotnet"]
 CMD ["--info"]^
 else:
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
-RUN {{InsertTemplate("../runtime/Dockerfile.linux.symlink")}}}}
+RUN {{InsertTemplate("../Dockerfile.linux.symlink", [
+    "from": "/usr/share/dotnet/dotnet",
+    "to": "/usr/bin/dotnet"
+])}}}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux
@@ -54,7 +54,10 @@ RUN {{InsertTemplate("../Dockerfile.download-dotnet", [
 if isDistroless:
 
 RUN mkdir /dotnet-symlink \
-    && ln -s /usr/share/dotnet/dotnet /dotnet-symlink/dotnet}}
+    && {{InsertTemplate("../Dockerfile.linux.symlink", [
+        "from": "/usr/share/dotnet/dotnet",
+        "to": "/dotnet-symlink/dotnet"
+    ])}}}}
 
 
 # .NET runtime image
@@ -73,4 +76,7 @@ CMD ["--info"]^
 else:
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-RUN {{InsertTemplate("Dockerfile.linux.symlink")}}}}
+RUN {{InsertTemplate("../Dockerfile.linux.symlink", [
+    "from": "/usr/share/dotnet/dotnet",
+    "to": "/usr/bin/dotnet"
+])}}}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.linux.symlink
+++ b/eng/dockerfile-templates/runtime/Dockerfile.linux.symlink
@@ -1,1 +1,0 @@
-ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -18,6 +18,8 @@
     set isPowerShellSupported to !(isAlpine && ARCH_SHORT != "x64") ^
     set includePowerShellVars to isPowerShellSupported || dotnetVersion = "8.0" || dotnetVersion = "9.0" ^
 
+    set dnxIsSupported to dotnetVersion != "8.0" && dotnetVersion != "9.0" ^
+
     set pkgs to filter(
         when(isAlpine,
             when(dotnetVersion = "8.0",
@@ -64,7 +66,7 @@
         "./LICENSE.txt",
         "./ThirdPartyNotices.txt"
     ]^
-    if (dotnetVersion != "8.0" && dotnetVersion != "9.0"):{{
+    if (dnxIsSupported):{{
         set sdkExtractPaths to cat(["./dnx"], sdkExtractPaths)
     }}^_
 
@@ -99,6 +101,14 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-{{InsertTemplate("Dockerfile.linux.first-run")}}{{if isPowerShellSupported:
+{{if dnxIsSupported:RUN {{
+        InsertTemplate("../Dockerfile.linux.symlink", [
+            "from": "/usr/share/dotnet/dnx",
+            "to": "/usr/bin/dnx"
+        ])
+    }} \
+    }}{{InsertTemplate("Dockerfile.linux.first-run", [
+        "append-cmd": dnxIsSupported
+    ], when(dnxIsSupported, "    ", ""))}}{{if isPowerShellSupported:
 
 {{InsertTemplate("Dockerfile.linux.install-powershell")}}}}

--- a/src/sdk/10.0/alpine3.22/amd64/Dockerfile
+++ b/src/sdk/10.0/alpine3.22/amd64/Dockerfile
@@ -46,8 +46,9 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.0-preview.4 \

--- a/src/sdk/10.0/alpine3.22/arm32v7/Dockerfile
+++ b/src/sdk/10.0/alpine3.22/arm32v7/Dockerfile
@@ -42,5 +42,6 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help

--- a/src/sdk/10.0/alpine3.22/arm64v8/Dockerfile
+++ b/src/sdk/10.0/alpine3.22/arm64v8/Dockerfile
@@ -42,5 +42,6 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help

--- a/src/sdk/10.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/10.0/azurelinux3.0/amd64/Dockerfile
@@ -46,8 +46,9 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.0-preview.4 \

--- a/src/sdk/10.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/10.0/azurelinux3.0/arm64v8/Dockerfile
@@ -46,8 +46,9 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.0-preview.4 \

--- a/src/sdk/10.0/noble/amd64/Dockerfile
+++ b/src/sdk/10.0/noble/amd64/Dockerfile
@@ -44,8 +44,9 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.0-preview.4 \

--- a/src/sdk/10.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/10.0/noble/arm32v7/Dockerfile
@@ -44,8 +44,9 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.0-preview.4 \

--- a/src/sdk/10.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/10.0/noble/arm64v8/Dockerfile
@@ -44,8 +44,9 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
-# Trigger first run experience by running arbitrary cmd
-RUN dotnet help
+RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.0-preview.4 \


### PR DESCRIPTION
This allows you to run `dnx` directly in Linux containers:

`docker run --rm mcr.microsoft.com/dotnet/sdk:10.0-preview dnx`

On Windows containers, there is nothing to change. `dnx` already works (sort of) because the entire `/Program Files/dotnet/` directory is already on the PATH.

- `docker run --rm mcr.microsoft.com/dotnet/sdk:10.0-preview-nanoserver-ltsc2025 dnx.cmd` - works because `dnx.cmd` is in the PATH
- `docker run --rm mcr.microsoft.com/dotnet/sdk:10.0-preview-nanoserver-ltsc2025 cmd /c 'dnx'` - works because `cmd.exe` resolves `dnx` to `dnx.cmd`
- `docker run --rm mcr.microsoft.com/dotnet/sdk:10.0-preview-nanoserver-ltsc2025 dnx` - does not work (by design), because there is not a `dnx` executable in the PATH
