### PR TITLE
Switch Aspire source build repo from dotnet to microsoft org

### DIFF
--- a/eng/pipelines/pipelines/update-dependencies.yml
+++ b/eng/pipelines/pipelines/update-dependencies.yml
@@ -73,8 +73,8 @@ extends:
                   dotnet run --project eng/update-dependencies/update-dependencies.csproj --
                   from-channel
                   ${{ parameters.aspireChannel }}
-                  https://github.com/dotnet/aspire
-                  --version-source-name 'dotnet/aspire'
+                  https://github.com/microsoft/aspire
+                  --version-source-name 'microsoft/aspire'
                   ${{ parameters.gitHubAuthArgs }}
 
       - ${{ each tool in parameters.tools }}:

--- a/eng/update-dependencies/BuildExtensions.cs
+++ b/eng/update-dependencies/BuildExtensions.cs
@@ -20,7 +20,6 @@ internal static class BuildExtensions
         return repo switch
         {
             "https://github.com/dotnet/dotnet" or "https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet" => BuildRepo.Vmr,
-            "https://github.com/dotnet/aspire" or "https://dev.azure.com/dnceng/internal/_git/dotnet-aspire" => BuildRepo.Aspire,
             "https://github.com/microsoft/aspire" or "https://dev.azure.com/dnceng/internal/_git/microsoft-aspire" => BuildRepo.Aspire,
             _ => throw new InvalidOperationException($"Build {build.Id} was from unsupported repository '{repo}'"),
         };

--- a/eng/update-dependencies/DockerfileShaUpdater.cs
+++ b/eng/update-dependencies/DockerfileShaUpdater.cs
@@ -138,7 +138,7 @@ namespace Dotnet.Docker
             usedBuildInfos = [dependencyBuildInfos.First(info => info.SimpleName == _productName)];
 
             string baseUrl = ManifestHelper.GetBaseUrls(_manifestVariables.Variables, _options).First();
-            // Remove Aspire Dashboard case once https://github.com/dotnet/aspire/issues/2035 is fixed.
+            // Remove Aspire Dashboard case once https://github.com/microsoft/aspire/issues/2035 is fixed.
             string archiveExt = _os.Contains("win") || _productName.Contains("aspire-dashboard") ? "zip" : "tar.gz";
             string versionDir = _buildVersion ?? "";
             string versionFile = VersionHelper.ResolveProductVersion(versionDir, _options.StableBranding);


### PR DESCRIPTION
The misconfiguration in the pipeline caused update-dependencies to pick up the most recent build from the dotnet org, and ignore builds from the microsoft org, which caused https://github.com/dotnet/dotnet-docker/pull/7229 to try and downgrade the dashboard version.

Related: https://github.com/dotnet/dotnet-docker/pull/7225