### PR TITLE
Add initial pipeline definition for nightly unofficial pipeline

### DIFF
--- a/eng/pipelines/dotnet-docker-nightly-unofficial.yml
+++ b/eng/pipelines/dotnet-docker-nightly-unofficial.yml
@@ -1,0 +1,42 @@
+# This pipeline is a work in progress.
+# See https://github.com/dotnet/dotnet-docker-internal/issues/8566 for more details.
+
+trigger: none
+pr: none
+
+parameters:
+- name: sourceBuildPipelineRunId
+  displayName: >
+    Source build pipeline run ID. This refers to runs of *this pipeline*.
+    Override this parameter in combination with disabling the `Build` stage to
+    test or publish images that were built in a different pipeline run. When
+    building new images, leave this value alone.
+  type: string
+  default: $(Build.BuildId)
+
+variables:
+- template: /eng/pipelines/variables/core.yml@self
+  parameters:
+    sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
+- name: officialBranches
+  # comma-delimited list of branch names
+  value: nightly
+
+resources:
+  repositories:
+  - repository: VersionsRepo
+    type: github
+    endpoint: dotnet
+    name: dotnet/versions
+    ref: ${{ variables['gitHubVersionsRepoInfo.branch'] }}
+
+extends:
+  template: /eng/common/templates/1es-unofficial.yml@self
+  parameters:
+    stages:
+    - template: /eng/pipelines/stages/build-test-publish-repo.yml@self
+      parameters:
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}
+        versionsRepoRef: VersionsRepo
+        sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}


### PR DESCRIPTION
Related:
- https://github.com/dotnet/dotnet-docker/pull/6583
- https://github.com/dotnet/dotnet-docker-internal/issues/8566

This PR adds an initial definition for an "unofficial" dotnet-docker nightly pipeline. This is intended to be a counterpart to the **dotnet-docker-nightly-official** pipeline.

The **dotnet-docker-nightly-playground** pipeline exists already, but it's based on the official pipeline definition. They share the same pipeline yaml, and differ only in what variables are defined in the pipeline GUI. It's easier to have a separate pipeline definition that references the unofficial pipeline base template. When it's complete, this new pipeline should replace the nightly-playground pipeline.