### PR TITLE
Implement sync-internal-release unofficial and official pipelines

### DIFF
--- a/eng/pipelines/pipelines/sync-internal-release.yml
+++ b/eng/pipelines/pipelines/sync-internal-release.yml
@@ -1,0 +1,57 @@
+parameters:
+# Service connection used to push new branches and submit pull requests.
+- name: serviceConnection
+  type: string
+# The branch that changes will be pulled from.
+- name: sourceBranch
+  type: string
+# The branch that needs to be updated with changes from sourceBranch.
+# If this branch doesn't exist, it will be created. Otherwise, a pull request
+# will be created targeting this branch.
+- name: targetBranch
+  type: string
+
+extends:
+  template: /eng/common/templates/1es.yml@self
+  parameters:
+    stages:
+    - stage: SyncReleaseBranchesStage
+      displayName: Sync Release Branches
+
+      jobs:
+      - job: SyncReleaseBranchesJob
+        displayName: Sync Release Branches
+        pool:
+          name: $(default1ESInternalPoolName)
+          image: $(default1ESInternalPoolImage)
+          os: linux
+
+        steps:
+        - checkout: self
+          fetchDepth: 1
+
+        - template: /eng/pipelines/steps/install-dotnet.yml@self
+
+        - task: AzureCLI@2
+          displayName: Sync Release Branches
+          inputs:
+            # Used to push new, non-protected branches and submit pull requests.
+            azureSubscription: "${{ parameters.serviceConnection }}"
+            scriptType: "pscore"
+            scriptLocation: "inlineScript"
+            addSpnToEnvironment: true
+            inlineScript: >-
+              dotnet run --configuration Release --project ./eng/update-dependencies/update-dependencies.csproj --
+              sync-internal-release
+              --azdo-organization "$env:SYSTEM_COLLECTIONURI"
+              --azdo-project "$env:SYSTEM_TEAMPROJECT"
+              --azdo-repo "$env:BUILD_REPOSITORY_NAME"
+              --source-branch "${{ parameters.sourceBranch }}"
+              --target-branch "${{ parameters.targetBranch }}"
+              --pr-branch-prefix "pr"
+              --user "$env:DOTNETDOCKERBOT_USERNAME"
+              --email "$env:DOTNETDOCKERBOT_EMAIL"
+              --staging-storage-account "dotnetstage"
+          env:
+            # Used to download build artifacts containing .NET version information.
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/pipelines/sync-internal-release-official.yml
+++ b/eng/pipelines/sync-internal-release-official.yml
@@ -1,0 +1,27 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - release/*
+pr: none
+
+variables:
+- template: /eng/common/templates/variables/dotnet/common.yml@self
+- group: DotNet-Docker-Common-2
+# Always run unofficial pipelines in debug mode
+- name: "System.Debug"
+  value: true
+  readonly: true
+
+extends:
+  template: /eng/pipelines/pipelines/sync-internal-release.yml@self
+  parameters:
+    # Source branch will always be a release/* branch due to the pipeline trigger above
+    sourceBranch: "$(Build.SourceBranchName)"
+    # Target branch should be the internal version of the release branch
+    targetBranch: "internal/$(Build.SourceBranchName)"
+    # Service connection used to push new branches and submit pull requests.
+    # The "test" service connection works here in the official pipeline because
+    # we don't need to force push to protected branches. This pipeline only
+    # submits pull requests to them.
+    serviceConnection: "$(updateDepsInt-test.serviceConnectionName)"

--- a/eng/pipelines/sync-internal-release-unofficial.yml
+++ b/eng/pipelines/sync-internal-release-unofficial.yml
@@ -12,6 +12,10 @@ parameters:
 variables:
 - template: /eng/common/templates/variables/dotnet/common.yml@self
 - group: DotNet-Docker-Common-2
+# Always run unofficial pipelines in debug mode
+- name: "System.Debug"
+  value: true
+  readonly: true
 
 extends:
   template: /eng/common/templates/1es.yml@self

--- a/eng/pipelines/sync-internal-release-unofficial.yml
+++ b/eng/pipelines/sync-internal-release-unofficial.yml
@@ -40,6 +40,7 @@ extends:
             azureSubscription: "$(updateDepsInt-test.serviceConnectionName)"
             scriptType: "pscore"
             scriptLocation: "inlineScript"
+            addSpnToEnvironment: true
             inlineScript: >-
               dotnet run --configuration Release --project ./eng/update-dependencies/update-dependencies.csproj --
               sync-internal-release

--- a/eng/pipelines/sync-internal-release-unofficial.yml
+++ b/eng/pipelines/sync-internal-release-unofficial.yml
@@ -41,6 +41,7 @@ extends:
         - task: AzureCLI@2
           displayName: Sync Release Branches
           inputs:
+            # Used to push new, non-protected branches and submit pull requests.
             azureSubscription: "$(updateDepsInt-test.serviceConnectionName)"
             scriptType: "pscore"
             scriptLocation: "inlineScript"
@@ -58,5 +59,5 @@ extends:
               --email "$env:DOTNETDOCKERBOT_EMAIL"
               --staging-storage-account "dotnetstage"
           env:
-            # Used to authenticate to Azure DevOps
+            # Used to download build artifacts containing .NET version information.
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/pipelines/sync-internal-release-unofficial.yml
+++ b/eng/pipelines/sync-internal-release-unofficial.yml
@@ -57,3 +57,6 @@ extends:
               --user "$env:DOTNETDOCKERBOT_USERNAME"
               --email "$env:DOTNETDOCKERBOT_EMAIL"
               --staging-storage-account "dotnetstage"
+          env:
+            # Used to authenticate to Azure DevOps
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/pipelines/sync-internal-release-unofficial.yml
+++ b/eng/pipelines/sync-internal-release-unofficial.yml
@@ -34,7 +34,7 @@ extends:
 
         steps:
         - checkout: self
-          fetchDepth: 0
+          fetchDepth: 1
 
         - template: /eng/pipelines/steps/install-dotnet.yml@self
 

--- a/eng/pipelines/sync-internal-release-unofficial.yml
+++ b/eng/pipelines/sync-internal-release-unofficial.yml
@@ -18,46 +18,9 @@ variables:
   readonly: true
 
 extends:
-  template: /eng/common/templates/1es.yml@self
+  template: /eng/pipelines/pipelines/sync-internal-release.yml@self
   parameters:
-    stages:
-    - stage: SyncReleaseBranchesStage
-      displayName: Sync Release Branches
-
-      jobs:
-      - job: SyncReleaseBranchesJob
-        displayName: Sync Release Branches
-        pool:
-          name: $(default1ESInternalPoolName)
-          image: $(default1ESInternalPoolImage)
-          os: linux
-
-        steps:
-        - checkout: self
-          fetchDepth: 1
-
-        - template: /eng/pipelines/steps/install-dotnet.yml@self
-
-        - task: AzureCLI@2
-          displayName: Sync Release Branches
-          inputs:
-            # Used to push new, non-protected branches and submit pull requests.
-            azureSubscription: "$(updateDepsInt-test.serviceConnectionName)"
-            scriptType: "pscore"
-            scriptLocation: "inlineScript"
-            addSpnToEnvironment: true
-            inlineScript: >-
-              dotnet run --configuration Release --project ./eng/update-dependencies/update-dependencies.csproj --
-              sync-internal-release
-              --azdo-organization "$env:SYSTEM_COLLECTIONURI"
-              --azdo-project "$env:SYSTEM_TEAMPROJECT"
-              --azdo-repo "$env:BUILD_REPOSITORY_NAME"
-              --source-branch "${{ parameters.sourceBranch }}"
-              --target-branch "${{ parameters.targetBranch }}"
-              --pr-branch-prefix "pr"
-              --user "$env:DOTNETDOCKERBOT_USERNAME"
-              --email "$env:DOTNETDOCKERBOT_EMAIL"
-              --staging-storage-account "dotnetstage"
-          env:
-            # Used to download build artifacts containing .NET version information.
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    sourceBranch: ${{ parameters.sourceBranch }}
+    targetBranch: ${{ parameters.targetBranch }}
+    # Service connection used to push new branches and submit pull requests.
+    serviceConnection: "$(updateDepsInt-test.serviceConnectionName)"

--- a/eng/pipelines/sync-internal-release-unofficial.yml
+++ b/eng/pipelines/sync-internal-release-unofficial.yml
@@ -41,9 +41,14 @@ extends:
             scriptType: "pscore"
             scriptLocation: "inlineScript"
             inlineScript: >-
-              dotnet run --project eng/update-dependencies/update-dependencies.csproj --
+              dotnet run --configuration Release --project ./eng/update-dependencies/update-dependencies.csproj --
               sync-internal-release
-              --pr-branch-prefix pr/unofficial
-              $(Build.Repository.Uri)
-              ${{ parameters.sourceBranch }}
-              ${{ parameters.targetBranch }}
+              --azdo-organization "$env:SYSTEM_COLLECTIONURI"
+              --azdo-project "$env:SYSTEM_TEAMPROJECT"
+              --azdo-repo "$env:BUILD_REPOSITORY_NAME"
+              --source-branch "${{ parameters.sourceBranch }}"
+              --target-branch "${{ parameters.targetBranch }}"
+              --pr-branch-prefix "pr"
+              --user "$env:DOTNETDOCKERBOT_USERNAME"
+              --email "$env:DOTNETDOCKERBOT_EMAIL"
+              --staging-storage-account "dotnetstage"


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-docker-internal/issues/6741.

The unofficial version of the pipeline allows you to specify the source and target branch for testing purposes. The official pipeline automatically triggers when the public `release/*` branch is updated and updates (via pull request) the corresponding `internal/release/*` branch.

Example successful unofficial pipeline runs:
- build#2807907
- build#2807923

I think that the official pipeline will likely run into an issue with creating the `internal/release/*` branch initially since it should be protected, but it's hard to know without letting it run.