### PR TITLE
Update .NET 8.0 with PowerShell v7.4.17

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -177,7 +177,7 @@
     "monitor|10.0|base-url|checksums|main": "$(base-url|public-checksums|maintenance|main)",
     "monitor|10.0|base-url|checksums|nightly": "$(base-url|public-checksums|preview|nightly)",
 
-    "powershell|8.0|build-version": "7.4.16",
+    "powershell|8.0|build-version": "7.4.17",
     "powershell|8.0|Linux.Alpine|sha": "5b9f1362121a45fc06a89a58b28b66fff85fd1c1236e9df5e20f1eb44e6a480b01769874e88156972fd6b33719fa98fb7a6dae72073e37a2f87f6da1127d3988",
     "powershell|8.0|Linux|arm32|sha": "f61674177ec9ee3557db3bbce669938a8e17e830634b310f93aada0b427aa8e2882a1fb4c2e3ac6f8246371753bc08c7f450a4fa8b6fe9bc96343767cda97405",
     "powershell|8.0|Linux|arm64|sha": "fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c",

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -178,11 +178,11 @@
     "monitor|10.0|base-url|checksums|nightly": "$(base-url|public-checksums|preview|nightly)",
 
     "powershell|8.0|build-version": "7.4.17",
-    "powershell|8.0|Linux.Alpine|sha": "5b9f1362121a45fc06a89a58b28b66fff85fd1c1236e9df5e20f1eb44e6a480b01769874e88156972fd6b33719fa98fb7a6dae72073e37a2f87f6da1127d3988",
-    "powershell|8.0|Linux|arm32|sha": "f61674177ec9ee3557db3bbce669938a8e17e830634b310f93aada0b427aa8e2882a1fb4c2e3ac6f8246371753bc08c7f450a4fa8b6fe9bc96343767cda97405",
-    "powershell|8.0|Linux|arm64|sha": "fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c",
-    "powershell|8.0|Linux|x64|sha": "446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4",
-    "powershell|8.0|Windows|x64|sha": "5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df",
+    "powershell|8.0|Linux.Alpine|sha": "2653ecb7c4423f5530f9847a47909a34692c36db9311e97d4b10f92af82d87943593762d8107cd27c4cc0cbaebb34c2919fe2e00302172f00a8cb6d5f84e8927",
+    "powershell|8.0|Linux|arm32|sha": "1fa6e803011747cd98feac935e694823a682d6285f9155b5cd4abc30fec0368cf35568776212d3039c36d3f43da4e866b28126766ecf28e0e6cc38b59612ea9c",
+    "powershell|8.0|Linux|arm64|sha": "83b7e6dcea9b235b3f2f87c98704746583a3403f7590f06f04483fd26a16b893930f35d17862ee7fdc6d189b3b069ba8b7b97d79d479124362687c0e8840da55",
+    "powershell|8.0|Linux|x64|sha": "e278f58ec3b86c2857dee5711d3d3d7f39b3a1ac0a732d3d0e6d9293fbfce246bbf1d24fd314a62d760a27e2664fdd3a5a44a1c61f1c1613cc8691602157b576",
+    "powershell|8.0|Windows|x64|sha": "b99fbfd7370a49bee61b4635d4158917089682fa021c7e9e219d747f1a7a33e893027195947688cfbe0caaa641360ab53ec919d8a5ba152ab29d23b4ecbe7dd4",
 
     "powershell|9.0|build-version": "7.5.7",
     "powershell|9.0|Linux.Alpine|sha": "c672bac9f736e794cd586195c87fcb6f26468cc49c1ec835cfcf25c79daeaef934b5d92bc0ce092cd02cc0a5b8d933e94dead0aa850a7b7f77afbec8338331fd",

--- a/src/sdk/8.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.23/amd64/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='5b9f1362121a45fc06a89a58b28b66fff85fd1c1236e9df5e20f1eb44e6a480b01769874e88156972fd6b33719fa98fb7a6dae72073e37a2f87f6da1127d3988' \
+    && powershell_sha512='2653ecb7c4423f5530f9847a47909a34692c36db9311e97d4b10f92af82d87943593762d8107cd27c4cc0cbaebb34c2919fe2e00302172f00a8cb6d5f84e8927' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \

--- a/src/sdk/8.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.23/amd64/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='5b9f1362121a45fc06a89a58b28b66fff85fd1c1236e9df5e20f1eb44e6a480b01769874e88156972fd6b33719fa98fb7a6dae72073e37a2f87f6da1127d3988' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
@@ -52,7 +52,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
+    && powershell_sha512='e278f58ec3b86c2857dee5711d3d3d7f39b3a1ac0a732d3d0e6d9293fbfce246bbf1d24fd314a62d760a27e2664fdd3a5a44a1c61f1c1613cc8691602157b576' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -52,7 +52,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
+    && powershell_sha512='83b7e6dcea9b235b3f2f87c98704746583a3403f7590f06f04483fd26a16b893930f35d17862ee7fdc6d189b3b069ba8b7b97d79d479124362687c0e8840da55' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
+    && powershell_sha512='e278f58ec3b86c2857dee5711d3d3d7f39b3a1ac0a732d3d0e6d9293fbfce246bbf1d24fd314a62d760a27e2664fdd3a5a44a1c61f1c1613cc8691602157b576' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='f61674177ec9ee3557db3bbce669938a8e17e830634b310f93aada0b427aa8e2882a1fb4c2e3ac6f8246371753bc08c7f450a4fa8b6fe9bc96343767cda97405' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='f61674177ec9ee3557db3bbce669938a8e17e830634b310f93aada0b427aa8e2882a1fb4c2e3ac6f8246371753bc08c7f450a4fa8b6fe9bc96343767cda97405' \
+    && powershell_sha512='1fa6e803011747cd98feac935e694823a682d6285f9155b5cd4abc30fec0368cf35568776212d3039c36d3f43da4e866b28126766ecf28e0e6cc38b59612ea9c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
+    && powershell_sha512='83b7e6dcea9b235b3f2f87c98704746583a3403f7590f06f04483fd26a16b893930f35d17862ee7fdc6d189b3b069ba8b7b97d79d479124362687c0e8840da55' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/jammy/amd64/Dockerfile
+++ b/src/sdk/8.0/jammy/amd64/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
+    && powershell_sha512='e278f58ec3b86c2857dee5711d3d3d7f39b3a1ac0a732d3d0e6d9293fbfce246bbf1d24fd314a62d760a27e2664fdd3a5a44a1c61f1c1613cc8691602157b576' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/jammy/amd64/Dockerfile
+++ b/src/sdk/8.0/jammy/amd64/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/8.0/jammy/arm32v7/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='f61674177ec9ee3557db3bbce669938a8e17e830634b310f93aada0b427aa8e2882a1fb4c2e3ac6f8246371753bc08c7f450a4fa8b6fe9bc96343767cda97405' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/8.0/jammy/arm32v7/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='f61674177ec9ee3557db3bbce669938a8e17e830634b310f93aada0b427aa8e2882a1fb4c2e3ac6f8246371753bc08c7f450a4fa8b6fe9bc96343767cda97405' \
+    && powershell_sha512='1fa6e803011747cd98feac935e694823a682d6285f9155b5cd4abc30fec0368cf35568776212d3039c36d3f43da4e866b28126766ecf28e0e6cc38b59612ea9c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/8.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/8.0/jammy/arm64v8/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
+    && powershell_sha512='83b7e6dcea9b235b3f2f87c98704746583a3403f7590f06f04483fd26a16b893930f35d17862ee7fdc6d189b3b069ba8b7b97d79d479124362687c0e8840da55' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/8.0/jammy/arm64v8/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.16'; `
+        $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-1809/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
+        $powershell_sha512 = 'b99fbfd7370a49bee61b4635d4158917089682fa021c7e9e219d747f1a7a33e893027195947688cfbe0caaa641360ab53ec919d8a5ba152ab29d23b4ecbe7dd4'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.16'; `
+        $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
+        $powershell_sha512 = 'b99fbfd7370a49bee61b4635d4158917089682fa021c7e9e219d747f1a7a33e893027195947688cfbe0caaa641360ab53ec919d8a5ba152ab29d23b4ecbe7dd4'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.16'; `
+        $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
+        $powershell_sha512 = 'b99fbfd7370a49bee61b4635d4158917089682fa021c7e9e219d747f1a7a33e893027195947688cfbe0caaa641360ab53ec919d8a5ba152ab29d23b4ecbe7dd4'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/noble/amd64/Dockerfile
+++ b/src/sdk/8.0/noble/amd64/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
+    && powershell_sha512='e278f58ec3b86c2857dee5711d3d3d7f39b3a1ac0a732d3d0e6d9293fbfce246bbf1d24fd314a62d760a27e2664fdd3a5a44a1c61f1c1613cc8691602157b576' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/8.0/noble/amd64/Dockerfile
+++ b/src/sdk/8.0/noble/amd64/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/8.0/noble/arm64v8/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
+    && powershell_sha512='83b7e6dcea9b235b3f2f87c98704746583a3403f7590f06f04483fd26a16b893930f35d17862ee7fdc6d189b3b069ba8b7b97d79d479124362687c0e8840da55' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/8.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/8.0/noble/arm64v8/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.4.16 \
+RUN powershell_version=7.4.17 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='fe29fe9126ada7cbf0b9aa4be4e80958268b7a1a5bc6dcd0f950d003af12a2c448672cd0d6081dab7fc6bd880eb1551ae06faad15e6210363c52e8ed5fd7b67c' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.16'; `
+        $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
+        $powershell_sha512 = 'b99fbfd7370a49bee61b4635d4158917089682fa021c7e9e219d747f1a7a33e893027195947688cfbe0caaa641360ab53ec919d8a5ba152ab29d23b4ecbe7dd4'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.16'; `
+        $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
+        $powershell_sha512 = 'b99fbfd7370a49bee61b4635d4158917089682fa021c7e9e219d747f1a7a33e893027195947688cfbe0caaa641360ab53ec919d8a5ba152ab29d23b4ecbe7dd4'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.4.16'; `
+        $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/8.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.4.17'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = '5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df'; `
+        $powershell_sha512 = 'b99fbfd7370a49bee61b4635d4158917089682fa021c7e9e219d747f1a7a33e893027195947688cfbe0caaa641360ab53ec919d8a5ba152ab29d23b4ecbe7dd4'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `


### PR DESCRIPTION
This pull request updates the PowerShell global tool version from 7.4.16 to 7.4.17 across all relevant Dockerfiles and the manifest. This ensures that all .NET SDK container images will include the latest patch release of PowerShell 7.4, which may contain important bug fixes or security updates.

**PowerShell Version Update:**

* Updated the PowerShell global tool version from `7.4.16` to `7.4.17` in all Dockerfiles for Linux (Alpine, Bookworm, Jammy, Noble, AzureLinux) and Windows (NanoServer, WindowsServerCore) images, ensuring consistency across all build targets. [[1]](diffhunk://#diff-dc810143537b8d56eeb63de2d79b17b65e5c0c791c0dc5cedbb7bc494da0d3a2L51-R51) [[2]](diffhunk://#diff-6ac4aa00b18490c4047c4ea9895a0b02bcc9cdd30a5373ff3a5c5f294a73758dL51-R51) [[3]](diffhunk://#diff-557400b5d1f9d0a2f5c67352d55b6475d6be6dc55b0dbceeffc6f58aadb95b58L51-R51) [[4]](diffhunk://#diff-6bdc3dc207e866e027a8114fc7676613441e8f45639abbbe15b893f664970ac9L51-R51) [[5]](diffhunk://#diff-fad7f562851dadf082f7f6dbbb964dfd66e91c1600a8bc1f723224b95f4d750cL51-R51) [[6]](diffhunk://#diff-cb40d1dcd3e48d8f6d823b0eec6859087c8df0614e78ca3700bb45ef5898015dL51-R51) [[7]](diffhunk://#diff-66448e8f2f0b5d53446c87853ff1affbe6642f8969d39a3811b8f5fbf064f7c4L51-R51) [[8]](diffhunk://#diff-42506bb10a71be4cb781a3c3a6e51e0bba841afded5f264da579a3dde463ab62L51-R51) [[9]](diffhunk://#diff-6e49965484ab2f0b325d99c913fcb2d0b66460220678279643382b60ba80add9L51-R51) [[10]](diffhunk://#diff-1f65f50deb5fcf972030edf337837161c4a676fb64fc96fc6407c4f266dafc1bL53-R53) [[11]](diffhunk://#diff-63ce660de3fcecee34e09d4884d46e8e5426a7f314db6ce0a2364834cc2896f2L53-R53) [[12]](diffhunk://#diff-9842a3a6860ec3ad0fabfbc0e9f4fd092e3f412adb6ae4cc9702a8a7ab1c0c14L57-R57) [[13]](diffhunk://#diff-68590b1c5f0a83ba4f5cffc66df5ef3a7eb32f26fdd4131d69949cd44b6ca5f0L57-R57) [[14]](diffhunk://#diff-b2b0b363d46e7e98ff4630e58bdbd03f6093a32a7cd3bafdae51ed3b70e6f078L57-R57) [[15]](diffhunk://#diff-943997ccff8789ef836f533f5cd0a37571fb54d30907bb770505007fa32398e6L57-R57) [[16]](diffhunk://#diff-a9a2d80d5137febfc7dc82190b66cc60bc4d50f559b65a2388e555a398c2451dL57-R57) [[17]](diffhunk://#diff-c00795f870b89504d8a0fc2b324e9c33a7af19d9908e7790397c6f091d4b7726L57-R57)

**Manifest Update:**

* Updated the `powershell|8.0|build-version` field in `manifest.versions.json` to reflect the new version `7.4.17`.