### PR TITLE
Temporarily revert ImageBuilder version

### DIFF
--- a/eng/docker-tools/templates/variables/docker-images.yml
+++ b/eng/docker-tools/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2986591
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2980918
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner


### PR DESCRIPTION
Publishing is failed due a bug in https://github.com/dotnet/docker-tools/pull/2117, which will be fixed in https://github.com/dotnet/docker-tools/pull/2137.