### PR TITLE
Fix resolute chiseled expected package lists

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -313,7 +313,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     [
                         "ca-certificates",
                         "gcc-14-base",
-                        ..GetResoluteChiseledAmd64Packages(imageData),
+                        ..GetResoluteChiseledArchSpecificPackages(imageData),
                         "libc6",
                         "libgcc-s1",
                         "libssl3t64",
@@ -392,11 +392,16 @@ namespace Microsoft.DotNet.Docker.Tests
         }
 
         /// <summary>
-        /// Syft detects gcc-16 and openssl-provider-legacy as separate binary packages
-        /// on amd64 resolute chiseled images but not on arm64/arm32.
+        /// Syft detects additional binary packages on specific architectures
+        /// for resolute chiseled images: gcc-16 on amd64, openssl-provider-legacy on arm32.
         /// </summary>
-        private static IEnumerable<string> GetResoluteChiseledAmd64Packages(ProductImageData imageData) =>
-            imageData.Arch == Arch.Amd64 ? ["gcc-16", "openssl-provider-legacy"] : [];
+        private static IEnumerable<string> GetResoluteChiseledArchSpecificPackages(ProductImageData imageData) =>
+            imageData.Arch switch
+            {
+                Arch.Amd64 => ["gcc-16"],
+                Arch.Arm => ["openssl-provider-legacy"],
+                _ => []
+            };
 
         private static IEnumerable<string> GetExtraPackages(ProductImageData imageData) => imageData switch
             {
@@ -409,7 +414,8 @@ namespace Microsoft.DotNet.Docker.Tests
                     {
                         "icu",
                         "libicu78",
-                        "tzdata"
+                        "tzdata",
+                        "tzdata-legacy"
                     },
                 { OS: var os } when os == OS.NobleChiseled => new[]
                     {


### PR DESCRIPTION
Fixes VerifyInstalledPackages test failures on all resolute (Ubuntu 26.04) chiseled images (10.0 and 11.0, all architectures).

**Changes:**
1. `openssl-provider-legacy` — removed from amd64 expected packages (no longer detected by Syft on amd64).
2. `openssl-provider-legacy` — added to arm32 expected packages (now detected by Syft on arm32).
3. `tzdata-legacy` — added to the resolute chiseled extra packages (present on all architectures).

**Failed build:** build#2949989