### PR TITLE
Mark .NET 10 as long-term support in Readmes

### DIFF
--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -4,7 +4,7 @@
 
 # Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:9.0`

--- a/.portal-docs/docker-hub/README.runtime-deps.md
+++ b/.portal-docs/docker-hub/README.runtime-deps.md
@@ -4,7 +4,7 @@
 
 # Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:9.0`

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -4,7 +4,7 @@
 
 # Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:9.0`

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -4,7 +4,7 @@
 
 # Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:9.0`

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -10,7 +10,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:9.0`

--- a/.portal-docs/mar/README.runtime-deps.portal.md
+++ b/.portal-docs/mar/README.runtime-deps.portal.md
@@ -10,7 +10,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:9.0`

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -10,7 +10,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:9.0`

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -16,7 +16,7 @@ Watch [discussions](https://github.com/dotnet/dotnet-docker/discussions/categori
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:9.0`

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -6,7 +6,7 @@
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/aspnet:9.0`

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -6,7 +6,7 @@
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime-deps:9.0`

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -6,7 +6,7 @@
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/runtime:9.0`

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -6,7 +6,7 @@
 
 ## Featured Tags
 
-* `10.0` (Release Candidate)
+* `10.0` (Long-Term Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:10.0`
 * `9.0` (Standard Support)
   * `docker pull mcr.microsoft.com/dotnet/nightly/sdk:9.0`

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -22,7 +22,7 @@ elif match(REPO, "aspire-dashboard"):* `9.5`
   * `docker pull {{FULL_REPO}}:9.5`^
 elif match(REPO, "yarp"):* `2.3-preview`
   * `docker pull {{FULL_REPO}}:2.3-preview`^
-else:* `10.0` (Release Candidate)
+else:* `10.0` (Long-Term Support)
   * `docker pull {{FULL_REPO}}:10.0`
 * `9.0` (Standard Support)
   * `docker pull {{FULL_REPO}}:9.0`


### PR DESCRIPTION
This PR is part of [Changes needed for .NET 10 GA (#6663)](https://github.com/dotnet/dotnet-docker/issues/6663).