### PR TITLE
Add script to update internal Dockerfile baselines

### DIFF
--- a/.github/agents/image-manager.agent.md
+++ b/.github/agents/image-manager.agent.md
@@ -50,7 +50,7 @@ Follow the below policies when adding or removing images:
 
 1. Update the [TestData.cs](../../tests/Microsoft.DotNet.Docker.Tests/TestData.cs) to include the new distro version
 2. Update internal Dockerfile baselines:
-    - To automatically update baselines, run `pwsh ./tests/run-tests.ps1 -Paths "*" -TestCategories "pre-build" -CustomTestFilter "VerifyInternalDockerfilesOutput"; pwsh ./tests/accept-changes.ps1`
+    - Run `pwsh ./tests/update-internal-baselines.ps1` to regenerate and accept baseline files.
     - Commit the updated baseline files.
 3. Ensure pre-build validation tests pass: `pwsh ./tests/run-tests.ps1 -Paths "*" -TestCategories "pre-build"`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,12 +166,9 @@ Press F5 (Continue) to start test execution.
 
 Internal Dockerfiles are validated using "snapshot" testing, which uses tooling to record and test the accepted state of the Dockerfiles.
 If your changes fail tests due to changes in the internal Dockerfiles, you will need to review the changes before the tests can pass.
-You can use a local dotnet tool to accept or reject the changes.
 
-1. Run the failing test(s). For example: `./tests/run-tests.ps1 -Paths "*" -TestCategories "pre-build" -CustomTestFilter "VerifyInternalDockerfilesOutput"`
-1. The failing test will output updated baseline files in the `tests/Microsoft.DotNet.Docker.Tests/Baselines/` directory, ending in `*.received.txt`.
-1. Accept or discard the changes: `./tests/accept-changes.ps1 [-Discard]`. This script will either rename all of the `.received.txt` files to `.approved.txt` or remove them.
-1. If the git diff of the changes look acceptable, then commit the changes.
+1. Run `./tests/update-internal-baselines.ps1` to regenerate the baselines. This script runs the `VerifyInternalDockerfilesOutput` tests, accepts the updated baseline files, and displays a git diff.
+1. If the diff looks acceptable, commit the changes.
 
 ### Metadata Changes
 

--- a/tests/update-internal-baselines.ps1
+++ b/tests/update-internal-baselines.ps1
@@ -1,0 +1,69 @@
+#!/usr/bin/env pwsh
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+<#
+.SYNOPSIS
+    Updates the internal Dockerfile baselines by running the snapshot tests and accepting the changes.
+
+.DESCRIPTION
+    This script automates the workflow described in CONTRIBUTING.md for verifying internal Dockerfiles.
+    It runs the VerifyInternalDockerfilesOutput pre-build tests to generate updated baseline files,
+    then accepts the changes by renaming .received.txt files to .approved.txt.
+
+    Steps performed:
+    1. Runs the pre-build tests filtered to VerifyInternalDockerfilesOutput.
+    2. If the tests fail (baselines changed), accepts the new baselines.
+    3. Displays the git diff of updated baseline files for review.
+
+.EXAMPLE
+    ./tests/update-internal-baselines.ps1
+    Runs the internal Dockerfile tests and accepts any baseline changes.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Get-Item "$PSScriptRoot").Parent.FullName
+
+Write-Host "`nStep 1: Running VerifyInternalDockerfilesOutput tests...`n" -ForegroundColor Cyan
+
+$testFailed = $false
+try {
+    & "$repoRoot/tests/run-tests.ps1" `
+        -Paths "*" `
+        -TestCategories "pre-build" `
+        -CustomTestFilter "VerifyInternalDockerfilesOutput"
+}
+catch {
+    $testFailed = $true
+    Write-Host "`nTests reported differences in internal Dockerfile baselines.`n" -ForegroundColor Yellow
+}
+
+$receivedFiles = Get-ChildItem `
+    -Recurse `
+    -Path "$PSScriptRoot/Microsoft.DotNet.Docker.Tests/Baselines" `
+    -Filter "*.received.txt" `
+    -ErrorAction SilentlyContinue
+
+if (-not $receivedFiles -or $receivedFiles.Count -eq 0) {
+    if ($testFailed) {
+        Write-Host "Tests failed but no .received.txt files were found. Review test output for errors." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "`nBaselines are up to date. No changes needed.`n" -ForegroundColor Green
+    exit 0
+}
+
+Write-Host "`nFound $($receivedFiles.Count) baseline file(s) with changes:`n" -ForegroundColor Cyan
+$receivedFiles | ForEach-Object { Write-Host "  $_" }
+
+Write-Host "`nStep 2: Accepting baseline changes...`n" -ForegroundColor Cyan
+& "$repoRoot/tests/accept-changes.ps1"
+Write-Host "Accepted all baseline changes.`n" -ForegroundColor Green
+
+Write-Host "Step 3: Reviewing changes...`n" -ForegroundColor Cyan
+git -C $repoRoot --no-pager diff -- "$PSScriptRoot/Microsoft.DotNet.Docker.Tests/Baselines/"
+Write-Host "`nDone. Review the diff above and commit the updated baselines if acceptable.`n" -ForegroundColor Green

--- a/tests/update-internal-baselines.ps1
+++ b/tests/update-internal-baselines.ps1
@@ -9,14 +9,10 @@
     Updates the internal Dockerfile baselines by running the snapshot tests and accepting the changes.
 
 .DESCRIPTION
-    This script automates the workflow described in CONTRIBUTING.md for verifying internal Dockerfiles.
-    It runs the VerifyInternalDockerfilesOutput pre-build tests to generate updated baseline files,
-    then accepts the changes by renaming .received.txt files to .approved.txt.
-
-    Steps performed:
-    1. Runs the pre-build tests filtered to VerifyInternalDockerfilesOutput.
-    2. If the tests fail (baselines changed), accepts the new baselines.
-    3. Displays the git diff of updated baseline files for review.
+    Internal Dockerfiles are validated using snapshot testing. This script runs the
+    VerifyInternalDockerfilesOutput pre-build tests to generate updated baseline files,
+    accepts the changes by renaming .received.txt files to .approved.txt, and displays
+    the git diff for review.
 
 .EXAMPLE
     ./tests/update-internal-baselines.ps1


### PR DESCRIPTION
This PR adds a script which simplifies the process of updating the internal Dockerfile test baselines.