### PR TITLE
Bump aspire-dashboard to 9.5.2 patch

### DIFF
--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -118,13 +118,13 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-9.5.0, 9.5, 9, latest | [Dockerfile](src/aspire-dashboard/amd64/Dockerfile) | Azure Linux 3.0
+9.5.2, 9.5, 9, latest | [Dockerfile](src/aspire-dashboard/amd64/Dockerfile) | Azure Linux 3.0
 
 ### Linux arm64 Tags
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-9.5.0, 9.5, 9, latest | [Dockerfile](src/aspire-dashboard/arm64v8/Dockerfile) | Azure Linux 3.0
+9.5.2, 9.5, 9, latest | [Dockerfile](src/aspire-dashboard/arm64v8/Dockerfile) | Azure Linux 3.0
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md). See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/nightly/aspire-dashboard/tags/list) for all supported and unsupported tags.*

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -13,13 +13,13 @@
     "alpine|9.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|8.0|floating-tag-version": "$(alpine|floating-tag-version)",
 
-    "aspire-dashboard|build-version": "9.5.0-preview.1.25474.7",
-    "aspire-dashboard|product-version": "9.5.0",
+    "aspire-dashboard|build-version": "9.5.2-preview.1.25522.3",
+    "aspire-dashboard|product-version": "9.5.2",
     "aspire-dashboard|fixed-tag": "$(aspire-dashboard|product-version)",
     "aspire-dashboard|minor-tag": "9.5",
     "aspire-dashboard|major-tag": "9",
-    "aspire-dashboard|linux|x64|sha": "c23c02bbb2b35be8c0ac8b21a0ae1a9374a2e5ef186eb79c3f5898387b3abe35a3da21c1f518582351e1b6209dab917b0b5b6393101c58f03f200d3efab4741d",
-    "aspire-dashboard|linux|arm64|sha": "ce48cfd8b6d21cd79af70f442d64d24de68b2c31a0f754f53ebd7a111ce2269a26e73026756a632b8e812e047fc0abd76ace0cf8991dc665d0083a93dceb1120",
+    "aspire-dashboard|linux|x64|sha": "973831c1f98fbeb84e4f0df74290bc9a1e72bd6eec4253e07472ad448389f11963549c5ab95468c352be9ba56a3f19b17c6059ece53e1cfe248068799714b1f7",
+    "aspire-dashboard|linux|arm64|sha": "d54cf460043428ee7493582affaf993ed7e9933f618b336d75028b5c2f64b9ebd061fead7bbd4b63f56d1524c16aafa5c758df8e35e52d2a0c8b40d7f4d8d6c3",
     "aspire-dashboard|base-url|main": "$(base-url|public|preview|nightly)",
     "aspire-dashboard|base-url|nightly": "$(base-url|public|preview|nightly)",
 

--- a/src/aspire-dashboard/amd64/Dockerfile
+++ b/src/aspire-dashboard/amd64/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=9.5.0-preview.1.25474.7 \
+RUN dotnet_aspire_version=9.5.2-preview.1.25522.3 \
     && curl --fail --show-error --location --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip \
-    && aspire_dashboard_sha512='c23c02bbb2b35be8c0ac8b21a0ae1a9374a2e5ef186eb79c3f5898387b3abe35a3da21c1f518582351e1b6209dab917b0b5b6393101c58f03f200d3efab4741d' \
+    && aspire_dashboard_sha512='973831c1f98fbeb84e4f0df74290bc9a1e72bd6eec4253e07472ad448389f11963549c5ab95468c352be9ba56a3f19b17c6059ece53e1cfe248068799714b1f7' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir --parents /app \
     && unzip aspire_dashboard.zip -d /app \

--- a/src/aspire-dashboard/arm64v8/Dockerfile
+++ b/src/aspire-dashboard/arm64v8/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=9.5.0-preview.1.25474.7 \
+RUN dotnet_aspire_version=9.5.2-preview.1.25522.3 \
     && curl --fail --show-error --location --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip \
-    && aspire_dashboard_sha512='ce48cfd8b6d21cd79af70f442d64d24de68b2c31a0f754f53ebd7a111ce2269a26e73026756a632b8e812e047fc0abd76ace0cf8991dc665d0083a93dceb1120' \
+    && aspire_dashboard_sha512='d54cf460043428ee7493582affaf993ed7e9933f618b336d75028b5c2f64b9ebd061fead7bbd4b63f56d1524c16aafa5c758df8e35e52d2a0c8b40d7f4d8d6c3' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir --parents /app \
     && unzip aspire_dashboard.zip -d /app \


### PR DESCRIPTION
cc @lbussell  I did use your new changes to update-dependencies and it worked great 😃. Something failed the first time I ran, not sure what, but I re-ran and things are looking good. Thanks!

FYI: @eerhardt 