### PR TITLE
Filter out variables that don't exist when resolving base URLs in update-dependencies

### DIFF
--- a/eng/update-dependencies/ManifestHelper.cs
+++ b/eng/update-dependencies/ManifestHelper.cs
@@ -31,6 +31,7 @@ public static partial class ManifestHelper
             versionSourceName: options.VersionSourceName);
 
         var baseUrlValues = baseUrlVariableNames
+            .Where(manifestVariables.ContainsKey)
             .Select(variable => ResolveVariableValue(variable, manifestVariables));
 
         return baseUrlValues;


### PR DESCRIPTION
Fixes #6776 