### PR TITLE
[release/2025-11B] Use the same base URLs for SDK and .NET binaries on main branches

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -219,9 +219,9 @@
 
     "sdk|10.0|build-version": "10.0.100-rtm.25523.113",
     "sdk|10.0|product-version": "10.0.100",
-    "sdk|10.0|base-url|main": "$(dotnet|10.0|base-url|nightly)",
+    "sdk|10.0|base-url|main": "$(dotnet|10.0|base-url|main)",
     "sdk|10.0|base-url|nightly": "$(dotnet|10.0|base-url|nightly)",
-    "sdk|10.0|base-url|checksums|main": "$(dotnet|10.0|base-url|checksums|nightly)",
+    "sdk|10.0|base-url|checksums|main": "$(dotnet|10.0|base-url|checksums|main)",
     "sdk|10.0|base-url|checksums|nightly": "$(dotnet|10.0|base-url|checksums|nightly)",
     "sdk|10.0|fixed-tag": "$(sdk|10.0|product-version)",
     "sdk|10.0|minor-tag": "$(dotnet|10.0|minor-tag)",


### PR DESCRIPTION
**Problem:** internal Dockerfiles for runtime and aspnet images have the correct download URLs, but sdk Dockerfiles are pointing to ci.dot.net instead of the internal staging storage account.

https://github.com/dotnet/dotnet-docker/pull/6770 included the commit https://github.com/dotnet/dotnet-docker/pull/6770/commits/866989f5ed939347f6f783962156e79e2e165add, which allowed update-dependencies to change the checksum base URL for internal .NET builds. That change works great for runtime and aspnet Dockerfiles. However, the base URL variables for the SDK point to the incorrect variables (after they were changed in https://github.com/dotnet/dotnet-docker/pull/6752/commits/0adaea3173db71c366d44dd0181bfd86b48d271f), so the internal Dockerfiles end up with the incorrect base URLs. This PR makes the SDK download URLs rely entirely on the .NET download URLs so that doesn't happen.

I confirmed that this change doesn't affect the public release branch, and also generates the correct Dockerfiles on the internal release branch.