### PR TITLE
Non-nightly images in samples

### DIFF
--- a/samples/aspnetapp/Dockerfile.alpine-composite
+++ b/samples/aspnetapp/Dockerfile.alpine-composite
@@ -16,7 +16,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 # Enable globalization and time zones:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:10.0-alpine-composite
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine-composite
 EXPOSE 8080
 WORKDIR /app
 COPY --link --from=build /app .

--- a/samples/aspnetapp/Dockerfile.chiseled-composite
+++ b/samples/aspnetapp/Dockerfile.chiseled-composite
@@ -14,7 +14,7 @@ RUN dotnet publish -a $TARGETARCH --no-restore -o /app
 
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:10.0-noble-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite
 EXPOSE 8080
 WORKDIR /app
 COPY --link --from=build /app .


### PR DESCRIPTION
The samples should be for end-users and consistent across all other samples, thus `nightly` versions should be discarded in the 2 samples found. 