### PR TITLE
Update dotnet-monitor to 10.0.3

### DIFF
--- a/README.monitor-base.md
+++ b/README.monitor-base.md
@@ -54,7 +54,7 @@ The following Dockerfiles demonstrate how you can use this base image to build a
 
 Tags | Dockerfile | OS Version
 ---- | ---------- | ----------
-10.0.2-preview.1-amd64, 10.0-amd64, 10.0.2-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
+10.0.3-preview.1-amd64, 10.0-amd64, 10.0.3-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 9.0.5-amd64, 9.0-amd64, 9.0.5, 9.0, 9 | [Dockerfile](src/monitor-base/9.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 8.1.3-ubuntu-chiseled-amd64, 8.1-ubuntu-chiseled-amd64, 8-ubuntu-chiseled-amd64, 8.1.3-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.3, 8.1, 8 | [Dockerfile](src/monitor-base/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 8.1.3-azurelinux-distroless-amd64, 8.1-azurelinux-distroless-amd64, 8-azurelinux-distroless-amd64, 8.1.3-azurelinux-distroless, 8.1-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](src/monitor-base/8.1/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
@@ -63,7 +63,7 @@ Tags | Dockerfile | OS Version
 
 Tags | Dockerfile | OS Version
 ---- | ---------- | ----------
-10.0.2-preview.1-arm64v8, 10.0-arm64v8, 10.0.2-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
+10.0.3-preview.1-arm64v8, 10.0-arm64v8, 10.0.3-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor-base/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.5-arm64v8, 9.0-arm64v8, 9.0.5, 9.0, 9 | [Dockerfile](src/monitor-base/9.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 8.1.3-ubuntu-chiseled-arm64v8, 8.1-ubuntu-chiseled-arm64v8, 8-ubuntu-chiseled-arm64v8, 8.1.3-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.3, 8.1, 8 | [Dockerfile](src/monitor-base/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 8.1.3-azurelinux-distroless-arm64v8, 8.1-azurelinux-distroless-arm64v8, 8-azurelinux-distroless-arm64v8, 8.1.3-azurelinux-distroless, 8.1-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](src/monitor-base/8.1/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0

--- a/README.monitor.md
+++ b/README.monitor.md
@@ -55,7 +55,7 @@ See [documentation](https://go.microsoft.com/fwlink/?linkid=2158052) for how to 
 
 Tags | Dockerfile | OS Version
 ---- | ---------- | ----------
-10.0.2-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
+10.0.3-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 9.0.5, 9.0, 9 | [Dockerfile](src/monitor/9.0/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
 8.1.3-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.3, 8.1, 8 | [Dockerfile](src/monitor/8.1/ubuntu-chiseled/amd64/Dockerfile) | Ubuntu 22.04
 8.1.3-azurelinux-distroless, 8.1-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](src/monitor/8.1/azurelinux-distroless/amd64/Dockerfile) | Azure Linux 3.0
@@ -64,7 +64,7 @@ Tags | Dockerfile | OS Version
 
 Tags | Dockerfile | OS Version
 ---- | ---------- | ----------
-10.0.2-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
+10.0.3-preview.1, 10.0, 10, latest | [Dockerfile](src/monitor/10.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 9.0.5, 9.0, 9 | [Dockerfile](src/monitor/9.0/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0
 8.1.3-ubuntu-chiseled, 8.1-ubuntu-chiseled, 8-ubuntu-chiseled, 8.1.3, 8.1, 8 | [Dockerfile](src/monitor/8.1/ubuntu-chiseled/arm64v8/Dockerfile) | Ubuntu 22.04
 8.1.3-azurelinux-distroless, 8.1-azurelinux-distroless, 8-azurelinux-distroless | [Dockerfile](src/monitor/8.1/azurelinux-distroless/arm64v8/Dockerfile) | Azure Linux 3.0

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -168,8 +168,8 @@
     "monitor-ext-s3storage|9.0|linux|x64|sha": "8fa19f1b002fa3d91571f960d7bb803a38bb81d237f5a44677726ca3b0d65e8231c9bbe1494c84a6998ac1c4dd138290e138eabd36fdf409da311736741d91d4",
     "monitor-ext-s3storage|9.0|linux|arm64|sha": "60dfe12e76badb3530a0ad0d9b8d58ea059883774f1a671c2702ae35ce2e3212ad9e3acb1134df448a9c7bcfdd264293584b74f02283b57e4a98d0ff0279ac4a",
 
-    "monitor|10.0|build-version": "10.0.2-preview.1.26206.1",
-    "monitor|10.0|product-version": "10.0.2-preview.1",
+    "monitor|10.0|build-version": "10.0.3-preview.1.26303.1",
+    "monitor|10.0|product-version": "10.0.3-preview.1",
     "monitor|10.0|fixed-tag": "$(monitor|10.0|product-version)",
     "monitor|10.0|minor-tag": "10.0",
     "monitor|10.0|base-url|main": "$(base-url|public|maintenance|main)",

--- a/src/monitor-base/10.0/azurelinux-distroless/amd64/Dockerfile
+++ b/src/monitor-base/10.0/azurelinux-distroless/amd64/Dockerfile
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=10.0.2-preview.1.26206.1 \
+RUN dotnet_monitor_version=10.0.3-preview.1.26303.1 \
     && curl --fail --show-error --location \
         --remote-name https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz \
         --remote-name https://ci.dot.net/public-checksums/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-x64.tar.gz.sha512 \

--- a/src/monitor-base/10.0/azurelinux-distroless/arm64v8/Dockerfile
+++ b/src/monitor-base/10.0/azurelinux-distroless/arm64v8/Dockerfile
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor Base
-RUN dotnet_monitor_version=10.0.2-preview.1.26206.1 \
+RUN dotnet_monitor_version=10.0.3-preview.1.26303.1 \
     && curl --fail --show-error --location \
         --remote-name https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz \
         --remote-name https://ci.dot.net/public-checksums/diagnostics/monitor/$dotnet_monitor_version/dotnet-monitor-base-$dotnet_monitor_version-linux-arm64.tar.gz.sha512 \

--- a/src/monitor/10.0/azurelinux-distroless/amd64/Dockerfile
+++ b/src/monitor/10.0/azurelinux-distroless/amd64/Dockerfile
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor extensions
-RUN dotnet_monitor_extension_version=10.0.2-preview.1.26206.1 \
+RUN dotnet_monitor_extension_version=10.0.3-preview.1.26303.1 \
     && curl --fail --show-error --location \
         --output dotnet-monitor-egress-azureblobstorage.tar.gz https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
         --output dotnet-monitor-egress-s3storage.tar.gz https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-x64.tar.gz \
@@ -29,6 +29,6 @@ RUN dotnet_monitor_extension_version=10.0.2-preview.1.26206.1 \
 
 
 # .NET Monitor image
-FROM $REPO:10.0.2-preview.1-amd64
+FROM $REPO:10.0.3-preview.1-amd64
 
 COPY --from=installer ["/app", "/app"]

--- a/src/monitor/10.0/azurelinux-distroless/arm64v8/Dockerfile
+++ b/src/monitor/10.0/azurelinux-distroless/arm64v8/Dockerfile
@@ -10,7 +10,7 @@ RUN tdnf install -y \
     && tdnf clean all
 
 # Retrieve .NET Monitor extensions
-RUN dotnet_monitor_extension_version=10.0.2-preview.1.26206.1 \
+RUN dotnet_monitor_extension_version=10.0.3-preview.1.26303.1 \
     && curl --fail --show-error --location \
         --output dotnet-monitor-egress-azureblobstorage.tar.gz https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-azureblobstorage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
         --output dotnet-monitor-egress-s3storage.tar.gz https://ci.dot.net/public/diagnostics/monitor/$dotnet_monitor_extension_version/dotnet-monitor-egress-s3storage-$dotnet_monitor_extension_version-linux-arm64.tar.gz \
@@ -29,6 +29,6 @@ RUN dotnet_monitor_extension_version=10.0.2-preview.1.26206.1 \
 
 
 # .NET Monitor image
-FROM $REPO:10.0.2-preview.1-arm64v8
+FROM $REPO:10.0.3-preview.1-arm64v8
 
 COPY --from=installer ["/app", "/app"]


### PR DESCRIPTION
This PR updates dotnet-monitor to 10.0.3.
The automated PR never lands due to #6427, so I created this one manually.