### PR TITLE
Fix git committer identity error in update-dependencies pipeline

### DIFF
--- a/eng/update-dependencies/FromStagingPipelineCommand.cs
+++ b/eng/update-dependencies/FromStagingPipelineCommand.cs
@@ -244,8 +244,8 @@ internal partial class FromStagingPipelineCommand : BaseCommand<FromStagingPipel
                 var prBranch = options.CreatePrBranchName($"update-deps-int-{options.StageContainer}", buildId);
                 var committer = options.GetCommitterIdentity();
 
-                // Clone the repo
-                var git = await gitRepoFactory.CreateAndCloneAsync(remoteUrl);
+                // Clone the repo and configure git identity for commits
+                var git = await gitRepoFactory.CreateAndCloneAsync(remoteUrl, gitIdentity: committer);
                 // Ensure the branch we want to modify exists, then check it out
                 await git.Remote.EnsureBranchExistsAsync(targetBranch);
                 // Create a new branch to push changes to and create a PR from

--- a/eng/update-dependencies/Sync/SyncInternalReleaseCommand.cs
+++ b/eng/update-dependencies/Sync/SyncInternalReleaseCommand.cs
@@ -43,7 +43,14 @@ internal sealed class SyncInternalReleaseCommand(
                 $"The source branch '{options.SourceBranch}' cannot be an internal branch.");
         }
 
-        using var repo = await _gitRepoHelperFactory.CreateAndCloneAsync(remoteUrl);
+        // Get git identity if available (required for commits, optional for read-only operations)
+        var gitIdentity = !string.IsNullOrWhiteSpace(options.User) && !string.IsNullOrWhiteSpace(options.Email)
+            ? options.GetCommitterIdentity()
+            : ((string, string)?)null;
+
+        using var repo = await _gitRepoHelperFactory.CreateAndCloneAsync(
+            remoteUrl,
+            gitIdentity: gitIdentity);
 
         // Verify that the source branch exists on the remote.
         var sourceBranchExists = await repo.Remote.RemoteBranchExistsAsync(options.SourceBranch);

--- a/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
+++ b/tests/UpdateDependencies.Tests/SyncInternalReleaseTests.cs
@@ -82,7 +82,7 @@ public sealed class SyncInternalReleaseTests
 
         var repoMock = new Mock<IGitRepoHelper>();
         var repoFactoryMock = new Mock<IGitRepoHelperFactory>();
-        repoFactoryMock.Setup(f => f.CreateAndCloneAsync(options.GetAzdoRepoUrl(), null)).ReturnsAsync(repoMock.Object);
+        repoFactoryMock.Setup(f => f.CreateAndCloneAsync(options.GetAzdoRepoUrl(), null, It.IsAny<(string, string)?>())).ReturnsAsync(repoMock.Object);
 
         // Setup:
         // Target branch does not exist on remote
@@ -112,7 +112,7 @@ public sealed class SyncInternalReleaseTests
         // not explicitly set up in this test.
         var repoMock = new Mock<IGitRepoHelper>(MockBehavior.Strict);
         var repoFactoryMock = new Mock<IGitRepoHelperFactory>();
-        repoFactoryMock.Setup(f => f.CreateAndCloneAsync(options.GetAzdoRepoUrl(), null)).ReturnsAsync(repoMock.Object);
+        repoFactoryMock.Setup(f => f.CreateAndCloneAsync(options.GetAzdoRepoUrl(), null, It.IsAny<(string, string)?>())).ReturnsAsync(repoMock.Object);
 
         // Setup: Both target and source branches exist on remote.
         repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(true);
@@ -149,7 +149,7 @@ public sealed class SyncInternalReleaseTests
         repoMock.Setup(r => r.Remote).Returns(remoteRepoMock.Object);
 
         var repoFactoryMock = new Mock<IGitRepoHelperFactory>();
-        repoFactoryMock.Setup(f => f.CreateAndCloneAsync(options.GetAzdoRepoUrl(), null)).ReturnsAsync(repoMock.Object);
+        repoFactoryMock.Setup(f => f.CreateAndCloneAsync(options.GetAzdoRepoUrl(), null, It.IsAny<(string, string)?>())).ReturnsAsync(repoMock.Object);
 
         // Setup: Both target and source branches exist on remote.
         repoMock.Setup(r => r.Remote.RemoteBranchExistsAsync(options.TargetBranch)).ReturnsAsync(true);
@@ -336,7 +336,7 @@ public sealed class SyncInternalReleaseTests
         public GitTestScenario(string localRepoPath, string remoteRepoUrl)
         {
             RepoMock.Setup(r => r.Local.LocalPath).Returns(localRepoPath);
-            RepoFactoryMock.Setup(f => f.CreateAndCloneAsync(remoteRepoUrl, null)).ReturnsAsync(RepoMock.Object);
+            RepoFactoryMock.Setup(f => f.CreateAndCloneAsync(remoteRepoUrl, null, It.IsAny<(string, string)?>())).ReturnsAsync(RepoMock.Object);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Fix "Committer identity unknown" error in the update-dependencies-internal pipeline by configuring git `user.name` and `user.email` on cloned repositories.

The pipeline was failing because DarcLib's `CommitAsync` only sets `--author` but Git also requires a committer identity to be configured. This issue surfaced after the recent change to Azure Linux 3 build agents, which don't have global git config set.

## Changes
- Add optional `gitIdentity` parameter to `GitRepoHelperFactory.CreateAndCloneAsync()`
- Configure `user.name` and `user.email` on cloned repos when identity is provided
- Pass committer identity when cloning in `FromStagingPipelineCommand` and `SyncInternalReleaseCommand`

## Testing
- [Successful pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2886352&view=results)