### PR TITLE
Reference official secrets variable group in samples pipeline

### DIFF
--- a/eng/pipelines/dotnet-core-samples.yml
+++ b/eng/pipelines/dotnet-core-samples.yml
@@ -13,6 +13,7 @@ parameters:
 
 variables:
 - template: /eng/pipelines/variables/samples.yml@self
+- template: /eng/common/templates/variables/dotnet/secrets.yml@self
 - name: publishEolAnnotations
   value: true
   readonly: true


### PR DESCRIPTION
This should fix the recent samples pipeline publishing failure.

In the meantime, I'm working on https://github.com/dotnet/dotnet-docker/issues/6632. I initially wanted to roll this fix into that PR, but I ended up wanting to change more than just the Target Framework for all the samples - which will take a little bit longer.