### PR TITLE
Update image-builder tag to latest version

### DIFF
--- a/eng/docker-tools/templates/variables/docker-images.yml
+++ b/eng/docker-tools/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2980918
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2996325
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner


### PR DESCRIPTION
This PR updates ImageBuilder to the latest version, 2996325, which contains changes from https://github.com/dotnet/docker-tools/pull/2139 necessary to fix rate limiting issues during image publishing.