### PR TITLE
Remove disabled `darc-pub-dotnet-...` NuGet feed

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config
+++ b/tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config
@@ -3,6 +3,5 @@
   <packageSources>
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-dotnet-0fc3e418/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Removes the disabled `darc-pub-dotnet-dotnet-0fc3e418` feed entry from `tests/Microsoft.DotNet.Docker.Tests/TestAppArtifacts/NuGet.config`.