### PR TITLE
Change .NET monitor 10 floating tag to `10-preview` instead of `10-rc`

### DIFF
--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -68,7 +68,7 @@ Tags | Dockerfile | OS Version
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-10.0.0-rc.1-amd64, 10.0-preview-amd64, 10.0.0-rc.1, 10.0-preview, 10-rc, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
+10.0.0-rc.1-amd64, 10.0-preview-amd64, 10.0.0-rc.1, 10.0-preview, 10-preview, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 
 ### Linux arm64 Tags
 
@@ -88,7 +88,7 @@ Tags | Dockerfile | OS Version
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-10.0.0-rc.1-arm64v8, 10.0-preview-arm64v8, 10.0.0-rc.1, 10.0-preview, 10-rc, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
+10.0.0-rc.1-arm64v8, 10.0-preview-arm64v8, 10.0.0-rc.1, 10.0-preview, 10-preview, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md). See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/nightly/monitor/base/tags/list) for all supported and unsupported tags.*

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -67,7 +67,7 @@ Tags | Dockerfile | OS Version
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-10.0.0-rc.1, 10.0-preview, 10-rc, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
+10.0.0-rc.1, 10.0-preview, 10-preview, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 
 ### Linux arm64 Tags
 
@@ -87,7 +87,7 @@ Tags | Dockerfile | OS Version
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-10.0.0-rc.1, 10.0-preview, 10-rc, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
+10.0.0-rc.1, 10.0-preview, 10-preview, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md). See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/nightly/monitor/tags/list) for all supported and unsupported tags.*

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -124,7 +124,7 @@
     "monitor|9|major-tag": "9",
     "monitor|9|major-preview-tag": "9-preview",
 
-    "monitor|10|major-preview-tag": "10-rc",
+    "monitor|10|major-preview-tag": "10-preview",
 
     "monitor|9.0|build-version": "9.0.4-servicing.25381.4",
     "monitor|9.0|product-version": "9.0.4",


### PR DESCRIPTION
Looking at the historical list of [all monitor tags](https://mcr.microsoft.com/v2/dotnet/monitor/tags/list) (and .NET tags as well), there is no precedent for an `*-rc` tag of any kind. Also, having both `10.0-preview` and `10-rc` tags could be confusing for users. Since this is the first preview of monitor 10.0, we should stick with the `-preview` suffix for all floating tags.