### PR TITLE
React to Aspire 13.1 stable release

### DIFF
--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -114,13 +114,13 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-13.0.0, 13.0, 13, latest | [Dockerfile](src/aspire-dashboard/amd64/Dockerfile) | Azure Linux 3.0
+13.1.0, 13.1, 13, latest | [Dockerfile](src/aspire-dashboard/amd64/Dockerfile) | Azure Linux 3.0
 
 ### Linux arm64 Tags
 
 Tags | Dockerfile | OS Version
 -----------| -------------| -------------
-13.0.0, 13.0, 13, latest | [Dockerfile](src/aspire-dashboard/arm64v8/Dockerfile) | Azure Linux 3.0
+13.1.0, 13.1, 13, latest | [Dockerfile](src/aspire-dashboard/arm64v8/Dockerfile) | Azure Linux 3.0
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md). See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/aspire-dashboard/tags/list) for all supported and unsupported tags.*

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -14,13 +14,13 @@
     "alpine|9.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|8.0|floating-tag-version": "$(alpine|floating-tag-version)",
 
-    "aspire-dashboard|build-version": "13.0.0-preview.1.25560.3",
-    "aspire-dashboard|product-version": "13.0.0",
+    "aspire-dashboard|build-version": "13.1.0-preview.1.25616.3",
+    "aspire-dashboard|product-version": "13.1.0",
     "aspire-dashboard|fixed-tag": "$(aspire-dashboard|product-version)",
-    "aspire-dashboard|minor-tag": "13.0",
+    "aspire-dashboard|minor-tag": "13.1",
     "aspire-dashboard|major-tag": "13",
-    "aspire-dashboard|linux|x64|sha": "69333bdef491527a4437fe60b92c12e7a5a00f15cbcb3ae2c355cb6538b9905a34de1a38ef0b9552a1c6ccc94f1d37d0c1ff16b4170f4bbe97b5596a3ec0072f",
-    "aspire-dashboard|linux|arm64|sha": "82a85c4755da7a6d277eb6b284aa0d9c7aa9fc5be41596e77f63312aa62bdb35653fe6b6f3c917882c2936be5ea91f93eaa0310db18fe32bb9be2d8dc6a30b18",
+    "aspire-dashboard|linux|x64|sha": "f0b1bad3dfdf84dc0532bb54305560df38fd3cc764f562548fcb262eea6c4ba84bb41bfe0926f1971fb5b180ebf16ffb4d2d5f0955d7b30648b2d4f6a0cb5b3d",
+    "aspire-dashboard|linux|arm64|sha": "d073b7760f45bd295f14da8145b19dd3b9f665a5dd2f4b3fcb6019124b3f6f4eaafb4fcd1d02950b0ff67f3f448a16b4249c16ca3a1d11fc5a7e77f0837abaed",
     "aspire-dashboard|base-url|main": "$(base-url|public|preview|nightly)",
     "aspire-dashboard|base-url|nightly": "$(base-url|public|preview|nightly)",
 

--- a/src/aspire-dashboard/amd64/Dockerfile
+++ b/src/aspire-dashboard/amd64/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=13.0.0-preview.1.25560.3 \
+RUN dotnet_aspire_version=13.1.0-preview.1.25616.3 \
     && curl --fail --show-error --location --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip \
-    && aspire_dashboard_sha512='69333bdef491527a4437fe60b92c12e7a5a00f15cbcb3ae2c355cb6538b9905a34de1a38ef0b9552a1c6ccc94f1d37d0c1ff16b4170f4bbe97b5596a3ec0072f' \
+    && aspire_dashboard_sha512='f0b1bad3dfdf84dc0532bb54305560df38fd3cc764f562548fcb262eea6c4ba84bb41bfe0926f1971fb5b180ebf16ffb4d2d5f0955d7b30648b2d4f6a0cb5b3d' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir --parents /app \
     && unzip aspire_dashboard.zip -d /app \

--- a/src/aspire-dashboard/arm64v8/Dockerfile
+++ b/src/aspire-dashboard/arm64v8/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=13.0.0-preview.1.25560.3 \
+RUN dotnet_aspire_version=13.1.0-preview.1.25616.3 \
     && curl --fail --show-error --location --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip \
-    && aspire_dashboard_sha512='82a85c4755da7a6d277eb6b284aa0d9c7aa9fc5be41596e77f63312aa62bdb35653fe6b6f3c917882c2936be5ea91f93eaa0310db18fe32bb9be2d8dc6a30b18' \
+    && aspire_dashboard_sha512='d073b7760f45bd295f14da8145b19dd3b9f665a5dd2f4b3fcb6019124b3f6f4eaafb4fcd1d02950b0ff67f3f448a16b4249c16ca3a1d11fc5a7e77f0837abaed' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir --parents /app \
     && unzip aspire_dashboard.zip -d /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static readonly ImageVersion V8_1 = new(new Version(8, 1), isPreview: false);
         public static readonly ImageVersion V9_0 = new(new Version(9, 0), isPreview: false);
         public static readonly ImageVersion V9_1 = new(new Version(9, 1), isPreview: false);
-        public static readonly ImageVersion V13_0 = new(new Version(13, 0), isPreview: false);
+        public static readonly ImageVersion V13_1 = new(new Version(13, 1), isPreview: false);
         public static readonly ImageVersion V9_2_Preview = new(new Version(9, 2), isPreview: true);
         public static readonly ImageVersion V10_0 = new(new Version(10, 0), isPreview: false);
 

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -376,7 +376,7 @@ namespace Microsoft.DotNet.Docker.Tests
         private static readonly ProductImageData[] s_AspireDashboardTestData =
         {
             new() {
-                Version = V13_0,
+                Version = V13_1,
                 VersionFamily = V9_0,
                 OS = OS.AzureLinux30Distroless,
                 OSTag = "",
@@ -385,7 +385,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 SupportedImageRepos = DotNetImageRepo.Aspire_Dashboard,
             },
             new() {
-                Version = V13_0,
+                Version = V13_1,
                 VersionFamily = V9_0,
                 OS = OS.AzureLinux30Distroless,
                 OSTag = "",


### PR DESCRIPTION
Changes required to ship the Aspire 13.1 dashboard image.