### PR TITLE
Add fast-forward PR functionality to sync-internal-release pipeline/tool

### DIFF
--- a/eng/update-dependencies/Git/GitRepoHelper.cs
+++ b/eng/update-dependencies/Git/GitRepoHelper.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib;
@@ -11,138 +8,20 @@ using Microsoft.Extensions.Logging;
 
 namespace Dotnet.Docker.Git;
 
-public interface IGitRepoHelper : IDisposable
-{
-    /// <summary>
-    /// The local path where the repository is cloned.
-    /// </summary>
-    string LocalPath { get; }
-
-    /// <summary>
-    /// Checks if a branch exists on the remote repository.
-    /// </summary>
-    Task<bool> RemoteBranchExistsAsync(string branchName);
-
-    /// <summary>
-    /// Checks out a remote branch locally.
-    /// </summary>
-    /// <throws cref="InvalidBranchException">
-    /// Thrown if the branch does not exist on the remote.
-    /// </throws>
-    Task CheckoutRemoteBranchAsync(string branchName);
-
-    /// <summary>
-    /// Commits all staged changes to the current branch.
-    /// </summary>
-    /// <param name="message">The commit message.</param>
-    /// <param name="author">The author information (name and email).</param>
-    /// <returns>The SHA of the created commit.</returns>
-    Task<string> CommitAsync(string message, (string Name, string Email) author);
-
-    /// <summary>
-    /// Create a new local branch. This does not push the branch to the remote.
-    /// The branch will be based off of the currently checked out branch.
-    /// </summary>
-    Task CreateAndCheckoutLocalBranchAsync(string branchName);
-
-    /// <summary>
-    /// Create a new branch in the remote repository. The <see cref="newBranch"/>
-    /// will be based off of the <see cref="baseBranch"/>.
-    /// </summary>
-    /// <param name="newBranch">
-    /// This branch will be created on the remote repository.
-    /// </param>
-    /// <param name="baseBranch">
-    /// The base branch must already exist on the remote repository.
-    /// </param>
-    Task CreateRemoteBranchAsync(string newBranch, string baseBranch);
-
-    /// <summary>
-    /// Create a pull request in the remote repository.
-    /// </summary>
-    /// <param name="request">
-    /// Information about the pull request to create. The <see cref="PullRequestCreationInfo.HeadBranch"/> and
-    /// <see cref="PullRequestCreationInfo.BaseBranch"/> must both already exist on the remote.
-    /// </param>
-    /// <returns>
-    /// Pull request API URL.
-    /// </returns>
-    Task<string> CreatePullRequestAsync(PullRequestCreationInfo request);
-
-    /// <summary>
-    /// Gets the name of the currently checked out branch.
-    /// </summary>
-    /// <returns>The name of the current branch.</returns>
-    Task<string> GetCurrentBranchAsync();
-
-    /// <summary>
-    /// Gets information about a pull request from its URL.
-    /// </summary>
-    /// <param name="pullRequestUrl">The URL of the pull request.</param>
-    /// <returns>Pull request information.</returns>
-    Task<PullRequest> GetPullRequestInfoAsync(string pullRequestUrl);
-
-    /// <summary>
-    /// Get the commit SHA of a branch that exists locally.
-    /// </summary>
-    /// <returns>
-    /// The commit SHA, or null if the branch doesn't exist locally.
-    /// </returns>
-    Task<string?> GetLocalBranchShaAsync(string branch);
-
-    /// <summary>
-    /// Gets the commit SHA of a remote branch.
-    /// </summary>
-    /// <param name="branch">The name of the remote branch.</param>
-    /// <returns>
-    /// The commit SHA, or null if the branch doesn't exist on the remote.
-    /// </returns>
-    Task<string?> GetRemoteBranchShaAsync(string branch);
-
-    /// <summary>
-    /// Push a local branch to the specified remote.
-    /// </summary>
-    /// <param name="branchName">A local branch that already exists.</param>
-    Task PushLocalBranchAsync(string branchName);
-
-    /// <summary>
-    /// Adds local files to the index/staging area
-    /// </summary>
-    /// <param name="paths">The file paths to stage.</param>
-    Task StageAsync(params IEnumerable<string> paths);
-
-    /// <summary>
-    /// Determines whether <paramref name="ancestorBranch"/> is an ancestor of
-    /// <paramref name="descendantBranch"/> in the remote repository.
-    /// </summary>
-    /// <param name="ancestorBranch">Branch that exists locally or on the remote.</param>
-    /// <param name="descendantBranch">Branch that exists locally or on the remote.</param>
-    /// <returns>
-    /// True if <paramref name="ancestorBranch"/>'s current commit is in the
-    /// history of <paramref name="descendantBranch"/>.
-    /// </returns>
-    Task<bool> IsBranchAncestorAsync(string ancestorBranch, string descendantBranch);
-}
-
 /// <remarks>
 /// Use <see cref="IGitRepoHelperFactory"/> to instantiate this.
 /// </remarks>
 public sealed class GitRepoHelper(
     string remoteRepoUrl,
-    string localPath,
-    ILocalGitRepo localGitRepo,
-    IRemoteGitRepo remoteGitRepo,
+    ILocalGitRepoHelper localGitRepoHelper,
+    IRemoteGitRepoHelper remoteGitRepoHelper,
     ILocalLibGit2Client libGit2Client,
     ILogger<GitRepoHelper> logger
 ) : IGitRepoHelper
 {
-    private readonly ILocalGitRepo _localGitRepo = localGitRepo;
-
-    private readonly IRemoteGitRepo _remoteGitRepo = remoteGitRepo;
-
     /// <summary>
     /// Use this client for "push" operations only, all other local git
-    /// operations should use <see cref="_localGitRepo"/>.
+    /// operations should use <see cref="Local"/>.
     /// </summary>
     private readonly ILocalLibGit2Client _libGit2Client = libGit2Client;
 
@@ -151,170 +30,38 @@ public sealed class GitRepoHelper(
     private readonly string _repoUri = remoteRepoUrl;
 
     /// <inheritdoc />
-    public string LocalPath { get; } = localPath;
+    public ILocalGitRepoHelper Local { get; } = localGitRepoHelper;
 
     /// <inheritdoc />
-    public Task<string> GetCurrentBranchAsync() => _localGitRepo.GetCheckedOutBranchAsync();
-
-    /// <inheritdoc />
-    public async Task CreateAndCheckoutLocalBranchAsync(string branchName)
-    {
-        var branchExists = await _remoteGitRepo.DoesBranchExistAsync(_repoUri, branchName);
-        if (branchExists)
-        {
-            _logger.LogWarning(
-                "Branch {BranchName} already exists on remote, creating local branch anyways",
-                branchName);
-        }
-
-        _logger.LogInformation("Creating branch {BranchName} locally", branchName);
-        await _localGitRepo.CreateBranchAsync(branchName, overwriteExistingBranch: false);
-    }
-
-    /// <inheritdoc />
-    public Task CreateRemoteBranchAsync(string newBranch, string baseBranch)
-    {
-        _logger.LogInformation(
-            "Creating new remote branch {BranchName} based on {BaseBranch} on remote",
-            newBranch, baseBranch);
-
-        return _remoteGitRepo.CreateBranchAsync(_repoUri, newBranch, baseBranch);
-    }
+    public IRemoteGitRepoHelper Remote { get; } = remoteGitRepoHelper;
 
     /// <inheritdoc />
     public async Task CheckoutRemoteBranchAsync(string branchName)
     {
-        var currentBranch = await _localGitRepo.GetCheckedOutBranchAsync();
+        var currentBranch = await Local.GetCurrentBranchAsync();
         if (currentBranch == branchName)
         {
             _logger.LogInformation("Already on branch {BranchName}", branchName);
             return;
         }
 
-        var branchExists = await _remoteGitRepo.DoesBranchExistAsync(_repoUri, branchName);
+        var branchExists = await Remote.RemoteBranchExistsAsync(branchName);
         if (!branchExists)
         {
             throw new InvalidBranchException($"Branch '{branchName}' does not exist on remote.");
         }
 
-        await _localGitRepo.CheckoutAsync(branchName);
-    }
-
-    /// <inheritdoc />
-    public async Task<string?> GetLocalBranchShaAsync(string branch)
-    {
-        try
-        {
-            var result = await _localGitRepo.GetShaForRefAsync($"refs/heads/{branch}");
-            return result;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    /// <inheritdoc />
-    public Task<string?> GetRemoteBranchShaAsync(string branch) =>
-        _remoteGitRepo.GetLastCommitShaAsync(_repoUri, branch);
-
-    /// <inheritdoc />
-    public async Task StageAsync(params IEnumerable<string> paths)
-    {
-        await _localGitRepo.StageAsync(paths);
-    }
-
-    /// <inheritdoc />
-    public async Task<string> CommitAsync(string message, (string Name, string Email) author)
-    {
-        await _localGitRepo.CommitAsync(message, allowEmpty: false, author);
-        var commitSha = await _localGitRepo.GetShaForRefAsync("HEAD");
-        return commitSha;
+        await Local.CheckoutBranchAsync(branchName);
     }
 
     /// <inheritdoc />
     public async Task PushLocalBranchAsync(string branchName)
     {
         // Get all remotes and find the one that matches the target repo.
-        var remotes = await ListAllRemotesAsync();
+        var remotes = await Local.ListAllRemotesAsync();
         var targetRemote = remotes.First(remote => remote.Url == _repoUri);
 
         _logger.LogInformation("Pushing branch {BranchName} to remote {RemoteUrl}", branchName, targetRemote.Url);
-        await _libGit2Client.Push(LocalPath, branchName, targetRemote.Url);
-    }
-
-    /// <inheritdoc />
-    public Task<string> CreatePullRequestAsync(PullRequestCreationInfo request)
-    {
-        var darcPullRequest = new PullRequest
-        {
-            Title = request.Title,
-            Description = request.Body,
-            BaseBranch = request.BaseBranch,
-            HeadBranch = request.HeadBranch,
-        };
-
-        return _remoteGitRepo.CreatePullRequestAsync(_repoUri, darcPullRequest);
-    }
-
-    /// <inheritdoc />
-    public Task<PullRequest> GetPullRequestInfoAsync(string pullRequestUrl) =>
-        _remoteGitRepo.GetPullRequestAsync(pullRequestUrl);
-
-    /// <inheritdoc />
-    public Task<bool> RemoteBranchExistsAsync(string branchName) =>
-        _remoteGitRepo.DoesBranchExistAsync(_repoUri, branchName);
-    
-    /// <inheritdoc />
-    public async Task<bool> IsBranchAncestorAsync(string ancestorBranch, string descendantBranch)
-    {
-        await _localGitRepo.FetchAllAsync([_repoUri]);
-
-        var ancestorCommit = await GetLocalBranchShaAsync(ancestorBranch);
-        var descendantCommit = await GetLocalBranchShaAsync(descendantBranch);
-
-        if (ancestorCommit is null || descendantCommit is null)
-        {
-            return false;
-        }
-
-        var isAncestor = await _localGitRepo.IsAncestorCommit(ancestorCommit, descendantCommit);
-        return isAncestor;
-    }
-
-    public void Dispose()
-    {
-        _logger.LogInformation("Cleaning up repo in {LocalPath}", LocalPath);
-
-        try
-        {
-            if (Directory.Exists(LocalPath))
-            {
-                Directory.Delete(LocalPath, recursive: true);
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning(
-                "Failed to delete temporary directory {LocalPath}: {ExceptionMessage}",
-                LocalPath, e.Message);
-        }
-    }
-
-    private async Task<IEnumerable<GitRemoteInfo>> ListAllRemotesAsync()
-    {
-        var remotesOutput = await _localGitRepo.ExecuteGitCommand("remote", "-v");
-
-        /* Example output of `git remote -v`:
-        origin  https://github.com/dotnet/runtime (fetch)
-        origin  https://github.com/dotnet/runtime (push)
-        */
-
-        return remotesOutput.GetOutputLines()
-            .Select(line =>
-                line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            .Select(parts => new GitRemoteInfo(parts[0], parts[1]))
-            // There are typically two entries per remote (fetch and push); we only want one
-            .Distinct();
+        await _libGit2Client.Push(Local.LocalPath, branchName, targetRemote.Url);
     }
 }

--- a/eng/update-dependencies/Git/GitRepoHelperFactory.cs
+++ b/eng/update-dependencies/Git/GitRepoHelperFactory.cs
@@ -40,13 +40,21 @@ public sealed class GitRepoHelperFactory(
             gitDirectory: null);
 
         var localGitRepo = _localGitRepoFactory.Create(new NativePath(localCloneDir));
-        var remoteGitRepo = _remoteFactory.CreateRemoteGitRepo(repoUri);
+        var localGitRepoHelper = new LocalGitRepoHelper(
+            localPath: localCloneDir,
+            localGitRepo: localGitRepo,
+            logger: _serviceProvider.GetRequiredService<ILogger<LocalGitRepoHelper>>());
+
+        var remoteGitRepoHelper = new RemoteGitRepoHelper(
+            repoUri,
+            _remoteFactory.CreateRemoteGitRepo(repoUri),
+            localGitRepo: localGitRepo,
+            logger: _serviceProvider.GetRequiredService<ILogger<RemoteGitRepoHelper>>());
 
         return new GitRepoHelper(
             remoteRepoUrl: repoUri,
-            localPath: localCloneDir,
-            localGitRepo: localGitRepo,
-            remoteGitRepo: remoteGitRepo,
+            localGitRepoHelper: localGitRepoHelper,
+            remoteGitRepoHelper: remoteGitRepoHelper,
             libGit2Client: _serviceProvider.GetRequiredService<ILocalLibGit2Client>(),
             logger: _serviceProvider.GetRequiredService<ILogger<GitRepoHelper>>());
     }

--- a/eng/update-dependencies/Git/IGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/IGitRepoHelper.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+
+namespace Dotnet.Docker.Git;
+
+/// <summary>
+/// Handles operations that require interactions with both local and remote git repos.
+/// </summary>
+public interface IGitRepoHelper
+{
+    /// <summary>
+    /// For any git operations that only affect the local repo.
+    /// </summary>
+    ILocalGitRepoHelper Local { get; }
+
+    /// <summary>
+    /// For any git operations that reach out to the internet.
+    /// </summary>
+    IRemoteGitRepoHelper Remote { get; }
+
+    /// <summary>
+    /// Checks out a remote branch locally.
+    /// </summary>
+    /// <throws cref="InvalidBranchException">
+    /// Thrown if the branch does not exist on the remote.
+    /// </throws>
+    Task CheckoutRemoteBranchAsync(string branchName);
+
+    /// <summary>
+    /// Push a local branch to the specified remote.
+    /// </summary>
+    /// <param name="branchName">A local branch that already exists.</param>
+    Task PushLocalBranchAsync(string branchName);
+
+}

--- a/eng/update-dependencies/Git/IGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/IGitRepoHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Dotnet.Docker.Git;
@@ -8,7 +9,7 @@ namespace Dotnet.Docker.Git;
 /// <summary>
 /// Handles operations that require interactions with both local and remote git repos.
 /// </summary>
-public interface IGitRepoHelper
+public interface IGitRepoHelper : IDisposable
 {
     /// <summary>
     /// For any git operations that only affect the local repo.

--- a/eng/update-dependencies/Git/ILocalGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/ILocalGitRepoHelper.cs
@@ -45,7 +45,7 @@ public interface ILocalGitRepoHelper
     /// <returns>
     /// The commit SHA, or null if the branch doesn't exist locally.
     /// </returns>
-    Task<string?> GetLocalBranchShaAsync(string branch);
+    Task<string?> GetShaForRefAsync(string gitRef);
 
     /// <summary>
     /// Adds local files to the index/staging area
@@ -54,16 +54,16 @@ public interface ILocalGitRepoHelper
     Task StageAsync(params IEnumerable<string> paths);
 
     /// <summary>
-    /// Determines whether <paramref name="ancestorBranch"/> is an ancestor of
-    /// <paramref name="descendantBranch"/> in the remote repository.
+    /// Determines whether <paramref name="ancestorRef"/> is an ancestor of
+    /// <paramref name="descendantRef"/> in the local repository.
     /// </summary>
-    /// <param name="ancestorBranch">Branch that exists locally or on the remote.</param>
-    /// <param name="descendantBranch">Branch that exists locally or on the remote.</param>
+    /// <param name="ancestorRef">Ref that exists locally.</param>
+    /// <param name="descendantRef">Ref that exists locally.</param>
     /// <returns>
-    /// True if <paramref name="ancestorBranch"/>'s current commit is in the
-    /// history of <paramref name="descendantBranch"/>.
+    /// True if <paramref name="ancestorRef"/>'s current commit is in the
+    /// history of <paramref name="descendantRef"/>.
     /// </returns>
-    Task<bool> IsBranchAncestorAsync(string ancestorBranch, string descendantBranch);
+    Task<bool> IsAncestorAsync(string ancestorRef, string descendantRef);
 
     /// <summary>
     /// List all remotes for the local repository.

--- a/eng/update-dependencies/Git/ILocalGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/ILocalGitRepoHelper.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dotnet.Docker.Git;
+
+public interface ILocalGitRepoHelper
+{
+    /// <summary>
+    /// The local path where the repository is cloned.
+    /// </summary>
+    string LocalPath { get; }
+
+    /// <summary>
+    /// Commits all staged changes to the current branch.
+    /// </summary>
+    /// <param name="message">The commit message.</param>
+    /// <param name="author">The author information (name and email).</param>
+    /// <returns>The SHA of the created commit.</returns>
+    Task<string> CommitAsync(string message, (string Name, string Email) author);
+
+    /// <summary>
+    /// Check out a local branch.
+    /// </summary>
+    /// <param name="branchName">A branch that exists locally.</param>
+    Task CheckoutBranchAsync(string branchName);
+
+    /// <summary>
+    /// Create a new local branch. This does not push the branch to the remote.
+    /// The branch will be based off of the currently checked out branch.
+    /// </summary>
+    Task CreateAndCheckoutLocalBranchAsync(string branchName);
+
+    /// <summary>
+    /// Gets the name of the currently checked out branch.
+    /// </summary>
+    /// <returns>The name of the current branch.</returns>
+    Task<string> GetCurrentBranchAsync();
+
+    /// <summary>
+    /// Get the commit SHA of a branch that exists locally.
+    /// </summary>
+    /// <returns>
+    /// The commit SHA, or null if the branch doesn't exist locally.
+    /// </returns>
+    Task<string?> GetLocalBranchShaAsync(string branch);
+
+    /// <summary>
+    /// Adds local files to the index/staging area
+    /// </summary>
+    /// <param name="paths">The file paths to stage.</param>
+    Task StageAsync(params IEnumerable<string> paths);
+
+    /// <summary>
+    /// Determines whether <paramref name="ancestorBranch"/> is an ancestor of
+    /// <paramref name="descendantBranch"/> in the remote repository.
+    /// </summary>
+    /// <param name="ancestorBranch">Branch that exists locally or on the remote.</param>
+    /// <param name="descendantBranch">Branch that exists locally or on the remote.</param>
+    /// <returns>
+    /// True if <paramref name="ancestorBranch"/>'s current commit is in the
+    /// history of <paramref name="descendantBranch"/>.
+    /// </returns>
+    Task<bool> IsBranchAncestorAsync(string ancestorBranch, string descendantBranch);
+
+    /// <summary>
+    /// List all remotes for the local repository.
+    /// </summary>
+    Task<IEnumerable<GitRemoteInfo>> ListAllRemotesAsync();
+}

--- a/eng/update-dependencies/Git/IRemoteGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/IRemoteGitRepoHelper.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib;
+
+namespace Dotnet.Docker.Git;
+
+public interface IRemoteGitRepoHelper
+{
+    /// <summary>
+    /// Checks if a branch exists on the remote repository.
+    /// </summary>
+    Task<bool> RemoteBranchExistsAsync(string branchName);
+
+    /// <summary>
+    /// Create a new branch in the remote repository. The <see cref="newBranch"/>
+    /// will be based off of the <see cref="baseBranch"/>.
+    /// </summary>
+    /// <param name="newBranch">
+    /// This branch will be created on the remote repository.
+    /// </param>
+    /// <param name="baseBranch">
+    /// The base branch must already exist on the remote repository.
+    /// </param>
+    Task CreateRemoteBranchAsync(string newBranch, string baseBranch);
+
+    /// <summary>
+    /// Create a pull request in the remote repository.
+    /// </summary>
+    /// <param name="request">
+    /// Information about the pull request to create. The <see cref="PullRequestCreationInfo.HeadBranch"/> and
+    /// <see cref="PullRequestCreationInfo.BaseBranch"/> must both already exist on the remote.
+    /// </param>
+    /// <returns>
+    /// Pull request API URL.
+    /// </returns>
+    Task<string> CreatePullRequestAsync(PullRequestCreationInfo request);
+
+    /// <summary>
+    /// Gets information about a pull request from its URL.
+    /// </summary>
+    /// <param name="pullRequestUrl">The URL of the pull request.</param>
+    /// <returns>Pull request information.</returns>
+    Task<PullRequest> GetPullRequestInfoAsync(string pullRequestUrl);
+
+    /// <summary>
+    /// Gets the commit SHA of a remote branch.
+    /// </summary>
+    /// <param name="branch">The name of the remote branch.</param>
+    /// <returns>
+    /// The commit SHA, or null if the branch doesn't exist on the remote.
+    /// </returns>
+    Task<string?> GetRemoteBranchShaAsync(string branch);
+
+    /// <summary>
+    /// Fetches updates from the remote repository.
+    /// </summary>
+    Task FetchAsync();
+}

--- a/eng/update-dependencies/Git/LocalGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/LocalGitRepoHelper.cs
@@ -35,17 +35,17 @@ public sealed class LocalGitRepoHelper(
     /// <inheritdoc />
     public Task CheckoutBranchAsync(string branchName)
     {
-        var branchRef = BranchToRef(branchName);
+        var branchRef = $"refs/heads/{branchName}";
         _logger.LogInformation("Checking out ref {BranchRef}", branchRef);
         return _localGitRepo.CheckoutAsync(branchRef);
     }
 
     /// <inheritdoc />
-    public async Task<string?> GetLocalBranchShaAsync(string branch)
+    public async Task<string?> GetShaForRefAsync(string gitRef)
     {
         try
         {
-            var result = await _localGitRepo.GetShaForRefAsync($"refs/heads/{branch}");
+            var result = await _localGitRepo.GetShaForRefAsync(gitRef);
             return result;
         }
         catch
@@ -69,10 +69,10 @@ public sealed class LocalGitRepoHelper(
     }
     
     /// <inheritdoc />
-    public async Task<bool> IsBranchAncestorAsync(string ancestorBranch, string descendantBranch)
+    public async Task<bool> IsAncestorAsync(string ancestorRef, string descendantRef)
     {
-        var ancestorCommit = await GetLocalBranchShaAsync(ancestorBranch);
-        var descendantCommit = await GetLocalBranchShaAsync(descendantBranch);
+        var ancestorCommit = await GetShaForRefAsync(ancestorRef);
+        var descendantCommit = await GetShaForRefAsync(descendantRef);
 
         if (ancestorCommit is null || descendantCommit is null)
         {

--- a/eng/update-dependencies/Git/LocalGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/LocalGitRepoHelper.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
+
+namespace Dotnet.Docker.Git;
+
+public sealed class LocalGitRepoHelper(
+    string localPath,
+    ILocalGitRepo localGitRepo,
+    ILogger<LocalGitRepoHelper> logger
+) : ILocalGitRepoHelper, IDisposable
+{
+    private readonly ILocalGitRepo _localGitRepo = localGitRepo;
+    private readonly ILogger<LocalGitRepoHelper> _logger = logger;
+
+    /// <inheritdoc />
+    public string LocalPath { get; } = localPath;
+
+    /// <inheritdoc />
+    public Task<string> GetCurrentBranchAsync() => _localGitRepo.GetCheckedOutBranchAsync();
+
+    /// <inheritdoc />
+    public async Task CreateAndCheckoutLocalBranchAsync(string branchName)
+    {
+        _logger.LogInformation("Creating branch {BranchName}", branchName);
+        await _localGitRepo.CreateBranchAsync(branchName, overwriteExistingBranch: false);
+    }
+
+    /// <inheritdoc />
+    public Task CheckoutBranchAsync(string branchName)
+    {
+        var branchRef = BranchToRef(branchName);
+        _logger.LogInformation("Checking out ref {BranchRef}", branchRef);
+        return _localGitRepo.CheckoutAsync(branchRef);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetLocalBranchShaAsync(string branch)
+    {
+        try
+        {
+            var result = await _localGitRepo.GetShaForRefAsync($"refs/heads/{branch}");
+            return result;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task StageAsync(params IEnumerable<string> paths)
+    {
+        await _localGitRepo.StageAsync(paths);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> CommitAsync(string message, (string Name, string Email) author)
+    {
+        await _localGitRepo.CommitAsync(message, allowEmpty: false, author);
+        var commitSha = await _localGitRepo.GetShaForRefAsync("HEAD");
+        return commitSha;
+    }
+    
+    /// <inheritdoc />
+    public async Task<bool> IsBranchAncestorAsync(string ancestorBranch, string descendantBranch)
+    {
+        var ancestorCommit = await GetLocalBranchShaAsync(ancestorBranch);
+        var descendantCommit = await GetLocalBranchShaAsync(descendantBranch);
+
+        if (ancestorCommit is null || descendantCommit is null)
+        {
+            return false;
+        }
+
+        var isAncestor = await _localGitRepo.IsAncestorCommit(ancestorCommit, descendantCommit);
+        return isAncestor;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<GitRemoteInfo>> ListAllRemotesAsync()
+    {
+        var remotesOutput = await _localGitRepo.ExecuteGitCommand("remote", "-v");
+
+        /* Example output of `git remote -v`:
+        origin  https://github.com/dotnet/runtime (fetch)
+        origin  https://github.com/dotnet/runtime (push)
+        */
+        return remotesOutput.GetOutputLines()
+            .Select(line =>
+                line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Select(parts => new GitRemoteInfo(parts[0], parts[1]))
+            // There are typically two entries per remote (fetch and push); we only want one
+            .Distinct();
+    }
+
+    public void Dispose()
+    {
+        _logger.LogInformation("Cleaning up repo in {LocalPath}", LocalPath);
+
+        try
+        {
+            if (Directory.Exists(LocalPath))
+            {
+                Directory.Delete(LocalPath, recursive: true);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(
+                "Failed to delete temporary directory {LocalPath}: {ExceptionMessage}",
+                LocalPath, e.Message);
+        }
+    }
+
+    private static string BranchToRef(string branch) => $"refs/heads/{branch}";
+}

--- a/eng/update-dependencies/Git/LocalGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/LocalGitRepoHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib;
@@ -15,7 +14,7 @@ public sealed class LocalGitRepoHelper(
     string localPath,
     ILocalGitRepo localGitRepo,
     ILogger<LocalGitRepoHelper> logger
-) : ILocalGitRepoHelper, IDisposable
+) : ILocalGitRepoHelper
 {
     private readonly ILocalGitRepo _localGitRepo = localGitRepo;
     private readonly ILogger<LocalGitRepoHelper> _logger = logger;
@@ -100,25 +99,4 @@ public sealed class LocalGitRepoHelper(
             // There are typically two entries per remote (fetch and push); we only want one
             .Distinct();
     }
-
-    public void Dispose()
-    {
-        _logger.LogInformation("Cleaning up repo in {LocalPath}", LocalPath);
-
-        try
-        {
-            if (Directory.Exists(LocalPath))
-            {
-                Directory.Delete(LocalPath, recursive: true);
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning(
-                "Failed to delete temporary directory {LocalPath}: {ExceptionMessage}",
-                LocalPath, e.Message);
-        }
-    }
-
-    private static string BranchToRef(string branch) => $"refs/heads/{branch}";
 }

--- a/eng/update-dependencies/Git/RemoteGitRepoHelper.cs
+++ b/eng/update-dependencies/Git/RemoteGitRepoHelper.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
+
+namespace Dotnet.Docker.Git;
+
+public sealed class RemoteGitRepoHelper(
+    string remoteRepoUrl,
+    IRemoteGitRepo remoteGitRepo,
+    ILocalGitRepo localGitRepo,
+    ILogger<RemoteGitRepoHelper> logger
+) : IRemoteGitRepoHelper
+{
+    private readonly IRemoteGitRepo _remoteGitRepo = remoteGitRepo;
+    private readonly ILocalGitRepo _localGitRepo = localGitRepo;
+    private readonly ILogger<RemoteGitRepoHelper> _logger = logger;
+    private readonly string _repoUri = remoteRepoUrl;
+
+    /// <inheritdoc />
+    public Task CreateRemoteBranchAsync(string newBranch, string baseBranch)
+    {
+        _logger.LogInformation(
+            "Creating new remote branch {BranchName} based on {BaseBranch} on remote",
+            newBranch, baseBranch);
+        return _remoteGitRepo.CreateBranchAsync(_repoUri, newBranch, baseBranch);
+    }
+
+    /// <inheritdoc />
+    public Task<string?> GetRemoteBranchShaAsync(string branch) =>
+        _remoteGitRepo.GetLastCommitShaAsync(_repoUri, branch);
+
+    /// <inheritdoc />
+    public Task<string> CreatePullRequestAsync(PullRequestCreationInfo request)
+    {
+        var darcPullRequest = new PullRequest
+        {
+            Title = request.Title,
+            Description = request.Body,
+            BaseBranch = request.BaseBranch,
+            HeadBranch = request.HeadBranch,
+        };
+
+        _logger.LogInformation(
+            "Creating pull request '{PrTitle}' from branch {PrHeadBranch} to {PrBaseBranch}",
+            darcPullRequest.Title, darcPullRequest.HeadBranch, darcPullRequest.BaseBranch);
+
+        return _remoteGitRepo.CreatePullRequestAsync(_repoUri, darcPullRequest);
+    }
+
+    /// <inheritdoc />
+    public Task<PullRequest> GetPullRequestInfoAsync(string pullRequestUrl) =>
+        _remoteGitRepo.GetPullRequestAsync(pullRequestUrl);
+
+    /// <inheritdoc />
+    public Task<bool> RemoteBranchExistsAsync(string branchName) =>
+        _remoteGitRepo.DoesBranchExistAsync(_repoUri, branchName);
+
+    /// <inheritdoc />
+    public Task FetchAsync() => _localGitRepo.FetchAllAsync([_repoUri]);
+}

--- a/eng/update-dependencies/Program.cs
+++ b/eng/update-dependencies/Program.cs
@@ -115,7 +115,7 @@ config.UseHost(
 
                 // Finally, this project's own Git client abstraction that abstracts over the
                 // various DarcLib implementations
-                services.AddSingleton<GitRepoHelperFactory>();
+                services.AddSingleton<IGitRepoHelperFactory, GitRepoHelperFactory>();
 
                 // Services needed for BAR build access/updates
                 services.AddSingleton<IBuildUpdaterService, BuildUpdaterService>();

--- a/eng/update-dependencies/Sync/SyncInternalReleaseCommand.cs
+++ b/eng/update-dependencies/Sync/SyncInternalReleaseCommand.cs
@@ -59,14 +59,27 @@ public sealed class SyncInternalReleaseCommand(
             return 0;
         }
 
-        // If both branches are at the same commit, then there is nothing to do.
         var sourceSha = await repo.GetRemoteBranchShaAsync(options.SourceBranch);
         var targetSha = await repo.GetRemoteBranchShaAsync(options.TargetBranch);
+
+        // If both branches are at the same commit, then there is nothing to do.
         if (sourceSha == targetSha)
         {
             _logger.LogInformation(
                 "The source branch '{SourceBranch}' and target branch '{TargetBranch}' are already in sync.",
                 options.SourceBranch, options.TargetBranch);
+            return 0;
+        }
+
+        // Determine if the target branch is an ancestor of the source branch.
+        // If so, then we can submit a fast-forward/merge pull request.
+        var targetIsAncestorOfSource = await repo.IsBranchAncestorAsync(
+            ancestorBranch: options.TargetBranch,
+            descendantBranch: options.SourceBranch);
+
+        if (targetIsAncestorOfSource)
+        {
+            // TODO: Implement fast-forward/merge PR logic.
             return 0;
         }
 

--- a/eng/update-dependencies/Sync/SyncInternalReleaseOptions.cs
+++ b/eng/update-dependencies/Sync/SyncInternalReleaseOptions.cs
@@ -11,8 +11,15 @@ public sealed record SyncInternalReleaseOptions : IOptions
     public string RemoteUrl { get; set; } = string.Empty;
     public string SourceBranch { get; set; } = string.Empty;
     public string TargetBranch { get; set; } = string.Empty;
+    public string PrBranchPrefix { get; set; } = "pr";
 
-    public static List<Option> Options => [];
+    public static List<Option> Options =>
+    [
+        new Option<string>("--pr-branch-prefix")
+        {
+            Description = "Prefix to use for branches created for pull requests",
+        }
+    ];
 
     public static List<Argument> Arguments =>
     [

--- a/tests/UpdateDependencies.Tests/LocalGitRepoHelperTests.cs
+++ b/tests/UpdateDependencies.Tests/LocalGitRepoHelperTests.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Dotnet.Docker.Git;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.Extensions.Logging;
+
+namespace UpdateDependencies.Tests;
+
+public sealed class LocalGitRepoHelperTests
+{
+    [Fact]
+    public async Task IsBranchAncestor()
+    {
+        const string AncestorBranch = "ancestor";
+        const string DescendantBranch = "descendant";
+
+        var repo = await CreateLocalRepoHelperAsync(
+            async localRepo =>
+            {
+                await localRepo.ExecuteGitCommand("init");
+
+                // Create initial commit on main branch
+                var initialFilePath = Path.Join(localRepo.Path, "initialFile.txt");
+                File.WriteAllText(initialFilePath, "");
+                await localRepo.StageAsync([initialFilePath]);
+                await localRepo.CommitAsync("Initial commit", allowEmpty: false);
+
+                // Create ancestor branch
+                await localRepo.CreateBranchAsync(AncestorBranch);
+
+                // Create descendant branch
+                await localRepo.CreateBranchAsync(DescendantBranch);
+                var newFilePath = Path.Join(localRepo.Path, "newFile.txt");
+                File.WriteAllText(newFilePath, "");
+                await localRepo.StageAsync([newFilePath]);
+                await localRepo.CommitAsync("New commit", allowEmpty: false);
+            });
+
+        // Validate that repo helper correctly identifies ancestor/descendant relationship
+        var isAncestorAsync = await repo.IsAncestorAsync(AncestorBranch, DescendantBranch);
+        isAncestorAsync.ShouldBeTrue();
+    }
+
+    private static async Task<ILocalGitRepoHelper> CreateLocalRepoHelperAsync(
+        Func<ILocalGitRepo, Task> setupLocalAsync)
+    {
+        var tempRepo = new TempRepo();
+        await setupLocalAsync(tempRepo.LocalGitRepo);
+
+        var localRepoHelper = new LocalGitRepoHelper(
+            localPath: tempRepo.LocalPath,
+            localGitRepo: tempRepo.LocalGitRepo,
+            logger: Mock.Of<ILogger<LocalGitRepoHelper>>());
+
+        return localRepoHelper;
+    }
+}

--- a/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
+++ b/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
@@ -29,6 +29,26 @@ public sealed class SyncInternalReleaseTests
     };
 
     /// <summary>
+    /// Calling the command with null or whitespace for any of the arguments should fail.
+    /// </summary>
+    [Fact]
+    public async Task WhitespaceArgumentsFails()
+    {
+        var options = new SyncInternalReleaseOptions
+        {
+            RemoteUrl = "   ",
+            SourceBranch = "   ",
+            TargetBranch = "   "
+        };
+
+        var command = new SyncInternalReleaseCommand(
+            Mock.Of<IGitRepoHelperFactory>(),
+            Mock.Of<ILogger<SyncInternalReleaseCommand>>());
+
+        await Should.ThrowAsync<ArgumentException>(() => command.ExecuteAsync(options));
+    }
+
+    /// <summary>
     /// If the source branch is an internal branch (i.e. "internal/foo"), the command should fail.
     /// Internal branches should always be the target branch of a sync operation, never the source
     /// branch.

--- a/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
+++ b/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
@@ -80,9 +80,9 @@ public sealed class SyncInternalReleaseTests
 
         // Setup:
         // Target branch does not exist on remote
-        repoMock.Setup(r => r.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(false);
+        repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(false);
         // Source branch exists on remote
-        repoMock.Setup(r => r.RemoteBranchExistsAsync(options.SourceBranch)).ReturnsAsync(true);
+        repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.SourceBranch)).ReturnsAsync(true);
 
         var command = new SyncInternalReleaseCommand(
             repoFactoryMock.Object,
@@ -92,7 +92,7 @@ public sealed class SyncInternalReleaseTests
         exitCode.ShouldBe(0);
 
         // The command should have created the target branch based off of the source branch.
-        repoMock.Verify(r => r.CreateRemoteBranchAsync(options.TargetBranch, options.SourceBranch), Times.Once);
+        repoMock.Verify(r => r.Remote.CreateRemoteBranchAsync(options.TargetBranch, options.SourceBranch), Times.Once);
     }
 
     /// <summary>
@@ -111,12 +111,12 @@ public sealed class SyncInternalReleaseTests
         repoFactoryMock.Setup(f => f.CreateAsync(options.RemoteUrl)).ReturnsAsync(repoMock.Object);
 
         // Setup: Both target and source branches exist on remote.
-        repoMock.Setup(r => r.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(true);
-        repoMock.Setup(r => r.RemoteBranchExistsAsync(options.SourceBranch)).ReturnsAsync(true);
+        repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(true);
+        repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.SourceBranch)).ReturnsAsync(true);
         // They point to the same commit.
         const string Sha = "0000000000000000000000000000000000000001";
-        repoMock.Setup(r => r.GetRemoteBranchShaAsync(options.TargetBranch)).ReturnsAsync(Sha);
-        repoMock.Setup(r => r.GetRemoteBranchShaAsync(options.SourceBranch)).ReturnsAsync(Sha);
+        repoMock.Setup(r => r.Remote.GetRemoteBranchShaAsync(options.TargetBranch)).ReturnsAsync(Sha);
+        repoMock.Setup(r => r.Remote.GetRemoteBranchShaAsync(options.SourceBranch)).ReturnsAsync(Sha);
         repoMock.Setup(r => r.Dispose());
 
         var command = new SyncInternalReleaseCommand(
@@ -146,15 +146,15 @@ public sealed class SyncInternalReleaseTests
         repoFactoryMock.Setup(f => f.CreateAsync(options.RemoteUrl)).ReturnsAsync(repoMock.Object);
 
         // Setup: Both target and source branches exist on remote.
-        repoMock.Setup(r => r.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(true);
-        repoMock.Setup(r => r.RemoteBranchExistsAsync(options.SourceBranch)).ReturnsAsync(true);
+        repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(true);
+        repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.SourceBranch)).ReturnsAsync(true);
 
         // They point to different commits. The target branch is behind the source branch.
         const string OldSha = "0000000000000000000000000000000000000001";
         const string NewSha = "0000000000000000000000000000000000000002";
-        repoMock.Setup(r => r.GetRemoteBranchShaAsync(options.TargetBranch)).ReturnsAsync(OldSha);
-        repoMock.Setup(r => r.GetRemoteBranchShaAsync(options.SourceBranch)).ReturnsAsync(NewSha);
-        repoMock.Setup(r => r.IsBranchAncestorAsync(options.TargetBranch, options.SourceBranch))
+        repoMock.Setup(r => r.Remote.GetRemoteBranchShaAsync(options.TargetBranch)).ReturnsAsync(OldSha);
+        repoMock.Setup(r => r.Remote.GetRemoteBranchShaAsync(options.SourceBranch)).ReturnsAsync(NewSha);
+        repoMock.Setup(r => r.Local.IsAncestorAsync(options.TargetBranch, options.SourceBranch))
             .ReturnsAsync(true);
 
         var command = new SyncInternalReleaseCommand(

--- a/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
+++ b/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
@@ -129,4 +129,13 @@ public sealed class SyncInternalReleaseTests
         // Command should not have done anything else that we didn't expect.
         repoMock.VerifyAll();
     }
+
+    /// <summary>
+    /// If the target branch is a direct ancestor of source branch, then we
+    /// should submit a pull request containing the missing commits.
+    /// </summary>
+    [Fact]
+    public async Task FastForward()
+    {
+    }
 }

--- a/tests/UpdateDependencies.Tests/TempRepo.cs
+++ b/tests/UpdateDependencies.Tests/TempRepo.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Common;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace UpdateDependencies.Tests;
+
+/// <summary>
+/// A temporary Git repository for testing purposes.
+/// </summary>
+internal sealed class TempRepo : IDisposable
+{
+    public TempRepo()
+    {
+        Directory.CreateDirectory(LocalPath);
+
+        // Create a temp repo that can be used for testing commands using a real git process
+        var logger = Mock.Of<ILogger>();
+        var processManager = new ProcessManager(logger, "git");
+        var git = new LocalGitClient(
+            Mock.Of<IRemoteTokenProvider>(),
+            Mock.Of<ITelemetryRecorder>(),
+            processManager,
+            new FileSystem(),
+            logger);
+        var localGitRepoFactory = new LocalGitRepoFactory(git, processManager);
+
+        LocalGitRepo = localGitRepoFactory.Create(new NativePath(LocalPath));
+    }
+
+    public string LocalPath { get; } = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    public ILocalGitRepo LocalGitRepo { get; }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(LocalPath, true);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            // Good, it's already gone
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #6668. Commits should be reviewable individually.

If the **internal/release/*** branch is behind the **release/*** branch in history, then create a new branch based off of **release/*** and submit a pull request targeting **internal/release/***.

Example pull request: https://dev.azure.com/dnceng/internal/_git/dotnet-docker-tools-internal/pullrequest/53787 [internal link]

The changeset looks larger than it actually is because I needed to split the **GitRepoHelper** class into **LocalGitRepoHelper** and **RemoteGitRepoHelper**. I chose to do this so that they could be mocked separately - I needed to ensure that the branch ancestry behavior works properly in a real (not mocked) git repo.

I define "remote" operations as those that reach out to the internet, even those that use a local git client instead of an API call. For example, `git fetch` would be a remote operation. This separation means we could use a real LocalGitRepoHelper and a mock RemoteGitRepoHelper at the same time in tests.

A few methods needed to use both local and remote functions - those stay on **GitRepoHelper**.