### PR TITLE
Fix .NET 11 release download URLs

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -106,9 +106,9 @@
     "dotnet|11.0|product-version": "11.0.0-rc.1",
     "dotnet|11.0|fixed-tag": "$(dotnet|11.0|product-version)",
     "dotnet|11.0|minor-tag": "11.0",
-    "dotnet|11.0|base-url|main": "$(base-url|public|preview|main)",
+    "dotnet|11.0|base-url|main": "$(base-url|public|maintenance|main)",
     "dotnet|11.0|base-url|nightly": "$(base-url|public|preview|nightly)",
-    "dotnet|11.0|base-url|checksums|main": "$(base-url|public-checksums|preview|main)",
+    "dotnet|11.0|base-url|checksums|main": "$(base-url|public-checksums|maintenance|main)",
     "dotnet|11.0|base-url|checksums|nightly": "$(base-url|public-checksums|preview|nightly)",
     "dotnet|11.0|use-final-version": "false",
 

--- a/src/aspnet/11.0/alpine3.24-composite-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-composite-extra/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-amd64 AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-composite-extra/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-composite-extra/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-arm32v7 AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-composite-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-composite-extra/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-arm64v8 AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-composite/amd64/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-composite/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-amd64 AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-composite/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-composite/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm32v7 AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-composite/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-composite/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm64v8 AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-extra/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-amd64 AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-extra/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-extra/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-arm32v7 AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/alpine3.24-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24-extra/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-arm64v8 AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/alpine3.24/amd64/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-amd64 AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/alpine3.24/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm32v7 AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/alpine3.24/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/alpine3.24/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm64v8 AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
-        https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-musl-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless-composite-extra/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless-composite-extra/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless-composite/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless-composite/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless-composite/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless-extra/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0-distroless/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0-distroless/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0/amd64/Dockerfile
@@ -10,9 +10,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux3.0/arm64v8/Dockerfile
@@ -10,9 +10,9 @@ RUN tdnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless-composite-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless-composite-extra/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless-composite-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless-composite-extra/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless-composite/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless-composite/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless-composite/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless-composite/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless-extra/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless-extra/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0-distroless/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0-distroless/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0/amd64/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0/amd64/Dockerfile
@@ -11,9 +11,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/azurelinux4.0/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/azurelinux4.0/arm64v8/Dockerfile
@@ -11,9 +11,9 @@ RUN dnf install -y \
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512)  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/aspnet/11.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -12,10 +12,10 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '11.0.0-rc.1.26425.128'; `
         $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
-        $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
+        $dotnet_sha512_file = $aspnetcore_file + '.sha512-bare'; `
         `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/aspnet/11.0/resolute-chiseled-composite-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-composite-extra/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-composite-extra/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-composite-extra/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-composite-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-composite-extra/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-composite/amd64/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-composite/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-composite/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-composite/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-composite/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-composite/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Composite Runtime
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-composite-$aspnetcore_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-extra/amd64/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-extra/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-extra/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-extra/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled-extra/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled-extra/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled/amd64/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute-chiseled/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/resolute-chiseled/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute/amd64/Dockerfile
+++ b/src/aspnet/11.0/resolute/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-x64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute/arm32v7/Dockerfile
+++ b/src/aspnet/11.0/resolute/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/resolute/arm64v8/Dockerfile
+++ b/src/aspnet/11.0/resolute/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve ASP.NET Core
 RUN aspnetcore_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file aspnetcore-runtime-$aspnetcore_version-linux-arm64.tar.gz --directory /dotnet ./shared/Microsoft.AspNetCore.App \
     && rm \

--- a/src/aspnet/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/aspnet/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -12,10 +12,10 @@ RUN powershell -Command `
         `
         $aspnetcore_version = '11.0.0-rc.1.26425.128'; `
         $aspnetcore_file = 'aspnetcore-runtime-' + $aspnetcore_version + '-win-x64.zip'; `
-        $dotnet_sha512_file = $aspnetcore_file + '.sha512'; `
+        $dotnet_sha512_file = $aspnetcore_file + '.sha512-bare'; `
         `
-        Invoke-WebRequest -OutFile $aspnetcore_file https://ci.dot.net/public/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://ci.dot.net/public-checksums/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file; `
+        Invoke-WebRequest -OutFile $aspnetcore_file https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/$aspnetcore_file; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$aspnetcore_version/$dotnet_sha512_file; `
         `
         if ((Get-FileHash $aspnetcore_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/11.0/alpine3.24-extra/amd64/Dockerfile
+++ b/src/runtime/11.0/alpine3.24-extra/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-amd64 AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/alpine3.24-extra/arm32v7/Dockerfile
+++ b/src/runtime/11.0/alpine3.24-extra/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-arm32v7 AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/alpine3.24-extra/arm64v8/Dockerfile
+++ b/src/runtime/11.0/alpine3.24-extra/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-extra-arm64v8 AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/alpine3.24/amd64/Dockerfile
+++ b/src/runtime/11.0/alpine3.24/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-amd64 AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
-        https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-x64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/alpine3.24/arm32v7/Dockerfile
+++ b/src/runtime/11.0/alpine3.24/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm32v7 AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
-        https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/alpine3.24/arm64v8/Dockerfile
+++ b/src/runtime/11.0/alpine3.24/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm64v8 AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
-        https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-musl-arm64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux3.0-distroless-extra/amd64/Dockerfile
+++ b/src/runtime/11.0/azurelinux3.0-distroless-extra/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile
+++ b/src/runtime/11.0/azurelinux3.0-distroless-extra/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux3.0-distroless/amd64/Dockerfile
+++ b/src/runtime/11.0/azurelinux3.0-distroless/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux3.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime/11.0/azurelinux3.0-distroless/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN tdnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/runtime/11.0/azurelinux3.0/amd64/Dockerfile
@@ -10,9 +10,9 @@ RUN tdnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/runtime/11.0/azurelinux3.0/arm64v8/Dockerfile
@@ -10,9 +10,9 @@ RUN tdnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux4.0-distroless-extra/amd64/Dockerfile
+++ b/src/runtime/11.0/azurelinux4.0-distroless-extra/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux4.0-distroless-extra/arm64v8/Dockerfile
+++ b/src/runtime/11.0/azurelinux4.0-distroless-extra/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux4.0-distroless/amd64/Dockerfile
+++ b/src/runtime/11.0/azurelinux4.0-distroless/amd64/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux4.0-distroless/arm64v8/Dockerfile
+++ b/src/runtime/11.0/azurelinux4.0-distroless/arm64v8/Dockerfile
@@ -12,9 +12,9 @@ RUN dnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux4.0/amd64/Dockerfile
+++ b/src/runtime/11.0/azurelinux4.0/amd64/Dockerfile
@@ -11,9 +11,9 @@ RUN dnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/azurelinux4.0/arm64v8/Dockerfile
+++ b/src/runtime/11.0/azurelinux4.0/arm64v8/Dockerfile
@@ -11,9 +11,9 @@ RUN dnf install -y \
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512)  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/runtime/11.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -10,10 +10,10 @@ RUN powershell -Command `
         `
         $dotnet_version = '11.0.0-rc.1.26425.128'; `
         $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
-        $dotnet_sha512_file = $dotnet_file + '.sha512'; `
+        $dotnet_sha512_file = $dotnet_file + '.sha512-bare'; `
         `
-        Invoke-WebRequest -OutFile $dotnet_file https://ci.dot.net/public/Runtime/$dotnet_version/$dotnet_file; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://ci.dot.net/public-checksums/Runtime/$dotnet_version/$dotnet_sha512_file; `
+        Invoke-WebRequest -OutFile $dotnet_file https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/$dotnet_file; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/$dotnet_sha512_file; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/runtime/11.0/resolute-chiseled-extra/amd64/Dockerfile
+++ b/src/runtime/11.0/resolute-chiseled-extra/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/resolute-chiseled-extra/arm32v7/Dockerfile
+++ b/src/runtime/11.0/resolute-chiseled-extra/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/resolute-chiseled-extra/arm64v8/Dockerfile
+++ b/src/runtime/11.0/resolute-chiseled-extra/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/resolute-chiseled/amd64/Dockerfile
+++ b/src/runtime/11.0/resolute-chiseled/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/resolute-chiseled/arm32v7/Dockerfile
+++ b/src/runtime/11.0/resolute-chiseled/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/resolute-chiseled/arm64v8/Dockerfile
+++ b/src/runtime/11.0/resolute-chiseled/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /usr/share/dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /usr/share/dotnet \
     && rm \

--- a/src/runtime/11.0/resolute/amd64/Dockerfile
+++ b/src/runtime/11.0/resolute/amd64/Dockerfile
@@ -6,9 +6,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-x64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/resolute/arm32v7/Dockerfile
+++ b/src/runtime/11.0/resolute/arm32v7/Dockerfile
@@ -6,9 +6,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/resolute/arm64v8/Dockerfile
+++ b/src/runtime/11.0/resolute/arm64v8/Dockerfile
@@ -6,9 +6,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Retrieve .NET Runtime
 RUN dotnet_version=11.0.0-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-runtime-$dotnet_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-runtime-$dotnet_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-runtime-$dotnet_version-linux-arm64.tar.gz --directory /dotnet \
     && rm \

--- a/src/runtime/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/runtime/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -10,10 +10,10 @@ RUN powershell -Command `
         `
         $dotnet_version = '11.0.0-rc.1.26425.128'; `
         $dotnet_file = 'dotnet-runtime-' + $dotnet_version + '-win-x64.zip'; `
-        $dotnet_sha512_file = $dotnet_file + '.sha512'; `
+        $dotnet_sha512_file = $dotnet_file + '.sha512-bare'; `
         `
-        Invoke-WebRequest -OutFile $dotnet_file https://ci.dot.net/public/Runtime/$dotnet_version/$dotnet_file; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://ci.dot.net/public-checksums/Runtime/$dotnet_version/$dotnet_sha512_file; `
+        Invoke-WebRequest -OutFile $dotnet_file https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/$dotnet_file; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://builds.dotnet.microsoft.com/dotnet/Runtime/$dotnet_version/$dotnet_sha512_file; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/11.0/alpine3.24/amd64/Dockerfile
+++ b/src/sdk/11.0/alpine3.24/amd64/Dockerfile
@@ -5,9 +5,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-amd64 AS installer
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
-        https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-x64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/alpine3.24/arm32v7/Dockerfile
+++ b/src/sdk/11.0/alpine3.24/arm32v7/Dockerfile
@@ -5,9 +5,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm32v7 AS installer
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
-        https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/alpine3.24/arm64v8/Dockerfile
+++ b/src/sdk/11.0/alpine3.24/arm64v8/Dockerfile
@@ -5,9 +5,9 @@ FROM $REPO:11.0.0-rc.1-alpine3.24-arm64v8 AS installer
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && wget \
-        https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
-        https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz" | sha512sum -c - \
+        https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz \
+        https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-musl-arm64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/azurelinux3.0/amd64/Dockerfile
+++ b/src/sdk/11.0/azurelinux3.0/amd64/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/azurelinux3.0/arm64v8/Dockerfile
+++ b/src/sdk/11.0/azurelinux3.0/arm64v8/Dockerfile
@@ -9,9 +9,9 @@ RUN tdnf install -y \
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/azurelinux4.0/amd64/Dockerfile
+++ b/src/sdk/11.0/azurelinux4.0/amd64/Dockerfile
@@ -10,9 +10,9 @@ RUN dnf install -y \
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/azurelinux4.0/arm64v8/Dockerfile
+++ b/src/sdk/11.0/azurelinux4.0/arm64v8/Dockerfile
@@ -10,9 +10,9 @@ RUN dnf install -y \
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512)  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/nanoserver-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/11.0/nanoserver-ltsc2025/amd64/Dockerfile
@@ -27,10 +27,10 @@ RUN powershell -Command " `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '11.0.100-rc.1.26425.128'; `
         $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
-        $dotnet_sha512_file = $dotnet_file + '.sha512'; `
+        $dotnet_sha512_file = $dotnet_file + '.sha512-bare'; `
         `
-        Invoke-WebRequest -OutFile $dotnet_file https://ci.dot.net/public/Sdk/$dotnet_sdk_version/$dotnet_file; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/$dotnet_sha512_file; `
+        Invoke-WebRequest -OutFile $dotnet_file https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/$dotnet_file; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/$dotnet_sha512_file; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `

--- a/src/sdk/11.0/resolute/amd64/Dockerfile
+++ b/src/sdk/11.0/resolute/amd64/Dockerfile
@@ -5,9 +5,9 @@ FROM amd64/buildpack-deps:resolute-curl AS installer
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/resolute/arm32v7/Dockerfile
+++ b/src/sdk/11.0/resolute/arm32v7/Dockerfile
@@ -5,9 +5,9 @@ FROM arm32v7/buildpack-deps:jammy-curl AS installer
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/resolute/arm64v8/Dockerfile
+++ b/src/sdk/11.0/resolute/arm64v8/Dockerfile
@@ -5,9 +5,9 @@ FROM arm64v8/buildpack-deps:resolute-curl AS installer
 # Install .NET SDK
 RUN dotnet_sdk_version=11.0.100-rc.1.26425.128 \
     && curl --fail --show-error --location \
-        --remote-name https://ci.dot.net/public/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
-        --remote-name https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
-    && echo "$(cat dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512| tr 'A-F' 'a-f')  dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz" | sha512sum -c - \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz \
+        --remote-name https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
+    && sha512sum -c dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz.sha512 \
     && mkdir --parents /dotnet \
     && tar --gzip --extract --no-same-owner --file dotnet-sdk-$dotnet_sdk_version-linux-arm64.tar.gz --directory /dotnet ./dnx ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm \

--- a/src/sdk/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
+++ b/src/sdk/11.0/windowsservercore-ltsc2025/amd64/Dockerfile
@@ -27,10 +27,10 @@ RUN powershell -Command " `
         # Retrieve .NET SDK
         $dotnet_sdk_version = '11.0.100-rc.1.26425.128'; `
         $dotnet_file = 'dotnet-sdk-' + $dotnet_sdk_version + '-win-x64.zip'; `
-        $dotnet_sha512_file = $dotnet_file + '.sha512'; `
+        $dotnet_sha512_file = $dotnet_file + '.sha512-bare'; `
         `
-        Invoke-WebRequest -OutFile $dotnet_file https://ci.dot.net/public/Sdk/$dotnet_sdk_version/$dotnet_file; `
-        Invoke-WebRequest -OutFile $dotnet_sha512_file https://ci.dot.net/public-checksums/Sdk/$dotnet_sdk_version/$dotnet_sha512_file; `
+        Invoke-WebRequest -OutFile $dotnet_file https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/$dotnet_file; `
+        Invoke-WebRequest -OutFile $dotnet_sha512_file https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnet_sdk_version/$dotnet_sha512_file; `
         `
         if ((Get-FileHash $dotnet_file -Algorithm sha512).Hash -ne (Get-Content $dotnet_sha512_file)) { `
             Write-Host 'CHECKSUM VERIFICATION FAILED!'; `


### PR DESCRIPTION
Download URLs for .NET 11 were set incorrectly in #7348. This PR updates them to the correct base URL.