### PR TITLE
Disable Chisel updates due to #6774

### DIFF
--- a/eng/pipelines/update-dependencies-official.yml
+++ b/eng/pipelines/update-dependencies-official.yml
@@ -26,6 +26,8 @@ parameters:
     type: stringList
     displayName: Tools to update
     values:
+      # Disabled due to https://github.com/dotnet/dotnet-docker/issues/6774 - re-enable when fixed.
+      # - "chisel"
       - "rocks-toolbox"
       - "syft"
       - "mingit"


### PR DESCRIPTION
This PR disables automatic Chisel updates. The issue should be resolved when https://github.com/dotnet/dotnet-docker/pull/6756 is eventually merged.