### PR TITLE
[release/2025-11B] Correct internal NuGet config filename computation

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestSolution.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestSolution.cs
@@ -59,7 +59,7 @@ public class TestSolution : IDisposable
             string nuGetConfigFileName = "NuGet.config";
             if (Config.IsInternal)
             {
-                nuGetConfigFileName += "NuGet.config.internal";
+                nuGetConfigFileName = "NuGet.config.internal";
             }
             else if (Config.IsNightlyRepo)
             {


### PR DESCRIPTION
This is a follow-up to 357567904b877bf2822f016dfebda2b6b6abfd4b. The NuGet config file name was computed incorrectly for internal branches, which prevented scenario tests from running internally.

Related:
- https://github.com/dotnet/dotnet-docker/pull/6755
- https://github.com/dotnet/dotnet-docker/pull/6752