### PR TITLE
Fix releases sample support phase handling

### DIFF
--- a/samples/releasesapi/ReportGenerator.cs
+++ b/samples/releasesapi/ReportGenerator.cs
@@ -15,7 +15,7 @@ public static class Generator
         await foreach(MajorRelease release in GetMajorReleasesAsync())
         {
             int supportDays = release.EolDate is null ? 0 : GetDaysAgo(release.EolDate);
-            bool supported = release.SupportPhase is "active" or "maintainence";
+            bool supported = IsSupported(release);
             MajorVersion version = new(release.ChannelVersion, supported, release.EolDate ?? "", supportDays, GetReleases(release).ToList());
             yield return version;
         }
@@ -43,7 +43,7 @@ public static class Generator
 
     public static MajorVersion GetVersion(MajorRelease release) =>
         new(release.ChannelVersion, 
-            release.SupportPhase is "active" or "maintainence", 
+            IsSupported(release), 
             release.EolDate ?? "", 
             release.EolDate is null ? 0 : GetDaysAgo(release.EolDate), 
             GetReleases(release).ToList()
@@ -80,6 +80,9 @@ public static class Generator
         var daysAgo = success ? (int)(day - DateTime.Now).TotalDays : 0;
         return positiveNumber ? Math.Abs(daysAgo) : daysAgo;
     }
+
+    static bool IsSupported(MajorRelease release) =>
+        release.SupportPhase is "active" or "maintenance";
 
 }
 

--- a/samples/releasesapp/ReportGenerator.cs
+++ b/samples/releasesapp/ReportGenerator.cs
@@ -16,7 +16,7 @@ public static class Generator
         await foreach(MajorRelease release in GetMajorReleasesAsync())
         {
             int supportDays = release.EolDate is null ? 0 : GetDaysAgo(release.EolDate);
-            bool supported = release.SupportPhase is "active" or "maintainence";
+            bool supported = IsSupported(release);
             MajorVersion version = new(release.ChannelVersion, supported, release.EolDate ?? "", supportDays, GetReleases(release).ToList());
             yield return version;
         }
@@ -44,7 +44,7 @@ public static class Generator
 
     public static MajorVersion GetVersion(MajorRelease release) =>
         new(release.ChannelVersion, 
-            release.SupportPhase is "active" or "maintainence", 
+            IsSupported(release), 
             release.EolDate ?? "", 
             release.EolDate is null ? 0 : GetDaysAgo(release.EolDate), 
             GetReleases(release).ToList()
@@ -81,6 +81,9 @@ public static class Generator
         var daysAgo = success ? (int)(day - DateTime.Now).TotalDays : 0;
         return positiveNumber ? Math.Abs(daysAgo) : daysAgo;
     }
+
+    static bool IsSupported(MajorRelease release) =>
+        release.SupportPhase is "active" or "maintenance";
 
 }
 


### PR DESCRIPTION
## Summary
- use a shared support-phase helper in the releases API and app samples
- treat only `active` and `maintenance` phases as supported
- keep preview releases like 11.0 reported as unsupported while restoring support for maintenance channels