### PR TITLE
Make Asp, AspBuild, and ReleaseDate optional in ReleaseConfig

### DIFF
--- a/eng/update-dependencies/Model/Release/ReleaseConfig.cs
+++ b/eng/update-dependencies/Model/Release/ReleaseConfig.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -49,6 +48,8 @@ internal record ReleaseConfig
 
     public required bool Internal { get; init; }
 
+    [MemberNotNullWhen(false, nameof(Asp))]
+    [MemberNotNullWhen(false, nameof(AspBuild))]
     public required bool SdkOnly { get; init; }
 
     private static readonly JsonSerializerOptions s_jsonOptions = new()


### PR DESCRIPTION
When `SdkOnly` is true, `Asp` and `AspBuild` are not required members in the `ReleaseConfig`. `ReleaseDate` is also apparently optional.

This caused a failure of the [dotnet-docker-update-dependencies-internal-official pipeline (build#2880021)](https://dev.azure.com/dnceng/internal/_build/results?buildId=2880021&view=logs&j=6b443fb8-dee0-558e-a185-67b40a667c8d&t=f9bc539e-e1ec-55fb-e6d6-dc57313d0488).