### PR TITLE
Update Resolute Chiseled GCC package baseline

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -312,7 +312,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 { OS: var os } when os == OS.ResoluteChiseled =>
                     [
                         "ca-certificates",
-                        "gcc-14-base",
+                        "gcc-16-base",
                         ..GetResoluteChiseledArchSpecificPackages(imageData),
                         "libc6",
                         "libgcc-s1",


### PR DESCRIPTION
Resolute's libgcc-s1 package now depends on gcc-16-base, which caused the Chiseled image package baseline to fail.

This PR updates the expected package from gcc-14-base to gcc-16-base.

Related: #7328