### PR TITLE
Update .NET 9.0 with PowerShell v7.5.8

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -184,7 +184,7 @@
     "powershell|8.0|Linux|x64|sha": "446e83a1a293be84f22b9a0a9243961caae33a7032a4e00a11434cf44aa546855174b5336efee284cb8d88a416e8f59145f3cd43aff8d7bf5939e079b7e2e3a4",
     "powershell|8.0|Windows|x64|sha": "5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df",
 
-    "powershell|9.0|build-version": "7.5.7",
+    "powershell|9.0|build-version": "7.5.8",
     "powershell|9.0|Linux.Alpine|sha": "c672bac9f736e794cd586195c87fcb6f26468cc49c1ec835cfcf25c79daeaef934b5d92bc0ce092cd02cc0a5b8d933e94dead0aa850a7b7f77afbec8338331fd",
     "powershell|9.0|Linux|arm32|sha": "4fdfe99c4e27dffccf4550a2571fba0bdf630a92bfe39c4b2af1ed0adad5ffe19e50df3eed1ed4bb18d88e7c7e26e2d1e1f41c164049f819aa1266b9b4a72db1",
     "powershell|9.0|Linux|arm64|sha": "b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95",

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -185,11 +185,11 @@
     "powershell|8.0|Windows|x64|sha": "5eedf11e4a54937713067e0796de3bf165afca0ad4002578ddd92fccbec37ebd70efd23160bfe7d9b6cb9c15b7afcc3c4635955112a950fb9b70fd8c1a9eb4df",
 
     "powershell|9.0|build-version": "7.5.8",
-    "powershell|9.0|Linux.Alpine|sha": "c672bac9f736e794cd586195c87fcb6f26468cc49c1ec835cfcf25c79daeaef934b5d92bc0ce092cd02cc0a5b8d933e94dead0aa850a7b7f77afbec8338331fd",
-    "powershell|9.0|Linux|arm32|sha": "4fdfe99c4e27dffccf4550a2571fba0bdf630a92bfe39c4b2af1ed0adad5ffe19e50df3eed1ed4bb18d88e7c7e26e2d1e1f41c164049f819aa1266b9b4a72db1",
-    "powershell|9.0|Linux|arm64|sha": "b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95",
-    "powershell|9.0|Linux|x64|sha": "a39f82dd75d697a1b004235d3c699636dce009196cec91b7d1a5cb4be6e260e178da4a37071598cfceda0c03bf1faaf0a557b88ec801a7fdc2ea6be2b6a82b08",
-    "powershell|9.0|Windows|x64|sha": "e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8",
+    "powershell|9.0|Linux.Alpine|sha": "b98caef3b68bb6b85c3b1cfad9d783b91d2e1b01e2e74502e2e1a6b33bbca92c0613b77aee45db95daeb7868266472cbe4bafc505904abe3852481c3b776b30f",
+    "powershell|9.0|Linux|arm32|sha": "e63f22b5402ddb8a480d708c7d7a0aeee5e8edc24a683e5d4fe64ed6c2aa106e9c6917185ab8a97a156598759c9028535c564fdc53967bed33d11ef4d753b712",
+    "powershell|9.0|Linux|arm64|sha": "5b972bda947d4762974ecdde770e4f8bb55deab6b8ae2e04d9d25e17662670432bbecceab7fcc584fa01e34dab355bbb58bc156a2cecfab9931030baa172f6bc",
+    "powershell|9.0|Linux|x64|sha": "2ab1face06a1da3ab3fc26ead6deb0e6b28c24438b606f10101c00099a12f5af38ffcbab00a9160669f4c9c85e5b48bf818e72ccf6a5316353562480537c87c4",
+    "powershell|9.0|Windows|x64|sha": "e4d0c535601f6ab5d671ad0a2fea967183e54794cb39027d1cf296eac8ec4c80b550e2d5d620ee00dbb29d800026ee3b103441b0018af92240902849d16f9c8b",
 
     "powershell|10.0|build-version": "7.6.2",
     "powershell|10.0|Linux.Alpine|sha": "a6f152b23c3ab16676f173fc61d532b5853ccc92715cbcef02c2ffb92172e18d28a11b11b0bea0a939bb5d543e197cdce3c1162bc4a52ad96d91c6fe6664f830",

--- a/src/sdk/9.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/9.0/alpine3.23/amd64/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='c672bac9f736e794cd586195c87fcb6f26468cc49c1ec835cfcf25c79daeaef934b5d92bc0ce092cd02cc0a5b8d933e94dead0aa850a7b7f77afbec8338331fd' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/9.0/alpine3.23/amd64/Dockerfile
@@ -51,7 +51,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='c672bac9f736e794cd586195c87fcb6f26468cc49c1ec835cfcf25c79daeaef934b5d92bc0ce092cd02cc0a5b8d933e94dead0aa850a7b7f77afbec8338331fd' \
+    && powershell_sha512='b98caef3b68bb6b85c3b1cfad9d783b91d2e1b01e2e74502e2e1a6b33bbca92c0613b77aee45db95daeb7868266472cbe4bafc505904abe3852481c3b776b30f' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \

--- a/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='a39f82dd75d697a1b004235d3c699636dce009196cec91b7d1a5cb4be6e260e178da4a37071598cfceda0c03bf1faaf0a557b88ec801a7fdc2ea6be2b6a82b08' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
@@ -52,7 +52,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='a39f82dd75d697a1b004235d3c699636dce009196cec91b7d1a5cb4be6e260e178da4a37071598cfceda0c03bf1faaf0a557b88ec801a7fdc2ea6be2b6a82b08' \
+    && powershell_sha512='2ab1face06a1da3ab3fc26ead6deb0e6b28c24438b606f10101c00099a12f5af38ffcbab00a9160669f4c9c85e5b48bf818e72ccf6a5316353562480537c87c4' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
@@ -52,7 +52,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95' \
+    && powershell_sha512='5b972bda947d4762974ecdde770e4f8bb55deab6b8ae2e04d9d25e17662670432bbecceab7fcc584fa01e34dab355bbb58bc156a2cecfab9931030baa172f6bc' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='a39f82dd75d697a1b004235d3c699636dce009196cec91b7d1a5cb4be6e260e178da4a37071598cfceda0c03bf1faaf0a557b88ec801a7fdc2ea6be2b6a82b08' \
+    && powershell_sha512='2ab1face06a1da3ab3fc26ead6deb0e6b28c24438b606f10101c00099a12f5af38ffcbab00a9160669f4c9c85e5b48bf818e72ccf6a5316353562480537c87c4' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='a39f82dd75d697a1b004235d3c699636dce009196cec91b7d1a5cb4be6e260e178da4a37071598cfceda0c03bf1faaf0a557b88ec801a7fdc2ea6be2b6a82b08' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='4fdfe99c4e27dffccf4550a2571fba0bdf630a92bfe39c4b2af1ed0adad5ffe19e50df3eed1ed4bb18d88e7c7e26e2d1e1f41c164049f819aa1266b9b4a72db1' \
+    && powershell_sha512='e63f22b5402ddb8a480d708c7d7a0aeee5e8edc24a683e5d4fe64ed6c2aa106e9c6917185ab8a97a156598759c9028535c564fdc53967bed33d11ef4d753b712' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='4fdfe99c4e27dffccf4550a2571fba0bdf630a92bfe39c4b2af1ed0adad5ffe19e50df3eed1ed4bb18d88e7c7e26e2d1e1f41c164049f819aa1266b9b4a72db1' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95' \
+    && powershell_sha512='5b972bda947d4762974ecdde770e4f8bb55deab6b8ae2e04d9d25e17662670432bbecceab7fcc584fa01e34dab355bbb58bc156a2cecfab9931030baa172f6bc' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-1809/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.7'; `
+        $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/9.0/nanoserver-1809/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-1809/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
+        $powershell_sha512 = 'e4d0c535601f6ab5d671ad0a2fea967183e54794cb39027d1cf296eac8ec4c80b550e2d5d620ee00dbb29d800026ee3b103441b0018af92240902849d16f9c8b'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.7'; `
+        $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
+        $powershell_sha512 = 'e4d0c535601f6ab5d671ad0a2fea967183e54794cb39027d1cf296eac8ec4c80b550e2d5d620ee00dbb29d800026ee3b103441b0018af92240902849d16f9c8b'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.7'; `
+        $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/9.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/9.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
+        $powershell_sha512 = 'e4d0c535601f6ab5d671ad0a2fea967183e54794cb39027d1cf296eac8ec4c80b550e2d5d620ee00dbb29d800026ee3b103441b0018af92240902849d16f9c8b'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/noble/amd64/Dockerfile
+++ b/src/sdk/9.0/noble/amd64/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='a39f82dd75d697a1b004235d3c699636dce009196cec91b7d1a5cb4be6e260e178da4a37071598cfceda0c03bf1faaf0a557b88ec801a7fdc2ea6be2b6a82b08' \
+    && powershell_sha512='2ab1face06a1da3ab3fc26ead6deb0e6b28c24438b606f10101c00099a12f5af38ffcbab00a9160669f4c9c85e5b48bf818e72ccf6a5316353562480537c87c4' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \

--- a/src/sdk/9.0/noble/amd64/Dockerfile
+++ b/src/sdk/9.0/noble/amd64/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='a39f82dd75d697a1b004235d3c699636dce009196cec91b7d1a5cb4be6e260e178da4a37071598cfceda0c03bf1faaf0a557b88ec801a7fdc2ea6be2b6a82b08' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/9.0/noble/arm32v7/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='4fdfe99c4e27dffccf4550a2571fba0bdf630a92bfe39c4b2af1ed0adad5ffe19e50df3eed1ed4bb18d88e7c7e26e2d1e1f41c164049f819aa1266b9b4a72db1' \
+    && powershell_sha512='e63f22b5402ddb8a480d708c7d7a0aeee5e8edc24a683e5d4fe64ed6c2aa106e9c6917185ab8a97a156598759c9028535c564fdc53967bed33d11ef4d753b712' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \

--- a/src/sdk/9.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/9.0/noble/arm32v7/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='4fdfe99c4e27dffccf4550a2571fba0bdf630a92bfe39c4b2af1ed0adad5ffe19e50df3eed1ed4bb18d88e7c7e26e2d1e1f41c164049f819aa1266b9b4a72db1' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/9.0/noble/arm64v8/Dockerfile
@@ -50,7 +50,7 @@ RUN dotnet help
 # Install PowerShell global tool
 RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95' \
+    && powershell_sha512='5b972bda947d4762974ecdde770e4f8bb55deab6b8ae2e04d9d25e17662670432bbecceab7fcc584fa01e34dab355bbb58bc156a2cecfab9931030baa172f6bc' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \

--- a/src/sdk/9.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/9.0/noble/arm64v8/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 RUN dotnet help
 
 # Install PowerShell global tool
-RUN powershell_version=7.5.7 \
+RUN powershell_version=7.5.8 \
     && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='b06e7a36b359fd10bfe86259849d5bcfebcc1d107578ac1135f899a3fe701a5e486475fce3bbe249c86def733848093662efe953e5851410a90dc90888ef5d95' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \

--- a/src/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.7'; `
+        $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2019/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
+        $powershell_sha512 = 'e4d0c535601f6ab5d671ad0a2fea967183e54794cb39027d1cf296eac8ec4c80b550e2d5d620ee00dbb29d800026ee3b103441b0018af92240902849d16f9c8b'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.7'; `
+        $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
+        $powershell_sha512 = 'e4d0c535601f6ab5d671ad0a2fea967183e54794cb39027d1cf296eac8ec4c80b550e2d5d620ee00dbb29d800026ee3b103441b0018af92240902849d16f9c8b'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `

--- a/src/sdk/9.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN powershell -Command " `
             $dotnet_checksums_file; `
         `
         # Install PowerShell global tool
-        $powershell_version = '7.5.7'; `
+        $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
         $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `

--- a/src/sdk/9.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/9.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -56,7 +56,7 @@ RUN powershell -Command " `
         # Install PowerShell global tool
         $powershell_version = '7.5.8'; `
         Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
-        $powershell_sha512 = 'e4ecdafdfdda73c6df53a7eb8da6929a71539d2df2ac204a6e7a870b118e28609f0d6a281411b5ce46c23899c650737eaf3681087cd0751be5d658bc8cfb25e8'; `
+        $powershell_sha512 = 'e4d0c535601f6ab5d671ad0a2fea967183e54794cb39027d1cf296eac8ec4c80b550e2d5d620ee00dbb29d800026ee3b103441b0018af92240902849d16f9c8b'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
             exit 1; `


### PR DESCRIPTION
This pull request updates the bundled PowerShell version in all .NET 9.0 SDK Dockerfiles and related manifests from 7.5.7 to 7.5.8. The update includes new download URLs and SHA512 checksums for the PowerShell package across all supported architectures and operating systems.

Key changes:

**PowerShell Version Update:**
* Updated the PowerShell version from 7.5.7 to 7.5.8 in all relevant Dockerfiles for both Linux and Windows images, ensuring that new builds will use the latest patch release. [[1]](diffhunk://#diff-c533f72f916826fb3ac32d8d34960da8878687803e1fd9aae3d340db2c3e6e2eL52-R54) [[2]](diffhunk://#diff-e9cbabde899510d1af7a7cf1e76612b928ade0da5d600f89247feebc274e6e02L53-R55) [[3]](diffhunk://#diff-d03ef4efb8d13a823aa748125616fdc97856ebc5bac4b14a265844e8de989a6fL53-R55) [[4]](diffhunk://#diff-ee2b5755ad619b6a333605a297cc4296e3cfc3b74262148b78386d0f7c8ccd8aL51-R53) [[5]](diffhunk://#diff-3248198d4c1797eb1c00a3a38e49899cd635c8a0afe8c9d7cc82888281da2ae4L51-R53) [[6]](diffhunk://#diff-b38784ec621b1ab7f1045548c58ba77772a89dec2524f99faf815330d2f29b34L51-R53) [[7]](diffhunk://#diff-b249fc03590bf82c06038ffe8ef82953be7f6eeed8eae40ecba2bdb32e07cc7cL51-R53) [[8]](diffhunk://#diff-9f4ce0ee04bfb6f01b0ba93e25a9b6a5eaef983ab2b50d7791dc1c7dafa29a85L51-R53) [[9]](diffhunk://#diff-5265ec999e4ba496cb072680bdfc832145297c9dc1c00b4b8a3f397625f38a5fL51-R53) [[10]](diffhunk://#diff-9bcafbf524ccd35fd4c8a327dca4bf778eddefe2d3e6eb757d7b420a998ab556L57-R59) [[11]](diffhunk://#diff-766bbbd3007b5ab540f3a0003795cda8cae0d0f98049ef4ec54944080feeaee0L57-R59) [[12]](diffhunk://#diff-7ce839352032d708dafc5620a6486a17ffd23aee3cef61890d8b7f127e754dc3L57-R59) [[13]](diffhunk://#diff-0f04a4a0c114b4f22a49ef3cb2462b5573b13fe1147597b10e84d23198f372b4L57-R59) [[14]](diffhunk://#diff-793430467ee389eeef8cb9d727acb1f70587b78781b0475c5d5842039d49f09cL57-R59) [[15]](diffhunk://#diff-ff1d54e7abcb168dbb3922caa2b67bedfbd5de5a2928a07d9623efb0efb3a95eL57-R59)

**Manifest and Checksum Updates:**
* Updated `manifest.versions.json` to reflect the new PowerShell 7.5.8 version and associated SHA512 checksums for all platforms. This ensures integrity verification and accurate image builds.

These changes keep the SDK images up to date with the latest PowerShell release and maintain security by updating checksums for package verification.