### PR TITLE
[release/2025-10B] Do not restore for `dotnet run` scenario in tests

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ProjectTemplateTestScenario.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestScenarios/ProjectTemplateTestScenario.cs
@@ -138,7 +138,7 @@ public abstract class ProjectTemplateTestScenario : ITestScenario, IDisposable
             // Build and run app on SDK image
             string buildTag = Build(TestDockerfile.BuildStageName, customBuildArgs);
             tags.Add(buildTag);
-            await RunAsync(buildTag, command: "dotnet run");
+            await RunAsync(buildTag, command: "dotnet run --no-restore");
 
             // Build and run app stage
             string tag = Build(TestDockerfile.AppStageName, customBuildArgs);


### PR DESCRIPTION
This change adds the `--no-restore` flag to `dotnet run` scenarios in the container image tests. This prevents the `dotnet run` command from reaching out to NuGet during the Blazor WASM `dotnet run` scenario test. The `dotnet run` scenario does not use NuGet authentication so it can't reach internal package feeds during internal builds/tests.