### PR TITLE
Do not run PR validation of .NET images when `eng/update-dependencies` is changed

### DIFF
--- a/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr-no-cache.yml
@@ -7,6 +7,8 @@ pr:
     include:
     - eng/*
     - tests/*
+    exclude:
+    - eng/update-dependencies
 
 variables:
 - template: /eng/pipelines/variables/core-unofficial.yml

--- a/eng/pipelines/dotnet-core-nightly-pr.yml
+++ b/eng/pipelines/dotnet-core-nightly-pr.yml
@@ -10,6 +10,8 @@ pr:
     - eng/*
     - src/*
     - tests/*
+    exclude:
+    - eng/update-dependencies
 
 variables:
 - template: /eng/pipelines/variables/core-unofficial.yml

--- a/eng/pipelines/dotnet-core-pr.yml
+++ b/eng/pipelines/dotnet-core-pr.yml
@@ -11,6 +11,8 @@ pr:
     - eng/*
     - src/*
     - tests/*
+    exclude:
+    - eng/update-dependencies
 
 variables:
 - template: /eng/pipelines/variables/core-official.yml@self

--- a/eng/pipelines/dotnet-core-samples-pr.yml
+++ b/eng/pipelines/dotnet-core-samples-pr.yml
@@ -10,6 +10,8 @@ pr:
     - eng/*
     - samples/*
     - tests/*
+    exclude:
+    - eng/update-dependencies
 
 variables:
 - template: /eng/pipelines/variables/samples.yml@self


### PR DESCRIPTION
At no point during an official build, test, or publish is the update-dependencies project used. We can save on compute and decrease PR validation time by not running the .NET images PR validation pipelines when we make changes in `eng/update-dependencies`.