### PR TITLE
Update Microsoft.Build.Utilities.Core to 17.8.43 to resolve CVE-2025-55247

### DIFF
--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Azure.Identity" Version="1.14.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
-  <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.43" />
     <PackageReference Include="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.25461.2" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
@@ -28,5 +27,10 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25210.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.25210.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25210.1" />
+
+    <!-- Fixes CVE-2025-55247 -->
+    <!-- Microsoft.Build.Utilities.Core is transitively referenced by Microsoft.DotNet.VersionTools -->
+    <!-- Remove when https://github.com/dotnet/docker-tools/issues/1658 is complete -->
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.43" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This package reference is required to mitigate CVE-2025-55247.