### PR TITLE
Add initial definitions for unofficial update-dependencies pipelines

### DIFF
--- a/eng/pipelines/update-dependencies-internal-unofficial.yml
+++ b/eng/pipelines/update-dependencies-internal-unofficial.yml
@@ -1,0 +1,20 @@
+trigger: none
+pr: none
+
+variables:
+- template: /eng/common/templates/variables/dotnet/common.yml@self
+
+extends:
+  template: /eng/common/templates/1es-unofficial.yml@self
+  parameters:
+    stages:
+    - stage: DotNet
+      jobs:
+      - job: UpdateDotNet
+        displayName: Update .NET (dotnet/dotnet)
+        pool:
+          vmImage: $(defaultLinuxAmd64PoolImage)
+        steps:
+        - powershell: |-
+            Write-Host "This pipeline is a work in progress.
+            Write-Host "See https://github.com/dotnet/dotnet-docker-internal/issues/8566 for more details."

--- a/eng/pipelines/update-dependencies-unofficial.yml
+++ b/eng/pipelines/update-dependencies-unofficial.yml
@@ -1,0 +1,20 @@
+trigger: none
+pr: none
+
+variables:
+- template: /eng/common/templates/variables/dotnet/common.yml@self
+
+extends:
+  template: /eng/common/templates/1es-unofficial.yml@self
+  parameters:
+    stages:
+    - stage: DotNet
+      jobs:
+      - job: UpdateDotNet
+        displayName: Update .NET (dotnet/dotnet)
+        pool:
+          vmImage: $(defaultLinuxAmd64PoolImage)
+        steps:
+        - powershell: |-
+            Write-Host "This pipeline is a work in progress.
+            Write-Host "See https://github.com/dotnet/dotnet-docker-internal/issues/8566 for more details."


### PR DESCRIPTION
This is part of https://github.com/dotnet/dotnet-docker-internal/issues/8566.

This PR creates the pipeline files, which will allow me to create the pipelines internally. Then I'll iterate on the pipelines internally before submitting a second, final PR with the implementation.