### PR TITLE
[release/2025-11B] Fix sync-internal-release pipeline string replacement (#6733)

### DIFF
--- a/eng/pipelines/pipelines/sync-internal-release.yml
+++ b/eng/pipelines/pipelines/sync-internal-release.yml
@@ -46,14 +46,21 @@ extends:
             scriptType: pscore
             scriptLocation: inlineScript
             addSpnToEnvironment: true
+            # $(Build.SourceBranch) always has a refs/heads/ prefix when this pipeline is triggered from a branch.
+            # The update-dependencies tool doesn't expect the prefix, so we need to remove it.
             inlineScript: >-
+              $sourceBranch = "${{ parameters.sourceBranch }}";
+              $sourceBranch = $sourceBranch -replace "refs/heads/", "";
+              $targetBranch = "${{ parameters.targetBranch }}";
+              $targetBranch = $targetBranch -replace "refs/heads/", "";
+
               dotnet run --configuration Release --project ./eng/update-dependencies/update-dependencies.csproj --
               sync-internal-release
               --azdo-organization "$env:SYSTEM_COLLECTIONURI"
               --azdo-project "$env:SYSTEM_TEAMPROJECT"
               --azdo-repo "$env:BUILD_REPOSITORY_NAME"
-              --source-branch "${{ parameters.sourceBranch }}"
-              --target-branch "${{ parameters.targetBranch }}"
+              --source-branch "$sourceBranch"
+              --target-branch "$targetBranch"
               --pr-branch-prefix "pr"
               --user "$env:DOTNETDOCKERBOT_USERNAME"
               --email "$env:DOTNETDOCKERBOT_EMAIL"

--- a/eng/pipelines/sync-internal-release-official.yml
+++ b/eng/pipelines/sync-internal-release-official.yml
@@ -12,9 +12,11 @@ variables:
 extends:
   template: /eng/pipelines/pipelines/sync-internal-release.yml@self
   parameters:
-    # Source branch will always be a release/* branch due to the pipeline trigger above
-    sourceBranch: "$(Build.SourceBranchName)"
+    # Source branch will always be a release/* branch due to the pipeline trigger above.
+    # Don't use Build.SourceBranchName because it strips all branch prefixes, which
+    # would turn 'release/foo' into just 'foo'.
+    sourceBranch: "$(Build.SourceBranch)"
     # Target branch should be the internal version of the release branch
-    targetBranch: "internal/$(Build.SourceBranchName)"
+    targetBranch: "internal/$(Build.SourceBranch)"
     # Service connection used to push new branches and submit pull requests.
     serviceConnection: "$(updateDepsInt.serviceConnectionName)"


### PR DESCRIPTION
Port of #6733 to release/2025-11B which hopefully gets the pipeline running.

Related: https://github.com/dotnet/dotnet-docker-internal/issues/6741