### PR TITLE
Fix portal docs root path when multiple repositories are checked out

### DIFF
--- a/eng/pipelines/steps/set-publish-mcrdocs-args-var.yml
+++ b/eng/pipelines/steps/set-publish-mcrdocs-args-var.yml
@@ -1,6 +1,16 @@
 steps:
 - powershell: |
-    $additionalPublishMcrDocsArgs = "--root /repo/.portal-docs"
+    # When multiple repos are checked out, the repo is in a subdirectory named after the repo.
+    # The buildRepoName variable is set in init-matrix-build-publish.yml, but only when mutiple
+    # repos are checked out.
+    $buildRepoName = "$env:BUILDREPONAME"
+    if ($buildRepoName) {
+        $portalDocsRoot = "/repo/$buildRepoName/.portal-docs"
+    } else {
+        $portalDocsRoot = "/repo/.portal-docs"
+    }
+
+    $additionalPublishMcrDocsArgs = "--root $portalDocsRoot"
     if ($env:SOURCEBRANCH -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly") {
         $additionalPublishMcrDocsArgs += " --exclude-product-family"
     }


### PR DESCRIPTION
Fixes #6857

#6857 happens because the `--root` variable isn't set correctly when multiple repos are checked out, which always happens during publishing. 

Related:
- https://github.com/dotnet/docker-tools/pull/1876 tried to solve this from a different angle, but that PR caused additional issues when flowing into this repo via https://github.com/dotnet/dotnet-docker/pull/6869. I think that this solution is probably simpler.