### PR TITLE
Ignore Canonical blog link in PR link validation

### DIFF
--- a/.github/linters/.linkspector.yml
+++ b/.github/linters/.linkspector.yml
@@ -14,4 +14,6 @@ ignorePatterns:
   - pattern: "^https://github.com/microsoft/mcr.*$"
   - pattern: "^https://github.com/dotnet/release.*$"
   - pattern: "^https://aka.ms/$"
+  # This link often fails with a 504 error - it's known good, though.
+  - pattern: "^https://canonical.com/blog/canonical-releases-ubuntu-24-04-noble-numbat$"
 useGitIgnore: true


### PR DESCRIPTION
This link often fails with a 504 error. We know that the page exists so this PR adds it to the ignore list.

https://canonical.com/blog/canonical-releases-ubuntu-24-04-noble-numbat