### PR TITLE
Remove internal PAT fallback from update-dependencies templates (WI 10142)

### DIFF
--- a/eng/pipelines/steps/update-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dependencies-specific.yml
@@ -7,6 +7,11 @@ parameters:
 - name: useInternalBuild
   type: boolean
   default: false
+# Token used for internal-build pushes when the internal path is enabled.
+# Set the `internalAccessToken` YAML variable to override this if needed.
+- name: internalAccessToken
+  type: string
+  default: '$(internalAccessToken)'
 - name: skipPullRequest
   type: boolean
   default: false
@@ -18,7 +23,7 @@ steps:
   displayName: Create Update Dependencies container
 - powershell: |
     if ("${{ parameters.useInternalBuild }}" -eq "true") {
-      $pat="$(dn-bot-devdiv-dnceng-rw-code-pat)"
+      $pat='${{ parameters.internalAccessToken }}'
     } else {
       $pat="$(BotAccount-dotnet-docker-bot-PAT)"
     }

--- a/eng/pipelines/steps/update-dotnet-dependencies-specific.yml
+++ b/eng/pipelines/steps/update-dotnet-dependencies-specific.yml
@@ -3,6 +3,9 @@ parameters:
   # Comma-delimited list of SDK versions to target (overrides the use of channel var to determine latest version)
   sdkVersions: ""
   buildId: ""
+  # Token used for AzdoVersionsRepoInfoAccessToken in the internal-build path.
+  # Set the `internalAccessToken` YAML variable to override this if needed.
+  internalAccessToken: '$(internalAccessToken)'
   skipPullRequest: false
 
 steps:
@@ -26,7 +29,7 @@ steps:
     if ("${{ parameters.useInternalBuild }}" -eq "true") {
       $args["UseInternalBuild"] = $true
       $args["InternalAccessToken"] = '$(System.AccessToken)'
-      $args["AzdoVersionsRepoInfoAccessToken"] = "$(dn-bot-devdiv-dnceng-rw-code-pat)"
+      $args["AzdoVersionsRepoInfoAccessToken"] = '${{ parameters.internalAccessToken }}'
     }
 
     $(engPath)/Get-DropVersions.ps1 @args
@@ -86,3 +89,4 @@ steps:
     customArgsArray: "$(customArgsArray)"
     skipPullRequest: ${{ parameters.skipPullRequest }}
     useInternalBuild: ${{ parameters.useInternalBuild }}
+    internalAccessToken: ${{ parameters.internalAccessToken }}


### PR DESCRIPTION
This updates the remaining internal `dn-bot-devdiv-dnceng-rw-code-pat` references in the update-dependencies templates to use an overridable YAML variable instead.

Specifically:
- `update-dependencies-specific.yml` now uses `${{ parameters.internalAccessToken }}` for the internal push credential path
- `update-dotnet-dependencies-specific.yml` now uses `${{ parameters.internalAccessToken }}` for `AzdoVersionsRepoInfoAccessToken`
- `InternalAccessToken` remains on `$(System.AccessToken)`

Current repo evidence: a fresh search for `useInternalBuild` / `internalAccessToken` only finds references inside these shared templates themselves. There are no checked-in callers in `dotnet-docker` currently setting `useInternalBuild: true`, so this appears to be a dormant path today.

This keeps the existing internal flow behavior while removing the direct dependency on the retired PAT name.

Work item: https://dev.azure.com/dnceng/internal/_workitems/edit/10142