### PR TITLE
Temporarily disable EOL annotation generation

### DIFF
--- a/eng/pipelines/variables/core-official.yml
+++ b/eng/pipelines/variables/core-official.yml
@@ -12,5 +12,7 @@ variables:
 - name: officialBranchPrefixes
   value: internal/release/
 
-# Set publishEolAnnotations to true or false in the Azure Pipelines UI to
-# control EOL annotation publishing. The default should be true.
+# Temporarily disabled due to https://github.com/dotnet/docker-tools/issues/2056.
+- name: publishEolAnnotations
+  value: false
+  readonly: true


### PR DESCRIPTION
Temporarily disables EOL annotation generation in official builds while the system is being cleaned up and redesigned.

Related:
- Same as dotnet/docker-tools#2065 but for this repo instead.
- Tracking issue for cleanup being broken: dotnet/docker-tools#2056