### PR TITLE
Update .NET 8 Images with PowerShell v7.4.14

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -174,12 +174,12 @@
     "monitor|10.0|base-url|checksums|main": "$(base-url|public-checksums|maintenance|main)",
     "monitor|10.0|base-url|checksums|nightly": "$(base-url|public-checksums|maintenance|nightly)",
 
-    "powershell|8.0|build-version": "7.4.13",
-    "powershell|8.0|Linux.Alpine|sha": "aad1256a8a29ae6646408a6bba00459745e4d676a4643541d55340fca0f311caecaa1f7a3490d49812d255d253d94ae06ba8134a5e5a304504decab556f58031",
-    "powershell|8.0|Linux|arm32|sha": "15c859b68ef134906720cc205302957bfad4d90971c27629bc1afeda5fc5b09eae28b7ddd7a343c3f30cb19b41ebfba325f6bc2deeafbccb2fb9fa83d24b179b",
-    "powershell|8.0|Linux|arm64|sha": "3f42234fe190b82bd2c48c32bd07f83ac800c3e44ea164f76dd527f3fff35575e3782b37d92efe93b83c6f9e27be501f1cd71eb0b536f4c48a2d8a8d38e8f12b",
-    "powershell|8.0|Linux|x64|sha": "0cefef90a34e9fb858eea3e1ceda95cdd6e403ae37b3222725dab76c25be55dadad8e500db65f8f4e9276ce53b8fcc2bb71a8dd035f1a07921dd65d35d88f4a0",
-    "powershell|8.0|Windows|x64|sha": "e819797e59c10e3da29e56184e4b6941bd731f7cfc79207a88ff3a5d42e913c2429d5cb28cdbb071b60061151c37395377d52d9e1e5f7c99e625a6f3be78efb7",
+    "powershell|8.0|build-version": "7.4.14",
+    "powershell|8.0|Linux.Alpine|sha": "f98387e51edd7e8238c587d65764c2013e1c5b4fc401b59b2e963c989738910db5c9344b057736e09c127ddb98ec6eea89c9d5705fd453da6882805f3514c8b9",
+    "powershell|8.0|Linux|arm32|sha": "c756c1bb21cd5fc945c7795039ad4d5a1dad06fade6c16424d79e7890807f0e55ee066d02a5da39056ce112ccb8816cef66ac0b17a694cd5960ef3d3af6559fe",
+    "powershell|8.0|Linux|arm64|sha": "70d400f518a38592152e53e0c552c8d2288a0d1631c2681cd5abd6b9f2f3647f4833e4d0778511a93d3a5dbab035d176680824c1eb19f686eab1fb125003de0c",
+    "powershell|8.0|Linux|x64|sha": "af099a529f14c347b91d568e855e5490730b4db17ffacdc8f30f93709a6ef721fc15654b4bf7415431c235ff504eca88969bc72cd00aa285d3ccd9947d47ead9",
+    "powershell|8.0|Windows|x64|sha": "a5b8db565143cd75275235d6fe9b570df1bb26fc55ac825f7bf0df638db407a7bafcb59207cd208ed9a32483398a408731007076b39ff9858a68eae9b45024c9",
 
     "powershell|9.0|build-version": "7.5.4",
     "powershell|9.0|Linux.Alpine|sha": "bc8d9677d49d625663e885461e74fdce1218d7e39da9bcd3cee7ea6bda488f34f92d0734263dd1bdbecdb47425130ae97e96be89658f70eebdab88dd75852252",

--- a/src/sdk/8.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.23/amd64/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='aad1256a8a29ae6646408a6bba00459745e4d676a4643541d55340fca0f311caecaa1f7a3490d49812d255d253d94ae06ba8134a5e5a304504decab556f58031' \
+    && powershell_sha512='f98387e51edd7e8238c587d65764c2013e1c5b4fc401b59b2e963c989738910db5c9344b057736e09c127ddb98ec6eea89c9d5705fd453da6882805f3514c8b9' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \

--- a/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
@@ -50,9 +50,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0cefef90a34e9fb858eea3e1ceda95cdd6e403ae37b3222725dab76c25be55dadad8e500db65f8f4e9276ce53b8fcc2bb71a8dd035f1a07921dd65d35d88f4a0' \
+    && powershell_sha512='af099a529f14c347b91d568e855e5490730b4db17ffacdc8f30f93709a6ef721fc15654b4bf7415431c235ff504eca88969bc72cd00aa285d3ccd9947d47ead9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -50,9 +50,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3f42234fe190b82bd2c48c32bd07f83ac800c3e44ea164f76dd527f3fff35575e3782b37d92efe93b83c6f9e27be501f1cd71eb0b536f4c48a2d8a8d38e8f12b' \
+    && powershell_sha512='70d400f518a38592152e53e0c552c8d2288a0d1631c2681cd5abd6b9f2f3647f4833e4d0778511a93d3a5dbab035d176680824c1eb19f686eab1fb125003de0c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0cefef90a34e9fb858eea3e1ceda95cdd6e403ae37b3222725dab76c25be55dadad8e500db65f8f4e9276ce53b8fcc2bb71a8dd035f1a07921dd65d35d88f4a0' \
+    && powershell_sha512='af099a529f14c347b91d568e855e5490730b4db17ffacdc8f30f93709a6ef721fc15654b4bf7415431c235ff504eca88969bc72cd00aa285d3ccd9947d47ead9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='15c859b68ef134906720cc205302957bfad4d90971c27629bc1afeda5fc5b09eae28b7ddd7a343c3f30cb19b41ebfba325f6bc2deeafbccb2fb9fa83d24b179b' \
+    && powershell_sha512='c756c1bb21cd5fc945c7795039ad4d5a1dad06fade6c16424d79e7890807f0e55ee066d02a5da39056ce112ccb8816cef66ac0b17a694cd5960ef3d3af6559fe' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3f42234fe190b82bd2c48c32bd07f83ac800c3e44ea164f76dd527f3fff35575e3782b37d92efe93b83c6f9e27be501f1cd71eb0b536f4c48a2d8a8d38e8f12b' \
+    && powershell_sha512='70d400f518a38592152e53e0c552c8d2288a0d1631c2681cd5abd6b9f2f3647f4833e4d0778511a93d3a5dbab035d176680824c1eb19f686eab1fb125003de0c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile
+++ b/src/sdk/8.0/cbl-mariner2.0/amd64/Dockerfile
@@ -50,9 +50,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0cefef90a34e9fb858eea3e1ceda95cdd6e403ae37b3222725dab76c25be55dadad8e500db65f8f4e9276ce53b8fcc2bb71a8dd035f1a07921dd65d35d88f4a0' \
+    && powershell_sha512='af099a529f14c347b91d568e855e5490730b4db17ffacdc8f30f93709a6ef721fc15654b4bf7415431c235ff504eca88969bc72cd00aa285d3ccd9947d47ead9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/cbl-mariner2.0/arm64v8/Dockerfile
@@ -50,9 +50,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3f42234fe190b82bd2c48c32bd07f83ac800c3e44ea164f76dd527f3fff35575e3782b37d92efe93b83c6f9e27be501f1cd71eb0b536f4c48a2d8a8d38e8f12b' \
+    && powershell_sha512='70d400f518a38592152e53e0c552c8d2288a0d1631c2681cd5abd6b9f2f3647f4833e4d0778511a93d3a5dbab035d176680824c1eb19f686eab1fb125003de0c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/jammy/amd64/Dockerfile
+++ b/src/sdk/8.0/jammy/amd64/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0cefef90a34e9fb858eea3e1ceda95cdd6e403ae37b3222725dab76c25be55dadad8e500db65f8f4e9276ce53b8fcc2bb71a8dd035f1a07921dd65d35d88f4a0' \
+    && powershell_sha512='af099a529f14c347b91d568e855e5490730b4db17ffacdc8f30f93709a6ef721fc15654b4bf7415431c235ff504eca88969bc72cd00aa285d3ccd9947d47ead9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/8.0/jammy/arm32v7/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='15c859b68ef134906720cc205302957bfad4d90971c27629bc1afeda5fc5b09eae28b7ddd7a343c3f30cb19b41ebfba325f6bc2deeafbccb2fb9fa83d24b179b' \
+    && powershell_sha512='c756c1bb21cd5fc945c7795039ad4d5a1dad06fade6c16424d79e7890807f0e55ee066d02a5da39056ce112ccb8816cef66ac0b17a694cd5960ef3d3af6559fe' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/8.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/8.0/jammy/arm64v8/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3f42234fe190b82bd2c48c32bd07f83ac800c3e44ea164f76dd527f3fff35575e3782b37d92efe93b83c6f9e27be501f1cd71eb0b536f4c48a2d8a8d38e8f12b' \
+    && powershell_sha512='70d400f518a38592152e53e0c552c8d2288a0d1631c2681cd5abd6b9f2f3647f4833e4d0778511a93d3a5dbab035d176680824c1eb19f686eab1fb125003de0c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
@@ -54,9 +54,9 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.13'; `
+        $powershell_version = '7.4.14'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e819797e59c10e3da29e56184e4b6941bd731f7cfc79207a88ff3a5d42e913c2429d5cb28cdbb071b60061151c37395377d52d9e1e5f7c99e625a6f3be78efb7'; `
+        $powershell_sha512 = 'a5b8db565143cd75275235d6fe9b570df1bb26fc55ac825f7bf0df638db407a7bafcb59207cd208ed9a32483398a408731007076b39ff9858a68eae9b45024c9'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -54,9 +54,9 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.13'; `
+        $powershell_version = '7.4.14'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e819797e59c10e3da29e56184e4b6941bd731f7cfc79207a88ff3a5d42e913c2429d5cb28cdbb071b60061151c37395377d52d9e1e5f7c99e625a6f3be78efb7'; `
+        $powershell_sha512 = 'a5b8db565143cd75275235d6fe9b570df1bb26fc55ac825f7bf0df638db407a7bafcb59207cd208ed9a32483398a408731007076b39ff9858a68eae9b45024c9'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -54,9 +54,9 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.13'; `
+        $powershell_version = '7.4.14'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e819797e59c10e3da29e56184e4b6941bd731f7cfc79207a88ff3a5d42e913c2429d5cb28cdbb071b60061151c37395377d52d9e1e5f7c99e625a6f3be78efb7'; `
+        $powershell_sha512 = 'a5b8db565143cd75275235d6fe9b570df1bb26fc55ac825f7bf0df638db407a7bafcb59207cd208ed9a32483398a408731007076b39ff9858a68eae9b45024c9'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/noble/amd64/Dockerfile
+++ b/src/sdk/8.0/noble/amd64/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0cefef90a34e9fb858eea3e1ceda95cdd6e403ae37b3222725dab76c25be55dadad8e500db65f8f4e9276ce53b8fcc2bb71a8dd035f1a07921dd65d35d88f4a0' \
+    && powershell_sha512='af099a529f14c347b91d568e855e5490730b4db17ffacdc8f30f93709a6ef721fc15654b4bf7415431c235ff504eca88969bc72cd00aa285d3ccd9947d47ead9' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/8.0/noble/arm64v8/Dockerfile
@@ -48,9 +48,9 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.13 \
+RUN powershell_version=7.4.14 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='3f42234fe190b82bd2c48c32bd07f83ac800c3e44ea164f76dd527f3fff35575e3782b37d92efe93b83c6f9e27be501f1cd71eb0b536f4c48a2d8a8d38e8f12b' \
+    && powershell_sha512='70d400f518a38592152e53e0c552c8d2288a0d1631c2681cd5abd6b9f2f3647f4833e4d0778511a93d3a5dbab035d176680824c1eb19f686eab1fb125003de0c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -54,9 +54,9 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.13'; `
+        $powershell_version = '7.4.14'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e819797e59c10e3da29e56184e4b6941bd731f7cfc79207a88ff3a5d42e913c2429d5cb28cdbb071b60061151c37395377d52d9e1e5f7c99e625a6f3be78efb7'; `
+        $powershell_sha512 = 'a5b8db565143cd75275235d6fe9b570df1bb26fc55ac825f7bf0df638db407a7bafcb59207cd208ed9a32483398a408731007076b39ff9858a68eae9b45024c9'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -54,9 +54,9 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.13'; `
+        $powershell_version = '7.4.14'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e819797e59c10e3da29e56184e4b6941bd731f7cfc79207a88ff3a5d42e913c2429d5cb28cdbb071b60061151c37395377d52d9e1e5f7c99e625a6f3be78efb7'; `
+        $powershell_sha512 = 'a5b8db565143cd75275235d6fe9b570df1bb26fc55ac825f7bf0df638db407a7bafcb59207cd208ed9a32483398a408731007076b39ff9858a68eae9b45024c9'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -54,9 +54,9 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.13'; `
+        $powershell_version = '7.4.14'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e819797e59c10e3da29e56184e4b6941bd731f7cfc79207a88ff3a5d42e913c2429d5cb28cdbb071b60061151c37395377d52d9e1e5f7c99e625a6f3be78efb7'; `
+        $powershell_sha512 = 'a5b8db565143cd75275235d6fe9b570df1bb26fc55ac825f7bf0df638db407a7bafcb59207cd208ed9a32483398a408731007076b39ff9858a68eae9b45024c9'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `


### PR DESCRIPTION
This pull request updates the bundled PowerShell version in the .NET 8.0 SDK images from 7.4.13 to 7.4.14 across all supported platforms and distributions. It also updates the corresponding SHA512 checksums for each platform to ensure integrity verification during installation.

Key changes:

**PowerShell Version Update:**
* Updated the PowerShell version from `7.4.13` to `7.4.14` in all Dockerfiles for .NET 8.0 SDK images, including Alpine, Azure Linux, Debian Bookworm, Ubuntu Jammy, Ubuntu Noble, CBL-Mariner, and Windows-based images. [[1]](diffhunk://#diff-dc810143537b8d56eeb63de2d79b17b65e5c0c791c0dc5cedbb7bc494da0d3a2L51-R53) [[2]](diffhunk://#diff-1f65f50deb5fcf972030edf337837161c4a676fb64fc96fc6407c4f266dafc1bL53-R55) [[3]](diffhunk://#diff-63ce660de3fcecee34e09d4884d46e8e5426a7f314db6ce0a2364834cc2896f2L53-R55) [[4]](diffhunk://#diff-6ac4aa00b18490c4047c4ea9895a0b02bcc9cdd30a5373ff3a5c5f294a73758dL51-R53) [[5]](diffhunk://#diff-557400b5d1f9d0a2f5c67352d55b6475d6be6dc55b0dbceeffc6f58aadb95b58L51-R53) [[6]](diffhunk://#diff-6bdc3dc207e866e027a8114fc7676613441e8f45639abbbe15b893f664970ac9L51-R53) [[7]](diffhunk://#diff-5803307fb43c9a449108cc74b465b1172006e9cad39be8460c1fb2a67a4fb169L53-R55) [[8]](diffhunk://#diff-c7da1754d25935dd3b8233d1532fbb3f93120643d80df1a51d5996cfc7c00d6bL53-R55) [[9]](diffhunk://#diff-fad7f562851dadf082f7f6dbbb964dfd66e91c1600a8bc1f723224b95f4d750cL51-R53) [[10]](diffhunk://#diff-cb40d1dcd3e48d8f6d823b0eec6859087c8df0614e78ca3700bb45ef5898015dL51-R53) [[11]](diffhunk://#diff-66448e8f2f0b5d53446c87853ff1affbe6642f8969d39a3811b8f5fbf064f7c4L51-R53) [[12]](diffhunk://#diff-42506bb10a71be4cb781a3c3a6e51e0bba841afded5f264da579a3dde463ab62L51-R53) [[13]](diffhunk://#diff-6e49965484ab2f0b325d99c913fcb2d0b66460220678279643382b60ba80add9L51-R53) [[14]](diffhunk://#diff-9842a3a6860ec3ad0fabfbc0e9f4fd092e3f412adb6ae4cc9702a8a7ab1c0c14L57-R59) [[15]](diffhunk://#diff-68590b1c5f0a83ba4f5cffc66df5ef3a7eb32f26fdd4131d69949cd44b6ca5f0L57-R59) [[16]](diffhunk://#diff-b2b0b363d46e7e98ff4630e58bdbd03f6093a32a7cd3bafdae51ed3b70e6f078L57-R59) [[17]](diffhunk://#diff-943997ccff8789ef836f533f5cd0a37571fb54d30907bb770505007fa32398e6L57-R59)

**Checksum Updates:**
* Updated the SHA512 checksums for all PowerShell package downloads in the Dockerfiles and in the `manifest.versions.json` file to match the new 7.4.14 release, ensuring the integrity of the downloaded artifacts. [[1]](diffhunk://#diff-f657b02176508554b475067f99d956c3c0fb1c08be55990212cb9179813b4acaL177-R182) [[2]](diffhunk://#diff-dc810143537b8d56eeb63de2d79b17b65e5c0c791c0dc5cedbb7bc494da0d3a2L51-R53) [[3]](diffhunk://#diff-1f65f50deb5fcf972030edf337837161c4a676fb64fc96fc6407c4f266dafc1bL53-R55) [[4]](diffhunk://#diff-63ce660de3fcecee34e09d4884d46e8e5426a7f314db6ce0a2364834cc2896f2L53-R55) [[5]](diffhunk://#diff-6ac4aa00b18490c4047c4ea9895a0b02bcc9cdd30a5373ff3a5c5f294a73758dL51-R53) [[6]](diffhunk://#diff-557400b5d1f9d0a2f5c67352d55b6475d6be6dc55b0dbceeffc6f58aadb95b58L51-R53) [[7]](diffhunk://#diff-6bdc3dc207e866e027a8114fc7676613441e8f45639abbbe15b893f664970ac9L51-R53) [[8]](diffhunk://#diff-5803307fb43c9a449108cc74b465b1172006e9cad39be8460c1fb2a67a4fb169L53-R55) [[9]](diffhunk://#diff-c7da1754d25935dd3b8233d1532fbb3f93120643d80df1a51d5996cfc7c00d6bL53-R55) [[10]](diffhunk://#diff-fad7f562851dadf082f7f6dbbb964dfd66e91c1600a8bc1f723224b95f4d750cL51-R53) [[11]](diffhunk://#diff-cb40d1dcd3e48d8f6d823b0eec6859087c8df0614e78ca3700bb45ef5898015dL51-R53) [[12]](diffhunk://#diff-66448e8f2f0b5d53446c87853ff1affbe6642f8969d39a3811b8f5fbf064f7c4L51-R53) [[13]](diffhunk://#diff-42506bb10a71be4cb781a3c3a6e51e0bba841afded5f264da579a3dde463ab62L51-R53) [[14]](diffhunk://#diff-6e49965484ab2f0b325d99c913fcb2d0b66460220678279643382b60ba80add9L51-R53) [[15]](diffhunk://#diff-9842a3a6860ec3ad0fabfbc0e9f4fd092e3f412adb6ae4cc9702a8a7ab1c0c14L57-R59) [[16]](diffhunk://#diff-68590b1c5f0a83ba4f5cffc66df5ef3a7eb32f26fdd4131d69949cd44b6ca5f0L57-R59) [[17]](diffhunk://#diff-b2b0b363d46e7e98ff4630e58bdbd03f6093a32a7cd3bafdae51ed3b70e6f078L57-R59) [[18]](diffhunk://#diff-943997ccff8789ef836f533f5cd0a37571fb54d30907bb770505007fa32398e6L57-R59)

These changes ensure that all .NET 8.0 SDK images ship with the latest PowerShell 7.4.14 release, improving security and stability.