### PR TITLE
Roll back Alpine floating tags from 3.21 to 3.22

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -81,10 +81,10 @@ For more information, see the [composite images section in the Image Variants do
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/aspnet/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.7-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.21-composite-amd64, 9.0-alpine3.21-composite-amd64, 9.0.7-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-9.0.7-alpine3.22-composite-amd64, 9.0-alpine3.22-composite-amd64, 9.0-alpine-composite-amd64, 9.0.7-alpine3.22-composite, 9.0-alpine3.22-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.21-composite-amd64, 9.0-alpine3.21-composite-amd64, 9.0-alpine-composite-amd64, 9.0.7-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/aspnet/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.22-composite-amd64, 9.0-alpine3.22-composite-amd64, 9.0.7-alpine3.22-composite, 9.0-alpine3.22-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
 9.0.7-noble-amd64, 9.0-noble-amd64, 9.0.7-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -96,10 +96,10 @@ Tags | Dockerfile | OS Version
 9.0.7-azurelinux3.0-distroless-composite-amd64, 9.0-azurelinux3.0-distroless-composite-amd64, 9.0.7-azurelinux3.0-distroless-composite, 9.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite/amd64/Dockerfile) | Azure Linux 3.0
 9.0.7-azurelinux3.0-distroless-composite-extra-amd64, 9.0-azurelinux3.0-distroless-composite-extra-amd64, 9.0.7-azurelinux3.0-distroless-composite-extra, 9.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.18-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.18-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.21-composite-amd64, 8.0-alpine3.21-composite-amd64, 8.0.18-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-8.0.18-alpine3.22-composite-amd64, 8.0-alpine3.22-composite-amd64, 8.0-alpine-composite-amd64, 8.0.18-alpine3.22-composite, 8.0-alpine3.22-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.21-composite-amd64, 8.0-alpine3.21-composite-amd64, 8.0-alpine-composite-amd64, 8.0.18-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/aspnet/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.22-composite-amd64, 8.0-alpine3.22-composite-amd64, 8.0.18-alpine3.22-composite, 8.0-alpine3.22-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
 8.0.18-noble-amd64, 8.0-noble-amd64, 8.0.18-noble, 8.0-noble | [Dockerfile](src/aspnet/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.18-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/aspnet/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.18-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/aspnet/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -143,10 +143,10 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/aspnet/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.7-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.21-composite-arm64v8, 9.0-alpine3.21-composite-arm64v8, 9.0.7-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-9.0.7-alpine3.22-composite-arm64v8, 9.0-alpine3.22-composite-arm64v8, 9.0-alpine-composite-arm64v8, 9.0.7-alpine3.22-composite, 9.0-alpine3.22-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.21-composite-arm64v8, 9.0-alpine3.21-composite-arm64v8, 9.0-alpine-composite-arm64v8, 9.0.7-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/aspnet/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.22-composite-arm64v8, 9.0-alpine3.22-composite-arm64v8, 9.0.7-alpine3.22-composite, 9.0-alpine3.22-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
 9.0.7-noble-arm64v8, 9.0-noble-arm64v8, 9.0.7-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -158,10 +158,10 @@ Tags | Dockerfile | OS Version
 9.0.7-azurelinux3.0-distroless-composite-arm64v8, 9.0-azurelinux3.0-distroless-composite-arm64v8, 9.0.7-azurelinux3.0-distroless-composite, 9.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.7-azurelinux3.0-distroless-composite-extra-arm64v8, 9.0-azurelinux3.0-distroless-composite-extra-arm64v8, 9.0.7-azurelinux3.0-distroless-composite-extra, 9.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.18-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.18-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.21-composite-arm64v8, 8.0-alpine3.21-composite-arm64v8, 8.0.18-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-8.0.18-alpine3.22-composite-arm64v8, 8.0-alpine3.22-composite-arm64v8, 8.0-alpine-composite-arm64v8, 8.0.18-alpine3.22-composite, 8.0-alpine3.22-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.21-composite-arm64v8, 8.0-alpine3.21-composite-arm64v8, 8.0-alpine-composite-arm64v8, 8.0.18-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/aspnet/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.22-composite-arm64v8, 8.0-alpine3.22-composite-arm64v8, 8.0.18-alpine3.22-composite, 8.0-alpine3.22-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
 8.0.18-noble-arm64v8, 8.0-noble-arm64v8, 8.0.18-noble, 8.0-noble | [Dockerfile](src/aspnet/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.18-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/aspnet/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.18-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/aspnet/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -205,20 +205,20 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/aspnet/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.7-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.21-composite-arm32v7, 9.0-alpine3.21-composite-arm32v7, 9.0.7-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-9.0.7-alpine3.22-composite-arm32v7, 9.0-alpine3.22-composite-arm32v7, 9.0-alpine-composite-arm32v7, 9.0.7-alpine3.22-composite, 9.0-alpine3.22-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.21-composite-arm32v7, 9.0-alpine3.21-composite-arm32v7, 9.0-alpine-composite-arm32v7, 9.0.7-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/aspnet/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.22-composite-arm32v7, 9.0-alpine3.22-composite-arm32v7, 9.0.7-alpine3.22-composite, 9.0-alpine3.22-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
 9.0.7-noble-arm32v7, 9.0-noble-arm32v7, 9.0.7-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-composite-arm32v7, 9.0-noble-chiseled-composite-arm32v7, 9.0.7-noble-chiseled-composite, 9.0-noble-chiseled-composite | [Dockerfile](src/aspnet/9.0/noble-chiseled-composite/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-composite-extra-arm32v7, 9.0-noble-chiseled-composite-extra-arm32v7, 9.0.7-noble-chiseled-composite-extra, 9.0-noble-chiseled-composite-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-composite-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.18-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.18-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.21-composite-arm32v7, 8.0-alpine3.21-composite-arm32v7, 8.0.18-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-8.0.18-alpine3.22-composite-arm32v7, 8.0-alpine3.22-composite-arm32v7, 8.0-alpine-composite-arm32v7, 8.0.18-alpine3.22-composite, 8.0-alpine3.22-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.21-composite-arm32v7, 8.0-alpine3.21-composite-arm32v7, 8.0-alpine-composite-arm32v7, 8.0.18-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/aspnet/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.22-composite-arm32v7, 8.0-alpine3.22-composite-arm32v7, 8.0.18-alpine3.22-composite, 8.0-alpine3.22-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
 8.0.18-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.18-jammy, 8.0-jammy | [Dockerfile](src/aspnet/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.18-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.18-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/aspnet/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.18-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.18-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/aspnet/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -63,10 +63,10 @@ They contain the following features:
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.7-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.21-extra-amd64, 9.0-alpine3.21-extra-amd64, 9.0.7-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-9.0.7-alpine3.22-extra-amd64, 9.0-alpine3.22-extra-amd64, 9.0-alpine-extra-amd64, 9.0.7-alpine3.22-extra, 9.0-alpine3.22-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.21-extra-amd64, 9.0-alpine3.21-extra-amd64, 9.0-alpine-extra-amd64, 9.0.7-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime-deps/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.22-extra-amd64, 9.0-alpine3.22-extra-amd64, 9.0.7-alpine3.22-extra, 9.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
 9.0.7-noble-amd64, 9.0-noble-amd64, 9.0.7-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -74,10 +74,10 @@ Tags | Dockerfile | OS Version
 9.0.7-azurelinux3.0-distroless-amd64, 9.0-azurelinux3.0-distroless-amd64, 9.0.7-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless/amd64/Dockerfile) | Azure Linux 3.0
 9.0.7-azurelinux3.0-distroless-extra-amd64, 9.0-azurelinux3.0-distroless-extra-amd64, 9.0.7-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.18-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.18-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.21-extra-amd64, 8.0-alpine3.21-extra-amd64, 8.0.18-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-8.0.18-alpine3.22-extra-amd64, 8.0-alpine3.22-extra-amd64, 8.0-alpine-extra-amd64, 8.0.18-alpine3.22-extra, 8.0-alpine3.22-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.21-extra-amd64, 8.0-alpine3.21-extra-amd64, 8.0-alpine-extra-amd64, 8.0.18-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime-deps/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.22-extra-amd64, 8.0-alpine3.22-extra-amd64, 8.0.18-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
 8.0.18-noble-amd64, 8.0-noble-amd64, 8.0.18-noble, 8.0-noble | [Dockerfile](src/runtime-deps/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.18-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.18-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -109,10 +109,10 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.7-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.21-extra-arm64v8, 9.0-alpine3.21-extra-arm64v8, 9.0.7-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-9.0.7-alpine3.22-extra-arm64v8, 9.0-alpine3.22-extra-arm64v8, 9.0-alpine-extra-arm64v8, 9.0.7-alpine3.22-extra, 9.0-alpine3.22-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.21-extra-arm64v8, 9.0-alpine3.21-extra-arm64v8, 9.0-alpine-extra-arm64v8, 9.0.7-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.22-extra-arm64v8, 9.0-alpine3.22-extra-arm64v8, 9.0.7-alpine3.22-extra, 9.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
 9.0.7-noble-arm64v8, 9.0-noble-arm64v8, 9.0.7-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -120,10 +120,10 @@ Tags | Dockerfile | OS Version
 9.0.7-azurelinux3.0-distroless-arm64v8, 9.0-azurelinux3.0-distroless-arm64v8, 9.0.7-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.7-azurelinux3.0-distroless-extra-arm64v8, 9.0-azurelinux3.0-distroless-extra-arm64v8, 9.0.7-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.18-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.18-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.21-extra-arm64v8, 8.0-alpine3.21-extra-arm64v8, 8.0.18-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-8.0.18-alpine3.22-extra-arm64v8, 8.0-alpine3.22-extra-arm64v8, 8.0-alpine-extra-arm64v8, 8.0.18-alpine3.22-extra, 8.0-alpine3.22-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.21-extra-arm64v8, 8.0-alpine3.21-extra-arm64v8, 8.0-alpine-extra-arm64v8, 8.0.18-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.22-extra-arm64v8, 8.0-alpine3.22-extra-arm64v8, 8.0.18-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
 8.0.18-noble-arm64v8, 8.0-noble-arm64v8, 8.0.18-noble, 8.0-noble | [Dockerfile](src/runtime-deps/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.18-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.18-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -155,18 +155,18 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.7-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.21-extra-arm32v7, 9.0-alpine3.21-extra-arm32v7, 9.0.7-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-9.0.7-alpine3.22-extra-arm32v7, 9.0-alpine3.22-extra-arm32v7, 9.0-alpine-extra-arm32v7, 9.0.7-alpine3.22-extra, 9.0-alpine3.22-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.21-extra-arm32v7, 9.0-alpine3.21-extra-arm32v7, 9.0-alpine-extra-arm32v7, 9.0.7-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.22-extra-arm32v7, 9.0-alpine3.22-extra-arm32v7, 9.0.7-alpine3.22-extra, 9.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
 9.0.7-noble-arm32v7, 9.0-noble-arm32v7, 9.0.7-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.18-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.18-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.21-extra-arm32v7, 8.0-alpine3.21-extra-arm32v7, 8.0.18-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-8.0.18-alpine3.22-extra-arm32v7, 8.0-alpine3.22-extra-arm32v7, 8.0-alpine-extra-arm32v7, 8.0.18-alpine3.22-extra, 8.0-alpine3.22-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.21-extra-arm32v7, 8.0-alpine3.21-extra-arm32v7, 8.0-alpine-extra-arm32v7, 8.0.18-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.22-extra-arm32v7, 8.0-alpine3.22-extra-arm32v7, 8.0.18-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
 8.0.18-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.18-jammy, 8.0-jammy | [Dockerfile](src/runtime-deps/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.18-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.18-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.18-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.18-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -70,8 +70,8 @@ They contain the following features:
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/runtime/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.7-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 9.0.7-noble-amd64, 9.0-noble-amd64, 9.0.7-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -79,8 +79,8 @@ Tags | Dockerfile | OS Version
 9.0.7-azurelinux3.0-distroless-amd64, 9.0-azurelinux3.0-distroless-amd64, 9.0.7-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless/amd64/Dockerfile) | Azure Linux 3.0
 9.0.7-azurelinux3.0-distroless-extra-amd64, 9.0-azurelinux3.0-distroless-extra-amd64, 9.0.7-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.18-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.18-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 8.0.18-noble-amd64, 8.0-noble-amd64, 8.0.18-noble, 8.0-noble | [Dockerfile](src/runtime/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.18-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.18-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -111,8 +111,8 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/runtime/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.7-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 9.0.7-noble-arm64v8, 9.0-noble-arm64v8, 9.0.7-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -120,8 +120,8 @@ Tags | Dockerfile | OS Version
 9.0.7-azurelinux3.0-distroless-arm64v8, 9.0-azurelinux3.0-distroless-arm64v8, 9.0.7-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.7-azurelinux3.0-distroless-extra-arm64v8, 9.0-azurelinux3.0-distroless-extra-arm64v8, 9.0.7-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.18-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.18-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 8.0.18-noble-arm64v8, 8.0-noble-arm64v8, 8.0.18-noble, 8.0-noble | [Dockerfile](src/runtime/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.18-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.18-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.18-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -152,14 +152,14 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.7-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.7-bookworm-slim, 9.0-bookworm-slim, 9.0.7, 9.0, latest | [Dockerfile](src/runtime/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.7-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.7-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.7-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.7-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.7-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.7-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.7-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.7-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 9.0.7-noble-arm32v7, 9.0-noble-arm32v7, 9.0.7-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.7-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.7-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.7-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.18-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.18-bookworm-slim, 8.0-bookworm-slim, 8.0.18, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.18-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.18-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.18-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.18-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.18-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.18-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.18-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.18-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 8.0.18-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.18-jammy, 8.0-jammy | [Dockerfile](src/runtime/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.18-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.18-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/runtime/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.18-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.18-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/runtime/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -66,13 +66,13 @@ The [Image Variants documentation](https://github.com/dotnet/dotnet-docker/blob/
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.303-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.303-bookworm-slim, 9.0-bookworm-slim, 9.0.303, 9.0, latest | [Dockerfile](src/sdk/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.303-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.303-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.303-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.303-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.303-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.303-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.303-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.303-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/sdk/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 9.0.303-noble-amd64, 9.0-noble-amd64, 9.0.303-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.303-azurelinux3.0-amd64, 9.0-azurelinux3.0-amd64, 9.0.303-azurelinux3.0, 9.0-azurelinux3.0 | [Dockerfile](src/sdk/9.0/azurelinux3.0/amd64/Dockerfile) | Azure Linux 3.0
 8.0.412-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.412-bookworm-slim, 8.0-bookworm-slim, 8.0.412, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.412-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.412-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.412-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.412-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.412-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.412-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.412-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.412-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/sdk/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 8.0.412-noble-amd64, 8.0-noble-amd64, 8.0.412-noble, 8.0-noble | [Dockerfile](src/sdk/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.412-jammy-amd64, 8.0-jammy-amd64, 8.0.412-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
 8.0.412-azurelinux3.0-amd64, 8.0-azurelinux3.0-amd64, 8.0.412-azurelinux3.0, 8.0-azurelinux3.0 | [Dockerfile](src/sdk/8.0/azurelinux3.0/amd64/Dockerfile) | Azure Linux 3.0
@@ -94,13 +94,13 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.303-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.303-bookworm-slim, 9.0-bookworm-slim, 9.0.303, 9.0, latest | [Dockerfile](src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.303-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.303-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.303-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.303-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.303-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.303-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.303-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.303-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/sdk/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 9.0.303-noble-arm64v8, 9.0-noble-arm64v8, 9.0.303-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.303-azurelinux3.0-arm64v8, 9.0-azurelinux3.0-arm64v8, 9.0.303-azurelinux3.0, 9.0-azurelinux3.0 | [Dockerfile](src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.412-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.412-bookworm-slim, 8.0-bookworm-slim, 8.0.412, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.412-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.412-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.412-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.412-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.412-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.412-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.412-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.412-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/sdk/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 8.0.412-noble-arm64v8, 8.0-noble-arm64v8, 8.0.412-noble, 8.0-noble | [Dockerfile](src/sdk/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.412-jammy-arm64v8, 8.0-jammy-arm64v8, 8.0.412-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
 8.0.412-azurelinux3.0-arm64v8, 8.0-azurelinux3.0-arm64v8, 8.0.412-azurelinux3.0, 8.0-azurelinux3.0 | [Dockerfile](src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile) | Azure Linux 3.0
@@ -122,12 +122,12 @@ Tags | Dockerfile | OS Version
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
 9.0.303-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.303-bookworm-slim, 9.0-bookworm-slim, 9.0.303, 9.0, latest | [Dockerfile](src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.303-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.303-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.303-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.303-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.303-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.303-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.303-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.303-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/sdk/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 9.0.303-noble-arm32v7, 9.0-noble-arm32v7, 9.0.303-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.412-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.412-bookworm-slim, 8.0-bookworm-slim, 8.0.412, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.412-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.412-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.412-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.412-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.412-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.412-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.412-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.412-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/sdk/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 8.0.412-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.412-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 
 #### .NET 10 Preview Tags

--- a/manifest.json
+++ b/manifest.json
@@ -82,7 +82,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -92,7 +93,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -103,7 +105,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -115,7 +118,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -125,7 +129,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21-extra": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21-extra": {},
+            "$(dotnet|8.0|minor-tag)-alpine-extra": {}
           },
           "platforms": [
             {
@@ -135,7 +140,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -155,7 +161,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -176,7 +183,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -196,7 +204,6 @@
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22": {},
             "$(dotnet|8.0|minor-tag)-alpine3.22": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {},
             "$(dotnet|8.0|fixed-tag)-alpine3.22-aot": {
               "docType": "Undocumented"
             },
@@ -213,7 +220,6 @@
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-amd64": {},
                 "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {},
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-aot-amd64": {
                   "docType": "Undocumented"
                 },
@@ -231,7 +237,6 @@
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm32v7": {},
                 "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {},
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-aot-arm32v7": {
                   "docType": "Undocumented"
                 },
@@ -250,7 +255,6 @@
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm64v8": {},
                 "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {},
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-aot-arm64v8": {
                   "docType": "Undocumented"
                 },
@@ -266,8 +270,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.22-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine-extra": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.22-extra": {}
           },
           "platforms": [
             {
@@ -277,8 +280,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -298,8 +300,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -320,8 +321,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1011,7 +1011,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -1021,7 +1022,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -1032,7 +1034,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -1044,7 +1047,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -1054,7 +1058,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21-extra": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21-extra": {},
+            "$(dotnet|9.0|minor-tag)-alpine-extra": {}
           },
           "platforms": [
             {
@@ -1064,7 +1069,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1084,7 +1090,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1105,7 +1112,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1125,7 +1133,6 @@
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22": {},
             "$(dotnet|9.0|minor-tag)-alpine3.22": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {},
             "$(dotnet|9.0|fixed-tag)-alpine3.22-aot": {
               "docType": "Undocumented"
             },
@@ -1142,7 +1149,6 @@
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-amd64": {},
                 "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {},
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-aot-amd64": {
                   "docType": "Undocumented"
                 },
@@ -1160,7 +1166,6 @@
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm32v7": {},
                 "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {},
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-aot-arm32v7": {
                   "docType": "Undocumented"
                 },
@@ -1179,7 +1184,6 @@
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm64v8": {},
                 "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {},
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-aot-arm64v8": {
                   "docType": "Undocumented"
                 },
@@ -1195,8 +1199,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine-extra": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22-extra": {}
           },
           "platforms": [
             {
@@ -1206,8 +1209,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1227,8 +1229,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1249,8 +1250,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -2119,7 +2119,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -2132,7 +2133,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -2146,7 +2148,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -2161,7 +2164,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -2171,8 +2175,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.22": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.22": {}
           },
           "platforms": [
             {
@@ -2185,8 +2188,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {}
               }
             },
             {
@@ -2200,8 +2202,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -2216,8 +2217,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -3076,7 +3076,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -3089,7 +3090,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -3103,7 +3105,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -3118,7 +3121,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -3128,8 +3132,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22": {}
           },
           "platforms": [
             {
@@ -3142,8 +3145,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {}
               }
             },
             {
@@ -3157,8 +3159,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -3173,8 +3174,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4251,7 +4251,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -4264,7 +4265,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -4278,7 +4280,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4293,7 +4296,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4303,7 +4307,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21-composite": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21-composite": {},
+            "$(dotnet|8.0|minor-tag)-alpine-composite": {}
           },
           "platforms": [
             {
@@ -4316,7 +4321,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-amd64": {}
               }
             },
             {
@@ -4330,7 +4336,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4345,7 +4352,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4355,8 +4363,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.22": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.22": {}
           },
           "platforms": [
             {
@@ -4369,8 +4376,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {}
               }
             },
             {
@@ -4384,8 +4390,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4400,8 +4405,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4411,8 +4415,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.22-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine-composite": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.22-composite": {}
           },
           "platforms": [
             {
@@ -4425,8 +4428,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-amd64": {}
               }
             },
             {
@@ -4440,8 +4442,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4456,8 +4457,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -5750,7 +5750,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -5763,7 +5764,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -5777,7 +5779,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5792,7 +5795,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -5802,7 +5806,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21-composite": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21-composite": {},
+            "$(dotnet|9.0|minor-tag)-alpine-composite": {}
           },
           "platforms": [
             {
@@ -5815,7 +5820,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-amd64": {}
               }
             },
             {
@@ -5829,7 +5835,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5844,7 +5851,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -5854,8 +5862,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22": {}
           },
           "platforms": [
             {
@@ -5868,8 +5875,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {}
               }
             },
             {
@@ -5883,8 +5889,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5899,8 +5904,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -5910,8 +5914,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine-composite": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22-composite": {}
           },
           "platforms": [
             {
@@ -5924,8 +5927,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-amd64": {}
               }
             },
             {
@@ -5939,8 +5941,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -5955,8 +5956,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -7631,7 +7631,8 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.21": {},
-            "$(sdk|8.0|minor-tag)-alpine3.21": {}
+            "$(sdk|8.0|minor-tag)-alpine3.21": {},
+            "$(sdk|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -7644,7 +7645,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-amd64": {},
+                "$(sdk|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -7658,7 +7660,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(sdk|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -7673,7 +7676,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(sdk|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -7683,8 +7687,7 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.22": {},
-            "$(sdk|8.0|minor-tag)-alpine3.22": {},
-            "$(sdk|8.0|minor-tag)-alpine": {}
+            "$(sdk|8.0|minor-tag)-alpine3.22": {}
           },
           "platforms": [
             {
@@ -7697,8 +7700,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.22-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.22-amd64": {}
               }
             },
             {
@@ -7712,8 +7714,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(sdk|8.0|minor-tag)-alpine3.22-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -7728,8 +7729,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.22-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8074,7 +8074,8 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.21": {},
-            "$(sdk|9.0|minor-tag)-alpine3.21": {}
+            "$(sdk|9.0|minor-tag)-alpine3.21": {},
+            "$(sdk|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -8087,7 +8088,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-amd64": {},
+                "$(sdk|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -8101,7 +8103,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-arm32v7": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-arm32v7": {},
+                "$(sdk|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8116,7 +8119,8 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-arm64v8": {},
+                "$(sdk|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8126,8 +8130,7 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.22": {},
-            "$(sdk|9.0|minor-tag)-alpine3.22": {},
-            "$(sdk|9.0|minor-tag)-alpine": {}
+            "$(sdk|9.0|minor-tag)-alpine3.22": {}
           },
           "platforms": [
             {
@@ -8140,8 +8143,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.22-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.22-amd64": {}
               }
             },
             {
@@ -8155,8 +8157,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine3.22-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(sdk|9.0|minor-tag)-alpine3.22-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8171,8 +8172,7 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.22-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.22-arm64v8": {}
               },
               "variant": "v8"
             }

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -6,7 +6,7 @@
     "base-url|public|preview|nightly": "https://ci.dot.net/public",
     "base-url|public-checksums|preview|nightly": "https://ci.dot.net/public-checksums",
 
-    "alpine|floating-tag-version": "alpine3.22",
+    "alpine|floating-tag-version": "alpine3.21",
     "alpine|10.0|floating-tag-version": "alpine3.22",
     "alpine|9.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|8.0|floating-tag-version": "$(alpine|floating-tag-version)",


### PR DESCRIPTION
This PR moves the Alpine floating tags from `3.22` to `3.21` due to this issue with OpenSSL 3.5 and CosmosDB:
- https://github.com/dotnet/dotnet-docker/issues/6560
- https://github.com/Azure/azure-cosmos-dotnet-v3/issues/5302

Related:
- https://github.com/dotnet/dotnet-docker/discussions/6488
- https://github.com/dotnet/dotnet-docker/discussions/6536