### PR TITLE
Don't treat RC builds as stable for .NET version environment variables

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile.envs
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.envs
@@ -8,7 +8,6 @@
     set isStableBranding to (
         find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0
         || find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0
-        || find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rc") >= 0
     ) ^
     set runtimeVersion to when(isStableBranding && ARGS["is-internal"],
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],

--- a/eng/dockerfile-templates/runtime/Dockerfile.envs
+++ b/eng/dockerfile-templates/runtime/Dockerfile.envs
@@ -7,7 +7,6 @@
     set isStableBranding to (
         find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0
         || find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0
-        || find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rc") >= 0
     ) ^
     set runtimeVersion to when(isStableBranding && ARGS["is-internal"],
         VARIABLES[cat("dotnet|", dotnetVersion, "|product-version")],

--- a/eng/dockerfile-templates/sdk/Dockerfile.envs
+++ b/eng/dockerfile-templates/sdk/Dockerfile.envs
@@ -7,7 +7,6 @@
     set isStableBranding to (
         find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-servicing") >= 0
         || find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rtm") >= 0
-        || find(VARIABLES[cat("sdk|", dotnetVersion, "|build-version")], "-rc") >= 0
     ) ^
     set sdkVersion to when(isStableBranding && ARGS["is-internal"],
         VARIABLES[cat("sdk|", dotnetVersion, "|product-version")],


### PR DESCRIPTION
This was a bug introduced in https://github.com/dotnet/dotnet-docker/pull/6614/commits/09fde89987f1ca363ed179522e65557f7a2286f8. That commit intended to fix download URLs for nightly release candidate builds, but it also included an additional unnecessary change to dotnet version environment variables for release candidates. That change didn't have an effect on nightly builds, but it is causing builds based on the main branch to fail the VerifyEnvironmentVariablesTest as shown here: build#2813077