### PR TITLE
Automatically update Aspire Dashboard

### DIFF
--- a/eng/pipelines/pipelines/update-dependencies.yml
+++ b/eng/pipelines/pipelines/update-dependencies.yml
@@ -22,6 +22,10 @@ parameters:
 - name: updateDotnet
   type: boolean
   default: true
+# Whether or not to try and update the Aspire Dashboard version according to the channel parameter
+- name: updateAspire
+  type: boolean
+  default: true
 # Additional authentication arguments to pass to update-dependencies
 - name: gitHubAuthArgs
   type: string
@@ -54,23 +58,24 @@ extends:
                   --version-source-name 'dotnet/dotnet'
                   ${{ parameters.gitHubAuthArgs }}
 
-      - template: /eng/pipelines/jobs/update-dependency.yml@self
-        parameters:
-          dependencyName: aspire
-          updateSteps:
-          - task: AzureCLI@2
-            displayName: Update Aspire
-            inputs:
-              azureSubscription: "Darc: Maestro Production"
-              scriptType: "pscore"
-              scriptLocation: "inlineScript"
-              inlineScript: >-
-                dotnet run --project eng/update-dependencies/update-dependencies.csproj --
-                from-channel
-                ${{ parameters.aspireChannel }}
-                https://github.com/dotnet/aspire
-                --version-source-name 'dotnet/aspire'
-                ${{ parameters.gitHubAuthArgs }}
+      - ${{ if parameters.updateAspire }}:
+        - template: /eng/pipelines/jobs/update-dependency.yml@self
+          parameters:
+            dependencyName: aspire
+            updateSteps:
+            - task: AzureCLI@2
+              displayName: Update Aspire
+              inputs:
+                azureSubscription: "Darc: Maestro Production"
+                scriptType: "pscore"
+                scriptLocation: "inlineScript"
+                inlineScript: >-
+                  dotnet run --project eng/update-dependencies/update-dependencies.csproj --
+                  from-channel
+                  ${{ parameters.aspireChannel }}
+                  https://github.com/dotnet/aspire
+                  --version-source-name 'dotnet/aspire'
+                  ${{ parameters.gitHubAuthArgs }}
 
       - ${{ each tool in parameters.tools }}:
         - template: /eng/pipelines/jobs/update-dependency.yml@self

--- a/eng/pipelines/update-dependencies-official.yml
+++ b/eng/pipelines/update-dependencies-official.yml
@@ -17,6 +17,10 @@ parameters:
     displayName: Update .NET?
     type: boolean
     default: true
+  - name: updateAspire
+    displayName: Update Aspire Dashboard?
+    type: boolean
+    default: true
   # This parameter will show up as a multi-select dropdown when queueing the pipeline
   - name: tools
     type: stringList
@@ -42,10 +46,11 @@ variables:
 extends:
   template: /eng/pipelines/pipelines/update-dependencies.yml@self
   parameters:
+    updateDotnet: ${{ parameters.updateDotnet }}
     vmrChannel: $(vmrChannel)
+    updateAspire: ${{ parameters.updateAspire }}
     aspireChannel: $(aspireChannel)
     tools: ${{ parameters.tools }}
-    updateDotnet: ${{ parameters.updateDotnet }}
     ${{ if ne(parameters.skipPullRequest, true) }}:
       gitHubAuthArgs: >-
         --user $(dotnetDockerBot.userName)

--- a/eng/pipelines/update-dependencies-unofficial.yml
+++ b/eng/pipelines/update-dependencies-unofficial.yml
@@ -2,18 +2,22 @@ trigger: none
 pr: none
 
 parameters:
-- name: vmrChannel
-  displayName: .NET VMR build channel (see aka.ms/bar)
-  type: string
-  default: ""
-- name: aspireChannel
-  displayName: Aspire build channel (see aka.ms/bar)
-  type: string
-  default: ""
 - name: updateDotnet
   displayName: Update .NET?
   type: boolean
   default: true
+- name: vmrChannel
+  displayName: .NET VMR build channel (see aka.ms/bar)
+  type: string
+  default: ""
+- name: updateAspire
+  displayName: Update Aspire Dashboard?
+  type: boolean
+  default: false
+- name: aspireChannel
+  displayName: Aspire build channel (see aka.ms/bar)
+  type: string
+  default: ""
 # This parameter will show up as a multi-select dropdown when queueing the pipeline
 - name: tools
   type: stringList


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-docker/issues/5154

Test run of update-dependencies-unofficial pipeline: https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2824048&view=logs&j=febfdd20-9be6-5d59-165b-103a9cc525ff&t=83872345-6a38-5471-ad84-e95ff636bdc2&l=303 (ignore the failure in the VMR update leg, I accidentally put in the wrong channel for that one - unrelated). Console output:

> Update aspire-dashboard|build-version, aspire-dashboard|fixed-tag, aspire-dashboard|linux|arm64|sha, aspire-dashboard|linux|x64|sha, aspire-dashboard|major-tag, aspire-dashboard|minor-tag, aspire-dashboard|product-version to 13.0.0-preview.1.25524.6, 13.0.0-preview.1.25524.6, b769ced73e8bb446f0c50d1da89a0950eebdc41e3c8149cf3c8784c93da580c49ad66e6fb81d0b7bab685930cfa73393098681aec5518087305884f807b8c22a, c84bb09207827945e15e1abc4d6432aad4dbf0e78ea28a8382ee93505e6e349d728cbd5cbfb7501eaa4550878b82e61f1d4dab4bffeb610ff7311db8a02ff1f3, 13, 13.0, 13.0.0-preview.1.25524.6, respectively