### PR TITLE
Use Syft inside a Dockerfile build to scan images during tests

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -224,6 +224,6 @@
     "sdk|10.0|minor-tag": "$(dotnet|10.0|minor-tag)",
 
     "syft|repo": "anchore/syft",
-    "syft|tag": "v1.26.1"
+    "syft|tag": "v1.31.0"
   }
 }

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -224,6 +224,7 @@
     "sdk|10.0|minor-tag": "$(dotnet|10.0|minor-tag)",
 
     "syft|repo": "anchore/syft",
-    "syft|tag": "v1.31.0"
+    "syft|version": "v1.31.0",
+    "syft|tag": "$(syft|version)-debug"
   }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/AspireDashboardImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspireDashboardImageTests.cs
@@ -77,7 +77,7 @@ public class AspireDashboardImageTests(ITestOutputHelper outputHelper) : CommonR
         IEnumerable<string> expectedPackages =
             GetExpectedPackages(expectedPackagesImageData with { ImageVariant = DotNetImageVariant.Extra }, ImageRepo);
         IEnumerable<string> actualPackages =
-            GetInstalledPackages(imageData, ImageRepo, DockerHelper, OutputHelper, [ AppPath ]);
+            GetInstalledPackages(imageData, ImageRepo, [ AppPath ]);
 
         string imageName = imageData.GetImage(ImageRepo, DockerHelper, skipPull: true);
         ComparePackages(expectedPackages, actualPackages, imageData.IsDistroless, imageName, OutputHelper);

--- a/tests/Microsoft.DotNet.Docker.Tests/AspireDashboardImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspireDashboardImageTests.cs
@@ -77,7 +77,7 @@ public class AspireDashboardImageTests(ITestOutputHelper outputHelper) : CommonR
         IEnumerable<string> expectedPackages =
             GetExpectedPackages(expectedPackagesImageData with { ImageVariant = DotNetImageVariant.Extra }, ImageRepo);
         IEnumerable<string> actualPackages =
-            GetInstalledPackages(imageData, ImageRepo, DockerHelper, [ AppPath ]);
+            GetInstalledPackages(imageData, ImageRepo, DockerHelper, OutputHelper, [ AppPath ]);
 
         string imageName = imageData.GetImage(ImageRepo, DockerHelper, skipPull: true);
         ComparePackages(expectedPackages, actualPackages, imageData.IsDistroless, imageName, OutputHelper);

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyInstalledPackages(ProductImageData imageData)
         {
-            ProductImageTests.VerifyInstalledPackagesBase(imageData, ImageRepo, DockerHelper, OutputHelper);
+            VerifyInstalledPackagesBase(imageData, ImageRepo);
         }
 
         [LinuxImageTheory]

--- a/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -30,36 +30,74 @@ namespace Microsoft.DotNet.Docker.Tests
             OutputHelper = outputHelper;
         }
 
+        #nullable enable
         public void Build(
-            string tag,
-            string dockerfile = null,
-            string target = null,
+            string tag = "",
+            string dockerfile = "",
+            string target = "",
             string contextDir = ".",
             bool pull = false,
-            string platform = null,
-            params string[] buildArgs)
+            string platform = "",
+            string output = "",
+            params string[] buildArgs
+        )
         {
-            string buildArgsOption = string.Empty;
-            if (buildArgs != null)
+            var args = new List<string>();
+
+            // Optional basic flags
+            if (!string.IsNullOrWhiteSpace(tag))
             {
-                foreach (string arg in buildArgs)
+                args.Add("-t");
+                args.Add(tag);
+            }
+
+            if (!string.IsNullOrWhiteSpace(dockerfile))
+            {
+                args.Add("-f");
+                args.Add(dockerfile);
+            }
+
+            if (!string.IsNullOrWhiteSpace(target))
+            {
+                args.Add("--target");
+                args.Add(target);
+            }
+
+            // Build args
+            if (buildArgs is not null)
+            {
+                foreach (string buildArg in buildArgs)
                 {
-                    buildArgsOption += $" --build-arg {arg}";
+                    if (!string.IsNullOrWhiteSpace(buildArg))
+                    {
+                        args.Add("--build-arg");
+                        args.Add(buildArg);
+                    }
                 }
             }
 
-            string platformOption = string.Empty;
-            if (platform is not null)
+            if (!string.IsNullOrWhiteSpace(platform))
             {
-                platformOption = $" --platform {platform}";
+                args.Add("--platform");
+                args.Add(platform);
             }
 
-            string targetArg = target == null ? string.Empty : $" --target {target}";
-            string dockerfileArg = dockerfile == null ? string.Empty : $" -f {dockerfile}";
-            string pullArg = pull ? " --pull" : string.Empty;
+            if (!string.IsNullOrWhiteSpace(output))
+            {
+                args.Add("--output");
+                args.Add(output);
+            }
 
-            ExecuteWithLogging($"build -t {tag}{targetArg}{buildArgsOption}{dockerfileArg}{pullArg}{platformOption} {contextDir}");
+            if (pull)
+            {
+                args.Add("--pull");
+            }
+
+            args.Add(contextDir);
+
+            ExecuteWithLogging($"build {string.Join(' ', args)}");
         }
+        #nullable disable
 
         /// <summary>
         /// Builds a helper image intended to test distroless scenarios.

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -210,6 +210,13 @@ namespace Microsoft.DotNet.Docker.Tests
             expectedPackages.Should().BeSubsetOf(actualPackages, because: $"image {imageName} is not distroless");
         }
 
+        /// <summary>
+        /// Gets a list of all unique linux packages in the image.
+        /// </summary>
+        /// <param name="excludePaths">
+        /// These paths will be excluded from image scanning.
+        /// </param>
+        /// <returns></returns>
         internal IEnumerable<string> GetInstalledPackages(
             ProductImageData imageData,
             DotNetImageRepo imageRepo,

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 return;
             }
 
-            var osReleaseInfo = GetOSReleaseInfo(imageData, ImageRepo, DockerHelper, OutputHelper);
+            var osReleaseInfo = GetOSReleaseInfo(imageData, ImageRepo);
             OutputHelper.WriteLine($"OS Release Info: {osReleaseInfo}");
             osReleaseInfo.ShouldNotBeEmpty();
         }
@@ -165,13 +165,11 @@ namespace Microsoft.DotNet.Docker.Tests
             }
         }
 
-        private static string GetOSReleaseInfo(
+        private string GetOSReleaseInfo(
             ProductImageData imageData,
-            DotNetImageRepo imageRepo,
-            DockerHelper dockerHelper,
-            ITestOutputHelper outputHelper)
+            DotNetImageRepo imageRepo)
         {
-            JsonNode output = SyftHelper.Scan(imageData, imageRepo, dockerHelper, outputHelper: outputHelper);
+            JsonNode output = SyftHelper.Scan(imageData, imageRepo);
             JsonObject distro = (JsonObject)output["distro"];
             return (string)distro["version"];
         }
@@ -181,7 +179,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyInstalledPackages(ProductImageData imageData)
         {
-            VerifyInstalledPackagesBase(imageData, ImageRepo, DockerHelper, OutputHelper);
+            VerifyInstalledPackagesBase(imageData, ImageRepo);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeDepsImageTests.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -118,7 +119,10 @@ namespace Microsoft.DotNet.Docker.Tests
                 OutputHelper.WriteLine("This test is only relevant to distroless images.");
                 return;
             }
-            Assert.NotEmpty(GetOSReleaseInfo(imageData, ImageRepo, DockerHelper));
+
+            var osReleaseInfo = GetOSReleaseInfo(imageData, ImageRepo, DockerHelper, OutputHelper);
+            OutputHelper.WriteLine($"OS Release Info: {osReleaseInfo}");
+            osReleaseInfo.ShouldNotBeEmpty();
         }
 
         /// <summary>
@@ -164,9 +168,10 @@ namespace Microsoft.DotNet.Docker.Tests
         private static string GetOSReleaseInfo(
             ProductImageData imageData,
             DotNetImageRepo imageRepo,
-            DockerHelper dockerHelper)
+            DockerHelper dockerHelper,
+            ITestOutputHelper outputHelper)
         {
-            JsonNode output = GetSyftOutput("os-release-info", imageData, imageRepo, dockerHelper);
+            JsonNode output = SyftHelper.Scan(imageData, imageRepo, dockerHelper, outputHelper: outputHelper);
             JsonObject distro = (JsonObject)output["distro"];
             return (string)distro["version"];
         }

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyInstalledPackages(ProductImageData imageData)
         {
-            ProductImageTests.VerifyInstalledPackagesBase(imageData, ImageRepo, DockerHelper, OutputHelper);
+            VerifyInstalledPackagesBase(imageData, ImageRepo);
         }
 
         [LinuxImageTheory]

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyInstalledPackages(ProductImageData imageData)
         {
-            ProductImageTests.VerifyInstalledPackagesBase(imageData, ImageRepo, DockerHelper, OutputHelper);
+            VerifyInstalledPackagesBase(imageData, ImageRepo);
         }
 
         [DotNetTheory]

--- a/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Docker.Tests;
+
+internal sealed class SyftHelper
+{
+    private static readonly Lazy<string> s_syftImageTag = new(() =>
+        $"{Config.GetVariableValue("syft|repo")}:{Config.GetVariableValue("syft|tag")}"
+    );
+
+    public static JsonNode Scan(
+        ProductImageData imageData,
+        DotNetImageRepo imageRepo,
+        DockerHelper dockerHelper,
+        ITestOutputHelper outputHelper,
+        IEnumerable<string>? extraExcludePaths = null
+    )
+    {
+        using var tempDir = FileHelper.UseTempFolder();
+        var tempDirPath = tempDir.Path;
+
+        var syftImage = dockerHelper.PullDockerHubImage(s_syftImageTag.Value);
+        var imageToInspect = imageData.GetImage(imageRepo, dockerHelper);
+
+        // Ignore the dotnet folder, or else syft will report all the packages in the .NET Runtime.
+        // We only care about the packages from the linux distro for these tests.
+        extraExcludePaths ??= [];
+        extraExcludePaths = extraExcludePaths.Append("./usr/share/dotnet");
+
+        // Create a Dockerfile tailored to this specific scan (allows us to inline the image name
+        // in exec-form RUN)
+        var dockerfilePath = Path.Combine(tempDirPath, "Dockerfile");
+        var dockerfileContents = CreateDockerfileContents(syftImage, imageToInspect, extraExcludePaths);
+        File.WriteAllText(dockerfilePath, dockerfileContents);
+
+        outputHelper.WriteLine(
+            $"""
+            Scanning image using generated Dockerfile content:
+
+            {dockerfileContents}
+
+            """
+        );
+
+        // Run docker build with --output to write syft.json to the output directory
+        dockerHelper.Build(dockerfile: dockerfilePath, contextDir: tempDirPath, output: tempDirPath);
+
+        string syftOutputPath = Path.Combine(tempDirPath, "syft.json");
+        if (!File.Exists(syftOutputPath))
+        {
+            throw new FileNotFoundException($"Expected syft output file was not produced: {syftOutputPath}");
+        }
+
+        string outputContents = File.ReadAllText(syftOutputPath);
+        return JsonNode.Parse(outputContents)
+            ?? throw new JsonException(
+                $"""
+                Unable to parse syft output as JSON:
+
+                {outputContents}
+
+                """
+            );
+    }
+
+    /// <summary>
+    /// Creates the contents of a Dockerfile that scans an image using Syft
+    /// </summary>
+    /// <param name="syftImage">The Syft image tag to use for scanning</param>
+    /// <param name="imageToScan">The image that will be scanned</param>
+    /// <returns>
+    /// The contents of a Dockerfile that, when built, will scan <see cref="imageToScan"/> using
+    /// Syft and output the results in a scratch image layer. When used in combination with the
+    /// docker build --output argument, the results will be written to a file named `syft.json`.
+    /// </returns>
+    /// <remarks>
+    /// The Dockerfile is generated instead of reading a static Dockerfile from the disk because
+    /// Dockerfile doesn't allow ARG substitution inside RUN instructions without invoking the
+    /// shell, meaning that we would not be able to set the source name or other arguments
+    /// programmatically.
+    /// </remarks>
+    private static string CreateDockerfileContents(
+        string syftImage,
+        string imageToScan,
+        IEnumerable<string> excludePaths
+    )
+    {
+        const string OutputFileName = "syft.json";
+
+        IEnumerable<string> syftCommand =
+        [
+            "/syft/syft",
+            "scan",
+            "/rootfs/",
+            "--source-name",
+            imageToScan,
+            "--output",
+            $"json=/{OutputFileName}",
+        ];
+
+        excludePaths ??= [];
+        IEnumerable<string> excludeArgs = excludePaths.SelectMany(path => new List<string> { "--exclude", path });
+
+        syftCommand = [.. syftCommand, .. excludeArgs];
+
+        var syftCommandString = string.Join(", ", syftCommand.Select(a => $"\"{a}\""));
+
+        return $"""
+            FROM {syftImage} AS syft
+            FROM {imageToScan} AS scan-image
+
+            FROM scratch AS run-scan
+            ARG SCAN_IMAGE
+            ENV SYFT_CHECK_FOR_APP_UPDATE=0
+            RUN --mount=from=syft,source=/,target=/syft \
+                --mount=from=scan-image,source=/,target=/rootfs \
+                [{syftCommandString}]
+
+            FROM scratch AS output
+            COPY --from=run-scan /{OutputFileName} /{OutputFileName}
+            """;
+    }
+}

--- a/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.Docker.Tests;
 
 public sealed class SyftHelper(DockerHelper dockerHelper, ITestOutputHelper outputHelper)
 {
+    private const string OutputFileName = "syft-output.json";
+
     private static readonly Lazy<string> s_syftImageTag = new(() =>
         $"{Config.GetVariableValue("syft|repo")}:{Config.GetVariableValue("syft|tag")}"
     );
@@ -58,7 +60,7 @@ public sealed class SyftHelper(DockerHelper dockerHelper, ITestOutputHelper outp
         // Run docker build with --output to write syft.json to the output directory
         _dockerHelper.Build(dockerfile: dockerfilePath, contextDir: tempDirPath, output: tempDirPath);
 
-        string syftOutputPath = Path.Combine(tempDirPath, "syft.json");
+        string syftOutputPath = Path.Combine(tempDirPath, OutputFileName);
         if (!File.Exists(syftOutputPath))
         {
             throw new FileNotFoundException($"Expected syft output file was not produced: {syftOutputPath}");
@@ -98,11 +100,10 @@ public sealed class SyftHelper(DockerHelper dockerHelper, ITestOutputHelper outp
         IEnumerable<string> excludePaths
     )
     {
-        const string OutputFileName = "syft.json";
 
         IEnumerable<string> syftCommand =
         [
-            "/syft/syft",
+            "/syft",
             "scan",
             "/rootfs/",
             "--source-name",

--- a/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
@@ -107,6 +107,8 @@ public sealed class SyftHelper(DockerHelper dockerHelper, ITestOutputHelper outp
             "/rootfs/",
             "--source-name",
             imageToScan,
+            "--select-catalogers",
+            "image",
             "--output",
             $"json=/{OutputFileName}",
         ];
@@ -126,10 +128,10 @@ public sealed class SyftHelper(DockerHelper dockerHelper, ITestOutputHelper outp
             FROM {syftImage} AS syft
             FROM {imageToScan} AS scan-image
 
-            FROM scratch AS run-scan
+            FROM syft AS run-scan
             {DisableSyftUpdateCheck}
-            RUN --mount=from=syft,source=/,target=/syft \
-                --mount=from=scan-image,source=/,target=/rootfs \
+            USER root
+            RUN --mount=from=scan-image,source=/,target=/rootfs \
                 [{syftCommandString}]
 
             FROM scratch AS output

--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ReverseProxyBasicScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ReverseProxyBasicScenario.cs
@@ -58,7 +58,6 @@ public class YarpBasicScenario : ITestScenario
         try
         {
             // Deploy opentelemetry endpoint
-            string otelAppTag = "otlptestlistener";
             string sampleFolder = Path.Combine(DockerHelper.TestArtifactsDir, "otlptestlistener");
             string dockerfilePath = $"{sampleFolder}/Dockerfile";
             _dockerHelper.Build(otelContainerTag, dockerfilePath, contextDir: sampleFolder, pull: Config.PullImages);


### PR DESCRIPTION
Related:
- https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/1435#issuecomment-2946447028

Syft images >= v1.27 use a non-root user by default, event for the `-debug` versions of images. That's incompatible with the way we were using the syft image. Instead of writing to a directory inside the syft image, mount the syft image and the image to scan in the same layer and copy syft's output to a `scratch` layer. This has the benefit of being much faster _and_ compatible with distroless + non-root images on both sides (syft and the target images).

Other changes:
- Fixed warning due to unused otel variable
- Update Syft image to latest version v1.31.0
- Some minor refactoring/better encapsulation for syft related code.