### PR TITLE
Update names of registries in publishConfig

### DIFF
--- a/eng/pipelines/stages/build-and-test.yml
+++ b/eng/pipelines/stages/build-and-test.yml
@@ -45,8 +45,8 @@ stages:
   - template: /eng/docker-tools/templates/stages/setup-service-connections.yml@self
     parameters:
       serviceConnections:
-      - name: ${{ parameters.publishConfig.internalMirrorAcr.serviceConnection.name }}
-      - name: ${{ parameters.publishConfig.buildAcr.serviceConnection.name }}
+      - name: ${{ parameters.publishConfig.InternalMirrorRegistry.serviceConnection.name }}
+      - name: ${{ parameters.publishConfig.BuildRegistry.serviceConnection.name }}
       - ${{ if parameters.storageAccountServiceConnection }}:
         - name: ${{ parameters.storageAccountServiceConnection.name }}
 

--- a/eng/pipelines/stages/build-test-publish-repo.yml
+++ b/eng/pipelines/stages/build-test-publish-repo.yml
@@ -37,9 +37,9 @@ stages:
   - template: /eng/docker-tools/templates/stages/setup-service-connections.yml@self
     parameters:
       serviceConnections:
-      - name: ${{ parameters.publishConfig.internalMirrorAcr.serviceConnection.name }}
-      - name: ${{ parameters.publishConfig.buildAcr.serviceConnection.name }}
-      - name: ${{ parameters.publishConfig.publishAcr.serviceConnection.name }}
+      - name: ${{ parameters.publishConfig.InternalMirrorRegistry.serviceConnection.name }}
+      - name: ${{ parameters.publishConfig.BuildRegistry.serviceConnection.name }}
+      - name: ${{ parameters.publishConfig.PublishRegistry.serviceConnection.name }}
       - ${{ each serviceConnection in parameters.additionalServiceConnections }}:
         - name: ${{ serviceConnection.name }}
 

--- a/eng/pipelines/stages/publish.yml
+++ b/eng/pipelines/stages/publish.yml
@@ -40,7 +40,7 @@ stages:
   - template: /eng/docker-tools/templates/stages/setup-service-connections.yml@self
     parameters:
       serviceConnections:
-      - name: ${{ parameters.publishConfig.publishAcr.serviceConnection.name }}
+      - name: ${{ parameters.publishConfig.PublishRegistry.serviceConnection.name }}
       - ${{ each serviceConnection in parameters.additionalServiceConnections }}:
         - name: ${{ serviceConnection.name }}
 

--- a/eng/pipelines/steps/set-custom-test-variables.yml
+++ b/eng/pipelines/steps/set-custom-test-variables.yml
@@ -14,7 +14,7 @@ steps:
     $testRunnerOptions="-e SYSTEM_TEAMPROJECT='$env:SYSTEM_TEAMPROJECT'"
     $testInit=""
 
-    if (("${{ parameters.publishConfig.publishAcr.repoPrefix }}".Contains("internal/")) -or $${{ parameters.isInternalServicingValidation }}) {
+    if (("${{ parameters.publishConfig.PublishRegistry.repoPrefix }}".Contains("internal/")) -or $${{ parameters.isInternalServicingValidation }}) {
       if ($Env:AGENT_OS -eq 'Linux') {
         $testRunnerOptions="$testRunnerOptions -e INTERNAL_TESTING='1' -e INTERNAL_ACCESS_TOKEN='$(System.AccessToken)'"
       }


### PR DESCRIPTION
These changes were missing from #6884. The names of the publishConfig members were changed in https://github.com/dotnet/docker-tools/pull/1900.