### PR TITLE
Add initial definitions for release staging/promotion unofficial pipelines

### DIFF
--- a/eng/pipelines/release-promotion-unofficial.yml
+++ b/eng/pipelines/release-promotion-unofficial.yml
@@ -1,0 +1,44 @@
+trigger: none
+pr: none
+
+variables:
+- template: /eng/pipelines/variables/core.yml@self
+  parameters:
+    sourceBuildPipelineRunId: "$(resources.pipeline.dotnet-docker-release-staging-unofficial.runID)"
+# Set pathArgs to empty in order to publish all images
+- name: imageBuilder.pathArgs
+  value: ""
+- name: imageBuilder.queueArgs
+  value: ""
+- name: gitHubVersionsRepoInfo.org
+  value: dotnet
+- name: gitHubVersionsRepoInfo.repo
+  value: dotnet-docker-internal
+- name: gitHubVersionsRepoInfo.branch
+  value: main
+
+resources:
+  pipelines:
+  - pipeline: dotnet-docker-release-staging-unofficial
+    source: dotnet-docker-release-staging-unofficial
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/dotnet-docker-internal
+    ref: ${{ variables['gitHubVersionsRepoInfo.branch'] }}
+
+extends:
+  template: /eng/common/templates/1es-unofficial.yml@self
+  parameters:
+    stages:
+    - stage: DotNet
+      jobs:
+      - job: PublishDotNet
+        displayName: Publish .NET images
+        pool:
+          vmImage: $(defaultLinuxAmd64PoolImage)
+        steps:
+        - powershell: |-
+            Write-Host "This pipeline is a work in progress.
+            Write-Host "See https://github.com/dotnet/dotnet-docker-internal/issues/8566 for more details."

--- a/eng/pipelines/release-staging-unofficial.yml
+++ b/eng/pipelines/release-staging-unofficial.yml
@@ -1,0 +1,48 @@
+trigger: none
+pr: none
+
+parameters:
+- name: sourceBuildPipelineRunId
+  displayName: >
+    Source build pipeline run ID. This refers to runs of *this pipeline*.
+    Override this parameter in combination with disabling the `Build` stage to
+    test images that were built in a different pipeline run. When
+    building new images, leave this value alone.
+  type: string
+  default: $(Build.BuildId)
+- name: noCache
+  displayName: >
+    Disable image caching. By default, an image is built only when its
+    Dockerfile was modified or its base image has been updated. Setting this
+    parameter to true forces all images to be built (except those excluded by
+    path arguments).
+  type: boolean
+  default: false
+
+variables:
+- template: /eng/pipelines/variables/core.yml@self
+  parameters:
+    sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+    ref: ${{ variables['gitHubVersionsRepoInfo.branch'] }}
+
+extends:
+  template: /eng/common/templates/1es-unofficial.yml@self
+  parameters:
+    stages:
+    - stage: DotNet
+      jobs:
+      - job: BuildDotNet
+        displayName: Build .NET images
+        pool:
+          vmImage: $(defaultLinuxAmd64PoolImage)
+        steps:
+        - powershell: |-
+            Write-Host "This pipeline is a work in progress.
+            Write-Host "See https://github.com/dotnet/dotnet-docker-internal/issues/8566 for more details."


### PR DESCRIPTION
This is part of https://github.com/dotnet/dotnet-docker-internal/issues/8566.

This PR creates the pipeline files, which will allow me to create the pipelines internally. Then I'll iterate on the pipelines internally before submitting a second, final PR with the implementation.

Related:
- #6582 