### PR TITLE
Move Alpine floating tags from 3.21 to 3.22

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -100,10 +100,10 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-azurelinux3.0-distroless-composite-amd64, 10.0-azurelinux3.0-distroless-composite-amd64, 10.0.0-rc.2-azurelinux3.0-distroless-composite, 10.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/10.0/azurelinux3.0-distroless-composite/amd64/Dockerfile) | Azure Linux 3.0
 10.0.0-rc.2-azurelinux3.0-distroless-composite-extra-amd64, 10.0-azurelinux3.0-distroless-composite-extra-amd64, 10.0.0-rc.2-azurelinux3.0-distroless-composite-extra, 10.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/10.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile) | Azure Linux 3.0
 9.0.9-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/aspnet/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.9-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.21-composite-amd64, 9.0-alpine3.21-composite-amd64, 9.0-alpine-composite-amd64, 9.0.9-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/aspnet/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-9.0.9-alpine3.22-composite-amd64, 9.0-alpine3.22-composite-amd64, 9.0.9-alpine3.22-composite, 9.0-alpine3.22-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.21-composite-amd64, 9.0-alpine3.21-composite-amd64, 9.0.9-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.22-composite-amd64, 9.0-alpine3.22-composite-amd64, 9.0-alpine-composite-amd64, 9.0.9-alpine3.22-composite, 9.0-alpine3.22-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
 9.0.9-noble-amd64, 9.0-noble-amd64, 9.0.9-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -115,10 +115,10 @@ Tags | Dockerfile | OS Version
 9.0.9-azurelinux3.0-distroless-composite-amd64, 9.0-azurelinux3.0-distroless-composite-amd64, 9.0.9-azurelinux3.0-distroless-composite, 9.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite/amd64/Dockerfile) | Azure Linux 3.0
 9.0.9-azurelinux3.0-distroless-composite-extra-amd64, 9.0-azurelinux3.0-distroless-composite-extra-amd64, 9.0.9-azurelinux3.0-distroless-composite-extra, 9.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.20-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.20-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.21-composite-amd64, 8.0-alpine3.21-composite-amd64, 8.0-alpine-composite-amd64, 8.0.20-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/aspnet/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-8.0.20-alpine3.22-composite-amd64, 8.0-alpine3.22-composite-amd64, 8.0.20-alpine3.22-composite, 8.0-alpine3.22-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.21-composite-amd64, 8.0-alpine3.21-composite-amd64, 8.0.20-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/amd64/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.22-composite-amd64, 8.0-alpine3.22-composite-amd64, 8.0-alpine-composite-amd64, 8.0.20-alpine3.22-composite, 8.0-alpine3.22-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/amd64/Dockerfile) | Alpine 3.22
 8.0.20-noble-amd64, 8.0-noble-amd64, 8.0.20-noble, 8.0-noble | [Dockerfile](src/aspnet/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.20-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/aspnet/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.20-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/aspnet/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -152,10 +152,10 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-azurelinux3.0-distroless-composite-arm64v8, 10.0-azurelinux3.0-distroless-composite-arm64v8, 10.0.0-rc.2-azurelinux3.0-distroless-composite, 10.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/10.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile) | Azure Linux 3.0
 10.0.0-rc.2-azurelinux3.0-distroless-composite-extra-arm64v8, 10.0-azurelinux3.0-distroless-composite-extra-arm64v8, 10.0.0-rc.2-azurelinux3.0-distroless-composite-extra, 10.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/10.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.9-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/aspnet/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.9-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.21-composite-arm64v8, 9.0-alpine3.21-composite-arm64v8, 9.0-alpine-composite-arm64v8, 9.0.9-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/aspnet/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-9.0.9-alpine3.22-composite-arm64v8, 9.0-alpine3.22-composite-arm64v8, 9.0.9-alpine3.22-composite, 9.0-alpine3.22-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.21-composite-arm64v8, 9.0-alpine3.21-composite-arm64v8, 9.0.9-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.22-composite-arm64v8, 9.0-alpine3.22-composite-arm64v8, 9.0-alpine-composite-arm64v8, 9.0.9-alpine3.22-composite, 9.0-alpine3.22-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
 9.0.9-noble-arm64v8, 9.0-noble-arm64v8, 9.0.9-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -167,10 +167,10 @@ Tags | Dockerfile | OS Version
 9.0.9-azurelinux3.0-distroless-composite-arm64v8, 9.0-azurelinux3.0-distroless-composite-arm64v8, 9.0.9-azurelinux3.0-distroless-composite, 9.0-azurelinux3.0-distroless-composite | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.9-azurelinux3.0-distroless-composite-extra-arm64v8, 9.0-azurelinux3.0-distroless-composite-extra-arm64v8, 9.0.9-azurelinux3.0-distroless-composite-extra, 9.0-azurelinux3.0-distroless-composite-extra | [Dockerfile](src/aspnet/9.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.20-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.20-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.21-composite-arm64v8, 8.0-alpine3.21-composite-arm64v8, 8.0-alpine-composite-arm64v8, 8.0.20-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/aspnet/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-8.0.20-alpine3.22-composite-arm64v8, 8.0-alpine3.22-composite-arm64v8, 8.0.20-alpine3.22-composite, 8.0-alpine3.22-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.21-composite-arm64v8, 8.0-alpine3.21-composite-arm64v8, 8.0.20-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm64v8/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.22-composite-arm64v8, 8.0-alpine3.22-composite-arm64v8, 8.0-alpine-composite-arm64v8, 8.0.20-alpine3.22-composite, 8.0-alpine3.22-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm64v8/Dockerfile) | Alpine 3.22
 8.0.20-noble-arm64v8, 8.0-noble-arm64v8, 8.0.20-noble, 8.0-noble | [Dockerfile](src/aspnet/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.20-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/aspnet/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.20-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/aspnet/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -199,20 +199,20 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-alpine3.22-arm32v7, 10.0-alpine3.22-arm32v7, 10.0-alpine-arm32v7, 10.0.0-rc.2-alpine3.22, 10.0-alpine3.22, 10.0-alpine | [Dockerfile](src/aspnet/10.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 10.0.0-rc.2-alpine3.22-composite-arm32v7, 10.0-alpine3.22-composite-arm32v7, 10.0-alpine-composite-arm32v7, 10.0.0-rc.2-alpine3.22-composite, 10.0-alpine3.22-composite, 10.0-alpine-composite | [Dockerfile](src/aspnet/10.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
 9.0.9-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/aspnet/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.9-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.21-composite-arm32v7, 9.0-alpine3.21-composite-arm32v7, 9.0-alpine-composite-arm32v7, 9.0.9-alpine3.21-composite, 9.0-alpine3.21-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/aspnet/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-9.0.9-alpine3.22-composite-arm32v7, 9.0-alpine3.22-composite-arm32v7, 9.0.9-alpine3.22-composite, 9.0-alpine3.22-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/aspnet/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.21-composite-arm32v7, 9.0-alpine3.21-composite-arm32v7, 9.0.9-alpine3.21-composite, 9.0-alpine3.21-composite | [Dockerfile](src/aspnet/9.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/aspnet/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.22-composite-arm32v7, 9.0-alpine3.22-composite-arm32v7, 9.0-alpine-composite-arm32v7, 9.0.9-alpine3.22-composite, 9.0-alpine3.22-composite, 9.0-alpine-composite | [Dockerfile](src/aspnet/9.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
 9.0.9-noble-arm32v7, 9.0-noble-arm32v7, 9.0.9-noble, 9.0-noble | [Dockerfile](src/aspnet/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/aspnet/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-composite-arm32v7, 9.0-noble-chiseled-composite-arm32v7, 9.0.9-noble-chiseled-composite, 9.0-noble-chiseled-composite | [Dockerfile](src/aspnet/9.0/noble-chiseled-composite/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-composite-extra-arm32v7, 9.0-noble-chiseled-composite-extra-arm32v7, 9.0.9-noble-chiseled-composite-extra, 9.0-noble-chiseled-composite-extra | [Dockerfile](src/aspnet/9.0/noble-chiseled-composite-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.20-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/aspnet/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.20-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.21-composite-arm32v7, 8.0-alpine3.21-composite-arm32v7, 8.0-alpine-composite-arm32v7, 8.0.20-alpine3.21-composite, 8.0-alpine3.21-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/aspnet/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-8.0.20-alpine3.22-composite-arm32v7, 8.0-alpine3.22-composite-arm32v7, 8.0.20-alpine3.22-composite, 8.0-alpine3.22-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/aspnet/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.21-composite-arm32v7, 8.0-alpine3.21-composite-arm32v7, 8.0.20-alpine3.21-composite, 8.0-alpine3.21-composite | [Dockerfile](src/aspnet/8.0/alpine3.21-composite/arm32v7/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/aspnet/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.22-composite-arm32v7, 8.0-alpine3.22-composite-arm32v7, 8.0-alpine-composite-arm32v7, 8.0.20-alpine3.22-composite, 8.0-alpine3.22-composite, 8.0-alpine-composite | [Dockerfile](src/aspnet/8.0/alpine3.22-composite/arm32v7/Dockerfile) | Alpine 3.22
 8.0.20-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.20-jammy, 8.0-jammy | [Dockerfile](src/aspnet/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.20-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.20-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/aspnet/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.20-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.20-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/aspnet/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -78,10 +78,10 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-azurelinux3.0-distroless-amd64, 10.0-azurelinux3.0-distroless-amd64, 10.0.0-rc.2-azurelinux3.0-distroless, 10.0-azurelinux3.0-distroless | [Dockerfile](src/runtime-deps/10.0/azurelinux3.0-distroless/amd64/Dockerfile) | Azure Linux 3.0
 10.0.0-rc.2-azurelinux3.0-distroless-extra-amd64, 10.0-azurelinux3.0-distroless-extra-amd64, 10.0.0-rc.2-azurelinux3.0-distroless-extra, 10.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/10.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 9.0.9-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.9-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.21-extra-amd64, 9.0-alpine3.21-extra-amd64, 9.0-alpine-extra-amd64, 9.0.9-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime-deps/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-9.0.9-alpine3.22-extra-amd64, 9.0-alpine3.22-extra-amd64, 9.0.9-alpine3.22-extra, 9.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.21-extra-amd64, 9.0-alpine3.21-extra-amd64, 9.0.9-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.22-extra-amd64, 9.0-alpine3.22-extra-amd64, 9.0-alpine-extra-amd64, 9.0.9-alpine3.22-extra, 9.0-alpine3.22-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
 9.0.9-noble-amd64, 9.0-noble-amd64, 9.0.9-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -89,10 +89,10 @@ Tags | Dockerfile | OS Version
 9.0.9-azurelinux3.0-distroless-amd64, 9.0-azurelinux3.0-distroless-amd64, 9.0.9-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless/amd64/Dockerfile) | Azure Linux 3.0
 9.0.9-azurelinux3.0-distroless-extra-amd64, 9.0-azurelinux3.0-distroless-extra-amd64, 9.0.9-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.20-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.20-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.21-extra-amd64, 8.0-alpine3.21-extra-amd64, 8.0-alpine-extra-amd64, 8.0.20-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime-deps/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
-8.0.20-alpine3.22-extra-amd64, 8.0-alpine3.22-extra-amd64, 8.0.20-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.21-extra-amd64, 8.0-alpine3.21-extra-amd64, 8.0.20-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/amd64/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.22-extra-amd64, 8.0-alpine3.22-extra-amd64, 8.0-alpine-extra-amd64, 8.0.20-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/amd64/Dockerfile) | Alpine 3.22
 8.0.20-noble-amd64, 8.0-noble-amd64, 8.0.20-noble, 8.0-noble | [Dockerfile](src/runtime-deps/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.20-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime-deps/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.20-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -116,10 +116,10 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-azurelinux3.0-distroless-arm64v8, 10.0-azurelinux3.0-distroless-arm64v8, 10.0.0-rc.2-azurelinux3.0-distroless, 10.0-azurelinux3.0-distroless | [Dockerfile](src/runtime-deps/10.0/azurelinux3.0-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 10.0.0-rc.2-azurelinux3.0-distroless-extra-arm64v8, 10.0-azurelinux3.0-distroless-extra-arm64v8, 10.0.0-rc.2-azurelinux3.0-distroless-extra, 10.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/10.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.9-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.9-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.21-extra-arm64v8, 9.0-alpine3.21-extra-arm64v8, 9.0-alpine-extra-arm64v8, 9.0.9-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-9.0.9-alpine3.22-extra-arm64v8, 9.0-alpine3.22-extra-arm64v8, 9.0.9-alpine3.22-extra, 9.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.21-extra-arm64v8, 9.0-alpine3.21-extra-arm64v8, 9.0.9-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.22-extra-arm64v8, 9.0-alpine3.22-extra-arm64v8, 9.0-alpine-extra-arm64v8, 9.0.9-alpine3.22-extra, 9.0-alpine3.22-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
 9.0.9-noble-arm64v8, 9.0-noble-arm64v8, 9.0.9-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -127,10 +127,10 @@ Tags | Dockerfile | OS Version
 9.0.9-azurelinux3.0-distroless-arm64v8, 9.0-azurelinux3.0-distroless-arm64v8, 9.0.9-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.9-azurelinux3.0-distroless-extra-arm64v8, 9.0-azurelinux3.0-distroless-extra-arm64v8, 9.0.9-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime-deps/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.20-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.20-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.21-extra-arm64v8, 8.0-alpine3.21-extra-arm64v8, 8.0-alpine-extra-arm64v8, 8.0.20-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
-8.0.20-alpine3.22-extra-arm64v8, 8.0-alpine3.22-extra-arm64v8, 8.0.20-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.21-extra-arm64v8, 8.0-alpine3.21-extra-arm64v8, 8.0.20-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm64v8/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.22-extra-arm64v8, 8.0-alpine3.22-extra-arm64v8, 8.0-alpine-extra-arm64v8, 8.0.20-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm64v8/Dockerfile) | Alpine 3.22
 8.0.20-noble-arm64v8, 8.0-noble-arm64v8, 8.0.20-noble, 8.0-noble | [Dockerfile](src/runtime-deps/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.20-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime-deps/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.20-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -151,18 +151,18 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-alpine3.22-arm32v7, 10.0-alpine3.22-arm32v7, 10.0-alpine-arm32v7, 10.0.0-rc.2-alpine3.22, 10.0-alpine3.22, 10.0-alpine | [Dockerfile](src/runtime-deps/10.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 10.0.0-rc.2-alpine3.22-extra-arm32v7, 10.0-alpine3.22-extra-arm32v7, 10.0-alpine-extra-arm32v7, 10.0.0-rc.2-alpine3.22-extra, 10.0-alpine3.22-extra, 10.0-alpine-extra | [Dockerfile](src/runtime-deps/10.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
 9.0.9-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/runtime-deps/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.9-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.21-extra-arm32v7, 9.0-alpine3.21-extra-arm32v7, 9.0-alpine-extra-arm32v7, 9.0.9-alpine3.21-extra, 9.0-alpine3.21-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-9.0.9-alpine3.22-extra-arm32v7, 9.0-alpine3.22-extra-arm32v7, 9.0.9-alpine3.22-extra, 9.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime-deps/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.21-extra-arm32v7, 9.0-alpine3.21-extra-arm32v7, 9.0.9-alpine3.21-extra, 9.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime-deps/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.22-extra-arm32v7, 9.0-alpine3.22-extra-arm32v7, 9.0-alpine-extra-arm32v7, 9.0.9-alpine3.22-extra, 9.0-alpine3.22-extra, 9.0-alpine-extra | [Dockerfile](src/runtime-deps/9.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
 9.0.9-noble-arm32v7, 9.0-noble-arm32v7, 9.0.9-noble, 9.0-noble | [Dockerfile](src/runtime-deps/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime-deps/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime-deps/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.20-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/runtime-deps/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.20-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.21-extra-arm32v7, 8.0-alpine3.21-extra-arm32v7, 8.0-alpine-extra-arm32v7, 8.0.20-alpine3.21-extra, 8.0-alpine3.21-extra, 8.0-alpine-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
-8.0.20-alpine3.22-extra-arm32v7, 8.0-alpine3.22-extra-arm32v7, 8.0.20-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime-deps/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.21-extra-arm32v7, 8.0-alpine3.21-extra-arm32v7, 8.0.20-alpine3.21-extra, 8.0-alpine3.21-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.21-extra/arm32v7/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime-deps/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.22-extra-arm32v7, 8.0-alpine3.22-extra-arm32v7, 8.0-alpine-extra-arm32v7, 8.0.20-alpine3.22-extra, 8.0-alpine3.22-extra | [Dockerfile](src/runtime-deps/8.0/alpine3.22-extra/arm32v7/Dockerfile) | Alpine 3.22
 8.0.20-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.20-jammy, 8.0-jammy | [Dockerfile](src/runtime-deps/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.20-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.20-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/runtime-deps/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.20-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.20-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/runtime-deps/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -84,8 +84,8 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-azurelinux3.0-distroless-amd64, 10.0-azurelinux3.0-distroless-amd64, 10.0.0-rc.2-azurelinux3.0-distroless, 10.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/10.0/azurelinux3.0-distroless/amd64/Dockerfile) | Azure Linux 3.0
 10.0.0-rc.2-azurelinux3.0-distroless-extra-amd64, 10.0-azurelinux3.0-distroless-extra-amd64, 10.0.0-rc.2-azurelinux3.0-distroless-extra, 10.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/10.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 9.0.9-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/runtime/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.9-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 9.0.9-noble-amd64, 9.0-noble-amd64, 9.0.9-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-amd64, 9.0-noble-chiseled-amd64, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-amd64, 9.0-noble-chiseled-extra-amd64, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -93,8 +93,8 @@ Tags | Dockerfile | OS Version
 9.0.9-azurelinux3.0-distroless-amd64, 9.0-azurelinux3.0-distroless-amd64, 9.0.9-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless/amd64/Dockerfile) | Azure Linux 3.0
 9.0.9-azurelinux3.0-distroless-extra-amd64, 9.0-azurelinux3.0-distroless-extra-amd64, 9.0.9-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless-extra/amd64/Dockerfile) | Azure Linux 3.0
 8.0.20-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.20-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 8.0.20-noble-amd64, 8.0-noble-amd64, 8.0.20-noble, 8.0-noble | [Dockerfile](src/runtime/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-amd64, 8.0-noble-chiseled-amd64, 8.0.20-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime/8.0/noble-chiseled/amd64/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-extra-amd64, 8.0-noble-chiseled-extra-amd64, 8.0.20-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime/8.0/noble-chiseled-extra/amd64/Dockerfile) | Ubuntu 24.04
@@ -117,8 +117,8 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-azurelinux3.0-distroless-arm64v8, 10.0-azurelinux3.0-distroless-arm64v8, 10.0.0-rc.2-azurelinux3.0-distroless, 10.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/10.0/azurelinux3.0-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 10.0.0-rc.2-azurelinux3.0-distroless-extra-arm64v8, 10.0-azurelinux3.0-distroless-extra-arm64v8, 10.0.0-rc.2-azurelinux3.0-distroless-extra, 10.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/10.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.9-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/runtime/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.9-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 9.0.9-noble-arm64v8, 9.0-noble-arm64v8, 9.0.9-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-arm64v8, 9.0-noble-chiseled-arm64v8, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-arm64v8, 9.0-noble-chiseled-extra-arm64v8, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -126,8 +126,8 @@ Tags | Dockerfile | OS Version
 9.0.9-azurelinux3.0-distroless-arm64v8, 9.0-azurelinux3.0-distroless-arm64v8, 9.0.9-azurelinux3.0-distroless, 9.0-azurelinux3.0-distroless | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.9-azurelinux3.0-distroless-extra-arm64v8, 9.0-azurelinux3.0-distroless-extra-arm64v8, 9.0.9-azurelinux3.0-distroless-extra, 9.0-azurelinux3.0-distroless-extra | [Dockerfile](src/runtime/9.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.20-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.20-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 8.0.20-noble-arm64v8, 8.0-noble-arm64v8, 8.0.20-noble, 8.0-noble | [Dockerfile](src/runtime/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-arm64v8, 8.0-noble-chiseled-arm64v8, 8.0.20-noble-chiseled, 8.0-noble-chiseled | [Dockerfile](src/runtime/8.0/noble-chiseled/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.20-noble-chiseled-extra-arm64v8, 8.0-noble-chiseled-extra-arm64v8, 8.0.20-noble-chiseled-extra, 8.0-noble-chiseled-extra | [Dockerfile](src/runtime/8.0/noble-chiseled-extra/arm64v8/Dockerfile) | Ubuntu 24.04
@@ -147,14 +147,14 @@ Tags | Dockerfile | OS Version
 10.0.0-rc.2-noble-chiseled-extra-arm32v7, 10.0-noble-chiseled-extra-arm32v7, 10.0.0-rc.2-noble-chiseled-extra, 10.0-noble-chiseled-extra | [Dockerfile](src/runtime/10.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 10.0.0-rc.2-alpine3.22-arm32v7, 10.0-alpine3.22-arm32v7, 10.0-alpine-arm32v7, 10.0.0-rc.2-alpine3.22, 10.0-alpine3.22, 10.0-alpine | [Dockerfile](src/runtime/10.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 9.0.9-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.9-bookworm-slim, 9.0-bookworm-slim, 9.0.9, 9.0 | [Dockerfile](src/runtime/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.9-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.9-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.9-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.9-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/runtime/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.9-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.9-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/runtime/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.9-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.9-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/runtime/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 9.0.9-noble-arm32v7, 9.0-noble-arm32v7, 9.0.9-noble, 9.0-noble | [Dockerfile](src/runtime/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-arm32v7, 9.0-noble-chiseled-arm32v7, 9.0.9-noble-chiseled, 9.0-noble-chiseled | [Dockerfile](src/runtime/9.0/noble-chiseled/arm32v7/Dockerfile) | Ubuntu 24.04
 9.0.9-noble-chiseled-extra-arm32v7, 9.0-noble-chiseled-extra-arm32v7, 9.0.9-noble-chiseled-extra, 9.0-noble-chiseled-extra | [Dockerfile](src/runtime/9.0/noble-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.20-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.20-bookworm-slim, 8.0-bookworm-slim, 8.0.20, 8.0 | [Dockerfile](src/runtime/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.20-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.20-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.20-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.20-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/runtime/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.20-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.20-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/runtime/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.20-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.20-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/runtime/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 8.0.20-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.20-jammy, 8.0-jammy | [Dockerfile](src/runtime/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.20-jammy-chiseled-arm32v7, 8.0-jammy-chiseled-arm32v7, 8.0.20-jammy-chiseled, 8.0-jammy-chiseled | [Dockerfile](src/runtime/8.0/jammy-chiseled/arm32v7/Dockerfile) | Ubuntu 22.04
 8.0.20-jammy-chiseled-extra-arm32v7, 8.0-jammy-chiseled-extra-arm32v7, 8.0.20-jammy-chiseled-extra, 8.0-jammy-chiseled-extra | [Dockerfile](src/runtime/8.0/jammy-chiseled-extra/arm32v7/Dockerfile) | Ubuntu 22.04

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -79,13 +79,13 @@ Tags | Dockerfile | OS Version
 10.0.100-rc.2-azurelinux3.0-amd64, 10.0-azurelinux3.0-amd64, 10.0.100-rc.2-azurelinux3.0, 10.0-azurelinux3.0 | [Dockerfile](src/sdk/10.0/azurelinux3.0/amd64/Dockerfile) | Azure Linux 3.0
 10.0.100-rc.2-azurelinux3.0-aot-amd64, 10.0-azurelinux3.0-aot-amd64, 10.0.100-rc.2-azurelinux3.0-aot, 10.0-azurelinux3.0-aot | [Dockerfile](src/sdk/10.0/azurelinux3.0-aot/amd64/Dockerfile) | Azure Linux 3.0
 9.0.305-bookworm-slim-amd64, 9.0-bookworm-slim-amd64, 9.0.305-bookworm-slim, 9.0-bookworm-slim, 9.0.305, 9.0 | [Dockerfile](src/sdk/9.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-9.0.305-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0-alpine-amd64, 9.0.305-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-9.0.305-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0.305-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/sdk/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+9.0.305-alpine3.21-amd64, 9.0-alpine3.21-amd64, 9.0.305-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+9.0.305-alpine3.22-amd64, 9.0-alpine3.22-amd64, 9.0-alpine-amd64, 9.0.305-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 9.0.305-noble-amd64, 9.0-noble-amd64, 9.0.305-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 9.0.305-azurelinux3.0-amd64, 9.0-azurelinux3.0-amd64, 9.0.305-azurelinux3.0, 9.0-azurelinux3.0 | [Dockerfile](src/sdk/9.0/azurelinux3.0/amd64/Dockerfile) | Azure Linux 3.0
 8.0.414-bookworm-slim-amd64, 8.0-bookworm-slim-amd64, 8.0.414-bookworm-slim, 8.0-bookworm-slim, 8.0.414, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/amd64/Dockerfile) | Debian 12
-8.0.414-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0-alpine-amd64, 8.0.414-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
-8.0.414-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0.414-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/sdk/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
+8.0.414-alpine3.21-amd64, 8.0-alpine3.21-amd64, 8.0.414-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/amd64/Dockerfile) | Alpine 3.21
+8.0.414-alpine3.22-amd64, 8.0-alpine3.22-amd64, 8.0-alpine-amd64, 8.0.414-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.22/amd64/Dockerfile) | Alpine 3.22
 8.0.414-noble-amd64, 8.0-noble-amd64, 8.0.414-noble, 8.0-noble | [Dockerfile](src/sdk/8.0/noble/amd64/Dockerfile) | Ubuntu 24.04
 8.0.414-jammy-amd64, 8.0-jammy-amd64, 8.0.414-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/amd64/Dockerfile) | Ubuntu 22.04
 8.0.414-azurelinux3.0-amd64, 8.0-azurelinux3.0-amd64, 8.0.414-azurelinux3.0, 8.0-azurelinux3.0 | [Dockerfile](src/sdk/8.0/azurelinux3.0/amd64/Dockerfile) | Azure Linux 3.0
@@ -101,13 +101,13 @@ Tags | Dockerfile | OS Version
 10.0.100-rc.2-azurelinux3.0-arm64v8, 10.0-azurelinux3.0-arm64v8, 10.0.100-rc.2-azurelinux3.0, 10.0-azurelinux3.0 | [Dockerfile](src/sdk/10.0/azurelinux3.0/arm64v8/Dockerfile) | Azure Linux 3.0
 10.0.100-rc.2-azurelinux3.0-aot-arm64v8, 10.0-azurelinux3.0-aot-arm64v8, 10.0.100-rc.2-azurelinux3.0-aot, 10.0-azurelinux3.0-aot | [Dockerfile](src/sdk/10.0/azurelinux3.0-aot/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.305-bookworm-slim-arm64v8, 9.0-bookworm-slim-arm64v8, 9.0.305-bookworm-slim, 9.0-bookworm-slim, 9.0.305, 9.0 | [Dockerfile](src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-9.0.305-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0-alpine-arm64v8, 9.0.305-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-9.0.305-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0.305-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/sdk/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+9.0.305-alpine3.21-arm64v8, 9.0-alpine3.21-arm64v8, 9.0.305-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+9.0.305-alpine3.22-arm64v8, 9.0-alpine3.22-arm64v8, 9.0-alpine-arm64v8, 9.0.305-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 9.0.305-noble-arm64v8, 9.0-noble-arm64v8, 9.0.305-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 9.0.305-azurelinux3.0-arm64v8, 9.0-azurelinux3.0-arm64v8, 9.0.305-azurelinux3.0, 9.0-azurelinux3.0 | [Dockerfile](src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile) | Azure Linux 3.0
 8.0.414-bookworm-slim-arm64v8, 8.0-bookworm-slim-arm64v8, 8.0.414-bookworm-slim, 8.0-bookworm-slim, 8.0.414, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile) | Debian 12
-8.0.414-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0-alpine-arm64v8, 8.0.414-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
-8.0.414-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0.414-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/sdk/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
+8.0.414-alpine3.21-arm64v8, 8.0-alpine3.21-arm64v8, 8.0.414-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/arm64v8/Dockerfile) | Alpine 3.21
+8.0.414-alpine3.22-arm64v8, 8.0-alpine3.22-arm64v8, 8.0-alpine-arm64v8, 8.0.414-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.22/arm64v8/Dockerfile) | Alpine 3.22
 8.0.414-noble-arm64v8, 8.0-noble-arm64v8, 8.0.414-noble, 8.0-noble | [Dockerfile](src/sdk/8.0/noble/arm64v8/Dockerfile) | Ubuntu 24.04
 8.0.414-jammy-arm64v8, 8.0-jammy-arm64v8, 8.0.414-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/arm64v8/Dockerfile) | Ubuntu 22.04
 8.0.414-azurelinux3.0-arm64v8, 8.0-azurelinux3.0-arm64v8, 8.0.414-azurelinux3.0, 8.0-azurelinux3.0 | [Dockerfile](src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile) | Azure Linux 3.0
@@ -119,12 +119,12 @@ Tags | Dockerfile | OS Version
 10.0.100-rc.2-noble-arm32v7, 10.0-noble-arm32v7, 10.0.100-rc.2-noble, 10.0-noble, 10.0.100-rc.2, 10.0, latest | [Dockerfile](src/sdk/10.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 10.0.100-rc.2-alpine3.22-arm32v7, 10.0-alpine3.22-arm32v7, 10.0-alpine-arm32v7, 10.0.100-rc.2-alpine3.22, 10.0-alpine3.22, 10.0-alpine | [Dockerfile](src/sdk/10.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 9.0.305-bookworm-slim-arm32v7, 9.0-bookworm-slim-arm32v7, 9.0.305-bookworm-slim, 9.0-bookworm-slim, 9.0.305, 9.0 | [Dockerfile](src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-9.0.305-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0-alpine-arm32v7, 9.0.305-alpine3.21, 9.0-alpine3.21, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-9.0.305-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0.305-alpine3.22, 9.0-alpine3.22 | [Dockerfile](src/sdk/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+9.0.305-alpine3.21-arm32v7, 9.0-alpine3.21-arm32v7, 9.0.305-alpine3.21, 9.0-alpine3.21 | [Dockerfile](src/sdk/9.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+9.0.305-alpine3.22-arm32v7, 9.0-alpine3.22-arm32v7, 9.0-alpine-arm32v7, 9.0.305-alpine3.22, 9.0-alpine3.22, 9.0-alpine | [Dockerfile](src/sdk/9.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 9.0.305-noble-arm32v7, 9.0-noble-arm32v7, 9.0.305-noble, 9.0-noble | [Dockerfile](src/sdk/9.0/noble/arm32v7/Dockerfile) | Ubuntu 24.04
 8.0.414-bookworm-slim-arm32v7, 8.0-bookworm-slim-arm32v7, 8.0.414-bookworm-slim, 8.0-bookworm-slim, 8.0.414, 8.0 | [Dockerfile](src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile) | Debian 12
-8.0.414-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0-alpine-arm32v7, 8.0.414-alpine3.21, 8.0-alpine3.21, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
-8.0.414-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0.414-alpine3.22, 8.0-alpine3.22 | [Dockerfile](src/sdk/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
+8.0.414-alpine3.21-arm32v7, 8.0-alpine3.21-arm32v7, 8.0.414-alpine3.21, 8.0-alpine3.21 | [Dockerfile](src/sdk/8.0/alpine3.21/arm32v7/Dockerfile) | Alpine 3.21
+8.0.414-alpine3.22-arm32v7, 8.0-alpine3.22-arm32v7, 8.0-alpine-arm32v7, 8.0.414-alpine3.22, 8.0-alpine3.22, 8.0-alpine | [Dockerfile](src/sdk/8.0/alpine3.22/arm32v7/Dockerfile) | Alpine 3.22
 8.0.414-jammy-arm32v7, 8.0-jammy-arm32v7, 8.0.414-jammy, 8.0-jammy | [Dockerfile](src/sdk/8.0/jammy/arm32v7/Dockerfile) | Ubuntu 22.04
 
 ### Nano Server 2025 amd64 Tags

--- a/manifest.json
+++ b/manifest.json
@@ -88,8 +88,7 @@
             },
             "$(dotnet|8.0|minor-tag)-alpine3.21-aot": {
               "docType": "Undocumented"
-            },
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            }
           },
           "platforms": [
             {
@@ -105,8 +104,7 @@
                 },
                 "$(dotnet|8.0|minor-tag)-alpine3.21-aot-amd64": {
                   "docType": "Undocumented"
-                },
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                }
               }
             },
             {
@@ -123,8 +121,7 @@
                 },
                 "$(dotnet|8.0|minor-tag)-alpine3.21-aot-arm32v7": {
                   "docType": "Undocumented"
-                },
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                }
               },
               "variant": "v7"
             },
@@ -142,8 +139,7 @@
                 },
                 "$(dotnet|8.0|minor-tag)-alpine3.21-aot-arm64v8": {
                   "docType": "Undocumented"
-                },
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                }
               },
               "variant": "v8"
             }
@@ -153,8 +149,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21-extra": {},
-            "$(dotnet|8.0|minor-tag)-alpine-extra": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21-extra": {}
           },
           "platforms": [
             {
@@ -164,8 +159,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -185,8 +179,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -207,8 +200,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-extra-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -228,13 +220,11 @@
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22": {},
             "$(dotnet|8.0|minor-tag)-alpine3.22": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {},
             "$(dotnet|8.0|fixed-tag)-alpine3.22-aot": {
               "docType": "Undocumented"
             },
             "$(dotnet|8.0|minor-tag)-alpine3.22-aot": {
-              "docType": "Undocumented"
-            },
-            "$(dotnet|8.0|minor-tag)-alpine-aot": {
               "docType": "Undocumented"
             }
           },
@@ -247,6 +237,7 @@
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-amd64": {},
                 "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {},
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-aot-amd64": {
                   "docType": "Undocumented"
                 },
@@ -267,6 +258,7 @@
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm32v7": {},
                 "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {},
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-aot-arm32v7": {
                   "docType": "Undocumented"
                 },
@@ -288,6 +280,7 @@
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm64v8": {},
                 "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {},
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-aot-arm64v8": {
                   "docType": "Undocumented"
                 },
@@ -316,7 +309,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-extra-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -336,7 +330,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-extra-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -357,7 +352,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-extra-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-extra-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1175,8 +1171,7 @@
             },
             "$(dotnet|9.0|minor-tag)-alpine3.21-aot": {
               "docType": "Undocumented"
-            },
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            }
           },
           "platforms": [
             {
@@ -1192,8 +1187,7 @@
                 },
                 "$(dotnet|9.0|minor-tag)-alpine3.21-aot-amd64": {
                   "docType": "Undocumented"
-                },
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                }
               }
             },
             {
@@ -1210,8 +1204,7 @@
                 },
                 "$(dotnet|9.0|minor-tag)-alpine3.21-aot-arm32v7": {
                   "docType": "Undocumented"
-                },
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                }
               },
               "variant": "v7"
             },
@@ -1229,8 +1222,7 @@
                 },
                 "$(dotnet|9.0|minor-tag)-alpine3.21-aot-arm64v8": {
                   "docType": "Undocumented"
-                },
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                }
               },
               "variant": "v8"
             }
@@ -1240,8 +1232,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine-extra": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21-extra": {}
           },
           "platforms": [
             {
@@ -1251,8 +1242,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1272,8 +1262,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1294,8 +1283,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-extra-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -1315,6 +1303,7 @@
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22": {},
             "$(dotnet|9.0|minor-tag)-alpine3.22": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {},
             "$(dotnet|9.0|fixed-tag)-alpine3.22-aot": {
               "docType": "Undocumented"
             },
@@ -1334,6 +1323,7 @@
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-amd64": {},
                 "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {},
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-aot-amd64": {
                   "docType": "Undocumented"
                 },
@@ -1354,6 +1344,7 @@
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm32v7": {},
                 "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {},
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-aot-arm32v7": {
                   "docType": "Undocumented"
                 },
@@ -1375,6 +1366,7 @@
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm64v8": {},
                 "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {},
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-aot-arm64v8": {
                   "docType": "Undocumented"
                 },
@@ -1393,7 +1385,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22-extra": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22-extra": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22-extra": {},
+            "$(dotnet|9.0|minor-tag)-alpine-extra": {}
           },
           "platforms": [
             {
@@ -1403,7 +1396,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-extra-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-amd64": {}
               },
               "customBuildLegGroups": [
                 {
@@ -1423,7 +1417,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-extra-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-arm32v7": {}
               },
               "variant": "v7",
               "customBuildLegGroups": [
@@ -1444,7 +1439,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-extra-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-extra-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-extra-arm64v8": {}
               },
               "variant": "v8",
               "customBuildLegGroups": [
@@ -2356,8 +2352,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
           },
           "platforms": [
             {
@@ -2370,8 +2365,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
               }
             },
             {
@@ -2385,8 +2379,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -2401,8 +2394,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -2412,7 +2404,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.22": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.22": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -2425,7 +2418,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -2439,7 +2433,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -2454,7 +2449,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -3348,8 +3344,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
           },
           "platforms": [
             {
@@ -3362,8 +3357,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
               }
             },
             {
@@ -3377,8 +3371,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -3393,8 +3386,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -3404,7 +3396,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -3417,7 +3410,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -3431,7 +3425,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -3446,7 +3441,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4524,8 +4520,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21": {},
-            "$(dotnet|8.0|minor-tag)-alpine": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21": {}
           },
           "platforms": [
             {
@@ -4538,8 +4533,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-amd64": {}
               }
             },
             {
@@ -4553,8 +4547,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4569,8 +4562,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4580,8 +4572,7 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.21-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.21-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine-composite": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.21-composite": {}
           },
           "platforms": [
             {
@@ -4594,8 +4585,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-amd64": {}
               }
             },
             {
@@ -4609,8 +4599,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4625,8 +4614,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine-composite-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.21-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4636,7 +4624,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.22": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.22": {},
+            "$(dotnet|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -4649,7 +4638,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -4663,7 +4653,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4678,7 +4669,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -4688,7 +4680,8 @@
           "productVersion": "$(dotnet|8.0|product-version)",
           "sharedTags": {
             "$(dotnet|8.0|fixed-tag)-alpine3.22-composite": {},
-            "$(dotnet|8.0|minor-tag)-alpine3.22-composite": {}
+            "$(dotnet|8.0|minor-tag)-alpine3.22-composite": {},
+            "$(dotnet|8.0|minor-tag)-alpine-composite": {}
           },
           "platforms": [
             {
@@ -4701,7 +4694,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-composite-amd64": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-amd64": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-amd64": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-amd64": {}
               }
             },
             {
@@ -4715,7 +4709,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-composite-arm32v7": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm32v7": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm32v7": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -4730,7 +4725,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|8.0|fixed-tag)-alpine3.22-composite-arm64v8": {},
-                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm64v8": {}
+                "$(dotnet|8.0|minor-tag)-alpine3.22-composite-arm64v8": {},
+                "$(dotnet|8.0|minor-tag)-alpine-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6082,8 +6078,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21": {},
-            "$(dotnet|9.0|minor-tag)-alpine": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21": {}
           },
           "platforms": [
             {
@@ -6096,8 +6091,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-amd64": {}
               }
             },
             {
@@ -6111,8 +6105,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6127,8 +6120,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6138,8 +6130,7 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.21-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.21-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine-composite": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.21-composite": {}
           },
           "platforms": [
             {
@@ -6152,8 +6143,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-amd64": {}
               }
             },
             {
@@ -6167,8 +6157,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6183,8 +6172,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine-composite-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.21-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6194,7 +6182,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22": {},
+            "$(dotnet|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -6207,7 +6196,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -6221,7 +6211,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6236,7 +6227,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -6246,7 +6238,8 @@
           "productVersion": "$(dotnet|9.0|product-version)",
           "sharedTags": {
             "$(dotnet|9.0|fixed-tag)-alpine3.22-composite": {},
-            "$(dotnet|9.0|minor-tag)-alpine3.22-composite": {}
+            "$(dotnet|9.0|minor-tag)-alpine3.22-composite": {},
+            "$(dotnet|9.0|minor-tag)-alpine-composite": {}
           },
           "platforms": [
             {
@@ -6259,7 +6252,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-composite-amd64": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-amd64": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-amd64": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-amd64": {}
               }
             },
             {
@@ -6273,7 +6267,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-composite-arm32v7": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm32v7": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm32v7": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -6288,7 +6283,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(dotnet|9.0|fixed-tag)-alpine3.22-composite-arm64v8": {},
-                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm64v8": {}
+                "$(dotnet|9.0|minor-tag)-alpine3.22-composite-arm64v8": {},
+                "$(dotnet|9.0|minor-tag)-alpine-composite-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -7964,8 +7960,7 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.21": {},
-            "$(sdk|8.0|minor-tag)-alpine3.21": {},
-            "$(sdk|8.0|minor-tag)-alpine": {}
+            "$(sdk|8.0|minor-tag)-alpine3.21": {}
           },
           "platforms": [
             {
@@ -7978,8 +7973,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-amd64": {}
               }
             },
             {
@@ -7993,8 +7987,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine-arm32v7": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8009,8 +8002,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.21-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8020,7 +8012,8 @@
           "productVersion": "$(sdk|8.0|product-version)",
           "sharedTags": {
             "$(sdk|8.0|fixed-tag)-alpine3.22": {},
-            "$(sdk|8.0|minor-tag)-alpine3.22": {}
+            "$(sdk|8.0|minor-tag)-alpine3.22": {},
+            "$(sdk|8.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -8033,7 +8026,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(sdk|8.0|minor-tag)-alpine3.22-amd64": {}
+                "$(sdk|8.0|minor-tag)-alpine3.22-amd64": {},
+                "$(sdk|8.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -8047,7 +8041,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(sdk|8.0|minor-tag)-alpine3.22-arm32v7": {}
+                "$(sdk|8.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(sdk|8.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8062,7 +8057,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|8.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(sdk|8.0|minor-tag)-alpine3.22-arm64v8": {}
+                "$(sdk|8.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(sdk|8.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8418,8 +8414,7 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.21": {},
-            "$(sdk|9.0|minor-tag)-alpine3.21": {},
-            "$(sdk|9.0|minor-tag)-alpine": {}
+            "$(sdk|9.0|minor-tag)-alpine3.21": {}
           },
           "platforms": [
             {
@@ -8432,8 +8427,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-amd64": {}
               }
             },
             {
@@ -8447,8 +8441,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine-arm32v7": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8463,8 +8456,7 @@
               "osVersion": "alpine3.21",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.21-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.21-arm64v8": {}
               },
               "variant": "v8"
             }
@@ -8474,7 +8466,8 @@
           "productVersion": "$(sdk|9.0|product-version)",
           "sharedTags": {
             "$(sdk|9.0|fixed-tag)-alpine3.22": {},
-            "$(sdk|9.0|minor-tag)-alpine3.22": {}
+            "$(sdk|9.0|minor-tag)-alpine3.22": {},
+            "$(sdk|9.0|minor-tag)-alpine": {}
           },
           "platforms": [
             {
@@ -8487,7 +8480,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.22-amd64": {},
-                "$(sdk|9.0|minor-tag)-alpine3.22-amd64": {}
+                "$(sdk|9.0|minor-tag)-alpine3.22-amd64": {},
+                "$(sdk|9.0|minor-tag)-alpine-amd64": {}
               }
             },
             {
@@ -8501,7 +8495,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.22-arm32v7": {},
-                "$(sdk|9.0|minor-tag)-alpine3.22-arm32v7": {}
+                "$(sdk|9.0|minor-tag)-alpine3.22-arm32v7": {},
+                "$(sdk|9.0|minor-tag)-alpine-arm32v7": {}
               },
               "variant": "v7"
             },
@@ -8516,7 +8511,8 @@
               "osVersion": "alpine3.22",
               "tags": {
                 "$(sdk|9.0|fixed-tag)-alpine3.22-arm64v8": {},
-                "$(sdk|9.0|minor-tag)-alpine3.22-arm64v8": {}
+                "$(sdk|9.0|minor-tag)-alpine3.22-arm64v8": {},
+                "$(sdk|9.0|minor-tag)-alpine-arm64v8": {}
               },
               "variant": "v8"
             }

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -8,8 +8,8 @@
     "base-url|public|preview|nightly": "https://ci.dot.net/public",
     "base-url|public-checksums|preview|nightly": "https://ci.dot.net/public-checksums",
 
-    "alpine|floating-tag-version": "alpine3.21",
-    "alpine|10.0|floating-tag-version": "alpine3.22",
+    "alpine|floating-tag-version": "alpine3.22",
+    "alpine|10.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|9.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|8.0|floating-tag-version": "$(alpine|floating-tag-version)",
 


### PR DESCRIPTION
Fixes #6671.

Related:
- https://github.com/dotnet/dotnet-docker/discussions/6566
- https://github.com/dotnet/dotnet-docker/pull/6498