### PR TITLE
Update Aspire Dashboard to 13.3.0

### DIFF
--- a/README.aspire-dashboard.md
+++ b/README.aspire-dashboard.md
@@ -114,13 +114,13 @@ Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures
 
 Tags | Dockerfile | OS Version
 ---- | ---------- | ----------
-13.2.0, 13.2, 13, latest | [Dockerfile](src/aspire-dashboard/amd64/Dockerfile) | Azure Linux 3.0
+13.3.0, 13.3, 13, latest | [Dockerfile](src/aspire-dashboard/amd64/Dockerfile) | Azure Linux 3.0
 
 ### Linux arm64 Tags
 
 Tags | Dockerfile | OS Version
 ---- | ---------- | ----------
-13.2.0, 13.2, 13, latest | [Dockerfile](src/aspire-dashboard/arm64v8/Dockerfile) | Azure Linux 3.0
+13.3.0, 13.3, 13, latest | [Dockerfile](src/aspire-dashboard/arm64v8/Dockerfile) | Azure Linux 3.0
 
 <!--End of generated tags-->
 

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -18,13 +18,13 @@
     "alpine|9.0|floating-tag-version": "$(alpine|floating-tag-version)",
     "alpine|8.0|floating-tag-version": "$(alpine|floating-tag-version)",
 
-    "aspire-dashboard|build-version": "13.2.0-preview.1.26170.3",
-    "aspire-dashboard|product-version": "13.2.0",
+    "aspire-dashboard|build-version": "13.3.0-preview.1.26256.5",
+    "aspire-dashboard|product-version": "13.3.0",
     "aspire-dashboard|fixed-tag": "$(aspire-dashboard|product-version)",
-    "aspire-dashboard|minor-tag": "13.2",
+    "aspire-dashboard|minor-tag": "13.3",
     "aspire-dashboard|major-tag": "13",
-    "aspire-dashboard|linux|x64|sha": "5d22e82c17478e94b2cf610d34359baae4fc4f01f53da863c663dd51321bd5d51cbf10ac3598dcf5cbd04e7c7050b6fb3bf37b945593cb40f5f44615be9d791c",
-    "aspire-dashboard|linux|arm64|sha": "b7d12a81afcc4f75d7726ba7b387e53860b52f33d13955deac7c3dd6bbccd1dbb9e092a60e7815a1802d4b8ec510577ce10f46d8df0f394be42e058bb43bff65",
+    "aspire-dashboard|linux|x64|sha": "cfafa97f3d8bca6a3e0d20d29d5d1a2c119ac2fd45650569bc596182598603512f46df91fd623d5818ed5795816419ddd7a0bd30b831df44e3256fcb30021557",
+    "aspire-dashboard|linux|arm64|sha": "e03dd6d54b9df414a70ffa16d962dddb4b83c516c8e8342ccf57aafb24c7c80fc3f0938ef98b2c1c7edbe221aa48cf66f302b719facffc62f2229356639667ac",
     "aspire-dashboard|base-url|main": "$(base-url|public|preview|nightly)",
     "aspire-dashboard|base-url|nightly": "$(base-url|public|preview|nightly)",
 

--- a/src/aspire-dashboard/amd64/Dockerfile
+++ b/src/aspire-dashboard/amd64/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=13.2.0-preview.1.26170.3 \
+RUN dotnet_aspire_version=13.3.0-preview.1.26256.5 \
     && curl --fail --show-error --location --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-x64.zip \
-    && aspire_dashboard_sha512='5d22e82c17478e94b2cf610d34359baae4fc4f01f53da863c663dd51321bd5d51cbf10ac3598dcf5cbd04e7c7050b6fb3bf37b945593cb40f5f44615be9d791c' \
+    && aspire_dashboard_sha512='cfafa97f3d8bca6a3e0d20d29d5d1a2c119ac2fd45650569bc596182598603512f46df91fd623d5818ed5795816419ddd7a0bd30b831df44e3256fcb30021557' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir --parents /app \
     && unzip aspire_dashboard.zip -d /app \

--- a/src/aspire-dashboard/arm64v8/Dockerfile
+++ b/src/aspire-dashboard/arm64v8/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve Aspire Dashboard
-RUN dotnet_aspire_version=13.2.0-preview.1.26170.3 \
+RUN dotnet_aspire_version=13.3.0-preview.1.26256.5 \
     && curl --fail --show-error --location --output aspire_dashboard.zip https://ci.dot.net/public/aspire/$dotnet_aspire_version/aspire-dashboard-linux-arm64.zip \
-    && aspire_dashboard_sha512='b7d12a81afcc4f75d7726ba7b387e53860b52f33d13955deac7c3dd6bbccd1dbb9e092a60e7815a1802d4b8ec510577ce10f46d8df0f394be42e058bb43bff65' \
+    && aspire_dashboard_sha512='e03dd6d54b9df414a70ffa16d962dddb4b83c516c8e8342ccf57aafb24c7c80fc3f0938ef98b2c1c7edbe221aa48cf66f302b719facffc62f2229356639667ac' \
     && echo "$aspire_dashboard_sha512  aspire_dashboard.zip" | sha512sum -c - \
     && mkdir --parents /app \
     && unzip aspire_dashboard.zip -d /app \

--- a/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ImageVersion.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Docker.Tests
         public static readonly ImageVersion V9_0 = new(new Version(9, 0), isPreview: false);
         public static readonly ImageVersion V9_1 = new(new Version(9, 1), isPreview: false);
         public static readonly ImageVersion V13_2 = new(new Version(13, 2), isPreview: false);
+        public static readonly ImageVersion V13_3 = new(new Version(13, 3), isPreview: false);
         public static readonly ImageVersion V9_2_Preview = new(new Version(9, 2), isPreview: true);
         public static readonly ImageVersion V10_0 = new(new Version(10, 0), isPreview: false);
         public static readonly ImageVersion V11_0 = new(new Version(11, 0), isPreview: true);

--- a/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestData.cs
@@ -433,7 +433,7 @@ namespace Microsoft.DotNet.Docker.Tests
         private static readonly ProductImageData[] s_AspireDashboardTestData =
         {
             new() {
-                Version = V13_2,
+                Version = V13_3,
                 VersionFamily = V9_0,
                 OS = OS.AzureLinux30Distroless,
                 OSTag = "",
@@ -442,7 +442,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 SupportedImageRepos = DotNetImageRepo.Aspire_Dashboard,
             },
             new() {
-                Version = V13_2,
+                Version = V13_3,
                 VersionFamily = V9_0,
                 OS = OS.AzureLinux30Distroless,
                 OSTag = "",


### PR DESCRIPTION
Updates Aspire Dashboard from 13.2.0 to 13.3.0 for the 2026-05B release.

Uses the latest build from BAR channel 8105. I confirmed the arm64 image builds locally.