### PR TITLE
Update Resolute Chiseled OpenSSL package baseline

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -321,6 +321,7 @@ namespace Microsoft.DotNet.Docker.Tests
                         "libzstd",
                         "libzstd1",
                         "openssl",
+                        "openssl-provider-legacy",
                         "zlib",
                         "zlib1g"
                     ],

--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -321,7 +321,6 @@ namespace Microsoft.DotNet.Docker.Tests
                         "libzstd",
                         "libzstd1",
                         "openssl",
-                        "openssl-provider-legacy",
                         "zlib",
                         "zlib1g"
                     ],
@@ -393,10 +392,15 @@ namespace Microsoft.DotNet.Docker.Tests
         }
 
         /// <summary>
-        /// Syft detects gcc-16 as an additional binary package on amd64 resolute chiseled images.
+        /// Syft detects additional binary packages in resolute chiseled images depending on the architecture.
         /// </summary>
         private static IEnumerable<string> GetResoluteChiseledArchSpecificPackages(ProductImageData imageData) =>
-            imageData.Arch == Arch.Amd64 ? ["gcc-16"] : [];
+            imageData.Arch switch
+            {
+                Arch.Amd64 => ["gcc-16", "openssl-provider-legacy"],
+                Arch.Arm => ["openssl-provider-legacy"],
+                _ => []
+            };
 
         private static IEnumerable<string> GetExtraPackages(ProductImageData imageData) => imageData switch
             {


### PR DESCRIPTION
Resolute Chiseled package validation reports `openssl-provider-legacy` on amd64 and arm32 images, but not arm64 images. This PR makes the expected package baseline architecture-specific so the .NET 10 and .NET 11 image tests match Syft's package inventory.

Related: https://dev.azure.com/dnceng/internal/_build/results?buildId=3058308&view=results