### PR TITLE
Use a common Resolute OpenSSL package baseline

### DIFF
--- a/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
+++ b/tests/Microsoft.DotNet.Docker.Tests/ProductImageTests.cs
@@ -321,6 +321,7 @@ namespace Microsoft.DotNet.Docker.Tests
                         "libzstd",
                         "libzstd1",
                         "openssl",
+                        "openssl-provider-legacy",
                         "zlib",
                         "zlib1g"
                     ],
@@ -392,15 +393,10 @@ namespace Microsoft.DotNet.Docker.Tests
         }
 
         /// <summary>
-        /// Syft detects additional binary packages in resolute chiseled images depending on the architecture.
+        /// Syft detects gcc-16 as an additional binary package on amd64 resolute chiseled images.
         /// </summary>
         private static IEnumerable<string> GetResoluteChiseledArchSpecificPackages(ProductImageData imageData) =>
-            imageData.Arch switch
-            {
-                Arch.Amd64 => ["gcc-16", "openssl-provider-legacy"],
-                Arch.Arm => ["openssl-provider-legacy"],
-                _ => []
-            };
+            imageData.Arch == Arch.Amd64 ? ["gcc-16"] : [];
 
         private static IEnumerable<string> GetExtraPackages(ProductImageData imageData) => imageData switch
             {


### PR DESCRIPTION
PR #7339 made `openssl-provider-legacy` architecture-specific because earlier package scans did not report it on ARM64. Current Resolute Chiseled images include the package on all supported architectures, causing the ARM64 validation in #7342 to fail.

This PR moves `openssl-provider-legacy` into the common Resolute Chiseled package baseline and leaves only `gcc-16` as AMD64-specific.

Related: #7339
Related: #7342