### PR TITLE
Add tzdata-legacy to Ubuntu Resolute images

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.install-deps
+++ b/eng/dockerfile-templates/Dockerfile.linux.install-deps
@@ -69,7 +69,7 @@
                 cat("libicu", VARIABLES[cat("libicu|", OS_VERSION_BASE)]),
                 "tzdata"
             ],
-            when(OS_VERSION_BASE = "noble", [ "tzdata-legacy" ], []))
+            when(isUbuntu && OS_VERSION_BASE != "jammy", [ "tzdata-legacy" ], []))
         )))) ^
 
     set pkgs to

--- a/src/runtime-deps/11.0/resolute/amd64/Dockerfile
+++ b/src/runtime-deps/11.0/resolute/amd64/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         libssl3t64 \
         libstdc++6 \
         tzdata \
+        tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user and group

--- a/src/runtime-deps/11.0/resolute/arm32v7/Dockerfile
+++ b/src/runtime-deps/11.0/resolute/arm32v7/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         libssl3t64 \
         libstdc++6 \
         tzdata \
+        tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user and group

--- a/src/runtime-deps/11.0/resolute/arm64v8/Dockerfile
+++ b/src/runtime-deps/11.0/resolute/arm64v8/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         libssl3t64 \
         libstdc++6 \
         tzdata \
+        tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user and group

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-amd64-Dockerfile.approved.txt
@@ -19,6 +19,7 @@ RUN apt-get update \
         libssl3t64 \
         libstdc++6 \
         tzdata \
+        tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user and group

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -19,6 +19,7 @@ RUN apt-get update \
         libssl3t64 \
         libstdc++6 \
         tzdata \
+        tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user and group

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/runtime-deps-11.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -19,6 +19,7 @@ RUN apt-get update \
         libssl3t64 \
         libstdc++6 \
         tzdata \
+        tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user and group

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -379,6 +379,12 @@ namespace Microsoft.DotNet.Docker.Tests
                         "icu",
                         "tzdata"
                     },
+                { OS: var os } when os == OS.ResoluteChiseled => new[]
+                    {
+                        "libicu78",
+                        "tzdata-legacy",
+                        "tzdata"
+                    },
                 { OS: var os } when os == OS.NobleChiseled => new[]
                     {
                         "libicu74",


### PR DESCRIPTION
The tzdata-legacy condition in the non-chiseled Dockerfile template was hardcoded to `OS_VERSION_BASE = "noble"`. When Resolute (26.04) was added for .NET 11, the condition didn't match, so `tzdata-legacy` was silently dropped. This was originally fixed in https://github.com/dotnet/dotnet-docker/issues/6078.

This PR changes the condition to install tzdata-legacy on all Ubuntu versions except Jammy, matching the pattern already used in the chiseled template.

Fixes #7087