### PR TITLE
Move PowerShell downloads to SDK installer stages

### DIFF
--- a/eng/dockerfile-templates/Dockerfile.linux.download-files
+++ b/eng/dockerfile-templates/Dockerfile.linux.download-files
@@ -13,7 +13,7 @@
         https://learn.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory#call-storage-operations-with-oauth-tokens ^
 
     for i, file in ARGS["files"]:{{
-        if (find(file["url"], "dotnetstage") >= 0):{{
+        if (find(file["url"], "dotnetstage") >= 0 || find(file["url"], "pscoretestdata") >= 0):{{
             set isInternal to 1
     }}}}^
 

--- a/eng/dockerfile-templates/Dockerfile.windows.download-files
+++ b/eng/dockerfile-templates/Dockerfile.windows.download-files
@@ -13,7 +13,7 @@
         https://learn.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory#call-storage-operations-with-oauth-tokens ^
 
     set isInternal(url) to:{{
-        return find(url, "dotnetstage") >= 0
+        return find(url, "dotnetstage") >= 0 || find(url, "pscoretestdata") >= 0
     }}^
 
     for i, file in ARGS["files"]:{{

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -17,6 +17,14 @@
 
     set isPowerShellSupported to !(isAlpine && ARCH_SHORT != "x64") ^
     set includePowerShellVars to isPowerShellSupported || dotnetVersion = "8.0" || dotnetVersion = "9.0" ^
+    set powershellNupkgPlatform to when(isAlpine, "Linux.Alpine", cat("Linux.", ARCH_NUPKG)) ^
+    set powershellNupkgName to cat(
+        "PowerShell.",
+        powershellNupkgPlatform,
+        ".",
+        VARIABLES[cat("powershell|", dotnetVersion, "|build-version")],
+        ".nupkg"
+    ) ^
 
     set dnxIsSupported to dotnetVersion != "8.0" && dotnetVersion != "9.0" ^
     set useDnxScript to isAlpine && dotnetVersion = "11.0" ^
@@ -81,7 +89,10 @@ RUN {{InsertTemplate("../Dockerfile.download-dotnet", [
     "product": "sdk",
     "extract-to": "/dotnet",
     "extract-paths": sdkExtractPaths
-], "    ")}}
+], "    ")}}{{if isPowerShellSupported:
+
+# Download PowerShell
+RUN {{InsertTemplate("Dockerfile.linux.download-powershell", [])}}}}
 
 
 # .NET SDK image
@@ -94,7 +105,9 @@ RUN {{InsertTemplate("../Dockerfile.linux.install-pkgs",
     "pkgs": pkgs
 ])}}
 
-COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
+COPY --from=installer ["/dotnet", "/usr/share/dotnet"]{{if isPowerShellSupported:
+
+COPY --from=installer ["/{{powershellNupkgName}}", "/"]}}
 
 {{if dnxIsSupported:{{if useDnxScript:# Workaround for https://github.com/dotnet/sdk/issues/55238
 }}RUN {{if useDnxScript:printf '%s\n' \

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux
@@ -92,7 +92,9 @@ RUN {{InsertTemplate("../Dockerfile.download-dotnet", [
 ], "    ")}}{{if isPowerShellSupported:
 
 # Download PowerShell
-RUN {{InsertTemplate("Dockerfile.linux.download-powershell", [])}}}}
+RUN {{InsertTemplate("Dockerfile.linux.download-powershell", [
+    "dotnet-is-internal": isInternal
+])}}}}
 
 
 # .NET SDK image

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.download-powershell
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.download-powershell
@@ -1,13 +1,21 @@
 {{
+    _ ARGS:
+        dotnet-is-internal (optional): Whether the Dockerfile is targeting an internal build of the .NET product. ^
+
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set nupkgPlatform to when(isAlpine, "Linux.Alpine", cat("Linux.", ARCH_NUPKG)) ^
     set shaPlatform to when(isAlpine, "Linux.Alpine", cat("Linux|", ARCH_NUPKG)) ^
     set powershellVersion to VARIABLES[cat("powershell|", dotnetVersion, "|build-version")] ^
     set nupkgName to cat("PowerShell.", nupkgPlatform, ".$powershell_version.nupkg") ^
-    set url to cat("https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/", nupkgName)
+    set url to when(
+        ARGS["dotnet-is-internal"],
+        cat("https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/", nupkgName),
+        cat("https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/", nupkgName)
+    )
 }}powershell_version={{powershellVersion}} \
-    && {{InsertTemplate("../Dockerfile.linux.download-files", ["files": [[
+{{if ARGS["dotnet-is-internal"]:    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+}}    && {{InsertTemplate("../Dockerfile.linux.download-files", ["files": [[
         "url": url,
         "out-file": nupkgName
     ]]], "    ")}} \

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.download-powershell
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.download-powershell
@@ -7,6 +7,8 @@
     set nupkgPlatform to when(isAlpine, "Linux.Alpine", cat("Linux.", ARCH_NUPKG)) ^
     set shaPlatform to when(isAlpine, "Linux.Alpine", cat("Linux|", ARCH_NUPKG)) ^
     set powershellVersion to VARIABLES[cat("powershell|", dotnetVersion, "|build-version")] ^
+    set shaFunction to VARIABLES[cat("powershell|", dotnetVersion, "|sha-function")] ^
+    set shaVarName to cat("powershell_sha", shaFunction) ^
     set nupkgName to cat("PowerShell.", nupkgPlatform, ".$powershell_version.nupkg") ^
     set url to when(
         ARGS["dotnet-is-internal"],
@@ -21,7 +23,7 @@
     ]]], "    ")}} \
     && {{InsertTemplate("../Dockerfile.linux.validate-checksum", [
         "file": nupkgName,
-        "sha-function": "512",
-        "sha-var-name": "powershell_sha512",
+        "sha-function": shaFunction,
+        "sha-var-name": shaVarName,
         "sha": VARIABLES[join(["powershell", dotnetVersion, shaPlatform, "sha"], "|")]
     ], "    ")}}

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.download-powershell
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.download-powershell
@@ -1,0 +1,19 @@
+{{
+    set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
+    set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
+    set nupkgPlatform to when(isAlpine, "Linux.Alpine", cat("Linux.", ARCH_NUPKG)) ^
+    set shaPlatform to when(isAlpine, "Linux.Alpine", cat("Linux|", ARCH_NUPKG)) ^
+    set powershellVersion to VARIABLES[cat("powershell|", dotnetVersion, "|build-version")] ^
+    set nupkgName to cat("PowerShell.", nupkgPlatform, ".$powershell_version.nupkg") ^
+    set url to cat("https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/", nupkgName)
+}}powershell_version={{powershellVersion}} \
+    && {{InsertTemplate("../Dockerfile.linux.download-files", ["files": [[
+        "url": url,
+        "out-file": nupkgName
+    ]]], "    ")}} \
+    && {{InsertTemplate("../Dockerfile.linux.validate-checksum", [
+        "file": nupkgName,
+        "sha-function": "512",
+        "sha-var-name": "powershell_sha512",
+        "sha": VARIABLES[join(["powershell", dotnetVersion, shaPlatform, "sha"], "|")]
+    ], "    ")}}

--- a/eng/dockerfile-templates/sdk/Dockerfile.linux.install-powershell
+++ b/eng/dockerfile-templates/sdk/Dockerfile.linux.install-powershell
@@ -2,21 +2,10 @@
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set isAlpine to find(OS_VERSION, "alpine") >= 0 ^
     set nupkgPlatform to when(isAlpine, "Linux.Alpine", cat("Linux.", ARCH_NUPKG)) ^
-    set shaPlatform to when(isAlpine, "Linux.Alpine", cat("Linux|", ARCH_NUPKG)) ^
-    set nupkgName to cat("PowerShell.", nupkgPlatform, ".$powershell_version.nupkg") ^
-    set url to cat("https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/", nupkgName)
+    set powershellVersion to VARIABLES[cat("powershell|", dotnetVersion, "|build-version")] ^
+    set nupkgName to cat("PowerShell.", nupkgPlatform, ".$powershell_version.nupkg")
 }}# Install PowerShell global tool
-RUN powershell_version={{VARIABLES[cat("powershell|", dotnetVersion, "|build-version")]}} \
-    && {{InsertTemplate("../Dockerfile.linux.download-files", ["files": [[
-        "url": url,
-        "out-file": nupkgName
-    ]]], "    ")}} \
-    && {{InsertTemplate("../Dockerfile.linux.validate-checksum", [
-        "file": nupkgName,
-        "sha-function": "512",
-        "sha-var-name": "powershell_sha512",
-        "sha": VARIABLES[join(["powershell", dotnetVersion, shaPlatform, "sha"], "|")]
-    ], "    ")}} \
+RUN powershell_version={{powershellVersion}} \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.{{nupkgPlatform}} \
     && dotnet nuget locals all --clear \

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.install-powershell
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.install-powershell
@@ -5,11 +5,16 @@
     set dotnetVersion to join(slice(split(PRODUCT_VERSION, "."), 0, 2), ".") ^
     set rootDir to "\" ^
     set nupkgFile to "PowerShell.Windows.x64.$powershell_version.nupkg" ^
-    set url to cat("https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/", nupkgFile) ^
+    set url to when(
+        ARGS["dotnet-is-internal"],
+        cat("https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/", nupkgFile),
+        cat("https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/", nupkgFile)
+    ) ^
     set powershellVersion to VARIABLES[cat("powershell|", dotnetVersion, "|build-version")]
 }}# Install PowerShell global tool
 $powershell_version = '{{VARIABLES[cat("powershell|", dotnetVersion, "|build-version")]}}'; `
-{{InsertTemplate("../Dockerfile.windows.download-files", ["files": [[
+{{if ARGS["dotnet-is-internal"]:$powershell_url_version = $powershell_version.Replace('.', '-'); `
+}}{{InsertTemplate("../Dockerfile.windows.download-files", ["files": [[
     "out-file": nupkgFile,
     "url": url
 ]]])}}; `

--- a/eng/dockerfile-templates/sdk/Dockerfile.windows.install-powershell
+++ b/eng/dockerfile-templates/sdk/Dockerfile.windows.install-powershell
@@ -10,7 +10,8 @@
         cat("https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/", nupkgFile),
         cat("https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/", nupkgFile)
     ) ^
-    set powershellVersion to VARIABLES[cat("powershell|", dotnetVersion, "|build-version")]
+    set powershellVersion to VARIABLES[cat("powershell|", dotnetVersion, "|build-version")] ^
+    set shaFunction to VARIABLES[cat("powershell|", dotnetVersion, "|sha-function")]
 }}# Install PowerShell global tool
 $powershell_version = '{{VARIABLES[cat("powershell|", dotnetVersion, "|build-version")]}}'; `
 {{if ARGS["dotnet-is-internal"]:$powershell_url_version = $powershell_version.Replace('.', '-'); `
@@ -21,8 +22,8 @@ $powershell_version = '{{VARIABLES[cat("powershell|", dotnetVersion, "|build-ver
 {{InsertTemplate("../Dockerfile.windows.validate-checksum", [
     "file": nupkgFile,
     "sha": VARIABLES[cat("powershell|", dotnetVersion, "|Windows|x64|sha")],
-    "sha-function": "512",
-    "sha-var-name": "$powershell_sha512"
+    "sha-function": shaFunction,
+    "sha-var-name": cat("$powershell_sha", shaFunction)
 ])}}; `
 & {{rootDir}}dotnet\dotnet tool install --add-source . --tool-path {{rootDir}}powershell --version $powershell_version PowerShell.Windows.x64; `
 & {{rootDir}}dotnet\dotnet nuget locals all --clear; `

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -179,6 +179,7 @@
     "monitor|10.0|base-url|checksums|nightly": "$(base-url|public-checksums|preview|nightly)",
 
     "powershell|8.0|build-version": "7.4.19",
+    "powershell|8.0|sha-function": "512",
     "powershell|8.0|Linux.Alpine|sha": "2b0c19fd71971eaf135193790fc3513e19f7ae527f66526e0a476c73bfaee8d62d1f03bf33cc7d775c10c927ed95744ccfe8989783c0fc7fdd84e7f26ff713ff",
     "powershell|8.0|Linux|arm32|sha": "e82c73185baf1ce368ddebf8c5eecd5c35c3df4c026b1a6c81aea1416fbaf6c39c7c83c5fabaadc21f97df2269f364d8e7630db87a796e843da0ce362a1bfd8f",
     "powershell|8.0|Linux|arm64|sha": "97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4",
@@ -186,6 +187,7 @@
     "powershell|8.0|Windows|x64|sha": "916cc2c65a0abbc8f29420c796ca542137152f8b8637379c1b19891768040308128daf04966436467459a852cd26cce772f9ffd06d55f17aed5ba99d67a7afa4",
 
     "powershell|9.0|build-version": "7.5.10",
+    "powershell|9.0|sha-function": "512",
     "powershell|9.0|Linux.Alpine|sha": "2c379c003cff9de263aa0d006300a67a784f69ab6ce9cfd822be0a66215bd4cea1c04b1289d2c58efdf62a8a6af6068fd06a946a58d5e6987d222a811698b4f1",
     "powershell|9.0|Linux|arm32|sha": "94815faa00214c435181cc76aa44e53c2d49d10b1f3a1b3a4f94592e854bbceeb67931eb300ad79dae71a7b5c4c4f555caf6df7e873a7326636998f6d6467e3b",
     "powershell|9.0|Linux|arm64|sha": "309cc2305d06bca3228796d785003fd5bdb8cab22170bf7bb48d5cd88de0248e67585439277b9ff9d5bceb632566dcbe52cfea2dcd26d40e10bd0b1a67c1ae19",
@@ -193,6 +195,7 @@
     "powershell|9.0|Windows|x64|sha": "c6c069144747210bbe41f6d0c07f58d790ea25ead56c3005ad650ea01bc00eeafa0c485648c63c5b5561e419935b3581707dcbf79337873d747098057ff579d6",
 
     "powershell|10.0|build-version": "7.6.5",
+    "powershell|10.0|sha-function": "512",
     "powershell|10.0|Linux.Alpine|sha": "5d6deaf0195971e7b6893f932eb04ec7502c90ae61ae5ee6de9364eb2e05345252d5d5df1df579a85f8a936260cba598f0a5a27be3a66670762c1b6d988743a9",
     "powershell|10.0|Linux|arm32|sha": "e1cc2888dd2048603e4c587d1e0df939bdc9955ebbe66616bb8f34e7cdc43ff9728c6ebfbcfe9353f046f4749b1f4b760c0bd5a47baad64d38bc16df9b280969",
     "powershell|10.0|Linux|arm64|sha": "2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48",
@@ -200,6 +203,7 @@
     "powershell|10.0|Windows|x64|sha": "0b9bdc4ab91b1c756faca808483a252ca2d26b3dafe5ef9859e5d052056302def0847367820be57657c8387cf766a57f3e3965960be9993292860e20bd974a1c",
 
     "powershell|11.0|build-version": "7.7.0-preview.2",
+    "powershell|11.0|sha-function": "512",
     "powershell|11.0|Linux.Alpine|sha": "4eba9c9b057620bef0b33d01e04b2d448d6c95896a27d4659c3b173e989f7c900e204b9b987d0587bc8941015f75a4bc2ab8f8cec6dd2e9860ffc02b98b72f62",
     "powershell|11.0|Linux|arm32|sha": "f35aa20ca9d521a0b7878c97737eca817e192093d3067f68cabd8928064f27982739ff3bd5261bf6776ae31c6934a86fb25fb98ac98830f8e4da77ad46cd6999",
     "powershell|11.0|Linux|arm64|sha": "4ea0c5fac453a9c1b3c5800acda1319c9db2df4c6e2dfa40c08fbb169c32def3e4688c5b89473fcdb4b218091a1f3836749fd59d8ee94d39f2c96e8761c08c94",

--- a/src/sdk/10.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/10.0/alpine3.23/amd64/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='5d6deaf0195971e7b6893f932eb04ec7502c90ae61ae5ee6de9364eb2e05345252d5d5df1df579a85f8a936260cba598f0a5a27be3a66670762c1b6d988743a9' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-alpine3.23-amd64
@@ -44,15 +50,14 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='5d6deaf0195971e7b6893f932eb04ec7502c90ae61ae5ee6de9364eb2e05345252d5d5df1df579a85f8a936260cba598f0a5a27be3a66670762c1b6d988743a9' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/alpine3.24/amd64/Dockerfile
+++ b/src/sdk/10.0/alpine3.24/amd64/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='5d6deaf0195971e7b6893f932eb04ec7502c90ae61ae5ee6de9364eb2e05345252d5d5df1df579a85f8a936260cba598f0a5a27be3a66670762c1b6d988743a9' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-alpine3.24-amd64
@@ -44,15 +50,14 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='5d6deaf0195971e7b6893f932eb04ec7502c90ae61ae5ee6de9364eb2e05345252d5d5df1df579a85f8a936260cba598f0a5a27be3a66670762c1b6d988743a9' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/10.0/azurelinux3.0/amd64/Dockerfile
@@ -18,6 +18,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-azurelinux3.0-amd64
@@ -44,15 +50,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/10.0/azurelinux3.0/arm64v8/Dockerfile
@@ -18,6 +18,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-azurelinux3.0-arm64v8
@@ -44,15 +50,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/azurelinux4.0/amd64/Dockerfile
+++ b/src/sdk/10.0/azurelinux4.0/amd64/Dockerfile
@@ -19,6 +19,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-azurelinux4.0-amd64
@@ -45,15 +51,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/azurelinux4.0/arm64v8/Dockerfile
+++ b/src/sdk/10.0/azurelinux4.0/arm64v8/Dockerfile
@@ -19,6 +19,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-azurelinux4.0-arm64v8
@@ -45,15 +51,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/noble/amd64/Dockerfile
+++ b/src/sdk/10.0/noble/amd64/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-noble-amd64
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/10.0/noble/arm32v7/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='e1cc2888dd2048603e4c587d1e0df939bdc9955ebbe66616bb8f34e7cdc43ff9728c6ebfbcfe9353f046f4749b1f4b760c0bd5a47baad64d38bc16df9b280969' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-noble-arm32v7
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm32.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='e1cc2888dd2048603e4c587d1e0df939bdc9955ebbe66616bb8f34e7cdc43ff9728c6ebfbcfe9353f046f4749b1f4b760c0bd5a47baad64d38bc16df9b280969' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/10.0/noble/arm64v8/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-noble-arm64v8
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/resolute/amd64/Dockerfile
+++ b/src/sdk/10.0/resolute/amd64/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-resolute-amd64
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='33bb73608db324e7efccb32722b778512b667b4983a39f96b7b069f9d06e726c2957351216c31cafec52e4a32043802bbf5e807596d143ecd67328c002c1295e' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/resolute/arm32v7/Dockerfile
+++ b/src/sdk/10.0/resolute/arm32v7/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='e1cc2888dd2048603e4c587d1e0df939bdc9955ebbe66616bb8f34e7cdc43ff9728c6ebfbcfe9353f046f4749b1f4b760c0bd5a47baad64d38bc16df9b280969' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-resolute-arm32v7
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm32.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='e1cc2888dd2048603e4c587d1e0df939bdc9955ebbe66616bb8f34e7cdc43ff9728c6ebfbcfe9353f046f4749b1f4b760c0bd5a47baad64d38bc16df9b280969' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/10.0/resolute/arm64v8/Dockerfile
+++ b/src/sdk/10.0/resolute/arm64v8/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=10.0.400 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.6.5 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:10.0.11-resolute-arm64v8
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.6.5.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.6.5 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='2e1085f6944bc25999fae30b51d6fce90a08dcbeec2011e99e879d85da5a3da6cd7d2e0fba2cbd3158e8ad412b16265afd0b0893a658f88223cb6ee557459d48' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/alpine3.24/amd64/Dockerfile
+++ b/src/sdk/11.0/alpine3.24/amd64/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='4eba9c9b057620bef0b33d01e04b2d448d6c95896a27d4659c3b173e989f7c900e204b9b987d0587bc8941015f75a4bc2ab8f8cec6dd2e9860ffc02b98b72f62' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-alpine3.24-amd64
@@ -44,6 +50,8 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.7.7.0-preview.2.nupkg", "/"]
+
 # Workaround for https://github.com/dotnet/sdk/issues/55238
 RUN printf '%s\n' \
         '#!/bin/sh' \
@@ -56,9 +64,6 @@ RUN printf '%s\n' \
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='4eba9c9b057620bef0b33d01e04b2d448d6c95896a27d4659c3b173e989f7c900e204b9b987d0587bc8941015f75a4bc2ab8f8cec6dd2e9860ffc02b98b72f62' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/11.0/azurelinux3.0/amd64/Dockerfile
@@ -18,6 +18,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='0bfdb2cb425e9dc45ce824746b9c686e0cfebe76e02918c3e09663cfb6d7c8a1fb9a8f983b61a30627ab5c48001e5e778ce30e977ce246bf6f48ac09f550bd6f' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-azurelinux3.0-amd64
@@ -44,15 +50,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.7.0-preview.2.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0bfdb2cb425e9dc45ce824746b9c686e0cfebe76e02918c3e09663cfb6d7c8a1fb9a8f983b61a30627ab5c48001e5e778ce30e977ce246bf6f48ac09f550bd6f' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/11.0/azurelinux3.0/arm64v8/Dockerfile
@@ -18,6 +18,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='4ea0c5fac453a9c1b3c5800acda1319c9db2df4c6e2dfa40c08fbb169c32def3e4688c5b89473fcdb4b218091a1f3836749fd59d8ee94d39f2c96e8761c08c94' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-azurelinux3.0-arm64v8
@@ -44,15 +50,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.7.0-preview.2.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='4ea0c5fac453a9c1b3c5800acda1319c9db2df4c6e2dfa40c08fbb169c32def3e4688c5b89473fcdb4b218091a1f3836749fd59d8ee94d39f2c96e8761c08c94' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/azurelinux4.0/amd64/Dockerfile
+++ b/src/sdk/11.0/azurelinux4.0/amd64/Dockerfile
@@ -19,6 +19,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='0bfdb2cb425e9dc45ce824746b9c686e0cfebe76e02918c3e09663cfb6d7c8a1fb9a8f983b61a30627ab5c48001e5e778ce30e977ce246bf6f48ac09f550bd6f' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-azurelinux4.0-amd64
@@ -45,15 +51,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.7.0-preview.2.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0bfdb2cb425e9dc45ce824746b9c686e0cfebe76e02918c3e09663cfb6d7c8a1fb9a8f983b61a30627ab5c48001e5e778ce30e977ce246bf6f48ac09f550bd6f' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/azurelinux4.0/arm64v8/Dockerfile
+++ b/src/sdk/11.0/azurelinux4.0/arm64v8/Dockerfile
@@ -19,6 +19,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='4ea0c5fac453a9c1b3c5800acda1319c9db2df4c6e2dfa40c08fbb169c32def3e4688c5b89473fcdb4b218091a1f3836749fd59d8ee94d39f2c96e8761c08c94' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-azurelinux4.0-arm64v8
@@ -45,15 +51,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.7.0-preview.2.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='4ea0c5fac453a9c1b3c5800acda1319c9db2df4c6e2dfa40c08fbb169c32def3e4688c5b89473fcdb4b218091a1f3836749fd59d8ee94d39f2c96e8761c08c94' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/resolute/amd64/Dockerfile
+++ b/src/sdk/11.0/resolute/amd64/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='0bfdb2cb425e9dc45ce824746b9c686e0cfebe76e02918c3e09663cfb6d7c8a1fb9a8f983b61a30627ab5c48001e5e778ce30e977ce246bf6f48ac09f550bd6f' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-resolute-amd64
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.7.0-preview.2.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='0bfdb2cb425e9dc45ce824746b9c686e0cfebe76e02918c3e09663cfb6d7c8a1fb9a8f983b61a30627ab5c48001e5e778ce30e977ce246bf6f48ac09f550bd6f' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/resolute/arm32v7/Dockerfile
+++ b/src/sdk/11.0/resolute/arm32v7/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='f35aa20ca9d521a0b7878c97737eca817e192093d3067f68cabd8928064f27982739ff3bd5261bf6776ae31c6934a86fb25fb98ac98830f8e4da77ad46cd6999' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-resolute-arm32v7
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm32.7.7.0-preview.2.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='f35aa20ca9d521a0b7878c97737eca817e192093d3067f68cabd8928064f27982739ff3bd5261bf6776ae31c6934a86fb25fb98ac98830f8e4da77ad46cd6999' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/11.0/resolute/arm64v8/Dockerfile
+++ b/src/sdk/11.0/resolute/arm64v8/Dockerfile
@@ -14,6 +14,12 @@ RUN dotnet_sdk_version=11.0.100-rc.1.26411.119 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=7.7.0-preview.2 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='4ea0c5fac453a9c1b3c5800acda1319c9db2df4c6e2dfa40c08fbb169c32def3e4688c5b89473fcdb4b218091a1f3836749fd59d8ee94d39f2c96e8761c08c94' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:11.0.0-rc.1-resolute-arm64v8
@@ -42,15 +48,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.7.0-preview.2.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.7.0-preview.2 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='4ea0c5fac453a9c1b3c5800acda1319c9db2df4c6e2dfa40c08fbb169c32def3e4688c5b89473fcdb4b218091a1f3836749fd59d8ee94d39f2c96e8761c08c94' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.23/amd64/Dockerfile
@@ -15,6 +15,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='2b0c19fd71971eaf135193790fc3513e19f7ae527f66526e0a476c73bfaee8d62d1f03bf33cc7d775c10c927ed95744ccfe8989783c0fc7fdd84e7f26ff713ff' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-alpine3.23-amd64
@@ -44,14 +50,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='2b0c19fd71971eaf135193790fc3513e19f7ae527f66526e0a476c73bfaee8d62d1f03bf33cc7d775c10c927ed95744ccfe8989783c0fc7fdd84e7f26ff713ff' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/alpine3.24/amd64/Dockerfile
+++ b/src/sdk/8.0/alpine3.24/amd64/Dockerfile
@@ -15,6 +15,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='2b0c19fd71971eaf135193790fc3513e19f7ae527f66526e0a476c73bfaee8d62d1f03bf33cc7d775c10c927ed95744ccfe8989783c0fc7fdd84e7f26ff713ff' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-alpine3.24-amd64
@@ -44,14 +50,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='2b0c19fd71971eaf135193790fc3513e19f7ae527f66526e0a476c73bfaee8d62d1f03bf33cc7d775c10c927ed95744ccfe8989783c0fc7fdd84e7f26ff713ff' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/amd64/Dockerfile
@@ -20,6 +20,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-azurelinux3.0-amd64
@@ -46,14 +52,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/8.0/azurelinux3.0/arm64v8/Dockerfile
@@ -20,6 +20,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-azurelinux3.0-arm64v8
@@ -46,14 +52,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/amd64/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-bookworm-slim-amd64
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm32v7/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='e82c73185baf1ce368ddebf8c5eecd5c35c3df4c026b1a6c81aea1416fbaf6c39c7c83c5fabaadc21f97df2269f364d8e7630db87a796e843da0ce362a1bfd8f' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-bookworm-slim-arm32v7
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm32.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='e82c73185baf1ce368ddebf8c5eecd5c35c3df4c026b1a6c81aea1416fbaf6c39c7c83c5fabaadc21f97df2269f364d8e7630db87a796e843da0ce362a1bfd8f' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/8.0/bookworm-slim/arm64v8/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-bookworm-slim-arm64v8
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/jammy/amd64/Dockerfile
+++ b/src/sdk/8.0/jammy/amd64/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-jammy-amd64
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/jammy/arm32v7/Dockerfile
+++ b/src/sdk/8.0/jammy/arm32v7/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='e82c73185baf1ce368ddebf8c5eecd5c35c3df4c026b1a6c81aea1416fbaf6c39c7c83c5fabaadc21f97df2269f364d8e7630db87a796e843da0ce362a1bfd8f' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-jammy-arm32v7
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm32.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='e82c73185baf1ce368ddebf8c5eecd5c35c3df4c026b1a6c81aea1416fbaf6c39c7c83c5fabaadc21f97df2269f364d8e7630db87a796e843da0ce362a1bfd8f' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/jammy/arm64v8/Dockerfile
+++ b/src/sdk/8.0/jammy/arm64v8/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-jammy-arm64v8
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/noble/amd64/Dockerfile
+++ b/src/sdk/8.0/noble/amd64/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-noble-amd64
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='d9689427a30d9cd0b5e125de676fd3b2bdca7108d7d7cbe11836ba8b1f29b4fadfaa1c54568f34d34326d02d7ca920cd28e6bf4df07d12095265cffafb4a2eb6' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/8.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/8.0/noble/arm64v8/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=8.0.424 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.4.19 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:8.0.30-noble-arm64v8
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.4.19.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.4.19 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='97a2788fb4a124792121bb8c5b1d47ca1efa4badf7733a5eee4bd9421e3886c3f0ea1030bf03ded132acb7da7c6b1a9a78b943ebc774d9481299451c560f53d4' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/alpine3.23/amd64/Dockerfile
+++ b/src/sdk/9.0/alpine3.23/amd64/Dockerfile
@@ -15,6 +15,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='2c379c003cff9de263aa0d006300a67a784f69ab6ce9cfd822be0a66215bd4cea1c04b1289d2c58efdf62a8a6af6068fd06a946a58d5e6987d222a811698b4f1' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-alpine3.23-amd64
@@ -45,14 +51,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='2c379c003cff9de263aa0d006300a67a784f69ab6ce9cfd822be0a66215bd4cea1c04b1289d2c58efdf62a8a6af6068fd06a946a58d5e6987d222a811698b4f1' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/alpine3.24/amd64/Dockerfile
+++ b/src/sdk/9.0/alpine3.24/amd64/Dockerfile
@@ -15,6 +15,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='2c379c003cff9de263aa0d006300a67a784f69ab6ce9cfd822be0a66215bd4cea1c04b1289d2c58efdf62a8a6af6068fd06a946a58d5e6987d222a811698b4f1' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-alpine3.24-amd64
@@ -45,14 +51,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='2c379c003cff9de263aa0d006300a67a784f69ab6ce9cfd822be0a66215bd4cea1c04b1289d2c58efdf62a8a6af6068fd06a946a58d5e6987d222a811698b4f1' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/amd64/Dockerfile
@@ -20,6 +20,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='fc3a60d5fd53c3675b0e26232d3eec90d9d1d123f2c68855404227b9ba627e39644c8303772c7165d05ab382e9f457ce398b8546e28e7e832e68b4e1b6989195' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-azurelinux3.0-amd64
@@ -46,14 +52,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='fc3a60d5fd53c3675b0e26232d3eec90d9d1d123f2c68855404227b9ba627e39644c8303772c7165d05ab382e9f457ce398b8546e28e7e832e68b4e1b6989195' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/9.0/azurelinux3.0/arm64v8/Dockerfile
@@ -20,6 +20,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='309cc2305d06bca3228796d785003fd5bdb8cab22170bf7bb48d5cd88de0248e67585439277b9ff9d5bceb632566dcbe52cfea2dcd26d40e10bd0b1a67c1ae19' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-azurelinux3.0-arm64v8
@@ -46,14 +52,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='309cc2305d06bca3228796d785003fd5bdb8cab22170bf7bb48d5cd88de0248e67585439277b9ff9d5bceb632566dcbe52cfea2dcd26d40e10bd0b1a67c1ae19' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/amd64/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='fc3a60d5fd53c3675b0e26232d3eec90d9d1d123f2c68855404227b9ba627e39644c8303772c7165d05ab382e9f457ce398b8546e28e7e832e68b4e1b6989195' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-bookworm-slim-amd64
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='fc3a60d5fd53c3675b0e26232d3eec90d9d1d123f2c68855404227b9ba627e39644c8303772c7165d05ab382e9f457ce398b8546e28e7e832e68b4e1b6989195' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm32v7/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='94815faa00214c435181cc76aa44e53c2d49d10b1f3a1b3a4f94592e854bbceeb67931eb300ad79dae71a7b5c4c4f555caf6df7e873a7326636998f6d6467e3b' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-bookworm-slim-arm32v7
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm32.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='94815faa00214c435181cc76aa44e53c2d49d10b1f3a1b3a4f94592e854bbceeb67931eb300ad79dae71a7b5c4c4f555caf6df7e873a7326636998f6d6467e3b' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
+++ b/src/sdk/9.0/bookworm-slim/arm64v8/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='309cc2305d06bca3228796d785003fd5bdb8cab22170bf7bb48d5cd88de0248e67585439277b9ff9d5bceb632566dcbe52cfea2dcd26d40e10bd0b1a67c1ae19' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-bookworm-slim-arm64v8
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='309cc2305d06bca3228796d785003fd5bdb8cab22170bf7bb48d5cd88de0248e67585439277b9ff9d5bceb632566dcbe52cfea2dcd26d40e10bd0b1a67c1ae19' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/noble/amd64/Dockerfile
+++ b/src/sdk/9.0/noble/amd64/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='fc3a60d5fd53c3675b0e26232d3eec90d9d1d123f2c68855404227b9ba627e39644c8303772c7165d05ab382e9f457ce398b8546e28e7e832e68b4e1b6989195' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-noble-amd64
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x64.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='fc3a60d5fd53c3675b0e26232d3eec90d9d1d123f2c68855404227b9ba627e39644c8303772c7165d05ab382e9f457ce398b8546e28e7e832e68b4e1b6989195' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/noble/arm32v7/Dockerfile
+++ b/src/sdk/9.0/noble/arm32v7/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='94815faa00214c435181cc76aa44e53c2d49d10b1f3a1b3a4f94592e854bbceeb67931eb300ad79dae71a7b5c4c4f555caf6df7e873a7326636998f6d6467e3b' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-noble-arm32v7
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm32.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='94815faa00214c435181cc76aa44e53c2d49d10b1f3a1b3a4f94592e854bbceeb67931eb300ad79dae71a7b5c4c4f555caf6df7e873a7326636998f6d6467e3b' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/src/sdk/9.0/noble/arm64v8/Dockerfile
+++ b/src/sdk/9.0/noble/arm64v8/Dockerfile
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=9.0.317 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         $dotnet_version-sha.txt
 
+# Download PowerShell
+RUN powershell_version=7.5.10 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='309cc2305d06bca3228796d785003fd5bdb8cab22170bf7bb48d5cd88de0248e67585439277b9ff9d5bceb632566dcbe52cfea2dcd26d40e10bd0b1a67c1ae19' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:9.0.19-noble-arm64v8
@@ -44,14 +50,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm64.7.5.10.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=7.5.10 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='309cc2305d06bca3228796d785003fd5bdb8cab22170bf7bb48d5cd88de0248e67585439277b9ff9d5bceb632566dcbe52cfea2dcd26d40e10bd0b1a67c1ae19' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.23-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.23-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-alpine3.XX-amd64
@@ -47,15 +53,14 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.23-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.23-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-alpine3.XX-amd64
@@ -47,15 +53,14 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-amd64
@@ -47,15 +53,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-arm64v8
@@ -47,15 +53,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-amd64-Dockerfile.approved.txt
@@ -22,6 +22,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux4.0-amd64
@@ -48,15 +54,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-amd64-Dockerfile.approved.txt
@@ -24,7 +24,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
@@ -24,7 +24,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
@@ -22,6 +22,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux4.0-arm64v8
@@ -48,15 +54,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-amd64
@@ -45,15 +51,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm32v7-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-arm32v7
@@ -45,15 +51,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-noble-arm64v8-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-arm64v8
@@ -45,15 +51,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-resolute-amd64
@@ -45,15 +51,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-resolute-arm32v7
@@ -45,15 +51,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-resolute-arm64v8
@@ -45,15 +51,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-10.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-alpine3.XX-amd64
@@ -46,6 +52,8 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.0.0.0.nupkg", "/"]
+
 # Workaround for https://github.com/dotnet/sdk/issues/55238
 RUN printf '%s\n' \
         '#!/bin/sh' \
@@ -58,9 +66,6 @@ RUN printf '%s\n' \
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -18,7 +18,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -22,7 +22,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -20,6 +20,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-amd64
@@ -46,15 +52,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -20,6 +20,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-arm64v8
@@ -46,15 +52,14 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -22,7 +22,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-amd64-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux4.0-amd64
@@ -47,15 +53,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-amd64-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux4.0-arm64v8
@@ -47,15 +53,14 @@ RUN dnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-azurelinux4.0-arm64v8-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -52,7 +52,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-amd64-Dockerfile.approved.txt
@@ -18,7 +18,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-amd64-Dockerfile.approved.txt
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-resolute-amd64
@@ -44,15 +50,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -18,7 +18,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm32v7-Dockerfile.approved.txt
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-resolute-arm32v7
@@ -44,15 +50,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -18,7 +18,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-resolute-arm64v8-Dockerfile.approved.txt
@@ -16,6 +16,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-resolute-arm64v8
@@ -44,15 +50,14 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 RUN ln -s /usr/share/dotnet/dnx /usr/bin/dnx \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-11.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -52,7 +52,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.23-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.23-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.23-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.23-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-alpine3.XX-amd64
@@ -46,14 +52,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-alpine3.XX-amd64
@@ -46,14 +52,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-amd64
@@ -47,14 +53,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-arm64v8
@@ -47,14 +53,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-bookworm-slim-amd64
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-bookworm-slim-arm32v7
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-bookworm-slim-arm64v8
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-jammy-amd64
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-jammy-arm32v7
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-jammy-arm64v8-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-jammy-arm64v8
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-amd64
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-noble-arm64v8-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-arm64v8
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-8.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.23-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.23-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-alpine3.XX-amd64
@@ -47,14 +53,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.23-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.23-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-musl-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-alpine3.XX-amd64
@@ -47,14 +53,13 @@ RUN apk add --upgrade --no-cache \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.Alpine.0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.Alpine \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.24-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-alpine3.24-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && wget --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.Alpine.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && wget --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --output-document PowerShell.Linux.Alpine.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.Alpine.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.Alpine.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-amd64
@@ -47,14 +53,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-amd64-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -21,6 +21,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-azurelinux3.0-arm64v8
@@ -47,14 +53,13 @@ RUN tdnf install -y \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-azurelinux3.0-arm64v8-Dockerfile.approved.txt
@@ -23,7 +23,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-bookworm-slim-amd64
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-bookworm-slim-arm32v7
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-bookworm-slim-arm64v8-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-bookworm-slim-arm64v8
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-1809-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2022-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-nanoserver-ltsc2025-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-x64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-amd64
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.x0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-amd64-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.x64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm32.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm32v7-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-arm32v7
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm32.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm32.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm32.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm32 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -19,7 +19,8 @@ RUN dotnet_sdk_version=0.0.0 \
 
 # Download PowerShell
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_url_version=$(printf '%s' "$powershell_version" | tr '.' '-') \
+    && curl --header "Authorization: Bearer $ACCESSTOKEN" --header "x-ms-version: 2017-11-09" --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Linux.arm64.$powershell_version.nupkg \
     && powershell_sha512='{sha512_placeholder}' \
     && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
 

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-noble-arm64v8-Dockerfile.approved.txt
@@ -17,6 +17,12 @@ RUN dotnet_sdk_version=0.0.0 \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz \
         dotnet-sdk-$dotnet_sdk_build_version-linux-arm64.tar.gz.sha512
 
+# Download PowerShell
+RUN powershell_version=0.0.0 \
+    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
+    && powershell_sha512='{sha512_placeholder}' \
+    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c -
+
 
 # .NET SDK image
 FROM $REPO:0.0.0-noble-arm64v8
@@ -45,14 +51,13 @@ RUN apt-get update \
 
 COPY --from=installer ["/dotnet", "/usr/share/dotnet"]
 
+COPY --from=installer ["/PowerShell.Linux.arm0.0.0.nupkg", "/"]
+
 # Trigger first run experience by running arbitrary cmd
 RUN dotnet help
 
 # Install PowerShell global tool
 RUN powershell_version=0.0.0 \
-    && curl --fail --show-error --location --output PowerShell.Linux.arm64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Linux.arm64.$powershell_version.nupkg \
-    && powershell_sha512='{sha512_placeholder}' \
-    && echo "$powershell_sha512  PowerShell.Linux.arm64.$powershell_version.nupkg" | sha512sum -c - \
     && mkdir --parents /usr/share/powershell \
     && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.arm64 \
     && dotnet nuget locals all --clear \

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2019-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2022-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
+++ b/tests/Microsoft.DotNet.Docker.Tests/Baselines/GeneratedArtifactTests/VerifyInternalDockerfilesOutput/sdk-9.0-windowsservercore-ltsc2025-amd64-Dockerfile.approved.txt
@@ -53,7 +53,12 @@ RUN `
         `
         # Install PowerShell global tool
         $powershell_version = '0.0.0'; `
-        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/tool/$powershell_version/PowerShell.Windows.x64.$powershell_version.nupkg; `
+        $powershell_url_version = $powershell_version.Replace('.', '-'); `
+        $Headers = @{ `
+            Authorization = \"Bearer $env:ACCESSTOKEN\"; `
+            'x-ms-version' = '2017-11-09'; `
+        }; `
+        Invoke-WebRequest -OutFile PowerShell.Windows.x64.$powershell_version.nupkg https://pscoretestdata.blob.core.windows.net/v$powershell_url_version-nuget/globaltool/PowerShell.Windows.x64.$powershell_version.nupkg -Headers $Headers; `
         $powershell_sha512 = '{sha512_placeholder}'; `
         if ((Get-FileHash PowerShell.Windows.x64.$powershell_version.nupkg -Algorithm sha512).Hash -ne $powershell_sha512) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `


### PR DESCRIPTION
Internal .NET builds are downloaded in dedicated installer stages. This PR brings PowerShell downloads in line with that pattern and adds the configuration needed to consume internal PowerShell packages using the existing `ACCESSTOKEN` build argument.