### PR TITLE
Set Permissive network isolation policy

### DIFF
--- a/eng/pipelines/dotnet-core-nightly.yml
+++ b/eng/pipelines/dotnet-core-nightly.yml
@@ -47,6 +47,9 @@ resources:
 extends:
   template: /eng/docker-tools/templates/1es.yml@self
   parameters:
+    # Temporarily use only Permissive because CFSClean blocks Ubuntu/Debian package feeds.
+    # Tracking issue: https://github.com/dotnet/dotnet-docker-internal/issues/11529
+    networkIsolationPolicy: Permissive
     reposToExcludeFromScanning:
     - VersionsRepo
     stages:

--- a/eng/pipelines/dotnet-core.yml
+++ b/eng/pipelines/dotnet-core.yml
@@ -34,6 +34,9 @@ resources:
 extends:
   template: /eng/docker-tools/templates/1es.yml@self
   parameters:
+    # Temporarily use only Permissive because CFSClean blocks Ubuntu/Debian package feeds.
+    # Tracking issue: https://github.com/dotnet/dotnet-docker-internal/issues/11529
+    networkIsolationPolicy: Permissive
     reposToExcludeFromScanning:
     - VersionsRepo
     stages:


### PR DESCRIPTION
CFSClean has started blocking Ubuntu and Debian package feeds. I am researching the best feeds to use instead. In the meantime, this PR sets the Permissive network isolation policy in an attempt to unblock builds.

Tracking issue:
- https://github.com/dotnet/dotnet-docker-internal/issues/11529

Related:
- https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1696
- https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1701
- https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1708