### PR TITLE
Remove DOTNET_ROLL_FORWARD environment variable from .NET 10 and 11 SDK images

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile.envs
+++ b/eng/dockerfile-templates/sdk/Dockerfile.envs
@@ -17,9 +17,7 @@
             VARIABLES[cat("sdk|", dotnetVersion, "|build-version")])) ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set isWindows to find(OS_VERSION, "nanoserver") >= 0 || find(OS_VERSION, "windowsservercore") >= 0 ^
-    set lineContinuation to when(isWindows, "`", "\") ^
-
-    set includePowerShellRollForward to dotnetVersion != "8.0" && dotnetVersion != "9.0"
+    set lineContinuation to when(isWindows, "`", "\")
 }}ENV {{lineContinuation}}
     # Do not generate certificate
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false {{lineContinuation}}
@@ -34,6 +32,4 @@
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip {{if ARGS["include-powershell-vars"]:{{lineContinuation}}
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}{{if includePowerShellRollForward: {{lineContinuation}}
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major}}}}
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-{{OS_ARCH_HYPHENATED}}}}

--- a/src/sdk/10.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/10.0/alpine3.23/amd64/Dockerfile
@@ -32,9 +32,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.23 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.23
 
 RUN apk add --upgrade --no-cache \
         curl \

--- a/src/sdk/10.0/alpine3.24/amd64/Dockerfile
+++ b/src/sdk/10.0/alpine3.24/amd64/Dockerfile
@@ -32,9 +32,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24
 
 RUN apk add --upgrade --no-cache \
         curl \

--- a/src/sdk/10.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/10.0/azurelinux3.0/amd64/Dockerfile
@@ -34,9 +34,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0
 
 RUN tdnf install -y \
         git \

--- a/src/sdk/10.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/10.0/azurelinux3.0/arm64v8/Dockerfile
@@ -34,9 +34,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64
 
 RUN tdnf install -y \
         git \

--- a/src/sdk/10.0/azurelinux4.0/amd64/Dockerfile
+++ b/src/sdk/10.0/azurelinux4.0/amd64/Dockerfile
@@ -35,9 +35,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0
 
 RUN dnf install -y \
         git \

--- a/src/sdk/10.0/azurelinux4.0/arm64v8/Dockerfile
+++ b/src/sdk/10.0/azurelinux4.0/arm64v8/Dockerfile
@@ -35,9 +35,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64
 
 RUN dnf install -y \
         git \

--- a/src/sdk/10.0/nanoserver-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/10.0/nanoserver-ltsc2022/amd64/Dockerfile
@@ -78,9 +78,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2022 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2022
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/src/sdk/10.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/10.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -78,9 +78,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/src/sdk/10.0/noble/amd64/Dockerfile
+++ b/src/sdk/10.0/noble/amd64/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/10.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/10.0/noble/arm32v7/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm32 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm32
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/10.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/10.0/noble/arm64v8/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/10.0/resolute/amd64/Dockerfile
+++ b/src/sdk/10.0/resolute/amd64/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/10.0/resolute/arm32v7/Dockerfile
+++ b/src/sdk/10.0/resolute/arm32v7/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/10.0/resolute/arm64v8/Dockerfile
+++ b/src/sdk/10.0/resolute/arm64v8/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/10.0/windowsservercore-ltsc2022/amd64/Dockerfile
+++ b/src/sdk/10.0/windowsservercore-ltsc2022/amd64/Dockerfile
@@ -78,9 +78,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2022 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2022
 
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 

--- a/src/sdk/10.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/10.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -78,9 +78,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025
 
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 

--- a/src/sdk/11.0/alpine3.24/amd64/Dockerfile
+++ b/src/sdk/11.0/alpine3.24/amd64/Dockerfile
@@ -32,9 +32,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24
 
 RUN apk add --upgrade --no-cache \
         curl \

--- a/src/sdk/11.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/11.0/azurelinux3.0/amd64/Dockerfile
@@ -34,9 +34,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0
 
 RUN tdnf install -y \
         git \

--- a/src/sdk/11.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/11.0/azurelinux3.0/arm64v8/Dockerfile
@@ -34,9 +34,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64
 
 RUN tdnf install -y \
         git \

--- a/src/sdk/11.0/azurelinux4.0/amd64/Dockerfile
+++ b/src/sdk/11.0/azurelinux4.0/amd64/Dockerfile
@@ -35,9 +35,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0
 
 RUN dnf install -y \
         git \

--- a/src/sdk/11.0/azurelinux4.0/arm64v8/Dockerfile
+++ b/src/sdk/11.0/azurelinux4.0/arm64v8/Dockerfile
@@ -35,9 +35,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64
 
 RUN dnf install -y \
         git \

--- a/src/sdk/11.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/11.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -78,9 +78,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/src/sdk/11.0/resolute/amd64/Dockerfile
+++ b/src/sdk/11.0/resolute/amd64/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/11.0/resolute/arm32v7/Dockerfile
+++ b/src/sdk/11.0/resolute/arm32v7/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/11.0/resolute/arm64v8/Dockerfile
+++ b/src/sdk/11.0/resolute/arm64v8/Dockerfile
@@ -30,9 +30,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/sdk/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -78,9 +78,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025
 
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/AspireDashboardImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspireDashboardImageTests.cs
@@ -47,11 +47,11 @@ public class AspireDashboardImageTests(ITestOutputHelper outputHelper) : CommonR
         IEnumerable<EnvironmentVariableInfo> expectedVariables =
         [
             // Unset ASPNETCORE_HTTP_PORTS from base image
-            new EnvironmentVariableInfo("ASPNETCORE_HTTP_PORTS", string.Empty),
-            new EnvironmentVariableInfo("ASPNETCORE_URLS", $"{baseUrl}:{DashboardWebPort}"),
-            new EnvironmentVariableInfo("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL", $"{baseUrl}:{DashboardOtlpPort}"),
-            new EnvironmentVariableInfo("DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL", $"{baseUrl}:{DashboardOtlpHttpPort}"),
-            new EnvironmentVariableInfo("DOTNET_DASHBOARD_MCP_ENDPOINT_URL", $"{baseUrl}:{DashboardMcpPort}"),
+            EnvironmentVariableInfo.Require("ASPNETCORE_HTTP_PORTS", string.Empty),
+            EnvironmentVariableInfo.Require("ASPNETCORE_URLS", $"{baseUrl}:{DashboardWebPort}"),
+            EnvironmentVariableInfo.Require("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL", $"{baseUrl}:{DashboardOtlpPort}"),
+            EnvironmentVariableInfo.Require("DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL", $"{baseUrl}:{DashboardOtlpHttpPort}"),
+            EnvironmentVariableInfo.Require("DOTNET_DASHBOARD_MCP_ENDPOINT_URL", $"{baseUrl}:{DashboardMcpPort}"),
         ];
 
         string imageTag = imageData.GetImage(ImageRepo, DockerHelper);

--- a/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/AspnetImageTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             string version = imageData.GetProductVersion(imageRepo, DotNetImageRepo.Aspnet, dockerHelper);
 
-            return new EnvironmentVariableInfo("ASPNET_VERSION", version)
+            return EnvironmentVariableInfo.Require("ASPNET_VERSION", version) with
             {
                 IsProductVersion = true
             };

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.23-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.23-amd64-Dockerfile.approved.txt
@@ -35,9 +35,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.23 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.23
 
 RUN apk add --upgrade --no-cache \
         curl \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -35,9 +35,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24
 
 RUN apk add --upgrade --no-cache \
         curl \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -37,9 +37,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0
 
 RUN tdnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -37,9 +37,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64
 
 RUN tdnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-amd64-Dockerfile.approved.txt
@@ -38,9 +38,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0
 
 RUN dnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
@@ -38,9 +38,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64
 
 RUN dnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -86,9 +86,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2022 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2022
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -86,9 +86,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
@@ -33,9 +33,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -33,9 +33,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm32 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm32
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -33,9 +33,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-24.04-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-amd64-Dockerfile.approved.txt
@@ -33,9 +33,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -33,9 +33,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -33,9 +33,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -86,9 +86,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2022 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2022
 
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -86,9 +86,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025
 
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -34,9 +34,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Alpine-3.24
 
 RUN apk add --upgrade --no-cache \
         curl \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -36,9 +36,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0
 
 RUN tdnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -36,9 +36,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-3.0-arm64
 
 RUN tdnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-amd64-Dockerfile.approved.txt
@@ -37,9 +37,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0
 
 RUN dnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
@@ -37,9 +37,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Azure-Linux-4.0-arm64
 
 RUN dnf install -y \
         git \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -85,9 +85,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-NanoServer-ltsc2025
 
 # In order to set system PATH, ContainerAdministrator must be used
 USER ContainerAdministrator

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-amd64-Dockerfile.approved.txt
@@ -32,9 +32,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -32,9 +32,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm32
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -32,9 +32,7 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64 \
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-26.04-arm64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -85,9 +85,7 @@ ENV `
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip `
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025 `
-    # Workaround for https://github.com/PowerShell/PowerShell/issues/20685
-    DOTNET_ROLL_FORWARD=Major
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-WindowsServerCore-ltsc2025
 
 RUN setx /M PATH "%PATH%;C:\Program Files\powershell;C:\Program Files\MinGit\cmd"
 

--- a/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/CommonRuntimeImageTests.cs
@@ -35,10 +35,10 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (!imageData.IsWindows)
             {
-                variables.Add(new EnvironmentVariableInfo("APP_UID", imageData.NonRootUID?.ToString()));
+                variables.Add(EnvironmentVariableInfo.Require("APP_UID", imageData.NonRootUID?.ToString()));
             }
 
-            variables.Add(new EnvironmentVariableInfo("ASPNETCORE_HTTP_PORTS", imageData.DefaultPort.ToString()));
+            variables.Add(EnvironmentVariableInfo.Require("ASPNETCORE_HTTP_PORTS", imageData.DefaultPort.ToString()));
 
             if (customVariables != null)
             {
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (imageData.GlobalizationInvariantMode)
             {
-                variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true"));
+                variables.Add(EnvironmentVariableInfo.Require("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true"));
             }
 
             string imageTag = imageData.GetImage(ImageRepo, DockerHelper);

--- a/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/EnvironmentVariableInfo.cs
@@ -16,17 +16,33 @@ namespace Microsoft.DotNet.Docker.Tests
         public string Name { get; init; }
         public bool IsProductVersion { get; init; } = false;
 
-        public EnvironmentVariableInfo(string name, string expectedValue)
+        /// <summary>
+        /// When true, the variable is expected to NOT be set on the image.
+        /// </summary>
+        public bool ShouldNotExist { get; init; } = false;
+
+        private EnvironmentVariableInfo(string name)
         {
             Name = name;
-            ExpectedValue = expectedValue;
         }
 
-        public EnvironmentVariableInfo(string name, bool allowAnyValue)
-        {
-            Name = name;
-            AllowAnyValue = allowAnyValue;
-        }
+        /// <summary>
+        /// Requires the named environment variable to be set to <paramref name="expectedValue"/>.
+        /// </summary>
+        public static EnvironmentVariableInfo Require(string name, string expectedValue) =>
+            new(name) { ExpectedValue = expectedValue };
+
+        /// <summary>
+        /// Requires the named environment variable to be set to any non-empty value.
+        /// </summary>
+        public static EnvironmentVariableInfo Require(string name) =>
+            new(name) { AllowAnyValue = true };
+
+        /// <summary>
+        /// Requires the named environment variable to NOT be set on the image.
+        /// </summary>
+        public static EnvironmentVariableInfo Forbid(string name) =>
+            new(name) { ShouldNotExist = true };
 
         public static void Validate(
             IEnumerable<EnvironmentVariableInfo> expectedVariables,
@@ -40,6 +56,14 @@ namespace Microsoft.DotNet.Docker.Tests
             {
                 foreach (EnvironmentVariableInfo variable in expectedVariables)
                 {
+                    if (variable.ShouldNotExist)
+                    {
+                        environmentVariables.Should().NotContainKey(
+                            variable.Name,
+                            because: $"{imageName} should not have the environment variable '{variable.Name}' defined");
+                        continue;
+                    }
+
                     string environmentVariable = environmentVariables.Should()
                         .ContainKey(
                             variable.Name,

--- a/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/MonitorImageTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -120,25 +120,25 @@ namespace Microsoft.DotNet.Docker.Tests
             List<EnvironmentVariableInfo> variables =
             [
                 ..GetCommonEnvironmentVariables(),
-                new EnvironmentVariableInfo("ASPNETCORE_HTTP_PORTS", string.Empty),
+                EnvironmentVariableInfo.Require("ASPNETCORE_HTTP_PORTS", string.Empty),
 
                 // Diagnostics should be disabled
-                new EnvironmentVariableInfo("COMPlus_EnableDiagnostics", "0"),
+                EnvironmentVariableInfo.Require("COMPlus_EnableDiagnostics", "0"),
 
                 // DefaultProcess filter should select a process with a process ID of 1
-                new EnvironmentVariableInfo("DefaultProcess__Filters__0__Key", "ProcessId"),
-                new EnvironmentVariableInfo("DefaultProcess__Filters__0__Value", "1"),
+                EnvironmentVariableInfo.Require("DefaultProcess__Filters__0__Key", "ProcessId"),
+                EnvironmentVariableInfo.Require("DefaultProcess__Filters__0__Value", "1"),
 
                 // Existing (orphaned) diagnostic port should be delete before starting server
-                new EnvironmentVariableInfo("DiagnosticPort__DeleteEndpointOnStartup", "true"),
+                EnvironmentVariableInfo.Require("DiagnosticPort__DeleteEndpointOnStartup", "true"),
 
                 // GC mode should be set to Server
-                new EnvironmentVariableInfo("DOTNET_gcServer", "1"),
+                EnvironmentVariableInfo.Require("DOTNET_gcServer", "1"),
 
                 // Console logger format should be JSON and output UTC timestamps without timezone information
-                new EnvironmentVariableInfo("Logging__Console__FormatterName", "json"),
-                new EnvironmentVariableInfo("Logging__Console__FormatterOptions__TimestampFormat", "yyyy-MM-ddTHH:mm:ss.fffffffZ"),
-                new EnvironmentVariableInfo("Logging__Console__FormatterOptions__UseUtcTimestamp", "true"),
+                EnvironmentVariableInfo.Require("Logging__Console__FormatterName", "json"),
+                EnvironmentVariableInfo.Require("Logging__Console__FormatterOptions__TimestampFormat", "yyyy-MM-ddTHH:mm:ss.fffffffZ"),
+                EnvironmentVariableInfo.Require("Logging__Console__FormatterOptions__UseUtcTimestamp", "true"),
             ];
 
             EnvironmentVariableInfo.Validate(

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public static IEnumerable<EnvironmentVariableInfo> GetCommonEnvironmentVariables()
         {
-            yield return new EnvironmentVariableInfo("DOTNET_RUNNING_IN_CONTAINER", "true");
+            yield return EnvironmentVariableInfo.Require("DOTNET_RUNNING_IN_CONTAINER", "true");
         }
 
         /// <summary>

--- a/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/RuntimeImageTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Docker.Tests
             DotNetImageRepo imageRepo, ProductImageData imageData, DockerHelper dockerHelper)
         {
             string version = imageData.GetProductVersion(imageRepo, DotNetImageRepo.Runtime, dockerHelper);
-            return new EnvironmentVariableInfo("DOTNET_VERSION", version)
+            return EnvironmentVariableInfo.Require("DOTNET_VERSION", version) with
             {
                 IsProductVersion = true
             };

--- a/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SampleImageTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (imageType == SampleImageType.Aspnetapp)
             {
-                variables.Add(new EnvironmentVariableInfo("ASPNETCORE_HTTP_PORTS", imageData.DefaultPort.ToString()));
+                variables.Add(EnvironmentVariableInfo.Require("ASPNETCORE_HTTP_PORTS", imageData.DefaultPort.ToString()));
             }
 
             EnvironmentVariableInfo.Validate(

--- a/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/SdkImageTests.cs
@@ -109,22 +109,26 @@ namespace Microsoft.DotNet.Docker.Tests
 
             List<EnvironmentVariableInfo> variables =
             [
-                new EnvironmentVariableInfo("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false"),
-                new EnvironmentVariableInfo("DOTNET_USE_POLLING_FILE_WATCHER", "true"),
-                new EnvironmentVariableInfo("NUGET_XMLDOC_MODE", "skip"),
-                new EnvironmentVariableInfo("DOTNET_SDK_VERSION", version)
+                EnvironmentVariableInfo.Require("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false"),
+                EnvironmentVariableInfo.Require("DOTNET_USE_POLLING_FILE_WATCHER", "true"),
+                EnvironmentVariableInfo.Require("NUGET_XMLDOC_MODE", "skip"),
+                EnvironmentVariableInfo.Require("DOTNET_SDK_VERSION", version) with
                 {
                     IsProductVersion = true
                 },
                 AspnetImageTests.GetAspnetVersionVariableInfo(ImageRepo, imageData, DockerHelper),
                 RuntimeImageTests.GetRuntimeVersionVariableInfo(ImageRepo, imageData, DockerHelper),
-                new EnvironmentVariableInfo("DOTNET_NOLOGO", "true"),
+                EnvironmentVariableInfo.Require("DOTNET_NOLOGO", "true"),
+                // DOTNET_ROLL_FORWARD must not be set globally, as it can silently change
+                // the runtime that unrelated workloads (e.g. dotnet test) execute on.
+                // See https://github.com/dotnet/dotnet-docker/issues/7255.
+                EnvironmentVariableInfo.Forbid("DOTNET_ROLL_FORWARD"),
                 ..GetCommonEnvironmentVariables(),
             ];
 
             if (imageData.SdkOS.Family == OSFamily.Alpine)
             {
-                variables.Add(new EnvironmentVariableInfo("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "false"));
+                variables.Add(EnvironmentVariableInfo.Require("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "false"));
             }
 
             EnvironmentVariableInfo.Validate(variables, imageName, imageData, DockerHelper);

--- a/tests/Microsoft.DotNet.Docker.Tests/YarpImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/YarpImageTests.cs
@@ -43,8 +43,8 @@ public class YarpImageTests(ITestOutputHelper outputHelper) : CommonRuntimeImage
         IEnumerable<EnvironmentVariableInfo> expectedVariables =
         [
             // Unset ASPNETCORE_HTTP_PORTS from base image
-            new EnvironmentVariableInfo("ASPNETCORE_HTTP_PORTS", string.Empty),
-            new EnvironmentVariableInfo("ASPNETCORE_URLS", "http://+:5000"),
+            EnvironmentVariableInfo.Require("ASPNETCORE_HTTP_PORTS", string.Empty),
+            EnvironmentVariableInfo.Require("ASPNETCORE_URLS", "http://+:5000"),
         ];
 
         string imageTag = imageData.GetImage(ImageRepo, DockerHelper);


### PR DESCRIPTION
This PR fixes #7255.