### PR TITLE
Target version variable instead of tag for automatic syft updates

### DIFF
--- a/eng/update-dependencies/SyftUpdater.cs
+++ b/eng/update-dependencies/SyftUpdater.cs
@@ -14,7 +14,7 @@ internal static class SyftUpdater
 
     public const string ToolName = Repo;
 
-    public const string VariableName = "syft|tag";
+    public const string VariableName = "syft|version";
 
     public static async Task<GitHubReleaseInfo> GetBuildInfoAsync() =>
          new GitHubReleaseInfo(

--- a/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
@@ -19,7 +19,7 @@ public sealed class SyftHelper(DockerHelper dockerHelper, ITestOutputHelper outp
     private const string OutputFileName = "syft-output.json";
 
     private static readonly Lazy<string> s_syftImageTag = new(() =>
-        $"{Config.GetVariableValue("syft|repo")}:{Config.GetVariableValue("syft|version")}"
+        $"{Config.GetVariableValue("syft|repo")}:{Config.GetVariableValue("syft|tag")}"
     );
 
     private readonly DockerHelper _dockerHelper = dockerHelper;

--- a/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SyftHelper.cs
@@ -19,7 +19,7 @@ public sealed class SyftHelper(DockerHelper dockerHelper, ITestOutputHelper outp
     private const string OutputFileName = "syft-output.json";
 
     private static readonly Lazy<string> s_syftImageTag = new(() =>
-        $"{Config.GetVariableValue("syft|repo")}:{Config.GetVariableValue("syft|tag")}"
+        $"{Config.GetVariableValue("syft|repo")}:{Config.GetVariableValue("syft|version")}"
     );
 
     private readonly DockerHelper _dockerHelper = dockerHelper;


### PR DESCRIPTION
This automatic PR is updating the wrong variable:
- https://github.com/dotnet/dotnet-docker/pull/6612

It was trying to update **syft|tag** instead of **syft|version**. **syft|version** was added in https://github.com/dotnet/dotnet-docker/pull/6611 so that we could use a different tag suffix for the syft image.