### PR TITLE
Allow official build and publish pipelines to run on internal/release/ branches

### DIFF
--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -11,7 +11,16 @@ steps:
         exit 0
       }
 
-      if ("$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
+      $isOfficialBranch = "$(officialBranches)".Split(',').Contains("$(sourceBranch)")
+      $hasOfficialBranchPrefix = $false
+      foreach ($prefix in "$(officialBranchPrefixes)".Split(',')) {
+        if ("$(sourceBranch)".StartsWith($prefix)) {
+          $hasOfficialBranchPrefix = $true
+          break
+        }
+      }
+
+      if (($isOfficialBranch -or $hasOfficialBranchPrefix) `
           -and "$(officialRepoPrefixes)".Split(',').Contains("${{ parameters.publishConfig.publishAcr.repoPrefix }}"))
       {
         echo "Conditions met for official build, continuing..."

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -33,6 +33,8 @@ variables:
 - name: officialBranches
   # comma-delimited list of branch names
   value: main
+- name: officialBranchPrefixes
+  value: internal/release/
 - name: mirrorRepoPrefix
   value: 'mirror/'
 - name: cgBuildGrepArgs


### PR DESCRIPTION
This allows the release-staging-official pipeline to run on any branch that starts with the `internal/release/` prefix.