### PR TITLE
Add internal/release to official branch prefixes

### DIFF
--- a/eng/pipelines/variables/core-official.yml
+++ b/eng/pipelines/variables/core-official.yml
@@ -10,7 +10,7 @@ variables:
   value: manifest.json
 
 - name: officialBranchPrefixes
-  value: internal/release
+  value: internal/release/
 
 - name: publishEolAnnotations
   value: true


### PR DESCRIPTION
This PR is a follow up to https://github.com/dotnet/docker-tools/pull/1836. It allows official builds to start from branches starting with the `internal/release` prefix.

Related:
- https://github.com/dotnet/docker-tools/pull/1836
- https://github.com/dotnet/dotnet-docker/pull/6716
- https://github.com/dotnet/dotnet-docker/pull/6717
- https://github.com/dotnet/dotnet-docker/pull/6744