### PR TITLE
Preserve ulimit option in release staging

### DIFF
--- a/eng/pipelines/stages/build-and-test.yml
+++ b/eng/pipelines/stages/build-and-test.yml
@@ -63,13 +63,13 @@ stages:
     customBuildInitSteps:
     - template: /eng/pipelines/steps/set-public-source-branch-var.yml@self
     - powershell: |
-        $imageBuilderBuildArgs = "$IMAGEBUILDERBUILDARGS --build-option `"--ulimit nofile=65536:65536`""
+        $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS --build-option `"--ulimit nofile=65536:65536`""
         echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
       displayName: Set ulimit Build Option
       condition: and(succeeded(), ne(variables['osType'], 'windows'))
     - ${{ if parameters.storageAccountServiceConnection }}:
       - powershell: |
-          $imageBuilderBuildArgs = "$IMAGEBUILDERBUILDARGS --internal"
+          $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS --internal"
           echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
         displayName: Set Custom Build Variables
     - template: /eng/pipelines/steps/set-custom-test-variables.yml@self


### PR DESCRIPTION
## Summary

- Read existing image builder arguments from the task environment before appending the ulimit and internal options.
- Preserve `--build-option "--ulimit nofile=65536:65536"` when release staging appends `--internal`.
- Prevent Azure Linux 4 image builds from losing the Docker ulimit override and exceeding the 60-minute job timeout.

## Validation

- `pwsh ./tests/run-tests.ps1 -paths '*' -TestCategories @('pre-build')` (116 passed)
