### PR TITLE
Remove reference to deleted core.yml pipeline variable template

### DIFF
--- a/eng/pipelines/release-promotion-official.yml
+++ b/eng/pipelines/release-promotion-official.yml
@@ -2,9 +2,7 @@ trigger: none
 pr: none
 
 variables:
-- template: /eng/pipelines/variables/core.yml@self
-  parameters:
-    sourceBuildPipelineRunId: "$(resources.pipeline.dotnet-docker-release-staging.runID)"
+- template: /eng/pipelines/variables/core-official.yml@self
 # Set pathArgs to empty in order to publish all images
 - name: imageBuilder.pathArgs
   value: ""

--- a/eng/pipelines/release-staging-official.yml
+++ b/eng/pipelines/release-staging-official.yml
@@ -29,10 +29,7 @@ parameters:
   default: true
 
 variables:
-- template: /eng/pipelines/variables/core.yml@self
-  parameters:
-    sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
-- template: /eng/common/templates/variables/dotnet/secrets.yml@self
+- template: /eng/pipelines/variables/core-official.yml@self
 - name: "publicSourceBranch"
   value: "main"
   readonly: true

--- a/eng/pipelines/update-readmes.yml
+++ b/eng/pipelines/update-readmes.yml
@@ -2,8 +2,7 @@ trigger: none
 pr: none
 
 variables:
-- template: /eng/pipelines/variables/core.yml@self
-- template: /eng/common/templates/variables/dotnet/secrets.yml@self
+- template: /eng/pipelines/variables/core-official.yml@self
 
 extends:
   template: /eng/common/templates/1es-official.yml@self


### PR DESCRIPTION
The core.yml variable template was removed in https://github.com/dotnet/dotnet-docker/pull/6621, but some pipelines still had references to it. This PR removes those references and points them to the newer core-official variable template.