### PR TITLE
Update repository tooling to .NET 10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/dotnet/sdk:9.0-noble",
+    "image": "mcr.microsoft.com/dotnet/sdk:10.0-noble",
     "features": {
         "ghcr.io/devcontainers/features/common-utils": {
             "username": "app",

--- a/eng/update-dependencies/Dockerfile
+++ b/eng/update-dependencies/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS build-env
 WORKDIR /update-dependencies
 
 # Build update-dependencies
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/root/.nuget \
     dotnet publish eng/update-dependencies/update-dependencies.csproj -o out
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0
 
 RUN tdnf install -y \
         ca-certificates \

--- a/eng/update-dependencies/update-dependencies.csproj
+++ b/eng/update-dependencies/update-dependencies.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     <PackageReference Include="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.25461.2" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="9.0.0-beta.24151.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25210.1" />


### PR DESCRIPTION
Repository development and dependency tooling still used .NET 9 images and libraries after the tooling projects moved to `net10.0`, leaving the containerized build unable to target the project's framework.

This PR aligns the supporting environments with .NET 10:

- Uses the .NET 10 Noble SDK for the development container.
- Builds and runs the dependency updater with the .NET 10 Azure Linux 3.0 SDK.
- Updates `Microsoft.Extensions.Hosting` to 10.0.11.