### PR TITLE
Record internal build version when using --internal flag

### DIFF
--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -1,12 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using System.Text;
-using System.Linq;
 
 namespace Dotnet.Docker;
 

--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -48,6 +48,9 @@ internal partial class FromStagingPipelineCommand(
         string dotnetProductVersion = VersionHelper.ResolveProductVersion(releaseConfig.RuntimeBuild);
         string dockerfileVersion = VersionHelper.ResolveMajorMinorVersion(releaseConfig.RuntimeBuild).ToString();
 
+        // Record pipeline run ID for this dockerfileVersion, for later use by sync-internal-release command
+        RecordInternalVersion(dockerfileVersion, options.StagingPipelineRunId.ToString());
+
         var productVersions = (options.Internal, releaseConfig.SdkOnly) switch
         {
             // SDK-only internal/staging release
@@ -109,6 +112,59 @@ internal partial class FromStagingPipelineCommand(
         };
 
         return await updateDependencies.ExecuteAsync(updateDependenciesOptions);
+    }
+
+    /// <summary>
+    /// Records the staging pipeline run ID in an easy to parse format. This
+    /// can be used by the sync-internal-release pipeline to record and
+    /// re-apply the same staging builds after resetting the state of the repo
+    /// to match the public release branch.
+    /// </summary>
+    /// <remarks>
+    /// This will only store one staging pipeline run ID per dockerfileVersion
+    /// </remarks>
+    /// <param name="dockerfileVersion">major-minor version</param>
+    /// <param name="stagingPipelineRunId">the build ID of the staging pipeline run</param>
+    private void RecordInternalVersion(string dockerfileVersion, string stagingPipelineRunId)
+    {
+        const string InternalVersionsFile = "internal-versions.txt";
+
+        // Internal versions file should have one line per dockerfileVersion
+        // Each line should be formatted as: <dockerfileVersion>=<stagingPipelineRunId>
+        //
+        // The preferable way to do this would be to record the version in
+        // manifest.versions.json, however that would require one of the following:
+        // 1) round-trip serialization, which would remove any whitespace/blank lines - which are
+        //    important for keeping the file readable and reducing git merge conflicts
+        // 2) lots of regex JSON manipulation which is error-prone and harder to maintain
+        //
+        // So for now, the separate file and format is a compromise.
+
+        var versionsFilePath = Path.GetFullPath(SpecificCommand.VersionsFilename);
+        var versionsFileDir = Path.GetDirectoryName(versionsFilePath) ?? "";
+        var internalVersionFile = Path.Combine(versionsFileDir, InternalVersionsFile);
+        Dictionary<string, string> versions = [];
+
+        _logger.LogInformation(
+            "Recording staging pipeline build ID in {internalVersionFile}",
+            internalVersionFile);
+
+        try
+        {
+            // File already exists - read existing versions
+            versions = File.ReadAllLines(internalVersionFile)
+                .Select(line => line.Split('=', 2))
+                .Where(parts => parts.Length == 2)
+                .ToDictionary(parts => parts[0], parts => parts[1]);
+        }
+        catch (FileNotFoundException)
+        {
+            // File doesn't exist - it will be created
+        }
+
+        versions[dockerfileVersion] = stagingPipelineRunId;
+        var versionLines = versions.Select(kv => $"{kv.Key}={kv.Value}");
+        File.WriteAllLines(internalVersionFile, versionLines);
     }
 
     /// <summary>

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Dotnet.Docker</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of https://github.com/dotnet/dotnet-docker-internal/issues/6741.

It's described pretty well in the code change, but we need to record all internal versions that we apply to the repo so that we can rewind and replay updates whenever we need to update the internal/release branch. Using this method will avoid merge conflicts.