### PR TITLE
[nightly] Update libicu to 78 version in Resolute images

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -112,7 +112,7 @@
     "libicu|focal": 66,
     "libicu|jammy": 70,
     "libicu|noble": 74,
-    "libicu|resolute": 76,
+    "libicu|resolute": 78,
 
     "libssl|alpine3.22": "3",
     "libssl|alpine3.23": "3",

--- a/src/runtime-deps/11.0/resolute-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime-deps/11.0/resolute-chiseled-extra/amd64/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir --parents /rootfs/var/lib/dpkg/ \
             ca-certificates_data \
             libc6_libs \
             libgcc-s1_libs \
-            libicu76_libs \
+            libicu78_libs \
             libssl3t64_libs \
             libstdc++6_libs \
             tzdata-legacy_zoneinfo \

--- a/src/runtime-deps/11.0/resolute-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime-deps/11.0/resolute-chiseled-extra/arm32v7/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir --parents /rootfs/var/lib/dpkg/ \
             ca-certificates_data \
             libc6_libs \
             libgcc-s1_libs \
-            libicu76_libs \
+            libicu78_libs \
             libssl3t64_libs \
             libstdc++6_libs \
             tzdata-legacy_zoneinfo \

--- a/src/runtime-deps/11.0/resolute-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime-deps/11.0/resolute-chiseled-extra/arm64v8/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir --parents /rootfs/var/lib/dpkg/ \
             ca-certificates_data \
             libc6_libs \
             libgcc-s1_libs \
-            libicu76_libs \
+            libicu78_libs \
             libssl3t64_libs \
             libstdc++6_libs \
             tzdata-legacy_zoneinfo \

--- a/src/runtime-deps/11.0/resolute/amd64/Dockerfile
+++ b/src/runtime-deps/11.0/resolute/amd64/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu76 \
+        libicu78 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/src/runtime-deps/11.0/resolute/arm32v7/Dockerfile
+++ b/src/runtime-deps/11.0/resolute/arm32v7/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu76 \
+        libicu78 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/src/runtime-deps/11.0/resolute/arm64v8/Dockerfile
+++ b/src/runtime-deps/11.0/resolute/arm64v8/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu76 \
+        libicu78 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-amd64-Dockerfile.approved.txt
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu76 \
+        libicu78 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu76 \
+        libicu78 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -15,7 +15,7 @@ RUN apt-get update \
         # .NET dependencies
         libc6 \
         libgcc-s1 \
-        libicu76 \
+        libicu78 \
         libssl3t64 \
         libstdc++6 \
         tzdata \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-chiseled-extra-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-chiseled-extra-amd64-Dockerfile.approved.txt
@@ -33,7 +33,7 @@ RUN mkdir --parents /rootfs/var/lib/dpkg/ \
             ca-certificates_data \
             libc6_libs \
             libgcc-s1_libs \
-            libicu76_libs \
+            libicu78_libs \
             libssl3t64_libs \
             libstdc++6_libs \
             tzdata-legacy_zoneinfo \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-chiseled-extra-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-chiseled-extra-arm32v7-Dockerfile.approved.txt
@@ -33,7 +33,7 @@ RUN mkdir --parents /rootfs/var/lib/dpkg/ \
             ca-certificates_data \
             libc6_libs \
             libgcc-s1_libs \
-            libicu76_libs \
+            libicu78_libs \
             libssl3t64_libs \
             libstdc++6_libs \
             tzdata-legacy_zoneinfo \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-chiseled-extra-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-chiseled-extra-arm64v8-Dockerfile.approved.txt
@@ -33,7 +33,7 @@ RUN mkdir --parents /rootfs/var/lib/dpkg/ \
             ca-certificates_data \
             libc6_libs \
             libgcc-s1_libs \
-            libicu76_libs \
+            libicu78_libs \
             libssl3t64_libs \
             libstdc++6_libs \
             tzdata-legacy_zoneinfo \


### PR DESCRIPTION
Ubuntu Resolute builds are failing because libicu got updated from version 76 to 78 in the package feed.