### PR TITLE
Disable .NET updates in update-dependencies pipeline

### DIFF
--- a/eng/pipelines/update-dependencies-official.yml
+++ b/eng/pipelines/update-dependencies-official.yml
@@ -16,7 +16,9 @@ parameters:
   - name: updateDotnet
     displayName: Update .NET?
     type: boolean
-    default: true
+    # Updates are disabled until .NET 11 Alpha images are added.
+    # Re-enable when https://github.com/dotnet/dotnet-docker/issues/6824 is resolved.
+    default: false
   - name: updateAspire
     displayName: Update Aspire Dashboard?
     type: boolean


### PR DESCRIPTION
.NET 10 has shipped and is now in maintenance mode. We typically do not ship daily builds of servicing releases. This PR disables automatic .NET updates until .NET 11 Alpha images are added.